### PR TITLE
[core] Simplify row ID assignment manifest scanning

### DIFF
--- a/paimon-common/src/main/java/org/apache/paimon/utils/ByteArrayKey.java
+++ b/paimon-common/src/main/java/org/apache/paimon/utils/ByteArrayKey.java
@@ -1,0 +1,58 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.utils;
+
+import java.util.Arrays;
+
+import static org.apache.paimon.utils.Preconditions.checkArgument;
+
+/**
+ * Stable hash key backed by a byte array.
+ *
+ * <p>The byte array is not copied and must not be modified while this key is stored in a hash
+ * collection. Use {@link ByteArrayLookupKey} for allocation-free lookups.
+ */
+public final class ByteArrayKey {
+
+    private final byte[] bytes;
+    private final int hash;
+
+    public ByteArrayKey(byte[] bytes) {
+        checkArgument(bytes != null, "Byte array cannot be null.");
+        this.bytes = bytes;
+        this.hash = Arrays.hashCode(bytes);
+    }
+
+    byte[] bytes() {
+        return bytes;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        return obj == this
+                || (obj instanceof ByteArrayKey && Arrays.equals(bytes, ((ByteArrayKey) obj).bytes))
+                || (obj instanceof ByteArrayLookupKey
+                        && Arrays.equals(bytes, ((ByteArrayLookupKey) obj).bytes()));
+    }
+
+    @Override
+    public int hashCode() {
+        return hash;
+    }
+}

--- a/paimon-common/src/main/java/org/apache/paimon/utils/ByteArrayLookupKey.java
+++ b/paimon-common/src/main/java/org/apache/paimon/utils/ByteArrayLookupKey.java
@@ -1,0 +1,75 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.utils;
+
+import javax.annotation.Nullable;
+
+import java.util.Arrays;
+
+import static org.apache.paimon.utils.Preconditions.checkArgument;
+
+/**
+ * Reusable lookup view compatible with {@link ByteArrayKey}.
+ *
+ * <p>This object is mutable and must not be stored in a hash collection. The byte array is not
+ * copied and only needs to remain unchanged for the duration of a lookup.
+ */
+public final class ByteArrayLookupKey {
+
+    private @Nullable byte[] bytes;
+    private int hash;
+
+    public ByteArrayLookupKey() {}
+
+    public ByteArrayLookupKey(byte[] bytes) {
+        reset(bytes);
+    }
+
+    public void reset(byte[] bytes) {
+        checkArgument(bytes != null, "Byte array cannot be null.");
+        this.bytes = bytes;
+        this.hash = Arrays.hashCode(bytes);
+    }
+
+    public void clear() {
+        bytes = null;
+        hash = 0;
+    }
+
+    @Nullable
+    byte[] bytes() {
+        return bytes;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        return obj == this
+                || (bytes != null
+                        && obj instanceof ByteArrayKey
+                        && Arrays.equals(bytes, ((ByteArrayKey) obj).bytes()))
+                || (bytes != null
+                        && obj instanceof ByteArrayLookupKey
+                        && Arrays.equals(bytes, ((ByteArrayLookupKey) obj).bytes));
+    }
+
+    @Override
+    public int hashCode() {
+        return hash;
+    }
+}

