### PR TITLE
[flink] Fix flaky UT timeout on testSpecifyKeys

### DIFF
--- a/paimon-flink/paimon-flink-cdc/src/test/java/org/apache/paimon/flink/action/cdc/mysql/MySqlSyncDatabaseActionITCase.java
+++ b/paimon-flink/paimon-flink-cdc/src/test/java/org/apache/paimon/flink/action/cdc/mysql/MySqlSyncDatabaseActionITCase.java
@@ -1392,7 +1392,7 @@ public class MySqlSyncDatabaseActionITCase extends MySqlActionITCaseBase {
     }
 
     @Test
-    @Timeout(60)
+    @Timeout(120)
     public void testSpecifyKeys() throws Exception {
         Map<String, String> mySqlConfig = getBasicMySqlConfig();
         mySqlConfig.put("database-name", "test_specify_keys");


### PR DESCRIPTION
### Purpose
 - MySqlSyncDatabaseActionITCase.testSpecifyKeys is timing out on CI occasionally, it has logic to randomly pick between divided/combined mode.
 - When combined mode is selected, there are additional create table statements executed.
 - Increase timeout to 120s to avoid timeout on high contention

### Tests
 - Existing UT