### PR TITLE
[spark] Reduce driver memory usage when deserializing compact commit messages

### DIFF
--- a/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/procedure/CompactProcedure.java
+++ b/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/procedure/CompactProcedure.java
@@ -382,10 +382,8 @@ public class CompactProcedure extends BaseProcedure {
         try (BatchTableCommit commit = writeBuilder.newCommit()) {
             CommitMessageSerializer serializer = new CommitMessageSerializer();
             List<byte[]> serializedMessages = commitMessageJavaRDD.collect();
-            List<CommitMessage> messages = new ArrayList<>(serializedMessages.size());
-            for (byte[] serializedMessage : serializedMessages) {
-                messages.add(serializer.deserialize(serializer.getVersion(), serializedMessage));
-            }
+            List<CommitMessage> messages =
+                    deserializeAndReleaseCommitMessages(serializer, serializedMessages);
             commit.commit(messages);
         } catch (Exception e) {
             throw new RuntimeException(e);
@@ -481,12 +479,8 @@ public class CompactProcedure extends BaseProcedure {
         try (TableCommitImpl commit = table.newCommit(commitUser)) {
             CommitMessageSerializer messageSerializerser = new CommitMessageSerializer();
             List<byte[]> serializedMessages = commitMessageJavaRDD.collect();
-            List<CommitMessage> messages = new ArrayList<>(serializedMessages.size());
-            for (byte[] serializedMessage : serializedMessages) {
-                messages.add(
-                        messageSerializerser.deserialize(
-                                messageSerializerser.getVersion(), serializedMessage));
-            }
+            List<CommitMessage> messages =
+                    deserializeAndReleaseCommitMessages(messageSerializerser, serializedMessages);
             commit.commit(messages);
         } catch (Exception e) {
             throw new RuntimeException(e);
@@ -578,14 +572,10 @@ public class CompactProcedure extends BaseProcedure {
                                                     return messagesBytes.iterator();
                                                 });
 
-                List<CommitMessage> messages = new ArrayList<>();
                 List<byte[]> serializedMessages = commitMessageJavaRDD.collect();
                 try (TableCommitImpl commit = table.newCommit(commitUser)) {
-                    for (byte[] serializedMessage : serializedMessages) {
-                        messages.add(
-                                messageSerializerser.deserialize(
-                                        messageSerializerser.getVersion(), serializedMessage));
-                    }
+                    List<CommitMessage> messages =
+                            deserializeAndReleaseCommitMessages(messageSerializerser, serializedMessages);
                     messages.addAll(
                             new DataEvolutionCompactionCommitPreparation(table, snapshot)
                                     .prepare(messages));
@@ -597,6 +587,17 @@ public class CompactProcedure extends BaseProcedure {
         } catch (EndOfScanException e) {
             LOG.info("Catching EndOfScanException, the compact job is finishing.");
         }
+    }
+
+    private static List<CommitMessage> deserializeAndReleaseCommitMessages(
+            CommitMessageSerializer serializer, List<byte[]> serializedMessages)
+            throws IOException {
+        List<CommitMessage> messages = new ArrayList<>(serializedMessages.size());
+        for (int i = 0; i < serializedMessages.size(); i++) {
+            byte[] serializedMessage = serializedMessages.set(i, null);
+            messages.add(serializer.deserialize(serializer.getVersion(), serializedMessage));
+        }
+        return messages;
     }
 
     private Set<BinaryRow> getHistoryPartition(

--- a/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/procedure/CompactProcedure.java
+++ b/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/procedure/CompactProcedure.java
@@ -575,7 +575,8 @@ public class CompactProcedure extends BaseProcedure {
                 List<byte[]> serializedMessages = commitMessageJavaRDD.collect();
                 try (TableCommitImpl commit = table.newCommit(commitUser)) {
                     List<CommitMessage> messages =
-                            deserializeAndReleaseCommitMessages(messageSerializerser, serializedMessages);
+                            deserializeAndReleaseCommitMessages(
+                                    messageSerializerser, serializedMessages);
                     messages.addAll(
                             new DataEvolutionCompactionCommitPreparation(table, snapshot)
                                     .prepare(messages));

--- a/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/procedure/CompactProcedure.java
+++ b/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/procedure/CompactProcedure.java
@@ -381,7 +381,7 @@ public class CompactProcedure extends BaseProcedure {
 
         try (BatchTableCommit commit = writeBuilder.newCommit()) {
             CommitMessageSerializer serializer = new CommitMessageSerializer();
-            List<byte[]> serializedMessages = commitMessageJavaRDD.collect();
+            List<byte[]> serializedMessages = new ArrayList<>(commitMessageJavaRDD.collect());
             List<CommitMessage> messages =
                     deserializeAndReleaseCommitMessages(serializer, serializedMessages);
             commit.commit(messages);
@@ -478,7 +478,7 @@ public class CompactProcedure extends BaseProcedure {
 
         try (TableCommitImpl commit = table.newCommit(commitUser)) {
             CommitMessageSerializer messageSerializerser = new CommitMessageSerializer();
-            List<byte[]> serializedMessages = commitMessageJavaRDD.collect();
+            List<byte[]> serializedMessages = new ArrayList<>(commitMessageJavaRDD.collect());
             List<CommitMessage> messages =
                     deserializeAndReleaseCommitMessages(messageSerializerser, serializedMessages);
             commit.commit(messages);
@@ -572,7 +572,7 @@ public class CompactProcedure extends BaseProcedure {
                                                     return messagesBytes.iterator();
                                                 });
 
-                List<byte[]> serializedMessages = commitMessageJavaRDD.collect();
+                List<byte[]> serializedMessages = new ArrayList<>(commitMessageJavaRDD.collect());
                 try (TableCommitImpl commit = table.newCommit(commitUser)) {
                     List<CommitMessage> messages =
                             deserializeAndReleaseCommitMessages(

--- a/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/procedure/CompactProcedure.java
+++ b/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/procedure/CompactProcedure.java
@@ -383,7 +383,8 @@ public class CompactProcedure extends BaseProcedure {
             CommitMessageSerializer serializer = new CommitMessageSerializer();
             List<byte[]> serializedMessages = new ArrayList<>(commitMessageJavaRDD.collect());
             List<CommitMessage> messages =
-                    deserializeAndReleaseCommitMessages(serializer, serializedMessages);
+                    deserializeCommitMessagesAndReleaseSerializedBytes(
+                            serializer, serializedMessages);
             commit.commit(messages);
         } catch (Exception e) {
             throw new RuntimeException(e);
@@ -480,7 +481,8 @@ public class CompactProcedure extends BaseProcedure {
             CommitMessageSerializer messageSerializerser = new CommitMessageSerializer();
             List<byte[]> serializedMessages = new ArrayList<>(commitMessageJavaRDD.collect());
             List<CommitMessage> messages =
-                    deserializeAndReleaseCommitMessages(messageSerializerser, serializedMessages);
+                    deserializeCommitMessagesAndReleaseSerializedBytes(
+                            messageSerializerser, serializedMessages);
             commit.commit(messages);
         } catch (Exception e) {
             throw new RuntimeException(e);
@@ -575,7 +577,7 @@ public class CompactProcedure extends BaseProcedure {
                 List<byte[]> serializedMessages = new ArrayList<>(commitMessageJavaRDD.collect());
                 try (TableCommitImpl commit = table.newCommit(commitUser)) {
                     List<CommitMessage> messages =
-                            deserializeAndReleaseCommitMessages(
+                            deserializeCommitMessagesAndReleaseSerializedBytes(
                                     messageSerializerser, serializedMessages);
                     messages.addAll(
                             new DataEvolutionCompactionCommitPreparation(table, snapshot)
@@ -590,7 +592,7 @@ public class CompactProcedure extends BaseProcedure {
         }
     }
 
-    private static List<CommitMessage> deserializeAndReleaseCommitMessages(
+    private static List<CommitMessage> deserializeCommitMessagesAndReleaseSerializedBytes(
             CommitMessageSerializer serializer, List<byte[]> serializedMessages)
             throws IOException {
         List<CommitMessage> messages = new ArrayList<>(serializedMessages.size());


### PR DESCRIPTION
### Purpose
  Release serialized commit message byte arrays as they are deserialized to avoid
  retaining both serialized and deserialized messages in driver memory.

### Tests
No