--- a/paimon-common/src/main/java/org/apache/paimon/utils/DeletedIdentifierSet.java
+++ b/paimon-common/src/main/java/org/apache/paimon/utils/DeletedIdentifierSet.java
@@ -1,0 +1,190 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.utils;
+
+import java.util.Arrays;
+
+import static org.apache.paimon.utils.Preconditions.checkArgument;
+import static org.apache.paimon.utils.Preconditions.checkState;
+
+/** Compact, collision-safe set backed by primitive arrays and one identifier byte arena. */
+public final class DeletedIdentifierSet {
+
+    private static final float LOAD_FACTOR = 0.75f;
+
+    private int[] buckets = filledWithMinusOne(16);
+    private long[] hashes = new long[16];
+    private int[] partitionIds = new int[16];
+    private int[] offsets = new int[16];
+    private int[] lengths = new int[16];
+    private int[] next = new int[16];
+    private byte[] arena = new byte[256];
+    private int arenaSize;
+    private int size;
+
+    public boolean isEmpty() {
+        return size == 0;
+    }
+
+    public int size() {
+        return size;
+    }
+
+    public int retainedIdentifierBytes() {
+        return arenaSize;
+    }
+
+    public void release() {
+        buckets = filledWithMinusOne(16);
+        hashes = new long[0];
+        partitionIds = new int[0];
+        offsets = new int[0];
+        lengths = new int[0];
+        next = new int[0];
+        arena = new byte[0];
+        arenaSize = 0;
+        size = 0;
+    }
+
+    public void add(int partitionId, byte[] identifier, int length) {
+        checkIdentifier(identifier, length);
+        long hash = hash(partitionId, identifier, length);
+        if (contains(partitionId, identifier, length, hash)) {
+            return;
+        }
+        if (size + 1 > (int) (buckets.length * LOAD_FACTOR)) {
+            growBuckets();
+        }
+        ensureEntryCapacity(size + 1);
+        ensureArenaCapacity(length);
+        int offset = arenaSize;
+        System.arraycopy(identifier, 0, arena, offset, length);
+        arenaSize = Math.addExact(arenaSize, length);
+
+        int bucket = bucket(hash);
+        hashes[size] = hash;
+        partitionIds[size] = partitionId;
+        offsets[size] = offset;
+        lengths[size] = length;
+        next[size] = buckets[bucket];
+        buckets[bucket] = size;
+        size++;
+    }
+
+    public boolean contains(int partitionId, byte[] identifier, int length) {
+        checkIdentifier(identifier, length);
+        return contains(partitionId, identifier, length, hash(partitionId, identifier, length));
+    }
+
+    private boolean contains(int partitionId, byte[] identifier, int length, long hash) {
+        for (int entry = buckets[bucket(hash)]; entry >= 0; entry = next[entry]) {
+            if (hashes[entry] == hash
+                    && partitionIds[entry] == partitionId
+                    && lengths[entry] == length
+                    && bytesEqual(arena, offsets[entry], identifier, length)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private void growBuckets() {
+        checkState(
+                buckets.length < (1 << 30), "Too many deleted identifiers in one manifest group.");
+        int[] grown = filledWithMinusOne(buckets.length << 1);
+        for (int entry = 0; entry < size; entry++) {
+            int bucket = bucket(hashes[entry], grown.length);
+            next[entry] = grown[bucket];
+            grown[bucket] = entry;
+        }
+        buckets = grown;
+    }
+
+    private void ensureEntryCapacity(int required) {
+        if (required <= hashes.length) {
+            return;
+        }
+        int grown = Math.max(required, hashes.length + (hashes.length >>> 1));
+        hashes = Arrays.copyOf(hashes, grown);
+        partitionIds = Arrays.copyOf(partitionIds, grown);
+        offsets = Arrays.copyOf(offsets, grown);
+        lengths = Arrays.copyOf(lengths, grown);
+        next = Arrays.copyOf(next, grown);
+    }
+
+    private void ensureArenaCapacity(int additional) {
+        int required;
+        try {
+            required = Math.addExact(arenaSize, additional);
+        } catch (ArithmeticException e) {
+            throw new IllegalStateException(
+                    "Deleted identifier arena exceeds the Java array limit.", e);
+        }
+        if (required <= arena.length) {
+            return;
+        }
+        int grown = Math.max(required, arena.length + (arena.length >>> 1));
+        if (grown < 0) {
+            grown = required;
+        }
+        arena = Arrays.copyOf(arena, grown);
+    }
+
+    private int bucket(long hash) {
+        return bucket(hash, buckets.length);
+    }
+
+    private static int bucket(long hash, int bucketCount) {
+        return ((int) (hash ^ (hash >>> 32))) & (bucketCount - 1);
+    }
+
+    private static long hash(int partitionId, byte[] bytes, int length) {
+        long hash = 0xcbf29ce484222325L;
+        hash ^= Integer.toUnsignedLong(partitionId);
+        hash *= 0x100000001b3L;
+        for (int i = 0; i < length; i++) {
+            hash ^= bytes[i] & 0xFFL;
+            hash *= 0x100000001b3L;
+        }
+        return hash;
+    }
+
+    private static boolean bytesEqual(byte[] left, int leftOffset, byte[] right, int length) {
+        for (int i = 0; i < length; i++) {
+            if (left[leftOffset + i] != right[i]) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private static void checkIdentifier(byte[] identifier, int length) {
+        checkArgument(identifier != null, "Identifier bytes cannot be null.");
+        checkArgument(
+                length >= 0 && length <= identifier.length,
+                "Invalid identifier length %s.",
+                length);
+    }
+
+    private static int[] filledWithMinusOne(int length) {
+        int[] values = new int[length];
+        Arrays.fill(values, -1);
+        return values;
+    }
+}

--- a/paimon-common/src/main/java/org/apache/paimon/utils/LongTripleArrayList.java
+++ b/paimon-common/src/main/java/org/apache/paimon/utils/LongTripleArrayList.java
@@ -1,0 +1,125 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.utils;
+
+import java.util.Arrays;
+
+import static org.apache.paimon.utils.Preconditions.checkArgument;
+import static org.apache.paimon.utils.Preconditions.checkState;
+
+/** Array-backed list whose elements are triples of primitive longs. */
+public final class LongTripleArrayList {
+
+    private static final int ELEMENT_WIDTH = 3;
+    private static final int MIN_GROWN_LONGS = 16 * ELEMENT_WIDTH;
+
+    private long[] longs;
+    private int size;
+
+    public LongTripleArrayList() {
+        this(0);
+    }
+
+    public LongTripleArrayList(int expectedSize) {
+        checkArgument(expectedSize >= 0, "Expected size cannot be negative.");
+        checkArgument(
+                expectedSize <= Integer.MAX_VALUE / ELEMENT_WIDTH, "Expected size is too large.");
+        longs = new long[expectedSize * ELEMENT_WIDTH];
+    }
+
+    public void add(long first, long second, long third) {
+        ensureCapacity(Math.addExact(size, 1));
+        int offset = size * ELEMENT_WIDTH;
+        longs[offset] = first;
+        longs[offset + 1] = second;
+        longs[offset + 2] = third;
+        size++;
+    }
+
+    public long first(int index) {
+        return longs[offset(index)];
+    }
+
+    public long second(int index) {
+        return longs[offset(index) + 1];
+    }
+
+    public long third(int index) {
+        return longs[offset(index) + 2];
+    }
+
+    public void swap(int left, int right) {
+        int leftOffset = offset(left);
+        int rightOffset = offset(right);
+        if (left == right) {
+            return;
+        }
+        for (int i = 0; i < ELEMENT_WIDTH; i++) {
+            long value = longs[leftOffset + i];
+            longs[leftOffset + i] = longs[rightOffset + i];
+            longs[rightOffset + i] = value;
+        }
+    }
+
+    public int size() {
+        return size;
+    }
+
+    public int usedLongCount() {
+        return size * ELEMENT_WIDTH;
+    }
+
+    public int retainedLongCount() {
+        return longs.length;
+    }
+
+    public void clear() {
+        size = 0;
+    }
+
+    public void release() {
+        longs = new long[0];
+        size = 0;
+    }
+
+    private int offset(int index) {
+        checkArgument(index >= 0 && index < size, "Long triple index is out of bounds.");
+        return index * ELEMENT_WIDTH;
+    }
+
+    private void ensureCapacity(int requiredSize) {
+        long requiredLongs = (long) requiredSize * ELEMENT_WIDTH;
+        checkState(
+                requiredLongs <= Integer.MAX_VALUE,
+                "Too many long triples to fit in a Java array.");
+        if (requiredLongs <= longs.length) {
+            return;
+        }
+        int newLength = Math.max(MIN_GROWN_LONGS, longs.length);
+        while (newLength < requiredLongs) {
+            int grown = newLength + (newLength >>> 1);
+            if (grown <= newLength || grown > Integer.MAX_VALUE) {
+                newLength = (int) requiredLongs;
+                break;
+            }
+            newLength = grown;
+        }
+        longs = Arrays.copyOf(longs, newLength);
+    }
+}

--- a/paimon-common/src/main/java/org/apache/paimon/utils/PrimitiveRowRanges.java
+++ b/paimon-common/src/main/java/org/apache/paimon/utils/PrimitiveRowRanges.java
@@ -1,0 +1,250 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.utils;
+
+import java.util.Arrays;
+
+import static org.apache.paimon.utils.Preconditions.checkArgument;
+
+/**
+ * Object-free mutable storage for inclusive row ranges.
+ *
+ * <p>Starts and ends are kept in separate primitive arrays. Ownership of both arrays can be
+ * transferred without copying when the initial capacity matches the final range count.
+ */
+public final class PrimitiveRowRanges {
+
+    private long[] starts;
+    private long[] ends;
+    private int size;
+    private boolean sorted = true;
+    private boolean normalized = true;
+
+    public PrimitiveRowRanges(int expectedRanges) {
+        checkArgument(expectedRanges >= 0, "Expected range count cannot be negative.");
+        starts = new long[expectedRanges];
+        ends = new long[expectedRanges];
+    }
+
+    public int size() {
+        return size;
+    }
+
+    public int retainedWordCount() {
+        return Math.addExact(starts.length, ends.length);
+    }
+
+    public long start(int index) {
+        checkIndex(index);
+        return starts[index];
+    }
+
+    public long end(int index) {
+        checkIndex(index);
+        return ends[index];
+    }
+
+    public void add(long start, long end) {
+        checkArgument(start <= end, "Invalid row range [%s, %s].", start, end);
+        ensureCapacity(Math.addExact(size, 1));
+        if (size > 0 && compare(starts[size - 1], ends[size - 1], start, end) > 0) {
+            sorted = false;
+        }
+        starts[size] = start;
+        ends[size] = end;
+        size++;
+        normalized = false;
+    }
+
+    public void append(PrimitiveRowRanges other) {
+        checkArgument(other != null, "Ranges to append cannot be null.");
+        if (other.size == 0) {
+            return;
+        }
+        int oldSize = size;
+        int combinedSize = Math.addExact(size, other.size);
+        ensureCapacity(combinedSize);
+        if (oldSize > 0
+                && compare(starts[oldSize - 1], ends[oldSize - 1], other.starts[0], other.ends[0])
+                        > 0) {
+            sorted = false;
+        }
+        sorted &= other.sorted;
+        System.arraycopy(other.starts, 0, starts, oldSize, other.size);
+        System.arraycopy(other.ends, 0, ends, oldSize, other.size);
+        size = combinedSize;
+        normalized = false;
+    }
+
+    public void normalizeOverlapping() {
+        if (normalized) {
+            return;
+        }
+        if (size <= 1) {
+            sorted = true;
+            normalized = true;
+            return;
+        }
+        if (!sorted) {
+            sort(0, size - 1);
+            sorted = true;
+        }
+        int writeIndex = 0;
+        for (int readIndex = 1; readIndex < size; readIndex++) {
+            if (starts[readIndex] <= ends[writeIndex]) {
+                ends[writeIndex] = Math.max(ends[writeIndex], ends[readIndex]);
+            } else {
+                writeIndex++;
+                starts[writeIndex] = starts[readIndex];
+                ends[writeIndex] = ends[readIndex];
+            }
+        }
+        size = writeIndex + 1;
+        normalized = true;
+    }
+
+    /**
+     * Returns whether these ranges fully cover the inclusive range from {@code start} to {@code
+     * end}.
+     */
+    public boolean covers(long start, long end) {
+        checkArgument(start <= end, "Invalid row range [%s, %s].", start, end);
+        normalizeOverlapping();
+        long cursor = start;
+        for (int i = 0; i < size; i++) {
+            if (ends[i] < cursor) {
+                continue;
+            }
+            if (starts[i] > cursor) {
+                return false;
+            }
+            long segmentEnd = Math.min(ends[i], end);
+            if (segmentEnd == end) {
+                return true;
+            }
+            if (segmentEnd == Long.MAX_VALUE) {
+                return false;
+            }
+            cursor = segmentEnd + 1L;
+        }
+        return false;
+    }
+
+    public Owned takeOwned() {
+        long[] ownedStarts = starts.length == size ? starts : Arrays.copyOf(starts, size);
+        long[] ownedEnds = ends.length == size ? ends : Arrays.copyOf(ends, size);
+        starts = new long[0];
+        ends = new long[0];
+        size = 0;
+        sorted = true;
+        normalized = true;
+        return new Owned(ownedStarts, ownedEnds);
+    }
+
+    private void ensureCapacity(int required) {
+        if (required <= starts.length) {
+            return;
+        }
+        int grown = Math.max(16, starts.length);
+        while (grown < required) {
+            int next = grown + (grown >>> 1);
+            if (next <= grown || next < 0) {
+                grown = required;
+                break;
+            }
+            grown = next;
+        }
+        starts = Arrays.copyOf(starts, grown);
+        ends = Arrays.copyOf(ends, grown);
+    }
+
+    private void sort(int left, int right) {
+        while (left < right) {
+            int middle = left + ((right - left) >>> 1);
+            long pivotStart = starts[middle];
+            long pivotEnd = ends[middle];
+            int lower = left;
+            int current = left;
+            int upper = right;
+            while (current <= upper) {
+                int comparison = compare(starts[current], ends[current], pivotStart, pivotEnd);
+                if (comparison < 0) {
+                    swap(lower++, current++);
+                } else if (comparison > 0) {
+                    swap(current, upper--);
+                } else {
+                    current++;
+                }
+            }
+
+            if (lower - left < right - upper) {
+                if (left < lower - 1) {
+                    sort(left, lower - 1);
+                }
+                left = upper + 1;
+            } else {
+                if (upper + 1 < right) {
+                    sort(upper + 1, right);
+                }
+                right = lower - 1;
+            }
+        }
+    }
+
+    private void swap(int left, int right) {
+        if (left == right) {
+            return;
+        }
+        long start = starts[left];
+        long end = ends[left];
+        starts[left] = starts[right];
+        ends[left] = ends[right];
+        starts[right] = start;
+        ends[right] = end;
+    }
+
+    private void checkIndex(int index) {
+        checkArgument(index >= 0 && index < size, "Row range index is out of bounds.");
+    }
+
+    private static int compare(long leftStart, long leftEnd, long rightStart, long rightEnd) {
+        int result = Long.compare(leftStart, rightStart);
+        return result == 0 ? Long.compare(leftEnd, rightEnd) : result;
+    }
+
+    /** Owned primitive arrays transferred from {@link PrimitiveRowRanges}. */
+    public static final class Owned {
+
+        private final long[] starts;
+        private final long[] ends;
+
+        private Owned(long[] starts, long[] ends) {
+            this.starts = starts;
+            this.ends = ends;
+        }
+
+        public long[] starts() {
+            return starts;
+        }
+
+        public long[] ends() {
+            return ends;
+        }
+    }
+}

--- a/paimon-common/src/test/java/org/apache/paimon/utils/ByteArrayKeyTest.java
+++ b/paimon-common/src/test/java/org/apache/paimon/utils/ByteArrayKeyTest.java
@@ -1,0 +1,83 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.utils;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/** Tests for {@link ByteArrayKey} and {@link ByteArrayLookupKey}. */
+class ByteArrayKeyTest {
+
+    @Test
+    void testCrossTypeEquality() {
+        ByteArrayKey key = new ByteArrayKey(new byte[] {1, 2, 3});
+        ByteArrayKey equalKey = new ByteArrayKey(new byte[] {1, 2, 3});
+        ByteArrayLookupKey lookup = new ByteArrayLookupKey(new byte[] {1, 2, 3});
+
+        assertThat(key).isEqualTo(equalKey).isEqualTo(lookup);
+        assertThat(lookup).isEqualTo(key);
+        assertThat(key.hashCode()).isEqualTo(equalKey.hashCode()).isEqualTo(lookup.hashCode());
+        assertThat(key).isNotEqualTo(new ByteArrayKey(new byte[] {1, 2, 4}));
+    }
+
+    @Test
+    void testReusableMapLookup() {
+        Map<ByteArrayKey, String> values = new HashMap<>();
+        values.put(new ByteArrayKey(new byte[] {1}), "one");
+        values.put(new ByteArrayKey(new byte[] {2}), "two");
+        ByteArrayLookupKey lookup = new ByteArrayLookupKey();
+
+        lookup.reset(new byte[] {1});
+        assertThat(values.get(lookup)).isEqualTo("one");
+
+        lookup.reset(new byte[] {2});
+        assertThat(values.get(lookup)).isEqualTo("two");
+
+        lookup.clear();
+        assertThat(values.get(lookup)).isNull();
+        assertThat(lookup.hashCode()).isZero();
+    }
+
+    @Test
+    void testLookupEqualityLifecycle() {
+        ByteArrayLookupKey first = new ByteArrayLookupKey(new byte[] {1});
+        ByteArrayLookupKey second = new ByteArrayLookupKey(new byte[] {1});
+
+        assertThat(first).isEqualTo(second);
+
+        first.clear();
+        assertThat(first).isNotEqualTo(second);
+        assertThat(first).isEqualTo(first);
+    }
+
+    @Test
+    void testRejectsNullArray() {
+        assertThatThrownBy(() -> new ByteArrayKey(null))
+                .isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> new ByteArrayLookupKey(null))
+                .isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> new ByteArrayLookupKey().reset(null))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+}

--- a/paimon-common/src/test/java/org/apache/paimon/utils/DeletedIdentifierSetTest.java
+++ b/paimon-common/src/test/java/org/apache/paimon/utils/DeletedIdentifierSetTest.java
@@ -1,0 +1,93 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.utils;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/** Tests for {@link DeletedIdentifierSet}. */
+class DeletedIdentifierSetTest {
+
+    @Test
+    void testDeduplicatesAndIncludesPartition() {
+        DeletedIdentifierSet identifiers = new DeletedIdentifierSet();
+        byte[] identifier = {1, 2, 3, 4};
+
+        identifiers.add(3, identifier, identifier.length);
+        identifiers.add(3, identifier, identifier.length);
+
+        assertThat(identifiers.size()).isOne();
+        assertThat(identifiers.retainedIdentifierBytes()).isEqualTo(identifier.length);
+        assertThat(identifiers.contains(3, identifier, identifier.length)).isTrue();
+        assertThat(identifiers.contains(4, identifier, identifier.length)).isFalse();
+
+        identifiers.add(4, identifier, identifier.length);
+        assertThat(identifiers.size()).isEqualTo(2);
+        assertThat(identifiers.retainedIdentifierBytes()).isEqualTo(identifier.length * 2);
+    }
+
+    @Test
+    void testCopiesOnlyIdentifierPrefix() {
+        DeletedIdentifierSet identifiers = new DeletedIdentifierSet();
+        byte[] identifier = {1, 2, 3};
+
+        identifiers.add(0, identifier, 2);
+        identifier[0] = 9;
+
+        assertThat(identifiers.contains(0, new byte[] {1, 2, 8}, 2)).isTrue();
+        assertThat(identifiers.contains(0, identifier, 2)).isFalse();
+        assertThat(identifiers.retainedIdentifierBytes()).isEqualTo(2);
+    }
+
+    @Test
+    void testGrowsAndReleases() {
+        DeletedIdentifierSet identifiers = new DeletedIdentifierSet();
+        for (int i = 0; i < 1_000; i++) {
+            byte[] identifier = {(byte) i, (byte) (i >>> 8)};
+            identifiers.add(i % 7, identifier, identifier.length);
+        }
+
+        assertThat(identifiers.size()).isEqualTo(1_000);
+        for (int i = 0; i < 1_000; i++) {
+            byte[] identifier = {(byte) i, (byte) (i >>> 8)};
+            assertThat(identifiers.contains(i % 7, identifier, identifier.length)).isTrue();
+        }
+
+        identifiers.release();
+        assertThat(identifiers.isEmpty()).isTrue();
+        assertThat(identifiers.retainedIdentifierBytes()).isZero();
+
+        identifiers.add(1, new byte[] {1}, 1);
+        assertThat(identifiers.contains(1, new byte[] {1}, 1)).isTrue();
+    }
+
+    @Test
+    void testRejectsInvalidIdentifier() {
+        DeletedIdentifierSet identifiers = new DeletedIdentifierSet();
+
+        assertThatThrownBy(() -> identifiers.add(0, null, 0))
+                .isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> identifiers.add(0, new byte[1], -1))
+                .isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> identifiers.contains(0, new byte[1], 2))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+}

--- a/paimon-common/src/test/java/org/apache/paimon/utils/LongTripleArrayListTest.java
+++ b/paimon-common/src/test/java/org/apache/paimon/utils/LongTripleArrayListTest.java
@@ -1,0 +1,95 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.utils;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/** Tests for {@link LongTripleArrayList}. */
+class LongTripleArrayListTest {
+
+    @Test
+    void testAddAndAccess() {
+        LongTripleArrayList triples = new LongTripleArrayList(2);
+        triples.add(1L, 2L, 3L);
+        triples.add(4L, 5L, 6L);
+
+        assertThat(triples.size()).isEqualTo(2);
+        assertThat(triples.usedLongCount()).isEqualTo(6);
+        assertThat(triples.retainedLongCount()).isEqualTo(6);
+        assertThat(triples.first(0)).isEqualTo(1L);
+        assertThat(triples.second(0)).isEqualTo(2L);
+        assertThat(triples.third(0)).isEqualTo(3L);
+        assertThat(triples.first(1)).isEqualTo(4L);
+        assertThat(triples.second(1)).isEqualTo(5L);
+        assertThat(triples.third(1)).isEqualTo(6L);
+    }
+
+    @Test
+    void testGrowAndSwap() {
+        LongTripleArrayList triples = new LongTripleArrayList();
+        for (int i = 0; i < 100; i++) {
+            triples.add(i, i + 1L, i + 2L);
+        }
+
+        triples.swap(0, 99);
+        triples.swap(50, 50);
+
+        assertThat(triples.first(0)).isEqualTo(99L);
+        assertThat(triples.second(0)).isEqualTo(100L);
+        assertThat(triples.third(0)).isEqualTo(101L);
+        assertThat(triples.first(99)).isZero();
+        assertThat(triples.second(99)).isEqualTo(1L);
+        assertThat(triples.third(99)).isEqualTo(2L);
+        assertThat(triples.first(50)).isEqualTo(50L);
+        assertThat(triples.retainedLongCount()).isGreaterThanOrEqualTo(300);
+    }
+
+    @Test
+    void testClearAndRelease() {
+        LongTripleArrayList triples = new LongTripleArrayList(2);
+        triples.add(1L, 2L, 3L);
+
+        triples.clear();
+        assertThat(triples.size()).isZero();
+        assertThat(triples.retainedLongCount()).isEqualTo(6);
+
+        triples.add(4L, 5L, 6L);
+        triples.release();
+        assertThat(triples.size()).isZero();
+        assertThat(triples.retainedLongCount()).isZero();
+
+        triples.add(7L, 8L, 9L);
+        assertThat(triples.first(0)).isEqualTo(7L);
+    }
+
+    @Test
+    void testRejectsInvalidAccess() {
+        assertThatThrownBy(() -> new LongTripleArrayList(-1))
+                .isInstanceOf(IllegalArgumentException.class);
+
+        LongTripleArrayList triples = new LongTripleArrayList();
+        assertThatThrownBy(() -> triples.first(0)).isInstanceOf(IllegalArgumentException.class);
+        triples.add(1L, 2L, 3L);
+        assertThatThrownBy(() -> triples.second(-1)).isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> triples.swap(0, 1)).isInstanceOf(IllegalArgumentException.class);
+    }
+}

--- a/paimon-common/src/test/java/org/apache/paimon/utils/PrimitiveRowRangesTest.java
+++ b/paimon-common/src/test/java/org/apache/paimon/utils/PrimitiveRowRangesTest.java
@@ -1,0 +1,117 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.utils;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/** Tests for {@link PrimitiveRowRanges}. */
+class PrimitiveRowRangesTest {
+
+    @Test
+    void testAddAndTakeOwnership() {
+        PrimitiveRowRanges ranges = new PrimitiveRowRanges(2);
+        ranges.add(2L, 3L);
+        ranges.add(5L, 8L);
+
+        assertThat(ranges.size()).isEqualTo(2);
+        assertThat(ranges.retainedWordCount()).isEqualTo(4);
+        assertThat(ranges.start(0)).isEqualTo(2L);
+        assertThat(ranges.end(1)).isEqualTo(8L);
+
+        PrimitiveRowRanges.Owned owned = ranges.takeOwned();
+        assertThat(owned.starts()).containsExactly(2L, 5L);
+        assertThat(owned.ends()).containsExactly(3L, 8L);
+        assertThat(ranges.size()).isZero();
+        assertThat(ranges.retainedWordCount()).isZero();
+    }
+
+    @Test
+    void testAppendSortAndNormalizeOverlapping() {
+        PrimitiveRowRanges ranges = new PrimitiveRowRanges(2);
+        ranges.add(10L, 15L);
+        ranges.add(30L, 35L);
+        PrimitiveRowRanges appended = new PrimitiveRowRanges(3);
+        appended.add(12L, 20L);
+        appended.add(5L, 8L);
+        appended.add(20L, 25L);
+
+        ranges.append(appended);
+        ranges.normalizeOverlapping();
+
+        assertThat(ranges.size()).isEqualTo(3);
+        assertThat(ranges.start(0)).isEqualTo(5L);
+        assertThat(ranges.end(0)).isEqualTo(8L);
+        assertThat(ranges.start(1)).isEqualTo(10L);
+        assertThat(ranges.end(1)).isEqualTo(25L);
+        assertThat(ranges.start(2)).isEqualTo(30L);
+        assertThat(ranges.end(2)).isEqualTo(35L);
+        assertThat(appended.size()).isEqualTo(3);
+    }
+
+    @Test
+    void testDoesNotMergeAdjacentRanges() {
+        PrimitiveRowRanges ranges = new PrimitiveRowRanges(2);
+        ranges.add(0L, 0L);
+        ranges.add(1L, 1L);
+
+        ranges.normalizeOverlapping();
+
+        assertThat(ranges.size()).isEqualTo(2);
+    }
+
+    @Test
+    void testCovers() {
+        PrimitiveRowRanges ranges = new PrimitiveRowRanges(4);
+        ranges.add(5L, 8L);
+        ranges.add(0L, 2L);
+        ranges.add(2L, 6L);
+        ranges.add(9L, 10L);
+
+        assertThat(ranges.covers(0L, 10L)).isTrue();
+        assertThat(ranges.covers(1L, 9L)).isTrue();
+        assertThat(ranges.covers(-1L, 10L)).isFalse();
+        assertThat(ranges.covers(0L, 11L)).isFalse();
+        assertThat(ranges.covers(10L, 10L)).isTrue();
+    }
+
+    @Test
+    void testCoversLongMaxValue() {
+        PrimitiveRowRanges ranges = new PrimitiveRowRanges(2);
+        ranges.add(Long.MAX_VALUE - 1L, Long.MAX_VALUE - 1L);
+        ranges.add(Long.MAX_VALUE, Long.MAX_VALUE);
+
+        assertThat(ranges.covers(Long.MAX_VALUE - 1L, Long.MAX_VALUE)).isTrue();
+    }
+
+    @Test
+    void testRejectsInvalidInput() {
+        assertThatThrownBy(() -> new PrimitiveRowRanges(-1))
+                .isInstanceOf(IllegalArgumentException.class);
+
+        PrimitiveRowRanges ranges = new PrimitiveRowRanges(0);
+        assertThatThrownBy(() -> ranges.add(2L, 1L)).isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> ranges.start(0)).isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> ranges.append(null)).isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> ranges.covers(2L, 1L))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+}

