### PR TITLE
[python] Fix Python CI checks

### DIFF
--- a/paimon-python/pypaimon/tests/py36/rest_ao_read_write_test.py
+++ b/paimon-python/pypaimon/tests/py36/rest_ao_read_write_test.py
@@ -16,8 +16,10 @@
 # under the License.
 
 import logging
-import time
 import random
+import sys
+import time
+import unittest
 from datetime import date
 from decimal import Decimal
 from unittest.mock import Mock
@@ -649,6 +651,10 @@ class RESTAOReadWritePy36Test(RESTBaseTest):
             table_write.write_arrow_batch(record_batch)
         self.assertTrue(str(e.exception).startswith("Input schema isn't consistent with table schema and write cols."))
 
+    @unittest.skipIf(
+        sys.version_info[:2] == (3, 6),
+        "Large wide-table test is prohibitively slow on Python 3.6."
+    )
     def test_write_wide_table_large_data(self):
         logging.basicConfig(level=logging.INFO)
         catalog = CatalogFactory.create(self.options)

--- a/paimon-python/pypaimon/tests/shard_table_updator_test.py
+++ b/paimon-python/pypaimon/tests/shard_table_updator_test.py
@@ -651,7 +651,6 @@ class ShardTableUpdatorTest(unittest.TestCase):
             "Row-id-check commits must enable conflict detection."
         )
 
-
     def test_shard_update_ignores_target_file_row_num(self):
         """Regression: a shard maps to exactly one output file, so
         target-file-row-num must not split it. Before the fix the


### PR DESCRIPTION
### Purpose

The Python 3.6 check spends hours in the wide-table stress test because it generates 500,000 rows across 200 string columns with the legacy dependency set. In addition, an existing E303 formatting violation on master makes every Python lint lane fail before tests start.

### Changes

- Skip the wide-table stress test only on Python 3.6; Python 3.7 and later continue to run it.
- Remove the extra blank line that causes the existing E303 failure.

### Tests

- Full Python flake8 check
- Python 3.6 rest_ao_read_write_test.py: 28 passed, 1 skipped