--- a/paimon-core/src/main/java/org/apache/paimon/append/dataevolution/CurrentRowIdEntries.java
+++ b/paimon-core/src/main/java/org/apache/paimon/append/dataevolution/CurrentRowIdEntries.java
@@ -1,0 +1,263 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.append.dataevolution;
+
+import org.apache.paimon.utils.LongTripleArrayList;
+import org.apache.paimon.utils.PrimitiveRowRanges;
+
+import javax.annotation.Nullable;
+
+import static org.apache.paimon.utils.Preconditions.checkArgument;
+import static org.apache.paimon.utils.Preconditions.checkState;
+
+/** Object-free storage for current row-id entries. */
+final class CurrentRowIdEntries {
+
+    private static final long SPECIAL = 1L << 32;
+
+    private final LongTripleArrayList entries;
+
+    CurrentRowIdEntries() {
+        this(0);
+    }
+
+    CurrentRowIdEntries(int expectedEntries) {
+        checkArgument(expectedEntries >= 0, "Expected current entry count cannot be negative.");
+        this.entries = new LongTripleArrayList(expectedEntries);
+    }
+
+    void add(int partitionId, boolean special, long firstRowId, long rowCount) {
+        checkArgument(partitionId >= 0, "Partition id cannot be negative.");
+        checkArgument(rowCount > 0, "Row count must be positive.");
+        Math.addExact(firstRowId, rowCount - 1L);
+        entries.add(
+                Integer.toUnsignedLong(partitionId) | (special ? SPECIAL : 0L),
+                firstRowId,
+                rowCount);
+    }
+
+    int size() {
+        return entries.size();
+    }
+
+    int retainedWordCount() {
+        return entries.retainedLongCount();
+    }
+
+    int usedWordCount() {
+        return entries.usedLongCount();
+    }
+
+    void release() {
+        entries.release();
+    }
+
+    int partitionId(int index) {
+        return (int) entries.first(index);
+    }
+
+    private boolean special(int index) {
+        return (entries.first(index) & SPECIAL) != 0;
+    }
+
+    private long firstRowId(int index) {
+        return entries.second(index);
+    }
+
+    private long rowCount(int index) {
+        return entries.third(index);
+    }
+
+    private long lastRowId(int index) {
+        return firstRowId(index) + rowCount(index) - 1L;
+    }
+
+    void sort() {
+        if (entries.size() > 1) {
+            sort(0, entries.size() - 1);
+        }
+    }
+
+    private void sort(int left, int right) {
+        while (left < right) {
+            int middle = left + ((right - left) >>> 1);
+            long pivotPartition = entries.first(middle);
+            long pivotFirst = entries.second(middle);
+            long pivotCount = entries.third(middle);
+            int lower = left;
+            int current = left;
+            int upper = right;
+            while (current <= upper) {
+                int comparison = compare(current, pivotPartition, pivotFirst, pivotCount);
+                if (comparison < 0) {
+                    swap(lower++, current++);
+                } else if (comparison > 0) {
+                    swap(current, upper--);
+                } else {
+                    current++;
+                }
+            }
+
+            if (lower - left < right - upper) {
+                if (left < lower - 1) {
+                    sort(left, lower - 1);
+                }
+                left = upper + 1;
+            } else {
+                if (upper + 1 < right) {
+                    sort(upper + 1, right);
+                }
+                right = lower - 1;
+            }
+        }
+    }
+
+    private int compare(int index, long pivotPartition, long pivotFirst, long pivotCount) {
+        int result =
+                Long.compare(entries.first(index) & 0xFFFF_FFFFL, pivotPartition & 0xFFFF_FFFFL);
+        if (result != 0) {
+            return result;
+        }
+        long first = entries.second(index);
+        result = Long.compare(first, pivotFirst);
+        if (result != 0) {
+            return result;
+        }
+        long end = first + entries.third(index) - 1L;
+        long pivotEnd = pivotFirst + pivotCount - 1L;
+        return Long.compare(end, pivotEnd);
+    }
+
+    private void swap(int left, int right) {
+        entries.swap(left, right);
+    }
+
+    /**
+     * Scans logical ranges without retaining one object (or even one primitive pair) per range.
+     *
+     * <p>The absolute return value is the number of logical ranges. A negative result means that
+     * all logical ranges are contiguous and therefore this partition does not need a plan. A
+     * positive result means that the ranges are fragmented and need materialization.
+     */
+    int scanLogicalRanges(int from, int to, long[] rangeScratch) {
+        checkArgument(from >= 0 && from < to && to <= entries.size(), "Invalid entry slice.");
+        int overlapStart = from;
+        long currentEnd = lastRowId(from);
+        int rangeCount = 0;
+        boolean contiguous = true;
+        boolean hasPrevious = false;
+        long previousEnd = 0L;
+        for (int i = from + 1; i < to; i++) {
+            if (firstRowId(i) <= currentEnd) {
+                currentEnd = Math.max(currentEnd, lastRowId(i));
+            } else {
+                computeLogicalRange(overlapStart, i, rangeScratch);
+                rangeCount++;
+                if (hasPrevious
+                        && (previousEnd == Long.MAX_VALUE || rangeScratch[0] != previousEnd + 1L)) {
+                    contiguous = false;
+                }
+                previousEnd = rangeScratch[1];
+                hasPrevious = true;
+                overlapStart = i;
+                currentEnd = lastRowId(i);
+            }
+        }
+        computeLogicalRange(overlapStart, to, rangeScratch);
+        rangeCount++;
+        if (hasPrevious && (previousEnd == Long.MAX_VALUE || rangeScratch[0] != previousEnd + 1L)) {
+            contiguous = false;
+        }
+        return contiguous ? -rangeCount : rangeCount;
+    }
+
+    PrimitiveRowRanges materializeLogicalRanges(
+            int from, int to, int expectedRangeCount, long[] rangeScratch) {
+        checkArgument(
+                from >= 0 && from < to && to <= entries.size() && expectedRangeCount > 0,
+                "Invalid fragmented entry slice.");
+        PrimitiveRowRanges ranges = new PrimitiveRowRanges(expectedRangeCount);
+        int overlapStart = from;
+        long currentEnd = lastRowId(from);
+        for (int i = from + 1; i < to; i++) {
+            if (firstRowId(i) <= currentEnd) {
+                currentEnd = Math.max(currentEnd, lastRowId(i));
+            } else {
+                computeLogicalRange(overlapStart, i, rangeScratch);
+                ranges.add(rangeScratch[0], rangeScratch[1]);
+                overlapStart = i;
+                currentEnd = lastRowId(i);
+            }
+        }
+        computeLogicalRange(overlapStart, to, rangeScratch);
+        ranges.add(rangeScratch[0], rangeScratch[1]);
+        checkState(
+                ranges.size() == expectedRangeCount,
+                "Logical range count changed between scan and materialization.");
+        return ranges;
+    }
+
+    private void computeLogicalRange(int from, int to, long[] result) {
+        boolean hasOrdinary = false;
+        long ordinaryStart = 0L;
+        long ordinaryEnd = 0L;
+        long spanningStart = Long.MAX_VALUE;
+        long spanningEnd = Long.MIN_VALUE;
+        for (int i = from; i < to; i++) {
+            long start = firstRowId(i);
+            long end = lastRowId(i);
+            spanningStart = Math.min(spanningStart, start);
+            spanningEnd = Math.max(spanningEnd, end);
+            if (!special(i)) {
+                checkState(
+                        !hasOrdinary || (ordinaryStart == start && ordinaryEnd == end),
+                        "Data files in one overlapping row-id group must have the same row-id range.");
+                ordinaryStart = start;
+                ordinaryEnd = end;
+                hasOrdinary = true;
+            }
+        }
+        long logicalStart = hasOrdinary ? ordinaryStart : spanningStart;
+        long logicalEnd = hasOrdinary ? ordinaryEnd : spanningEnd;
+        for (int i = from; i < to; i++) {
+            checkState(
+                    firstRowId(i) >= logicalStart && lastRowId(i) <= logicalEnd,
+                    "File row-id range is outside its logical row-id range.");
+        }
+        result[0] = logicalStart;
+        result[1] = logicalEnd;
+    }
+
+    @Nullable
+    PrimitiveRowRanges selectedRangesForTesting() {
+        checkState(entries.size() > 0, "Cannot inspect an empty current-entry buffer.");
+        sort();
+        int partitionId = partitionId(0);
+        for (int i = 1; i < entries.size(); i++) {
+            checkState(
+                    partitionId(i) == partitionId,
+                    "The structural range test helper requires one partition.");
+        }
+        long[] rangeScratch = new long[2];
+        int rangeScan = scanLogicalRanges(0, entries.size(), rangeScratch);
+        return rangeScan < 0
+                ? null
+                : materializeLogicalRanges(0, entries.size(), rangeScan, rangeScratch);
+    }
+}

--- a/paimon-core/src/main/java/org/apache/paimon/append/dataevolution/DataEvolutionRowIdAssignmentPlanner.java
+++ b/paimon-core/src/main/java/org/apache/paimon/append/dataevolution/DataEvolutionRowIdAssignmentPlanner.java
@@ -22,29 +22,29 @@ import org.apache.paimon.codegen.CodeGenUtils;
 import org.apache.paimon.codegen.RecordComparator;
 import org.apache.paimon.data.BinaryRow;
 import org.apache.paimon.data.BinaryString;
-import org.apache.paimon.data.InternalRow;
-import org.apache.paimon.format.FileFormat;
 import org.apache.paimon.io.BinaryDataFileMeta;
 import org.apache.paimon.io.DataFileMeta;
 import org.apache.paimon.manifest.BinaryManifestEntry;
 import org.apache.paimon.manifest.BinaryManifestEntry.Projection;
+import org.apache.paimon.manifest.BinaryManifestEntry.ReusableIdentifier;
 import org.apache.paimon.manifest.ManifestEntry;
+import org.apache.paimon.manifest.ManifestFile;
 import org.apache.paimon.manifest.ManifestFileMeta;
-import org.apache.paimon.memory.MemorySegmentUtils;
 import org.apache.paimon.partition.PartitionPredicate;
-import org.apache.paimon.reader.RecordReader;
 import org.apache.paimon.table.FileStoreTable;
 import org.apache.paimon.table.SpecialFields;
 import org.apache.paimon.types.DataField;
 import org.apache.paimon.types.RowType;
-import org.apache.paimon.utils.FileUtils;
+import org.apache.paimon.utils.ByteArrayKey;
+import org.apache.paimon.utils.ByteArrayLookupKey;
+import org.apache.paimon.utils.CloseableIterator;
+import org.apache.paimon.utils.DeletedIdentifierSet;
+import org.apache.paimon.utils.PrimitiveRowRanges;
 import org.apache.paimon.utils.SerializationUtils;
 import org.apache.paimon.utils.VersionedObjectSerializer;
 
 import javax.annotation.Nullable;
 
-import java.io.IOException;
-import java.io.UncheckedIOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -65,23 +65,52 @@ import static org.apache.paimon.utils.Preconditions.checkState;
 final class DataEvolutionRowIdAssignmentPlanner {
 
     private static final int EXCLUDED_PARTITION_CACHE_SIZE = 1024;
-    private static final int CURRENT_ENTRY_WORDS = 3;
     private static final int MAX_INITIAL_CURRENT_ENTRIES = 1 << 24;
-    private static final long CURRENT_SPECIAL = 1L << 32;
     private static final BinaryString ROW_ID_FIELD =
             BinaryString.fromString(SpecialFields.ROW_ID.name());
     private static final BinaryString BLOB_FILE_SUFFIX = BinaryString.fromString(".blob");
     private static final BinaryString VECTOR_FILE_MARKER = BinaryString.fromString(".vector.");
+    private static final Projection DELETE_PROJECTION =
+            manifestProjection(
+                    true,
+                    DataFileMeta.FILE_NAME,
+                    DataFileMeta.LEVEL,
+                    DataFileMeta.EXTRA_FILES,
+                    DataFileMeta.EMBEDDED_FILE_INDEX,
+                    DataFileMeta.EXTERNAL_PATH);
+    private static final Projection ADD_IDENTIFIER_PROJECTION =
+            manifestProjection(
+                    true,
+                    DataFileMeta.FILE_NAME,
+                    DataFileMeta.ROW_COUNT,
+                    DataFileMeta.LEVEL,
+                    DataFileMeta.EXTRA_FILES,
+                    DataFileMeta.EMBEDDED_FILE_INDEX,
+                    DataFileMeta.EXTERNAL_PATH,
+                    DataFileMeta.FIRST_ROW_ID,
+                    DataFileMeta.WRITE_COLS,
+                    DataFileMeta.MAX_SEQUENCE_NUMBER);
+    private static final Projection COMPACT_ADD_PROJECTION =
+            manifestProjection(
+                    false,
+                    DataFileMeta.FILE_NAME,
+                    DataFileMeta.ROW_COUNT,
+                    DataFileMeta.FIRST_ROW_ID,
+                    DataFileMeta.WRITE_COLS,
+                    DataFileMeta.MAX_SEQUENCE_NUMBER);
+    private static final Projection REWRITE_PROJECTION =
+            manifestProjection(
+                    false,
+                    DataFileMeta.ROW_COUNT,
+                    DataFileMeta.FIRST_ROW_ID,
+                    DataFileMeta.WRITE_COLS);
 
     private final FileStoreTable table;
+    private final ManifestFile manifestFile;
     private final @Nullable PartitionPredicate partitionPredicate;
     private final List<ManifestFileMeta> manifestMetas;
     private final Map<String, Integer> manifestOrdinals;
     private final boolean[] rewrittenManifests;
-    private final Projection deleteProjection;
-    private final Projection addIdentifierProjection;
-    private final Projection compactAddProjection;
-    private final Projection rewriteProjection;
     private final Map<ByteArrayKey, SelectedPartition> selectedPartitions;
     private long nextManifestGroupOrdinal;
     private long nextRetainedAddScanOrdinal;
@@ -91,54 +120,16 @@ final class DataEvolutionRowIdAssignmentPlanner {
             @Nullable PartitionPredicate partitionPredicate,
             List<ManifestFileMeta> manifestMetas) {
         this.table = table;
+        this.manifestFile = table.store().manifestFileFactory().create();
         this.partitionPredicate = partitionPredicate;
         this.manifestMetas = manifestMetas;
         this.manifestOrdinals = manifestOrdinals(manifestMetas);
         this.rewrittenManifests = new boolean[manifestMetas.size()];
-        FileFormat format = FileFormat.manifestFormat(table.coreOptions());
-        this.deleteProjection =
-                manifestProjection(
-                        format,
-                        true,
-                        DataFileMeta.FILE_NAME,
-                        DataFileMeta.LEVEL,
-                        DataFileMeta.EXTRA_FILES,
-                        DataFileMeta.EMBEDDED_FILE_INDEX,
-                        DataFileMeta.EXTERNAL_PATH);
-        this.addIdentifierProjection =
-                manifestProjection(
-                        format,
-                        true,
-                        DataFileMeta.FILE_NAME,
-                        DataFileMeta.ROW_COUNT,
-                        DataFileMeta.LEVEL,
-                        DataFileMeta.EXTRA_FILES,
-                        DataFileMeta.EMBEDDED_FILE_INDEX,
-                        DataFileMeta.EXTERNAL_PATH,
-                        DataFileMeta.FIRST_ROW_ID,
-                        DataFileMeta.WRITE_COLS,
-                        DataFileMeta.MAX_SEQUENCE_NUMBER);
-        this.compactAddProjection =
-                manifestProjection(
-                        format,
-                        false,
-                        DataFileMeta.FILE_NAME,
-                        DataFileMeta.ROW_COUNT,
-                        DataFileMeta.FIRST_ROW_ID,
-                        DataFileMeta.WRITE_COLS,
-                        DataFileMeta.MAX_SEQUENCE_NUMBER);
-        this.rewriteProjection =
-                manifestProjection(
-                        format,
-                        false,
-                        DataFileMeta.ROW_COUNT,
-                        DataFileMeta.FIRST_ROW_ID,
-                        DataFileMeta.WRITE_COLS);
         this.selectedPartitions = new LinkedHashMap<>();
     }
 
     private static Projection manifestProjection(
-            FileFormat format, boolean includeBucket, String... projectedFileFields) {
+            boolean includeBucket, String... projectedFileFields) {
         RowType manifestType = VersionedObjectSerializer.versionType(ManifestEntry.SCHEMA);
         List<DataField> fields = new ArrayList<>();
         fields.add(manifestType.getField(ManifestEntry.KIND));
@@ -150,10 +141,18 @@ final class DataEvolutionRowIdAssignmentPlanner {
                 manifestType
                         .getField(ManifestEntry.FILE)
                         .newType(DataFileMeta.SCHEMA.project(projectedFileFields)));
-        return Projection.create(format, new RowType(false, fields));
+        return Projection.create(new RowType(false, fields));
     }
 
-    void planGroup(List<ManifestFileMeta> manifestGroup) {
+    Result plan(List<List<ManifestFileMeta>> groups) {
+        validateGroups(groups);
+        for (List<ManifestFileMeta> group : groups) {
+            planGroup(group);
+        }
+        return buildResult();
+    }
+
+    private void planGroup(List<ManifestFileMeta> manifestGroup) {
         long manifestGroupOrdinal = nextManifestGroupOrdinal;
         nextManifestGroupOrdinal = Math.addExact(nextManifestGroupOrdinal, 1L);
         GroupState group =
@@ -164,134 +163,151 @@ final class DataEvolutionRowIdAssignmentPlanner {
                         partitionPredicate == null
                                 ? initialCurrentEntryCapacity(manifestGroup)
                                 : 0);
-        IdentifierScratch identifier = new IdentifierScratch();
+        ReusableIdentifier identifier = new ReusableIdentifier();
         long[] rowRangeScratch = new long[2];
 
+        collectDeletedIdentifiers(manifestGroup, group, identifier);
+        collectCurrentEntries(
+                manifestGroup, group, identifier, manifestGroupOrdinal, rowRangeScratch);
+        identifier.release();
+        group.releaseDeletedIdentifiers();
+
+        List<PartitionState> selections = group.finishAddPass();
+        for (PartitionState selection : selections) {
+            mergeSelectedPartition(selection);
+        }
+        if (!selections.isEmpty()) {
+            markRewrittenManifests(manifestGroup, group, rowRangeScratch);
+        }
+    }
+
+    private void collectDeletedIdentifiers(
+            List<ManifestFileMeta> manifestGroup, GroupState group, ReusableIdentifier identifier) {
         for (ManifestFileMeta manifestMeta : manifestGroup) {
             if (manifestMeta.numDeletedFiles() <= 0) {
                 continue;
             }
-            scan(
-                    manifestMeta,
-                    deleteProjection,
-                    entry -> {
-                        if (!entry.isDelete()) {
-                            return true;
-                        }
-                        PartitionState partition = group.internPartition(entry.partitionBytes());
-                        if (partition == null) {
-                            return true;
-                        }
-                        identifier.encode(entry);
-                        group.deletedIdentifiers.add(
-                                partition.id, identifier.bytes(), identifier.length());
-                        return true;
-                    });
+            try (CloseableIterator<BinaryManifestEntry> entries =
+                    manifestFile.scan(
+                            manifestMeta.fileName(), manifestMeta.fileSize(), DELETE_PROJECTION)) {
+                while (entries.hasNext()) {
+                    BinaryManifestEntry entry = entries.next();
+                    if (!entry.isDelete()) {
+                        continue;
+                    }
+                    PartitionState partition = group.internPartition(entry.partitionBytes());
+                    if (partition == null) {
+                        continue;
+                    }
+                    identifier.replace(entry);
+                    group.deletedIdentifiers.add(
+                            partition.id, identifier.bytes(), identifier.length());
+                }
+            } catch (Exception e) {
+                throw scanException(manifestMeta, e);
+            }
         }
+    }
 
+    private void collectCurrentEntries(
+            List<ManifestFileMeta> manifestGroup,
+            GroupState group,
+            ReusableIdentifier identifier,
+            long manifestGroupOrdinal,
+            long[] rowRangeScratch) {
         Projection addProjection =
-                group.deletedIdentifiers.isEmpty() ? compactAddProjection : addIdentifierProjection;
+                group.deletedIdentifiers.isEmpty()
+                        ? COMPACT_ADD_PROJECTION
+                        : ADD_IDENTIFIER_PROJECTION;
         for (ManifestFileMeta manifestMeta : manifestGroup) {
             if (manifestMeta.numAddedFiles() <= 0) {
                 continue;
             }
             int manifestOrdinal = ordinal(manifestMeta);
-            scan(
-                    manifestMeta,
-                    addProjection,
-                    entry -> {
-                        if (!entry.isAdd()) {
-                            return true;
+            try (CloseableIterator<BinaryManifestEntry> entries =
+                    manifestFile.scan(
+                            manifestMeta.fileName(), manifestMeta.fileSize(), addProjection)) {
+                while (entries.hasNext()) {
+                    BinaryManifestEntry entry = entries.next();
+                    if (!entry.isAdd()) {
+                        continue;
+                    }
+                    PartitionState partition = group.internPartition(entry.partitionBytes());
+                    if (partition == null) {
+                        continue;
+                    }
+                    if (!group.deletedIdentifiers.isEmpty()) {
+                        identifier.replace(entry);
+                        if (group.deletedIdentifiers.contains(
+                                partition.id, identifier.bytes(), identifier.length())) {
+                            continue;
                         }
-                        PartitionState partition = group.internPartition(entry.partitionBytes());
-                        if (partition == null) {
-                            return true;
-                        }
-                        if (!group.deletedIdentifiers.isEmpty()) {
-                            identifier.encode(entry);
-                            if (group.deletedIdentifiers.contains(
-                                    partition.id, identifier.bytes(), identifier.length())) {
-                                return true;
-                            }
-                        }
+                    }
 
-                        BinaryDataFileMeta file = entry.file();
-                        BinaryString fileName = file.fileNameBinary();
-                        readRowRange(file, manifestOrdinal, fileName, rowRangeScratch);
-                        checkState(
-                                !file.containsWriteColumn(ROW_ID_FIELD),
-                                "Cannot reassign row IDs for file '%s' because it physically stores the row-id field.",
-                                fileName);
-                        long maxSequenceNumber = file.maxSequenceNumber();
-                        long retainedAddScanOrdinal = nextRetainedAddScanOrdinal;
-                        nextRetainedAddScanOrdinal = Math.addExact(nextRetainedAddScanOrdinal, 1L);
-                        partition.considerLegacyOrderKey(
-                                manifestGroupOrdinal,
-                                rowRangeScratch[0],
-                                fileOrder(fileName),
-                                maxSequenceNumber,
-                                fileName,
-                                retainedAddScanOrdinal);
-                        group.currentEntries.add(
-                                partition.id,
-                                isSpecialFile(fileName),
-                                rowRangeScratch[0],
-                                inclusiveRangeCount(rowRangeScratch[0], rowRangeScratch[1]));
-                        return true;
-                    });
-        }
-        identifier.release();
-        group.releaseDeletedIdentifiers();
-
-        GroupSelection[] groupSelections = group.finishAddPass();
-        boolean selected = false;
-        for (GroupSelection selection : groupSelections) {
-            if (selection == null) {
-                continue;
+                    BinaryDataFileMeta file = entry.file();
+                    BinaryString fileName = file.fileNameBinary();
+                    readRowRange(file, manifestOrdinal, fileName, rowRangeScratch);
+                    checkState(
+                            !file.containsWriteColumn(ROW_ID_FIELD),
+                            "Cannot reassign row IDs for file '%s' because it physically stores the row-id field.",
+                            fileName);
+                    long maxSequenceNumber = file.maxSequenceNumber();
+                    long retainedAddScanOrdinal = nextRetainedAddScanOrdinal;
+                    nextRetainedAddScanOrdinal = Math.addExact(nextRetainedAddScanOrdinal, 1L);
+                    int fileOrder = fileOrder(fileName);
+                    partition.considerLegacyOrderKey(
+                            manifestGroupOrdinal,
+                            rowRangeScratch[0],
+                            fileOrder,
+                            maxSequenceNumber,
+                            fileName,
+                            retainedAddScanOrdinal);
+                    group.currentEntries.add(
+                            partition.id,
+                            fileOrder != 0,
+                            rowRangeScratch[0],
+                            inclusiveRangeCount(rowRangeScratch[0], rowRangeScratch[1]));
+                }
+            } catch (Exception e) {
+                throw scanException(manifestMeta, e);
             }
-            selected = true;
-            mergeSelectedPartition(selection);
-        }
-        if (!selected) {
-            return;
-        }
-
-        for (ManifestFileMeta manifestMeta : manifestGroup) {
-            int manifestOrdinal = ordinal(manifestMeta);
-            scan(
-                    manifestMeta,
-                    rewriteProjection,
-                    entry -> {
-                        PartitionState partition = group.internPartition(entry.partitionBytes());
-                        if (partition == null) {
-                            return true;
-                        }
-                        if (partition.id >= groupSelections.length) {
-                            return true;
-                        }
-                        GroupSelection selection = groupSelections[partition.id];
-                        if (selection == null) {
-                            return true;
-                        }
-                        BinaryDataFileMeta file = entry.file();
-                        readRowRange(file, manifestOrdinal, null, rowRangeScratch);
-                        if (!rangesFullyCover(
-                                rowRangeScratch[0], rowRangeScratch[1], selection.logicalRanges)) {
-                            return true;
-                        }
-                        checkState(
-                                !file.containsWriteColumn(ROW_ID_FIELD),
-                                "Cannot reassign an entry in manifest '%s' because it physically stores the row-id field.",
-                                manifestMeta.fileName());
-                        rewrittenManifests[manifestOrdinal] = true;
-                        return false;
-                    });
         }
     }
 
-    Result buildResult() {
+    private void markRewrittenManifests(
+            List<ManifestFileMeta> manifestGroup, GroupState group, long[] rowRangeScratch) {
+        for (ManifestFileMeta manifestMeta : manifestGroup) {
+            int manifestOrdinal = ordinal(manifestMeta);
+            try (CloseableIterator<BinaryManifestEntry> entries =
+                    manifestFile.scan(
+                            manifestMeta.fileName(), manifestMeta.fileSize(), REWRITE_PROJECTION)) {
+                while (entries.hasNext()) {
+                    BinaryManifestEntry entry = entries.next();
+                    PartitionState partition = group.internPartition(entry.partitionBytes());
+                    if (partition == null || partition.logicalRanges == null) {
+                        continue;
+                    }
+                    BinaryDataFileMeta file = entry.file();
+                    readRowRange(file, manifestOrdinal, null, rowRangeScratch);
+                    if (!partition.logicalRanges.covers(rowRangeScratch[0], rowRangeScratch[1])) {
+                        continue;
+                    }
+                    checkState(
+                            !file.containsWriteColumn(ROW_ID_FIELD),
+                            "Cannot reassign an entry in manifest '%s' because it physically stores the row-id field.",
+                            manifestMeta.fileName());
+                    rewrittenManifests[manifestOrdinal] = true;
+                    break;
+                }
+            } catch (Exception e) {
+                throw scanException(manifestMeta, e);
+            }
+        }
+    }
+
+    private Result buildResult() {
         if (selectedPartitions.isEmpty()) {
-            return new Result(new int[0], Collections.emptyList(), 0L);
+            return new Result(new int[0], Collections.emptyMap(), 0L);
         }
 
         List<SelectedPartition> partitions = new ArrayList<>(selectedPartitions.values());
@@ -306,22 +322,24 @@ final class DataEvolutionRowIdAssignmentPlanner {
                             : left.legacyOrderKey.compareTo(right.legacyOrderKey);
                 });
 
-        List<PartitionMapping> mappings = new ArrayList<>(partitions.size());
+        Map<BinaryRow, RowRangeMappingIndex> mappings = new LinkedHashMap<>();
         long nextOffset = 0L;
         for (SelectedPartition partition : partitions) {
             partition.logicalRanges.normalizeOverlapping();
             int rangeCount = partition.logicalRanges.size();
             checkState(rangeCount > 0, "Selected partition has no logical row-id ranges.");
-            OwnedPrimitiveRanges ownedRanges = partition.logicalRanges.takeOwned();
-            long[] oldStarts = ownedRanges.starts;
-            long[] oldEnds = ownedRanges.ends;
+            PrimitiveRowRanges.Owned ownedRanges = partition.logicalRanges.takeOwned();
+            long[] oldStarts = ownedRanges.starts();
+            long[] oldEnds = ownedRanges.ends();
             long[] newStarts = new long[rangeCount];
             for (int i = 0; i < rangeCount; i++) {
                 newStarts[i] = nextOffset;
                 nextOffset =
                         Math.addExact(nextOffset, inclusiveRangeCount(oldStarts[i], oldEnds[i]));
             }
-            mappings.add(new PartitionMapping(partition.partition, oldStarts, oldEnds, newStarts));
+            mappings.put(
+                    partition.partition,
+                    RowRangeMappingIndex.createFromOwnedArrays(oldStarts, oldEnds, newStarts));
         }
 
         int rewrittenCount = 0;
@@ -343,60 +361,29 @@ final class DataEvolutionRowIdAssignmentPlanner {
         return new Result(ordinals, mappings, nextOffset);
     }
 
-    private void mergeSelectedPartition(GroupSelection selection) {
-        ByteArrayLookupKey lookup = new ByteArrayLookupKey(selection.partition.serialized);
+    private void mergeSelectedPartition(PartitionState selection) {
+        PrimitiveRowRanges logicalRanges = selection.requiredLogicalRanges();
+        ByteArrayLookupKey lookup = new ByteArrayLookupKey(selection.serialized);
         SelectedPartition selected = selectedPartitions.get(lookup);
         if (selected == null) {
-            LegacyPartitionOrderKey legacyOrderKey = selection.partition.requiredLegacyOrderKey();
-            selected =
-                    new SelectedPartition(
-                            selection.partition.serialized,
-                            selection.partition.partition,
-                            legacyOrderKey,
-                            selection.logicalRanges);
-            selectedPartitions.put(new ByteArrayKey(selection.partition.serialized), selected);
+            LegacyPartitionOrderKey legacyOrderKey = selection.requiredLegacyOrderKey();
+            selected = new SelectedPartition(selection.partition, legacyOrderKey, logicalRanges);
+            selectedPartitions.put(new ByteArrayKey(selection.serialized), selected);
             return;
         }
-        LegacyPartitionOrderKey incomingOrderKey = selection.partition.requiredLegacyOrderKey();
+        LegacyPartitionOrderKey incomingOrderKey = selection.requiredLegacyOrderKey();
         if (incomingOrderKey.compareTo(selected.legacyOrderKey) < 0) {
             selected.legacyOrderKey = incomingOrderKey;
         }
-        selected.logicalRanges.append(selection.logicalRanges);
+        selected.logicalRanges.append(logicalRanges);
         selected.logicalRanges.normalizeOverlapping();
     }
 
-    private void scan(
-            ManifestFileMeta manifestMeta, Projection projection, ProjectedRowVisitor visitor) {
-        BinaryManifestEntry entry = projection.createEntry();
-        try (RecordReader<InternalRow> reader =
-                FileUtils.createFormatReader(
-                        table.fileIO(),
-                        projection.readerFactory(),
-                        table.store().pathFactory().toManifestFilePath(manifestMeta.fileName()),
-                        manifestMeta.fileSize())) {
-            boolean keepReading = true;
-            while (keepReading) {
-                RecordReader.RecordIterator<InternalRow> batch = reader.readBatch();
-                if (batch == null) {
-                    break;
-                }
-                try {
-                    InternalRow row;
-                    while ((row = batch.next()) != null) {
-                        if (!visitor.visit(entry.replace(row))) {
-                            keepReading = false;
-                            break;
-                        }
-                    }
-                } finally {
-                    entry.clear();
-                    batch.releaseBatch();
-                }
-            }
-        } catch (IOException e) {
-            throw new UncheckedIOException(
-                    "Failed to read manifest file " + manifestMeta.fileName(), e);
+    private static RuntimeException scanException(ManifestFileMeta manifestMeta, Exception e) {
+        if (e instanceof RuntimeException) {
+            return (RuntimeException) e;
         }
+        return new RuntimeException("Failed to scan manifest file " + manifestMeta.fileName(), e);
     }
 
     private static void readRowRange(
@@ -431,10 +418,6 @@ final class DataEvolutionRowIdAssignmentPlanner {
         return 0;
     }
 
-    private static boolean isSpecialFile(BinaryString fileName) {
-        return fileOrder(fileName) != 0;
-    }
-
     private int ordinal(ManifestFileMeta manifestMeta) {
         Integer ordinal = manifestOrdinals.get(manifestMeta.fileName());
         checkArgument(
@@ -460,16 +443,12 @@ final class DataEvolutionRowIdAssignmentPlanner {
     static int initialCurrentEntryCapacity(long addedCount, long deletedCount) {
         checkArgument(addedCount >= 0, "Added entry count cannot be negative.");
         checkArgument(deletedCount >= 0, "Deleted entry count cannot be negative.");
-        // Counts are only a sizing hint: DELETE entries may be duplicated or may not match an
-        // ADD
-        // in this group. Estimate the live set, cap the eager allocation, and let
-        // CurrentEntries
-        // grow if the actual number of retained ADD entries is larger.
+        // Counts are only a sizing hint: DELETE entries may be duplicated or may not match an ADD in this group. Estimate the live set, cap the eager allocation, and let CurrentRowIdEntries grow if the actual number of retained ADD entries is larger.
         long estimatedLiveCount = addedCount > deletedCount ? addedCount - deletedCount : 0L;
         return (int) Math.min(estimatedLiveCount, MAX_INITIAL_CURRENT_ENTRIES);
     }
 
-    void validateGroups(List<List<ManifestFileMeta>> groups) {
+    private void validateGroups(List<List<ManifestFileMeta>> groups) {
         boolean[] seen = new boolean[manifestMetas.size()];
         for (List<ManifestFileMeta> group : groups) {
             checkArgument(group != null && !group.isEmpty(), "Manifest group cannot be empty.");
@@ -498,30 +477,6 @@ final class DataEvolutionRowIdAssignmentPlanner {
         return result;
     }
 
-    private static boolean rangesFullyCover(
-            long rangeStart, long rangeEnd, PrimitiveRangeBuffer mappings) {
-        long cursor = rangeStart;
-        for (int i = 0; i < mappings.size(); i++) {
-            long mappingStart = mappings.start(i);
-            long mappingEnd = mappings.end(i);
-            if (mappingEnd < cursor) {
-                continue;
-            }
-            if (mappingStart > cursor) {
-                return false;
-            }
-            long segmentEnd = Math.min(mappingEnd, rangeEnd);
-            if (segmentEnd == rangeEnd) {
-                return true;
-            }
-            if (segmentEnd == Long.MAX_VALUE) {
-                return false;
-            }
-            cursor = segmentEnd + 1L;
-        }
-        return false;
-    }
-
     private static long inclusiveRangeCount(long start, long end) {
         return Math.addExact(Math.subtractExact(end, start), 1L);
     }
@@ -530,51 +485,28 @@ final class DataEvolutionRowIdAssignmentPlanner {
     static final class Result {
 
         final int[] manifestOrdinals;
-        final List<PartitionMapping> partitionMappings;
+        final Map<BinaryRow, RowRangeMappingIndex> rowIdMappings;
         final long totalOffset;
 
         private Result(
                 int[] manifestOrdinals,
-                List<PartitionMapping> partitionMappings,
+                Map<BinaryRow, RowRangeMappingIndex> rowIdMappings,
                 long totalOffset) {
             this.manifestOrdinals = manifestOrdinals;
-            this.partitionMappings =
-                    Collections.unmodifiableList(new ArrayList<>(partitionMappings));
+            this.rowIdMappings = Collections.unmodifiableMap(rowIdMappings);
             this.totalOffset = totalOffset;
         }
 
         boolean isEmpty() {
-            return partitionMappings.isEmpty();
+            return rowIdMappings.isEmpty();
         }
-    }
-
-    /** Mapping arrays for one partition. Elements at the same index form one mapping. */
-    static final class PartitionMapping {
-
-        final BinaryRow partition;
-        final long[] oldStarts;
-        final long[] oldEnds;
-        final long[] newRelativeStarts;
-
-        private PartitionMapping(
-                BinaryRow partition, long[] oldStarts, long[] oldEnds, long[] newRelativeStarts) {
-            this.partition = partition;
-            this.oldStarts = oldStarts;
-            this.oldEnds = oldEnds;
-            this.newRelativeStarts = newRelativeStarts;
-        }
-    }
-
-    private interface ProjectedRowVisitor {
-
-        boolean visit(BinaryManifestEntry entry);
     }
 
     private static final class GroupState {
 
         private final GroupPartitionDictionary partitions;
         private final DeletedIdentifierSet deletedIdentifiers = new DeletedIdentifierSet();
-        private final CurrentEntries currentEntries;
+        private final CurrentRowIdEntries currentEntries;
 
         private GroupState(
                 int partitionArity,
@@ -584,7 +516,7 @@ final class DataEvolutionRowIdAssignmentPlanner {
             this.partitions =
                     new GroupPartitionDictionary(
                             partitionArity, partitionPredicate, excludedPartitionCacheSize);
-            this.currentEntries = new CurrentEntries(expectedAddEntryCount);
+            this.currentEntries = new CurrentRowIdEntries(expectedAddEntryCount);
         }
 
         private @Nullable PartitionState internPartition(byte[] serialized) {
@@ -595,9 +527,9 @@ final class DataEvolutionRowIdAssignmentPlanner {
             deletedIdentifiers.release();
         }
 
-        private GroupSelection[] finishAddPass() {
+        private List<PartitionState> finishAddPass() {
             currentEntries.sort();
-            GroupSelection[] selections = new GroupSelection[partitions.partitionCount()];
+            List<PartitionState> selections = new ArrayList<>();
             long[] rangeScratch = new long[2];
             int groupStart = 0;
             while (groupStart < currentEntries.size()) {
@@ -610,11 +542,12 @@ final class DataEvolutionRowIdAssignmentPlanner {
                 int rangeScan =
                         currentEntries.scanLogicalRanges(groupStart, groupEnd, rangeScratch);
                 if (rangeScan > 0) {
-                    PrimitiveRangeBuffer logicalRanges =
+                    PrimitiveRowRanges logicalRanges =
                             currentEntries.materializeLogicalRanges(
                                     groupStart, groupEnd, rangeScan, rangeScratch);
-                    selections[partitionId] =
-                            new GroupSelection(partitions.partition(partitionId), logicalRanges);
+                    PartitionState partition = partitions.partition(partitionId);
+                    partition.select(logicalRanges);
+                    selections.add(partition);
                 }
                 groupStart = groupEnd;
             }
@@ -685,10 +618,6 @@ final class DataEvolutionRowIdAssignmentPlanner {
             }
         }
 
-        private int partitionCount() {
-            return partitions.size();
-        }
-
         private PartitionState partition(int partitionId) {
             return partitions.get(partitionId);
         }
@@ -718,6 +647,7 @@ final class DataEvolutionRowIdAssignmentPlanner {
         private final byte[] serialized;
         private final BinaryRow partition;
         private @Nullable LegacyPartitionOrderKey legacyOrderKey;
+        private @Nullable PrimitiveRowRanges logicalRanges;
 
         private PartitionState(int id, byte[] serialized, BinaryRow partition) {
             this.id = id;
@@ -786,6 +716,16 @@ final class DataEvolutionRowIdAssignmentPlanner {
                     "Selected partition does not have a retained ADD ordering key.");
             return legacyOrderKey;
         }
+
+        private void select(PrimitiveRowRanges logicalRanges) {
+            checkState(this.logicalRanges == null, "Partition is already selected.");
+            this.logicalRanges = logicalRanges;
+        }
+
+        private PrimitiveRowRanges requiredLogicalRanges() {
+            checkState(logicalRanges != null, "Selected partition has no logical row-id ranges.");
+            return logicalRanges;
+        }
     }
 
     private static final class LegacyPartitionOrderKey
@@ -838,802 +778,19 @@ final class DataEvolutionRowIdAssignmentPlanner {
         }
     }
 
-    private static final class GroupSelection {
-
-        private final PartitionState partition;
-        private final PrimitiveRangeBuffer logicalRanges;
-
-        private GroupSelection(PartitionState partition, PrimitiveRangeBuffer logicalRanges) {
-            this.partition = partition;
-            this.logicalRanges = logicalRanges;
-        }
-    }
-
     private static final class SelectedPartition {
 
-        private final byte[] serializedPartition;
         private final BinaryRow partition;
         private LegacyPartitionOrderKey legacyOrderKey;
-        private final PrimitiveRangeBuffer logicalRanges;
+        private final PrimitiveRowRanges logicalRanges;
 
         private SelectedPartition(
-                byte[] serializedPartition,
                 BinaryRow partition,
                 LegacyPartitionOrderKey legacyOrderKey,
-                PrimitiveRangeBuffer logicalRanges) {
-            this.serializedPartition = serializedPartition;
+                PrimitiveRowRanges logicalRanges) {
             this.partition = partition;
             this.legacyOrderKey = legacyOrderKey;
             this.logicalRanges = logicalRanges;
-        }
-    }
-
-    /** Object-free storage for current entries. */
-    static final class CurrentEntries {
-
-        private long[] words;
-        private int size;
-
-        CurrentEntries() {
-            this(0);
-        }
-
-        CurrentEntries(int expectedEntries) {
-            checkArgument(expectedEntries >= 0, "Expected current entry count cannot be negative.");
-            this.words = new long[Math.multiplyExact(expectedEntries, CURRENT_ENTRY_WORDS)];
-        }
-
-        void add(int partitionId, boolean special, long firstRowId, long rowCount) {
-            checkArgument(partitionId >= 0, "Partition id cannot be negative.");
-            checkArgument(rowCount > 0, "Row count must be positive.");
-            Math.addExact(firstRowId, rowCount - 1L);
-            ensureCapacity(Math.addExact(size, 1));
-            int offset = size * CURRENT_ENTRY_WORDS;
-            words[offset] = Integer.toUnsignedLong(partitionId) | (special ? CURRENT_SPECIAL : 0L);
-            words[offset + 1] = firstRowId;
-            words[offset + 2] = rowCount;
-            size++;
-        }
-
-        int size() {
-            return size;
-        }
-
-        int retainedWordCount() {
-            return words.length;
-        }
-
-        int usedWordCount() {
-            return size * CURRENT_ENTRY_WORDS;
-        }
-
-        private void release() {
-            words = new long[0];
-            size = 0;
-        }
-
-        int partitionId(int index) {
-            return (int) words[offset(index)];
-        }
-
-        private boolean special(int index) {
-            return (words[offset(index)] & CURRENT_SPECIAL) != 0;
-        }
-
-        private long firstRowId(int index) {
-            return words[offset(index) + 1];
-        }
-
-        private long rowCount(int index) {
-            return words[offset(index) + 2];
-        }
-
-        private long lastRowId(int index) {
-            return firstRowId(index) + rowCount(index) - 1L;
-        }
-
-        private int offset(int index) {
-            checkArgument(index >= 0 && index < size, "Current entry index is out of bounds.");
-            return index * CURRENT_ENTRY_WORDS;
-        }
-
-        private void ensureCapacity(int requiredEntries) {
-            long requiredWords = (long) requiredEntries * CURRENT_ENTRY_WORDS;
-            checkState(
-                    requiredWords <= Integer.MAX_VALUE,
-                    "Too many current entries in one manifest group.");
-            if (requiredWords <= words.length) {
-                return;
-            }
-            int newLength = Math.max(48, words.length);
-            while (newLength < requiredWords) {
-                int grown = newLength + (newLength >>> 1);
-                if (grown <= newLength || grown > Integer.MAX_VALUE) {
-                    newLength = (int) requiredWords;
-                    break;
-                }
-                newLength = grown;
-            }
-            words = Arrays.copyOf(words, newLength);
-        }
-
-        private void sort() {
-            if (size > 1) {
-                sort(0, size - 1);
-            }
-        }
-
-        private void sort(int left, int right) {
-            while (left < right) {
-                int middle = left + ((right - left) >>> 1);
-                long pivotPartition = words[middle * CURRENT_ENTRY_WORDS];
-                long pivotFirst = words[middle * CURRENT_ENTRY_WORDS + 1];
-                long pivotCount = words[middle * CURRENT_ENTRY_WORDS + 2];
-                int lower = left;
-                int current = left;
-                int upper = right;
-                while (current <= upper) {
-                    int comparison = compare(current, pivotPartition, pivotFirst, pivotCount);
-                    if (comparison < 0) {
-                        swap(lower++, current++);
-                    } else if (comparison > 0) {
-                        swap(current, upper--);
-                    } else {
-                        current++;
-                    }
-                }
-
-                if (lower - left < right - upper) {
-                    if (left < lower - 1) {
-                        sort(left, lower - 1);
-                    }
-                    left = upper + 1;
-                } else {
-                    if (upper + 1 < right) {
-                        sort(upper + 1, right);
-                    }
-                    right = lower - 1;
-                }
-            }
-        }
-
-        private int compare(int index, long pivotPartition, long pivotFirst, long pivotCount) {
-            int offset = index * CURRENT_ENTRY_WORDS;
-            int result = Long.compare(words[offset] & 0xFFFF_FFFFL, pivotPartition & 0xFFFF_FFFFL);
-            if (result != 0) {
-                return result;
-            }
-            result = Long.compare(words[offset + 1], pivotFirst);
-            if (result != 0) {
-                return result;
-            }
-            long end = words[offset + 1] + words[offset + 2] - 1L;
-            long pivotEnd = pivotFirst + pivotCount - 1L;
-            return Long.compare(end, pivotEnd);
-        }
-
-        private void swap(int left, int right) {
-            if (left == right) {
-                return;
-            }
-            int leftOffset = left * CURRENT_ENTRY_WORDS;
-            int rightOffset = right * CURRENT_ENTRY_WORDS;
-            for (int i = 0; i < CURRENT_ENTRY_WORDS; i++) {
-                long value = words[leftOffset + i];
-                words[leftOffset + i] = words[rightOffset + i];
-                words[rightOffset + i] = value;
-            }
-        }
-
-        /**
-         * Scans logical ranges without retaining one object (or even one primitive pair) per range.
-         *
-         * <p>The absolute return value is the number of logical ranges. A negative result means
-         * that all logical ranges are contiguous and therefore this partition does not need a plan.
-         * A positive result means that the ranges are fragmented and need materialization.
-         */
-        private int scanLogicalRanges(int from, int to, long[] rangeScratch) {
-            checkArgument(from >= 0 && from < to && to <= size, "Invalid entry slice.");
-            int overlapStart = from;
-            long currentEnd = lastRowId(from);
-            int rangeCount = 0;
-            boolean contiguous = true;
-            boolean hasPrevious = false;
-            long previousEnd = 0L;
-            for (int i = from + 1; i < to; i++) {
-                if (firstRowId(i) <= currentEnd) {
-                    currentEnd = Math.max(currentEnd, lastRowId(i));
-                } else {
-                    computeLogicalRange(overlapStart, i, rangeScratch);
-                    rangeCount++;
-                    if (hasPrevious
-                            && (previousEnd == Long.MAX_VALUE
-                                    || rangeScratch[0] != previousEnd + 1L)) {
-                        contiguous = false;
-                    }
-                    previousEnd = rangeScratch[1];
-                    hasPrevious = true;
-                    overlapStart = i;
-                    currentEnd = lastRowId(i);
-                }
-            }
-            computeLogicalRange(overlapStart, to, rangeScratch);
-            rangeCount++;
-            if (hasPrevious
-                    && (previousEnd == Long.MAX_VALUE || rangeScratch[0] != previousEnd + 1L)) {
-                contiguous = false;
-            }
-            return contiguous ? -rangeCount : rangeCount;
-        }
-
-        private PrimitiveRangeBuffer materializeLogicalRanges(
-                int from, int to, int expectedRangeCount, long[] rangeScratch) {
-            checkArgument(
-                    from >= 0 && from < to && to <= size && expectedRangeCount > 0,
-                    "Invalid fragmented entry slice.");
-            PrimitiveRangeBuffer ranges = new PrimitiveRangeBuffer(expectedRangeCount);
-            int overlapStart = from;
-            long currentEnd = lastRowId(from);
-            for (int i = from + 1; i < to; i++) {
-                if (firstRowId(i) <= currentEnd) {
-                    currentEnd = Math.max(currentEnd, lastRowId(i));
-                } else {
-                    computeLogicalRange(overlapStart, i, rangeScratch);
-                    ranges.add(rangeScratch[0], rangeScratch[1]);
-                    overlapStart = i;
-                    currentEnd = lastRowId(i);
-                }
-            }
-            computeLogicalRange(overlapStart, to, rangeScratch);
-            ranges.add(rangeScratch[0], rangeScratch[1]);
-            checkState(
-                    ranges.size() == expectedRangeCount,
-                    "Logical range count changed between scan and materialization.");
-            return ranges;
-        }
-
-        private void computeLogicalRange(int from, int to, long[] result) {
-            boolean hasOrdinary = false;
-            long ordinaryStart = 0L;
-            long ordinaryEnd = 0L;
-            long spanningStart = Long.MAX_VALUE;
-            long spanningEnd = Long.MIN_VALUE;
-            for (int i = from; i < to; i++) {
-                long start = firstRowId(i);
-                long end = lastRowId(i);
-                spanningStart = Math.min(spanningStart, start);
-                spanningEnd = Math.max(spanningEnd, end);
-                if (!special(i)) {
-                    checkState(
-                            !hasOrdinary || (ordinaryStart == start && ordinaryEnd == end),
-                            "Data files in one overlapping row-id group must have the same row-id range.");
-                    ordinaryStart = start;
-                    ordinaryEnd = end;
-                    hasOrdinary = true;
-                }
-            }
-            long logicalStart = hasOrdinary ? ordinaryStart : spanningStart;
-            long logicalEnd = hasOrdinary ? ordinaryEnd : spanningEnd;
-            for (int i = from; i < to; i++) {
-                checkState(
-                        firstRowId(i) >= logicalStart && lastRowId(i) <= logicalEnd,
-                        "File row-id range is outside its logical row-id range.");
-            }
-            result[0] = logicalStart;
-            result[1] = logicalEnd;
-        }
-
-        @Nullable
-        PrimitiveRangeBuffer selectedRangesForTesting() {
-            checkState(size > 0, "Cannot inspect an empty current-entry buffer.");
-            sort();
-            int partitionId = partitionId(0);
-            for (int i = 1; i < size; i++) {
-                checkState(
-                        partitionId(i) == partitionId,
-                        "The structural range test helper requires one partition.");
-            }
-            long[] rangeScratch = new long[2];
-            int rangeScan = scanLogicalRanges(0, size, rangeScratch);
-            return rangeScan < 0
-                    ? null
-                    : materializeLogicalRanges(0, size, rangeScan, rangeScratch);
-        }
-    }
-
-    /** Compact, collision-safe set backed by primitive arrays and one identifier byte arena. */
-    static final class DeletedIdentifierSet {
-
-        private static final float LOAD_FACTOR = 0.75f;
-
-        private int[] buckets = filledWithMinusOne(16);
-        private long[] hashes = new long[16];
-        private int[] partitionIds = new int[16];
-        private int[] offsets = new int[16];
-        private int[] lengths = new int[16];
-        private int[] next = new int[16];
-        private byte[] arena = new byte[256];
-        private int arenaSize;
-        private int size;
-
-        boolean isEmpty() {
-            return size == 0;
-        }
-
-        int size() {
-            return size;
-        }
-
-        int retainedIdentifierBytes() {
-            return arenaSize;
-        }
-
-        private void release() {
-            buckets = filledWithMinusOne(16);
-            hashes = new long[0];
-            partitionIds = new int[0];
-            offsets = new int[0];
-            lengths = new int[0];
-            next = new int[0];
-            arena = new byte[0];
-            arenaSize = 0;
-            size = 0;
-        }
-
-        void add(int partitionId, byte[] identifier, int length) {
-            checkIdentifier(identifier, length);
-            long hash = hash(partitionId, identifier, length);
-            if (contains(partitionId, identifier, length, hash)) {
-                return;
-            }
-            if (size + 1 > (int) (buckets.length * LOAD_FACTOR)) {
-                growBuckets();
-            }
-            ensureEntryCapacity(size + 1);
-            ensureArenaCapacity(length);
-            int offset = arenaSize;
-            System.arraycopy(identifier, 0, arena, offset, length);
-            arenaSize = Math.addExact(arenaSize, length);
-
-            int bucket = bucket(hash);
-            hashes[size] = hash;
-            partitionIds[size] = partitionId;
-            offsets[size] = offset;
-            lengths[size] = length;
-            next[size] = buckets[bucket];
-            buckets[bucket] = size;
-            size++;
-        }
-
-        boolean contains(int partitionId, byte[] identifier, int length) {
-            checkIdentifier(identifier, length);
-            return contains(partitionId, identifier, length, hash(partitionId, identifier, length));
-        }
-
-        private boolean contains(int partitionId, byte[] identifier, int length, long hash) {
-            for (int entry = buckets[bucket(hash)]; entry >= 0; entry = next[entry]) {
-                if (hashes[entry] == hash
-                        && partitionIds[entry] == partitionId
-                        && lengths[entry] == length
-                        && bytesEqual(arena, offsets[entry], identifier, length)) {
-                    return true;
-                }
-            }
-            return false;
-        }
-
-        private void growBuckets() {
-            checkState(
-                    buckets.length < (1 << 30),
-                    "Too many deleted identifiers in one manifest group.");
-            int[] grown = filledWithMinusOne(buckets.length << 1);
-            for (int entry = 0; entry < size; entry++) {
-                int bucket = bucket(hashes[entry], grown.length);
-                next[entry] = grown[bucket];
-                grown[bucket] = entry;
-            }
-            buckets = grown;
-        }
-
-        private void ensureEntryCapacity(int required) {
-            if (required <= hashes.length) {
-                return;
-            }
-            int grown = Math.max(required, hashes.length + (hashes.length >>> 1));
-            hashes = Arrays.copyOf(hashes, grown);
-            partitionIds = Arrays.copyOf(partitionIds, grown);
-            offsets = Arrays.copyOf(offsets, grown);
-            lengths = Arrays.copyOf(lengths, grown);
-            next = Arrays.copyOf(next, grown);
-        }
-
-        private void ensureArenaCapacity(int additional) {
-            int required;
-            try {
-                required = Math.addExact(arenaSize, additional);
-            } catch (ArithmeticException e) {
-                throw new IllegalStateException(
-                        "Deleted identifier arena exceeds the Java array limit.", e);
-            }
-            if (required <= arena.length) {
-                return;
-            }
-            int grown = Math.max(required, arena.length + (arena.length >>> 1));
-            if (grown < 0) {
-                grown = required;
-            }
-            arena = Arrays.copyOf(arena, grown);
-        }
-
-        private int bucket(long hash) {
-            return bucket(hash, buckets.length);
-        }
-
-        private static int bucket(long hash, int bucketCount) {
-            return ((int) (hash ^ (hash >>> 32))) & (bucketCount - 1);
-        }
-
-        private static long hash(int partitionId, byte[] bytes, int length) {
-            long hash = 0xcbf29ce484222325L;
-            hash ^= Integer.toUnsignedLong(partitionId);
-            hash *= 0x100000001b3L;
-            for (int i = 0; i < length; i++) {
-                hash ^= bytes[i] & 0xFFL;
-                hash *= 0x100000001b3L;
-            }
-            return hash;
-        }
-
-        private static boolean bytesEqual(byte[] left, int leftOffset, byte[] right, int length) {
-            for (int i = 0; i < length; i++) {
-                if (left[leftOffset + i] != right[i]) {
-                    return false;
-                }
-            }
-            return true;
-        }
-
-        private static void checkIdentifier(byte[] identifier, int length) {
-            checkArgument(identifier != null, "Identifier bytes cannot be null.");
-            checkArgument(
-                    length >= 0 && length <= identifier.length,
-                    "Invalid identifier length %s.",
-                    length);
-        }
-
-        private static int[] filledWithMinusOne(int length) {
-            int[] values = new int[length];
-            Arrays.fill(values, -1);
-            return values;
-        }
-    }
-
-    private static final class IdentifierScratch {
-
-        private byte[] bytes = new byte[256];
-        private int length;
-
-        private void encode(BinaryManifestEntry entry) {
-            length = 0;
-            putInt(entry.bucket());
-            BinaryDataFileMeta file = entry.file();
-            putInt(file.level());
-            putString(file.fileNameBinary());
-
-            int extraFileCount = file.extraFileCount();
-            putInt(extraFileCount);
-            for (int i = 0; i < extraFileCount; i++) {
-                putString(file.extraFile(i));
-            }
-
-            if (!file.hasEmbeddedIndex()) {
-                putInt(-1);
-            } else {
-                putBytes(file.embeddedIndex());
-            }
-            if (!file.hasExternalPath()) {
-                putInt(-1);
-            } else {
-                putString(file.externalPathBinary());
-            }
-        }
-
-        private byte[] bytes() {
-            return bytes;
-        }
-
-        private int length() {
-            return length;
-        }
-
-        private void release() {
-            bytes = new byte[0];
-            length = 0;
-        }
-
-        private void putString(BinaryString value) {
-            checkState(value != null, "Manifest string field cannot be null.");
-            int valueLength = value.getSizeInBytes();
-            putInt(valueLength);
-            ensureCapacity(valueLength);
-            MemorySegmentUtils.copyToBytes(
-                    value.getSegments(), value.getOffset(), bytes, length, valueLength);
-            length += valueLength;
-        }
-
-        private void putBytes(byte[] value) {
-            checkState(value != null, "Manifest binary field cannot be null.");
-            putInt(value.length);
-            ensureCapacity(value.length);
-            System.arraycopy(value, 0, bytes, length, value.length);
-            length += value.length;
-        }
-
-        private void putInt(int value) {
-            ensureCapacity(Integer.BYTES);
-            bytes[length++] = (byte) (value >>> 24);
-            bytes[length++] = (byte) (value >>> 16);
-            bytes[length++] = (byte) (value >>> 8);
-            bytes[length++] = (byte) value;
-        }
-
-        private void ensureCapacity(int additional) {
-            int required = Math.addExact(length, additional);
-            if (required <= bytes.length) {
-                return;
-            }
-            int grown = Math.max(required, bytes.length + (bytes.length >>> 1));
-            bytes = Arrays.copyOf(bytes, grown);
-        }
-    }
-
-    /**
-     * Object-free logical range storage.
-     *
-     * <p>Starts and ends are kept in separate primitive arrays so that the planner can transfer
-     * ownership of both arrays directly into the final mapping. The common one-group path allocates
-     * the exact range count and requires no copy during that transfer.
-     */
-    static final class PrimitiveRangeBuffer {
-
-        private long[] starts;
-        private long[] ends;
-        private int size;
-        private boolean sorted = true;
-
-        private PrimitiveRangeBuffer(int expectedRanges) {
-            checkArgument(expectedRanges >= 0, "Expected range count cannot be negative.");
-            starts = new long[expectedRanges];
-            ends = new long[expectedRanges];
-        }
-
-        int size() {
-            return size;
-        }
-
-        int retainedWordCount() {
-            return Math.addExact(starts.length, ends.length);
-        }
-
-        long start(int index) {
-            checkIndex(index);
-            return starts[index];
-        }
-
-        long end(int index) {
-            checkIndex(index);
-            return ends[index];
-        }
-
-        private void add(long start, long end) {
-            checkArgument(start <= end, "Invalid row-id range [%s, %s].", start, end);
-            ensureCapacity(Math.addExact(size, 1));
-            if (size > 0 && compare(starts[size - 1], ends[size - 1], start, end) > 0) {
-                sorted = false;
-            }
-            starts[size] = start;
-            ends[size] = end;
-            size++;
-        }
-
-        private void append(PrimitiveRangeBuffer other) {
-            checkArgument(other != null, "Ranges to append cannot be null.");
-            if (other.size == 0) {
-                return;
-            }
-            int oldSize = size;
-            int combinedSize = Math.addExact(size, other.size);
-            ensureCapacity(combinedSize);
-            if (oldSize > 0
-                    && compare(
-                                    starts[oldSize - 1],
-                                    ends[oldSize - 1],
-                                    other.starts[0],
-                                    other.ends[0])
-                            > 0) {
-                sorted = false;
-            }
-            sorted &= other.sorted;
-            System.arraycopy(other.starts, 0, starts, oldSize, other.size);
-            System.arraycopy(other.ends, 0, ends, oldSize, other.size);
-            size = combinedSize;
-        }
-
-        private void normalizeOverlapping() {
-            if (size <= 1) {
-                sorted = true;
-                return;
-            }
-            if (!sorted) {
-                sort(0, size - 1);
-                sorted = true;
-            }
-            int writeIndex = 0;
-            for (int readIndex = 1; readIndex < size; readIndex++) {
-                if (starts[readIndex] <= ends[writeIndex]) {
-                    ends[writeIndex] = Math.max(ends[writeIndex], ends[readIndex]);
-                } else {
-                    writeIndex++;
-                    starts[writeIndex] = starts[readIndex];
-                    ends[writeIndex] = ends[readIndex];
-                }
-            }
-            size = writeIndex + 1;
-        }
-
-        private OwnedPrimitiveRanges takeOwned() {
-            long[] ownedStarts = starts.length == size ? starts : Arrays.copyOf(starts, size);
-            long[] ownedEnds = ends.length == size ? ends : Arrays.copyOf(ends, size);
-            starts = new long[0];
-            ends = new long[0];
-            size = 0;
-            sorted = true;
-            return new OwnedPrimitiveRanges(ownedStarts, ownedEnds);
-        }
-
-        private void ensureCapacity(int required) {
-            if (required <= starts.length) {
-                return;
-            }
-            int grown = Math.max(16, starts.length);
-            while (grown < required) {
-                int next = grown + (grown >>> 1);
-                if (next <= grown || next < 0) {
-                    grown = required;
-                    break;
-                }
-                grown = next;
-            }
-            starts = Arrays.copyOf(starts, grown);
-            ends = Arrays.copyOf(ends, grown);
-        }
-
-        private void sort(int left, int right) {
-            while (left < right) {
-                int middle = left + ((right - left) >>> 1);
-                long pivotStart = starts[middle];
-                long pivotEnd = ends[middle];
-                int lower = left;
-                int current = left;
-                int upper = right;
-                while (current <= upper) {
-                    int comparison = compare(starts[current], ends[current], pivotStart, pivotEnd);
-                    if (comparison < 0) {
-                        swap(lower++, current++);
-                    } else if (comparison > 0) {
-                        swap(current, upper--);
-                    } else {
-                        current++;
-                    }
-                }
-
-                if (lower - left < right - upper) {
-                    if (left < lower - 1) {
-                        sort(left, lower - 1);
-                    }
-                    left = upper + 1;
-                } else {
-                    if (upper + 1 < right) {
-                        sort(upper + 1, right);
-                    }
-                    right = lower - 1;
-                }
-            }
-        }
-
-        private void swap(int left, int right) {
-            if (left == right) {
-                return;
-            }
-            long start = starts[left];
-            long end = ends[left];
-            starts[left] = starts[right];
-            ends[left] = ends[right];
-            starts[right] = start;
-            ends[right] = end;
-        }
-
-        private void checkIndex(int index) {
-            checkArgument(index >= 0 && index < size, "Logical range index is out of bounds.");
-        }
-
-        private static int compare(long leftStart, long leftEnd, long rightStart, long rightEnd) {
-            int result = Long.compare(leftStart, rightStart);
-            return result == 0 ? Long.compare(leftEnd, rightEnd) : result;
-        }
-    }
-
-    private static final class OwnedPrimitiveRanges {
-
-        private final long[] starts;
-        private final long[] ends;
-
-        private OwnedPrimitiveRanges(long[] starts, long[] ends) {
-            this.starts = starts;
-            this.ends = ends;
-        }
-    }
-
-    private static final class ByteArrayKey {
-
-        private final byte[] bytes;
-        private final int hash;
-
-        private ByteArrayKey(byte[] bytes) {
-            this.bytes = bytes;
-            this.hash = Arrays.hashCode(bytes);
-        }
-
-        @Override
-        public boolean equals(Object obj) {
-            return obj == this
-                    || (obj instanceof ByteArrayKey
-                            && Arrays.equals(bytes, ((ByteArrayKey) obj).bytes))
-                    || (obj instanceof ByteArrayLookupKey
-                            && Arrays.equals(bytes, ((ByteArrayLookupKey) obj).bytes));
-        }
-
-        @Override
-        public int hashCode() {
-            return hash;
-        }
-    }
-
-    private static final class ByteArrayLookupKey {
-
-        private @Nullable byte[] bytes;
-        private int hash;
-
-        private ByteArrayLookupKey() {}
-
-        private ByteArrayLookupKey(byte[] bytes) {
-            reset(bytes);
-        }
-
-        private void reset(byte[] bytes) {
-            this.bytes = bytes;
-            this.hash = Arrays.hashCode(bytes);
-        }
-
-        private void clear() {
-            bytes = null;
-            hash = 0;
-        }
-
-        @Override
-        public boolean equals(Object obj) {
-            return obj == this
-                    || (bytes != null
-                            && obj instanceof ByteArrayKey
-                            && Arrays.equals(bytes, ((ByteArrayKey) obj).bytes))
-                    || (bytes != null
-                            && obj instanceof ByteArrayLookupKey
-                            && Arrays.equals(bytes, ((ByteArrayLookupKey) obj).bytes));
-        }
-
-        @Override
-        public int hashCode() {
-            return hash;
         }
     }
 }

--- a/paimon-core/src/main/java/org/apache/paimon/append/dataevolution/DataEvolutionRowIdAssignmentPlanner.java
+++ b/paimon-core/src/main/java/org/apache/paimon/append/dataevolution/DataEvolutionRowIdAssignmentPlanner.java
@@ -443,7 +443,9 @@ final class DataEvolutionRowIdAssignmentPlanner {
     static int initialCurrentEntryCapacity(long addedCount, long deletedCount) {
         checkArgument(addedCount >= 0, "Added entry count cannot be negative.");
         checkArgument(deletedCount >= 0, "Deleted entry count cannot be negative.");
-        // Counts are only a sizing hint: DELETE entries may be duplicated or may not match an ADD in this group. Estimate the live set, cap the eager allocation, and let CurrentRowIdEntries grow if the actual number of retained ADD entries is larger.
+        // Counts are only a sizing hint: DELETE entries may be duplicated or may not match an ADD
+        // in this group. Estimate the live set, cap the eager allocation, and let
+        // CurrentRowIdEntries grow if the actual number of retained ADD entries is larger.
         long estimatedLiveCount = addedCount > deletedCount ? addedCount - deletedCount : 0L;
         return (int) Math.min(estimatedLiveCount, MAX_INITIAL_CURRENT_ENTRIES);
     }

--- a/paimon-core/src/main/java/org/apache/paimon/append/dataevolution/DataEvolutionRowIdReassigner.java
+++ b/paimon-core/src/main/java/org/apache/paimon/append/dataevolution/DataEvolutionRowIdReassigner.java
@@ -194,11 +194,7 @@ public class DataEvolutionRowIdReassigner {
         DataEvolutionRowIdAssignmentPlanner planner =
                 new DataEvolutionRowIdAssignmentPlanner(
                         table, partitionPredicate, new ArrayList<>(manifestMetas));
-        planner.validateGroups(includedGroups);
-        for (List<ManifestFileMeta> manifestGroup : includedGroups) {
-            planner.planGroup(manifestGroup);
-        }
-        DataEvolutionRowIdAssignmentPlanner.Result compactPlan = planner.buildResult();
+        DataEvolutionRowIdAssignmentPlanner.Result compactPlan = planner.plan(includedGroups);
         if (compactPlan.isEmpty()) {
             return Optional.empty();
         }
@@ -209,18 +205,11 @@ public class DataEvolutionRowIdReassigner {
             manifestMetasToRewrite.add(manifestMetas.get(ordinal));
         }
 
-        Map<BinaryRow, RowRangeMappingIndex> mappings = new LinkedHashMap<>();
-        for (DataEvolutionRowIdAssignmentPlanner.PartitionMapping mapping :
-                compactPlan.partitionMappings) {
-            mappings.put(
-                    mapping.partition,
-                    RowRangeMappingIndex.createFromOwnedArrays(
-                            mapping.oldStarts, mapping.oldEnds, mapping.newRelativeStarts));
-        }
         return Optional.of(
                 new AssignmentPlan(
                         manifestMetasToRewrite,
-                        new RelativeRowIdMappings(mappings, compactPlan.totalOffset)));
+                        new RelativeRowIdMappings(
+                                compactPlan.rowIdMappings, compactPlan.totalOffset)));
     }
 
     private List<List<ManifestFileMeta>> manifestGroupsByPartition(

--- a/paimon-core/src/main/java/org/apache/paimon/manifest/BinaryManifestEntry.java
+++ b/paimon-core/src/main/java/org/apache/paimon/manifest/BinaryManifestEntry.java
@@ -19,17 +19,17 @@
 package org.apache.paimon.manifest;
 
 import org.apache.paimon.data.BinaryRow;
+import org.apache.paimon.data.BinaryString;
 import org.apache.paimon.data.InternalRow;
-import org.apache.paimon.format.FileFormat;
-import org.apache.paimon.format.FormatReaderFactory;
 import org.apache.paimon.io.BinaryDataFileMeta;
+import org.apache.paimon.memory.MemorySegmentUtils;
 import org.apache.paimon.types.DataField;
 import org.apache.paimon.types.RowType;
 import org.apache.paimon.utils.VersionedObjectSerializer;
 
 import javax.annotation.Nullable;
 
-import java.util.Collections;
+import java.util.Arrays;
 import java.util.List;
 
 import static org.apache.paimon.utils.Preconditions.checkArgument;
@@ -227,6 +227,94 @@ public final class BinaryManifestEntry implements ManifestEntry {
     }
 
     /**
+     * Reusable byte encoding of a binary manifest entry's identity fields.
+     *
+     * <p>The encoded identifier is the prefix of {@link #bytes()} ending at {@link #length()}. It
+     * is valid until the next call to {@link #replace(BinaryManifestEntry)} or {@link #release()}
+     * and must not be modified by callers.
+     */
+    public static final class ReusableIdentifier {
+
+        private byte[] bytes = new byte[256];
+        private int length;
+
+        public ReusableIdentifier replace(BinaryManifestEntry entry) {
+            checkArgument(entry != null, "Binary manifest entry cannot be null.");
+            length = 0;
+            putInt(entry.bucket());
+            BinaryDataFileMeta file = entry.file();
+            putInt(file.level());
+            putString(file.fileNameBinary());
+
+            int extraFileCount = file.extraFileCount();
+            putInt(extraFileCount);
+            for (int i = 0; i < extraFileCount; i++) {
+                putString(file.extraFile(i));
+            }
+
+            if (!file.hasEmbeddedIndex()) {
+                putInt(-1);
+            } else {
+                putBytes(file.embeddedIndex());
+            }
+            if (!file.hasExternalPath()) {
+                putInt(-1);
+            } else {
+                putString(file.externalPathBinary());
+            }
+            return this;
+        }
+
+        public byte[] bytes() {
+            return bytes;
+        }
+
+        public int length() {
+            return length;
+        }
+
+        public void release() {
+            bytes = new byte[0];
+            length = 0;
+        }
+
+        private void putString(BinaryString value) {
+            checkState(value != null, "Manifest string field cannot be null.");
+            int valueLength = value.getSizeInBytes();
+            putInt(valueLength);
+            ensureCapacity(valueLength);
+            MemorySegmentUtils.copyToBytes(
+                    value.getSegments(), value.getOffset(), bytes, length, valueLength);
+            length += valueLength;
+        }
+
+        private void putBytes(byte[] value) {
+            checkState(value != null, "Manifest binary field cannot be null.");
+            putInt(value.length);
+            ensureCapacity(value.length);
+            System.arraycopy(value, 0, bytes, length, value.length);
+            length += value.length;
+        }
+
+        private void putInt(int value) {
+            ensureCapacity(Integer.BYTES);
+            bytes[length++] = (byte) (value >>> 24);
+            bytes[length++] = (byte) (value >>> 16);
+            bytes[length++] = (byte) (value >>> 8);
+            bytes[length++] = (byte) value;
+        }
+
+        private void ensureCapacity(int additional) {
+            int required = Math.addExact(length, additional);
+            if (required <= bytes.length) {
+                return;
+            }
+            int grown = Math.max(required, bytes.length + (bytes.length >>> 1));
+            bytes = Arrays.copyOf(bytes, grown);
+        }
+    }
+
+    /**
      * Projected manifest schema together with its bound binary field layout.
      *
      * <p>The projected type may contain any subset and ordering of the versioned {@link
@@ -235,7 +323,7 @@ public final class BinaryManifestEntry implements ManifestEntry {
      */
     public static final class Projection {
 
-        private final FormatReaderFactory readerFactory;
+        private final RowType projectedType;
         private final int kindPosition;
         private final int partitionPosition;
         private final int bucketPosition;
@@ -245,7 +333,7 @@ public final class BinaryManifestEntry implements ManifestEntry {
         private final @Nullable BinaryDataFileMeta.Projection fileProjection;
 
         private Projection(
-                FormatReaderFactory readerFactory,
+                RowType projectedType,
                 int kindPosition,
                 int partitionPosition,
                 int bucketPosition,
@@ -253,7 +341,7 @@ public final class BinaryManifestEntry implements ManifestEntry {
                 int filePosition,
                 int projectedFileFieldCount,
                 @Nullable BinaryDataFileMeta.Projection fileProjection) {
-            this.readerFactory = readerFactory;
+            this.projectedType = projectedType;
             this.kindPosition = kindPosition;
             this.partitionPosition = partitionPosition;
             this.bucketPosition = bucketPosition;
@@ -263,8 +351,7 @@ public final class BinaryManifestEntry implements ManifestEntry {
             this.fileProjection = fileProjection;
         }
 
-        public static Projection create(FileFormat format, RowType projectedType) {
-            checkArgument(format != null, "Manifest format cannot be null.");
+        public static Projection create(RowType projectedType) {
             checkArgument(projectedType != null, "Projected manifest type cannot be null.");
             validateProjection(projectedType);
 
@@ -279,8 +366,7 @@ public final class BinaryManifestEntry implements ManifestEntry {
             }
 
             return new Projection(
-                    format.createReaderFactory(
-                            MANIFEST_TYPE, projectedType, Collections.emptyList()),
+                    projectedType,
                     projectedType.getFieldIndex(ManifestEntry.KIND),
                     projectedType.getFieldIndex(ManifestEntry.PARTITION),
                     projectedType.getFieldIndex(ManifestEntry.BUCKET),
@@ -306,8 +392,8 @@ public final class BinaryManifestEntry implements ManifestEntry {
             }
         }
 
-        public FormatReaderFactory readerFactory() {
-            return readerFactory;
+        RowType projectedType() {
+            return projectedType;
         }
 
         public BinaryManifestEntry createEntry() {

--- a/paimon-core/src/main/java/org/apache/paimon/manifest/ManifestFile.java
+++ b/paimon-core/src/main/java/org/apache/paimon/manifest/ManifestFile.java
@@ -29,12 +29,15 @@ import org.apache.paimon.fs.Path;
 import org.apache.paimon.io.RollingFileWriter;
 import org.apache.paimon.io.RollingFileWriterImpl;
 import org.apache.paimon.io.SingleFileWriter;
+import org.apache.paimon.manifest.BinaryManifestEntry.Projection;
 import org.apache.paimon.operation.metrics.CacheMetrics;
 import org.apache.paimon.partition.PartitionPredicate;
 import org.apache.paimon.schema.SchemaManager;
 import org.apache.paimon.stats.SimpleStatsConverter;
 import org.apache.paimon.types.RowType;
+import org.apache.paimon.utils.CloseableIterator;
 import org.apache.paimon.utils.FileStorePathFactory;
+import org.apache.paimon.utils.FileUtils;
 import org.apache.paimon.utils.Filter;
 import org.apache.paimon.utils.ObjectsFile;
 import org.apache.paimon.utils.PathFactory;
@@ -46,6 +49,7 @@ import javax.annotation.Nullable;
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.function.Function;
 
@@ -57,6 +61,8 @@ public class ManifestFile extends ObjectsFile<ManifestEntry> {
 
     private final SchemaManager schemaManager;
     private final RowType partitionType;
+    private final FileFormat fileFormat;
+    private final RowType manifestType;
     private final FormatWriterFactory writerFactory;
     private final long suggestedFileSize;
 
@@ -64,8 +70,9 @@ public class ManifestFile extends ObjectsFile<ManifestEntry> {
             FileIO fileIO,
             SchemaManager schemaManager,
             RowType partitionType,
+            FileFormat fileFormat,
             ManifestEntrySerializer serializer,
-            RowType schema,
+            RowType manifestType,
             FormatReaderFactory readerFactory,
             FormatWriterFactory writerFactory,
             String compression,
@@ -75,7 +82,7 @@ public class ManifestFile extends ObjectsFile<ManifestEntry> {
         super(
                 fileIO,
                 serializer,
-                schema,
+                manifestType,
                 readerFactory,
                 writerFactory,
                 compression,
@@ -83,6 +90,8 @@ public class ManifestFile extends ObjectsFile<ManifestEntry> {
                 cache);
         this.schemaManager = schemaManager;
         this.partitionType = partitionType;
+        this.fileFormat = fileFormat;
+        this.manifestType = manifestType;
         this.writerFactory = writerFactory;
         this.suggestedFileSize = suggestedFileSize;
     }
@@ -138,6 +147,57 @@ public class ManifestFile extends ObjectsFile<ManifestEntry> {
                     createIterator(path, fileSize), serializer, readFilter, readTFilter, convertor);
         } catch (IOException e) {
             throw new UncheckedIOException(e);
+        }
+    }
+
+    /**
+     * Scans projected manifest entries without materializing {@link PojoManifestEntry}s.
+     *
+     * <p>The returned iterator reuses the same mutable {@link BinaryManifestEntry} for all records.
+     * An entry is only valid until the next call to {@link CloseableIterator#hasNext()}, {@link
+     * CloseableIterator#next()}, or {@link CloseableIterator#close()}, and must not be retained.
+     * The caller must close the iterator.
+     *
+     * <p>This method intentionally bypasses the manifest cache because cached entries are
+     * materialized with the complete manifest schema.
+     */
+    public CloseableIterator<BinaryManifestEntry> scan(
+            String fileName, @Nullable Long fileSize, Projection projection) {
+        BinaryManifestEntry entry = projection.createEntry();
+        try {
+            CloseableIterator<InternalRow> rows =
+                    FileUtils.createFormatReader(
+                                    fileIO,
+                                    fileFormat.createReaderFactory(
+                                            manifestType,
+                                            projection.projectedType(),
+                                            Collections.emptyList()),
+                                    pathFactory.toPath(fileName),
+                                    fileSize)
+                            .toCloseableIterator();
+            return new CloseableIterator<BinaryManifestEntry>() {
+
+                @Override
+                public boolean hasNext() {
+                    entry.clear();
+                    return rows.hasNext();
+                }
+
+                @Override
+                public BinaryManifestEntry next() {
+                    entry.clear();
+                    InternalRow row = rows.next();
+                    return row == null ? null : entry.replace(row);
+                }
+
+                @Override
+                public void close() throws Exception {
+                    entry.clear();
+                    rows.close();
+                }
+            };
+        } catch (IOException e) {
+            throw new UncheckedIOException("Failed to read manifest file " + fileName, e);
         }
     }
 
@@ -312,6 +372,7 @@ public class ManifestFile extends ObjectsFile<ManifestEntry> {
                     fileIO,
                     schemaManager,
                     partitionType,
+                    fileFormat,
                     new ManifestEntrySerializer(),
                     entryType,
                     fileFormat.createReaderFactory(entryType, entryType, new ArrayList<>()),

--- a/paimon-core/src/test/java/org/apache/paimon/append/dataevolution/CurrentRowIdEntriesTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/append/dataevolution/CurrentRowIdEntriesTest.java
@@ -1,0 +1,76 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.append.dataevolution;
+
+import org.apache.paimon.utils.PrimitiveRowRanges;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Tests for {@link CurrentRowIdEntries}. */
+class CurrentRowIdEntriesTest {
+
+    @Test
+    void testHotStateUsesThreePrimitiveWords() {
+        CurrentRowIdEntries entries = new CurrentRowIdEntries(10_000);
+
+        for (int i = 0; i < 10_000; i++) {
+            entries.add(i % 7, (i & 1) == 0, i * 10L, 3L);
+        }
+
+        assertThat(entries.size()).isEqualTo(10_000);
+        assertThat(entries.usedWordCount()).isEqualTo(30_000);
+        assertThat(entries.retainedWordCount()).isEqualTo(30_000);
+    }
+
+    @Test
+    void testContiguousEntriesDoNotMaterializePerEntryRanges() {
+        CurrentRowIdEntries entries = new CurrentRowIdEntries(10_000);
+        for (int i = 0; i < 10_000; i++) {
+            entries.add(0, false, i, 1L);
+        }
+
+        PrimitiveRowRanges ranges = entries.selectedRangesForTesting();
+
+        assertThat(ranges).isNull();
+        assertThat(entries.usedWordCount()).isEqualTo(30_000);
+        assertThat(entries.retainedWordCount()).isEqualTo(30_000);
+    }
+
+    @Test
+    void testFragmentedEntriesUsePrimitiveLogicalRanges() {
+        CurrentRowIdEntries entries = new CurrentRowIdEntries(10_000);
+        for (int i = 0; i < 10_000; i++) {
+            entries.add(0, false, i * 2L, 1L);
+        }
+
+        PrimitiveRowRanges ranges = entries.selectedRangesForTesting();
+
+        assertThat(ranges).isNotNull();
+        assertThat(ranges.size()).isEqualTo(10_000);
+        assertThat(ranges.retainedWordCount()).isEqualTo(20_000);
+        assertThat(ranges.start(0)).isZero();
+        assertThat(ranges.end(0)).isZero();
+        assertThat(ranges.start(9_999)).isEqualTo(19_998L);
+        assertThat(ranges.end(9_999)).isEqualTo(19_998L);
+        assertThat(entries.usedWordCount()).isEqualTo(30_000);
+        assertThat(entries.retainedWordCount()).isEqualTo(30_000);
+    }
+}

--- a/paimon-core/src/test/java/org/apache/paimon/append/dataevolution/DataEvolutionRowIdReassignerTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/append/dataevolution/DataEvolutionRowIdReassignerTest.java
@@ -139,13 +139,13 @@ public class DataEvolutionRowIdReassignerTest extends TableTestBase {
         assertThat(result.isEmpty()).isFalse();
         assertThat(result.totalOffset).isEqualTo(2L);
         assertThat(result.manifestOrdinals).isNotEmpty().isSorted();
-        assertThat(result.partitionMappings).hasSize(1);
-        DataEvolutionRowIdAssignmentPlanner.PartitionMapping mapping =
-                result.partitionMappings.get(0);
-        assertThat(mapping.partition.getString(0).toString()).isEqualTo("a");
-        assertThat(mapping.oldStarts).containsExactly(0L, 2L);
-        assertThat(mapping.oldEnds).containsExactly(0L, 2L);
-        assertThat(mapping.newRelativeStarts).containsExactly(0L, 1L);
+        assertThat(result.rowIdMappings).hasSize(1);
+        Map.Entry<BinaryRow, RowRangeMappingIndex> mapping =
+                result.rowIdMappings.entrySet().iterator().next();
+        assertThat(mapping.getKey().getString(0).toString()).isEqualTo("a");
+        assertThat(mapping.getValue().map(new Range(0L, 0L))).hasValue(new Range(0L, 0L));
+        assertThat(mapping.getValue().map(new Range(1L, 1L))).isEmpty();
+        assertThat(mapping.getValue().map(new Range(2L, 2L))).hasValue(new Range(1L, 1L));
     }
 
     @Test
@@ -178,23 +178,11 @@ public class DataEvolutionRowIdReassignerTest extends TableTestBase {
 
         DataEvolutionRowIdAssignmentPlanner.Result result = planProjectedState(table, null);
 
-        assertThat(result.partitionMappings).hasSize(1);
-        assertThat(result.partitionMappings.get(0).oldStarts).containsExactly(0L, 2L);
+        assertThat(result.rowIdMappings).hasSize(1);
+        RowRangeMappingIndex mapping = result.rowIdMappings.values().iterator().next();
+        assertThat(mapping.map(new Range(0L, 0L))).hasValue(new Range(0L, 0L));
+        assertThat(mapping.map(new Range(2L, 2L))).hasValue(new Range(1L, 1L));
         assertThat(result.totalOffset).isEqualTo(2L);
-    }
-
-    @Test
-    public void testCurrentEntryHotStateUsesThreePrimitiveWords() {
-        DataEvolutionRowIdAssignmentPlanner.CurrentEntries entries =
-                new DataEvolutionRowIdAssignmentPlanner.CurrentEntries(10_000);
-
-        for (int i = 0; i < 10_000; i++) {
-            entries.add(i % 7, (i & 1) == 0, i * 10L, 3L);
-        }
-
-        assertThat(entries.size()).isEqualTo(10_000);
-        assertThat(entries.usedWordCount()).isEqualTo(30_000);
-        assertThat(entries.retainedWordCount()).isEqualTo(30_000);
     }
 
     @Test
@@ -211,66 +199,6 @@ public class DataEvolutionRowIdReassignerTest extends TableTestBase {
                 .isEqualTo(1 << 24);
     }
 
-    @Test
-    public void testContiguousEntriesDoNotMaterializePerEntryRanges() {
-        DataEvolutionRowIdAssignmentPlanner.CurrentEntries entries =
-                new DataEvolutionRowIdAssignmentPlanner.CurrentEntries(10_000);
-        for (int i = 0; i < 10_000; i++) {
-            entries.add(0, false, i, 1L);
-        }
-
-        DataEvolutionRowIdAssignmentPlanner.PrimitiveRangeBuffer ranges =
-                entries.selectedRangesForTesting();
-
-        assertThat(ranges).isNull();
-        assertThat(entries.usedWordCount()).isEqualTo(30_000);
-        assertThat(entries.retainedWordCount()).isEqualTo(30_000);
-        assertThat(DataEvolutionRowIdAssignmentPlanner.class.getDeclaredClasses())
-                .extracting(Class::getSimpleName)
-                .doesNotContain("RowRange");
-    }
-
-    @Test
-    public void testFragmentedEntriesUsePrimitiveLogicalRanges() {
-        DataEvolutionRowIdAssignmentPlanner.CurrentEntries entries =
-                new DataEvolutionRowIdAssignmentPlanner.CurrentEntries(10_000);
-        for (int i = 0; i < 10_000; i++) {
-            entries.add(0, false, i * 2L, 1L);
-        }
-
-        DataEvolutionRowIdAssignmentPlanner.PrimitiveRangeBuffer ranges =
-                entries.selectedRangesForTesting();
-
-        assertThat(ranges).isNotNull();
-        assertThat(ranges.size()).isEqualTo(10_000);
-        assertThat(ranges.retainedWordCount()).isEqualTo(20_000);
-        assertThat(ranges.start(0)).isZero();
-        assertThat(ranges.end(0)).isZero();
-        assertThat(ranges.start(9_999)).isEqualTo(19_998L);
-        assertThat(ranges.end(9_999)).isEqualTo(19_998L);
-        assertThat(entries.usedWordCount()).isEqualTo(30_000);
-        assertThat(entries.retainedWordCount()).isEqualTo(30_000);
-    }
-
-    @Test
-    public void testDeletedIdentifiersUseCompactArenaAndIncludePartition() {
-        DataEvolutionRowIdAssignmentPlanner.DeletedIdentifierSet identifiers =
-                new DataEvolutionRowIdAssignmentPlanner.DeletedIdentifierSet();
-        byte[] identifier = {1, 2, 3, 4};
-
-        identifiers.add(3, identifier, identifier.length);
-        identifiers.add(3, identifier, identifier.length);
-
-        assertThat(identifiers.size()).isOne();
-        assertThat(identifiers.retainedIdentifierBytes()).isEqualTo(identifier.length);
-        assertThat(identifiers.contains(3, identifier, identifier.length)).isTrue();
-        assertThat(identifiers.contains(4, identifier, identifier.length)).isFalse();
-
-        identifiers.add(4, identifier, identifier.length);
-        assertThat(identifiers.size()).isEqualTo(2);
-        assertThat(identifiers.retainedIdentifierBytes()).isEqualTo(identifier.length * 2);
-    }
-
     private DataEvolutionRowIdAssignmentPlanner.Result planProjectedState(
             FileStoreTable table, PartitionPredicate predicate) {
         Snapshot snapshot = table.snapshotManager().latestSnapshot();
@@ -279,9 +207,7 @@ public class DataEvolutionRowIdReassignerTest extends TableTestBase {
         DataEvolutionRowIdAssignmentPlanner state =
                 new DataEvolutionRowIdAssignmentPlanner(table, predicate, manifestMetas);
         List<List<ManifestFileMeta>> groups = Collections.singletonList(manifestMetas);
-        state.validateGroups(groups);
-        state.planGroup(manifestMetas);
-        return state.buildResult();
+        return state.plan(groups);
     }
 
     private Schema projectedPlannerSchema(String manifestFormat) {

--- a/paimon-core/src/test/java/org/apache/paimon/manifest/BinaryManifestEntryReusableIdentifierTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/manifest/BinaryManifestEntryReusableIdentifierTest.java
@@ -1,0 +1,118 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.manifest;
+
+import org.apache.paimon.data.BinaryString;
+import org.apache.paimon.data.GenericArray;
+import org.apache.paimon.data.GenericRow;
+import org.apache.paimon.io.DataFileMeta;
+import org.apache.paimon.manifest.BinaryManifestEntry.ReusableIdentifier;
+import org.apache.paimon.types.DataField;
+import org.apache.paimon.types.RowType;
+import org.apache.paimon.utils.VersionedObjectSerializer;
+
+import org.junit.jupiter.api.Test;
+
+import javax.annotation.Nullable;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/** Tests for {@link ReusableIdentifier}. */
+class BinaryManifestEntryReusableIdentifierTest {
+
+    @Test
+    void testEncodesIdentifierFields() {
+        ReusableIdentifier identifier = new ReusableIdentifier();
+
+        assertThat(
+                        identifier.replace(
+                                entry(3, 2, "f", new String[] {"a", "bc"}, new byte[] {7, 8}, "x")))
+                .isSameAs(identifier);
+
+        assertThat(Arrays.copyOf(identifier.bytes(), identifier.length()))
+                .containsExactly(
+                        0, 0, 0, 3, 0, 0, 0, 2, 0, 0, 0, 1, 102, 0, 0, 0, 2, 0, 0, 0, 1, 97, 0, 0,
+                        0, 2, 98, 99, 0, 0, 0, 2, 7, 8, 0, 0, 0, 1, 120);
+    }
+
+    @Test
+    void testReusesAndReleasesBuffer() {
+        ReusableIdentifier identifier = new ReusableIdentifier();
+        BinaryManifestEntry entry = entry(1, 0, "file", new String[0], null, null);
+
+        identifier.replace(entry);
+        byte[] expected = Arrays.copyOf(identifier.bytes(), identifier.length());
+        assertThat(expected).endsWith((byte) 0xff, (byte) 0xff, (byte) 0xff, (byte) 0xff);
+
+        identifier.release();
+        assertThat(identifier.length()).isZero();
+        assertThat(identifier.bytes()).isEmpty();
+
+        identifier.replace(entry);
+        assertThat(Arrays.copyOf(identifier.bytes(), identifier.length())).isEqualTo(expected);
+    }
+
+    @Test
+    void testRejectsNullEntry() {
+        assertThatThrownBy(() -> new ReusableIdentifier().replace(null))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    private static BinaryManifestEntry entry(
+            int bucket,
+            int level,
+            String fileName,
+            String[] extraFiles,
+            @Nullable byte[] embeddedIndex,
+            @Nullable String externalPath) {
+        RowType manifestType = VersionedObjectSerializer.versionType(ManifestEntry.SCHEMA);
+        RowType fileType =
+                DataFileMeta.SCHEMA.project(
+                        DataFileMeta.LEVEL,
+                        DataFileMeta.FILE_NAME,
+                        DataFileMeta.EXTRA_FILES,
+                        DataFileMeta.EMBEDDED_FILE_INDEX,
+                        DataFileMeta.EXTERNAL_PATH);
+        List<DataField> fields =
+                Arrays.asList(
+                        manifestType.getField(ManifestEntry.BUCKET),
+                        manifestType.getField(ManifestEntry.FILE).newType(fileType));
+        Object[] extraFileValues = new Object[extraFiles.length];
+        for (int i = 0; i < extraFiles.length; i++) {
+            extraFileValues[i] = BinaryString.fromString(extraFiles[i]);
+        }
+        return BinaryManifestEntry.Projection.create(new RowType(false, fields))
+                .createEntry()
+                .replace(
+                        GenericRow.of(
+                                bucket,
+                                GenericRow.of(
+                                        level,
+                                        BinaryString.fromString(fileName),
+                                        new GenericArray(extraFileValues),
+                                        embeddedIndex,
+                                        externalPath == null
+                                                ? null
+                                                : BinaryString.fromString(externalPath))));
+    }
+}

--- a/paimon-core/src/test/java/org/apache/paimon/manifest/BinaryManifestEntryTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/manifest/BinaryManifestEntryTest.java
@@ -18,15 +18,12 @@
 
 package org.apache.paimon.manifest;
 
-import org.apache.paimon.CoreOptions;
 import org.apache.paimon.data.BinaryRow;
 import org.apache.paimon.data.BinaryString;
 import org.apache.paimon.data.GenericArray;
 import org.apache.paimon.data.GenericRow;
-import org.apache.paimon.format.FileFormat;
 import org.apache.paimon.io.BinaryDataFileMeta;
 import org.apache.paimon.io.DataFileMeta;
-import org.apache.paimon.options.Options;
 import org.apache.paimon.types.DataField;
 import org.apache.paimon.types.RowType;
 import org.apache.paimon.utils.VersionedObjectSerializer;
@@ -156,7 +153,7 @@ public class BinaryManifestEntryTest {
                                 manifestType.getField(ManifestEntry.PARTITION),
                                 manifestType.getField(ManifestEntry.KIND)));
         BinaryManifestEntry entry =
-                BinaryManifestEntry.Projection.create(format(), projectedType)
+                BinaryManifestEntry.Projection.create(projectedType)
                         .createEntry()
                         .replace(
                                 GenericRow.of(
@@ -215,7 +212,7 @@ public class BinaryManifestEntryTest {
                         java.util.Collections.singletonList(
                                 manifestType.getField(ManifestEntry.KIND)));
         BinaryManifestEntry entry =
-                BinaryManifestEntry.Projection.create(format(), projectedType)
+                BinaryManifestEntry.Projection.create(projectedType)
                         .createEntry()
                         .replace(GenericRow.of(FileKind.ADD.toByteValue()));
 
@@ -232,7 +229,7 @@ public class BinaryManifestEntryTest {
                         java.util.Collections.singletonList(
                                 manifestType.getField(ManifestEntry.KIND)));
         BinaryManifestEntry entry =
-                BinaryManifestEntry.Projection.create(format(), projectedType)
+                BinaryManifestEntry.Projection.create(projectedType)
                         .createEntry()
                         .replace(GenericRow.of((byte) 99));
 
@@ -253,11 +250,7 @@ public class BinaryManifestEntryTest {
                 manifestType
                         .getField(ManifestEntry.FILE)
                         .newType(DataFileMeta.SCHEMA.project(projectedFileFields)));
-        return BinaryManifestEntry.Projection.create(format(), new RowType(false, fields));
-    }
-
-    private static FileFormat format() {
-        return FileFormat.manifestFormat(new CoreOptions(new Options()));
+        return BinaryManifestEntry.Projection.create(new RowType(false, fields));
     }
 
     private static void assertUnsupported(ThrowingSupplier call, String field) {

--- a/paimon-core/src/test/java/org/apache/paimon/manifest/ManifestFileTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/manifest/ManifestFileTest.java
@@ -25,11 +25,16 @@ import org.apache.paimon.fs.FileIO;
 import org.apache.paimon.fs.FileIOFinder;
 import org.apache.paimon.fs.Path;
 import org.apache.paimon.fs.local.LocalFileIO;
+import org.apache.paimon.io.DataFileMeta;
 import org.apache.paimon.options.Options;
 import org.apache.paimon.schema.SchemaManager;
 import org.apache.paimon.stats.StatsTestUtils;
+import org.apache.paimon.types.DataField;
+import org.apache.paimon.types.RowType;
+import org.apache.paimon.utils.CloseableIterator;
 import org.apache.paimon.utils.FailingFileIO;
 import org.apache.paimon.utils.FileStorePathFactory;
+import org.apache.paimon.utils.VersionedObjectSerializer;
 
 import org.junit.jupiter.api.RepeatedTest;
 import org.junit.jupiter.api.Test;
@@ -37,14 +42,18 @@ import org.junit.jupiter.api.io.TempDir;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.UUID;
 import java.util.concurrent.ThreadLocalRandom;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
 
 import static org.apache.paimon.TestKeyValueGenerator.DEFAULT_PART_TYPE;
 import static org.apache.paimon.stats.StatsTestUtils.convertWithoutSchemaEvolution;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /** Tests for {@link ManifestFile}. */
 public class ManifestFileTest {
@@ -120,6 +129,112 @@ public class ManifestFileTest {
         assertThat(creationTimesFound).isPositive();
     }
 
+    @Test
+    void testScanProjectedManifestEntries() throws Exception {
+        List<ManifestEntry> entries = Arrays.asList(gen.next(), gen.next(), gen.next());
+        ManifestFile manifestFile = createManifestFile(tempDir.toString(), Long.MAX_VALUE);
+        ManifestFileMeta manifest = writeSingleManifest(manifestFile, entries);
+        BinaryManifestEntry.Projection projection =
+                projection(DataFileMeta.FILE_NAME, DataFileMeta.ROW_COUNT);
+        List<String> fileNames = new ArrayList<>();
+        List<Long> rowCounts = new ArrayList<>();
+        AtomicReference<BinaryManifestEntry> retained = new AtomicReference<>();
+
+        try (CloseableIterator<BinaryManifestEntry> iterator =
+                manifestFile.scan(manifest.fileName(), manifest.fileSize(), projection)) {
+            while (iterator.hasNext()) {
+                BinaryManifestEntry entry = iterator.next();
+                BinaryManifestEntry previous = retained.getAndSet(entry);
+                if (previous != null) {
+                    assertThat(entry).isSameAs(previous);
+                }
+                fileNames.add(entry.fileName());
+                rowCounts.add(entry.rowCount());
+            }
+        }
+
+        assertThat(fileNames)
+                .containsExactlyElementsOf(
+                        entries.stream().map(ManifestEntry::fileName).collect(Collectors.toList()));
+        assertThat(rowCounts)
+                .containsExactlyElementsOf(
+                        entries.stream().map(ManifestEntry::rowCount).collect(Collectors.toList()));
+        assertCleared(retained.get());
+    }
+
+    @Test
+    void testScanProjectedManifestInvalidatesEntryWhenAdvancing() throws Exception {
+        List<ManifestEntry> entries = Arrays.asList(gen.next(), gen.next());
+        ManifestFile manifestFile = createManifestFile(tempDir.toString(), Long.MAX_VALUE);
+        ManifestFileMeta manifest = writeSingleManifest(manifestFile, entries);
+
+        try (CloseableIterator<BinaryManifestEntry> iterator =
+                manifestFile.scan(
+                        manifest.fileName(),
+                        manifest.fileSize(),
+                        projection(DataFileMeta.FILE_NAME))) {
+            assertThat(iterator.hasNext()).isTrue();
+            BinaryManifestEntry first = iterator.next();
+            assertThat(first.fileName()).isEqualTo(entries.get(0).fileName());
+
+            assertThat(iterator.hasNext()).isTrue();
+            assertCleared(first);
+            BinaryManifestEntry second = iterator.next();
+            assertThat(second).isSameAs(first);
+            assertThat(second.fileName()).isEqualTo(entries.get(1).fileName());
+        }
+    }
+
+    @Test
+    void testScanProjectedManifestCanStopEarly() throws Exception {
+        List<ManifestEntry> entries = Arrays.asList(gen.next(), gen.next(), gen.next());
+        ManifestFile manifestFile = createManifestFile(tempDir.toString(), Long.MAX_VALUE);
+        ManifestFileMeta manifest = writeSingleManifest(manifestFile, entries);
+        AtomicInteger visited = new AtomicInteger();
+        AtomicReference<BinaryManifestEntry> retained = new AtomicReference<>();
+
+        try (CloseableIterator<BinaryManifestEntry> iterator =
+                manifestFile.scan(
+                        manifest.fileName(),
+                        manifest.fileSize(),
+                        projection(DataFileMeta.FILE_NAME))) {
+            while (iterator.hasNext()) {
+                BinaryManifestEntry entry = iterator.next();
+                retained.set(entry);
+                visited.incrementAndGet();
+                break;
+            }
+        }
+
+        assertThat(visited).hasValue(1);
+        assertCleared(retained.get());
+    }
+
+    @Test
+    void testScanProjectedManifestClearsEntryWhenProcessingFails() {
+        List<ManifestEntry> entries = Arrays.asList(gen.next(), gen.next());
+        ManifestFile manifestFile = createManifestFile(tempDir.toString(), Long.MAX_VALUE);
+        ManifestFileMeta manifest = writeSingleManifest(manifestFile, entries);
+        RuntimeException failure = new RuntimeException("Expected processing failure.");
+        AtomicReference<BinaryManifestEntry> retained = new AtomicReference<>();
+
+        assertThatThrownBy(
+                        () -> {
+                            try (CloseableIterator<BinaryManifestEntry> iterator =
+                                    manifestFile.scan(
+                                            manifest.fileName(),
+                                            manifest.fileSize(),
+                                            projection(DataFileMeta.FILE_NAME))) {
+                                assertThat(iterator.hasNext()).isTrue();
+                                BinaryManifestEntry entry = iterator.next();
+                                retained.set(entry);
+                                throw failure;
+                            }
+                        })
+                .isSameAs(failure);
+        assertCleared(retained.get());
+    }
+
     private List<ManifestEntry> generateData() {
         List<ManifestEntry> entries = new ArrayList<>();
         for (int i = 0; i < 100; i++) {
@@ -129,6 +244,10 @@ public class ManifestFileTest {
     }
 
     private ManifestFile createManifestFile(String pathStr) {
+        return createManifestFile(pathStr, ThreadLocalRandom.current().nextInt(8192) + 1024);
+    }
+
+    private ManifestFile createManifestFile(String pathStr, long suggestedFileSize) {
         Path path = new Path(pathStr);
         FileStorePathFactory pathFactory =
                 new FileStorePathFactory(
@@ -147,7 +266,6 @@ public class ManifestFileTest {
                         null,
                         false,
                         null);
-        int suggestedFileSize = ThreadLocalRandom.current().nextInt(8192) + 1024;
         FileIO fileIO = FileIOFinder.find(path);
         return new ManifestFile.Factory(
                         fileIO,
@@ -159,6 +277,31 @@ public class ManifestFileTest {
                         suggestedFileSize,
                         null)
                 .create();
+    }
+
+    private ManifestFileMeta writeSingleManifest(
+            ManifestFile manifestFile, List<ManifestEntry> entries) {
+        List<ManifestFileMeta> manifests = manifestFile.write(entries);
+        assertThat(manifests).hasSize(1);
+        return manifests.get(0);
+    }
+
+    private BinaryManifestEntry.Projection projection(String... projectedFileFields) {
+        RowType manifestType = VersionedObjectSerializer.versionType(ManifestEntry.SCHEMA);
+        List<DataField> fields =
+                Arrays.asList(
+                        manifestType.getField(ManifestEntry.KIND),
+                        manifestType.getField(ManifestEntry.PARTITION),
+                        manifestType
+                                .getField(ManifestEntry.FILE)
+                                .newType(DataFileMeta.SCHEMA.project(projectedFileFields)));
+        return BinaryManifestEntry.Projection.create(new RowType(false, fields));
+    }
+
+    private static void assertCleared(BinaryManifestEntry entry) {
+        assertThatThrownBy(entry::fileName)
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("not backed by a row");
     }
 
     private void checkRollingFiles(


### PR DESCRIPTION
## What changed

- Generalize `BinaryManifestEntry` and `BinaryDataFileMeta` so projected manifest rows can be consumed through the standard manifest entry interfaces.
- Add a closeable projected scan API to `ManifestFile` and reuse it from row ID assignment planning.
- Make `DataEvolutionRowIdAssignmentPlanner` a one-shot planner that directly produces `RowRangeMappingIndex` values, with the manifest passes split into focused methods.
- Extract reusable primitive utilities for byte-array lookup, deleted identifiers, triples, and row ranges.
- Move current row ID entry storage into `CurrentRowIdEntries` and add focused tests for the new abstractions.

## Why

The row ID assignment planner contained format-specific manifest reading, schema-specific binary wrappers, identifier encoding, and several primitive data structures. This made the planner difficult to follow and duplicated functionality that can be shared by other low-memory manifest consumers.

## Impact

The planner keeps the existing row ID assignment behavior while reducing its responsibilities and retaining projected binary data instead of materializing full manifest entries. The new manifest scan and primitive range abstractions are reusable by other callers.

## Tests

```text
mvn -pl paimon-core -am -DfailIfNoTests=false -DwildcardSuites=none \
  -Dtest=ByteArrayKeyTest,DeletedIdentifierSetTest,LongTripleArrayListTest,PrimitiveRowRangesTest,BinaryManifestEntryReusableIdentifierTest,CurrentRowIdEntriesTest,ManifestFileTest,BinaryManifestEntryTest,BinaryDataFileMetaTest,RowRangeMappingIndexTest,DataEvolutionRowIdReassignerTest test
```

Common: 18 tests passed.
Core: 93 tests passed.
