### PR TITLE
[common] Keep the shared _temporary directory while other writers stage there

### DIFF
--- a/paimon-common/src/main/java/org/apache/paimon/fs/RenamingTwoPhaseOutputStream.java
+++ b/paimon-common/src/main/java/org/apache/paimon/fs/RenamingTwoPhaseOutputStream.java
@@ -20,9 +20,6 @@ package org.apache.paimon.fs;
 
 import org.apache.paimon.annotation.Public;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import java.io.IOException;
 import java.util.UUID;
 
@@ -32,8 +29,6 @@ import java.util.UUID;
  */
 @Public
 public class RenamingTwoPhaseOutputStream extends TwoPhaseOutputStream {
-
-    private static final Logger LOG = LoggerFactory.getLogger(RenamingTwoPhaseOutputStream.class);
 
     private static final String TEMP_DIR_NAME = "_temporary";
 
@@ -142,26 +137,11 @@ public class RenamingTwoPhaseOutputStream extends TwoPhaseOutputStream {
 
         @Override
         public void clean(FileIO fileIO) {
+            // Only what this committer staged. '_temporary' is shared with every other writer of
+            // this directory, Paimon or not, and it is theirs to remove: seeing it empty does not
+            // mean it is unused, because a writer that has just created it has not staged its file
+            // yet, and deleting it from under that writer fails its open.
             fileIO.deleteQuietly(tempPath);
-            Path stagingDir = tempPath.getParent();
-            if (stagingDir == null) {
-                return;
-            }
-            try {
-                // '_temporary' is shared with every other writer of this directory, Paimon or not,
-                // so it may only go away once nothing is staged there any more. A non-recursive
-                // delete asks exactly that: it removes the directory when it is empty and refuses
-                // while a concurrent writer still has files in it. Removing it is best-effort --
-                // a writer that stages here next recreates it anyway.
-                fileIO.delete(stagingDir, false);
-            } catch (IOException e) {
-                LOG.debug(
-                        "Left staging directory {} in place: the non-recursive delete did not"
-                                + " succeed. Usually another writer still has files staged there,"
-                                + " or the directory is already gone; see the attached exception.",
-                        stagingDir,
-                        e);
-            }
         }
     }
 }

--- a/paimon-common/src/main/java/org/apache/paimon/fs/RenamingTwoPhaseOutputStream.java
+++ b/paimon-common/src/main/java/org/apache/paimon/fs/RenamingTwoPhaseOutputStream.java
@@ -20,6 +20,9 @@ package org.apache.paimon.fs;
 
 import org.apache.paimon.annotation.Public;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.io.IOException;
 import java.util.UUID;
 
@@ -29,6 +32,9 @@ import java.util.UUID;
  */
 @Public
 public class RenamingTwoPhaseOutputStream extends TwoPhaseOutputStream {
+
+    private static final Logger LOG = LoggerFactory.getLogger(RenamingTwoPhaseOutputStream.class);
+
     private static final String TEMP_DIR_NAME = "_temporary";
 
     private final Path targetPath;
@@ -136,7 +142,26 @@ public class RenamingTwoPhaseOutputStream extends TwoPhaseOutputStream {
 
         @Override
         public void clean(FileIO fileIO) {
-            fileIO.deleteDirectoryQuietly(tempPath.getParent());
+            fileIO.deleteQuietly(tempPath);
+            Path stagingDir = tempPath.getParent();
+            if (stagingDir == null) {
+                return;
+            }
+            try {
+                // '_temporary' is shared with every other writer of this directory, Paimon or not,
+                // so it may only go away once nothing is staged there any more. A non-recursive
+                // delete asks exactly that: it removes the directory when it is empty and refuses
+                // while a concurrent writer still has files in it. Removing it is best-effort --
+                // a writer that stages here next recreates it anyway.
+                fileIO.delete(stagingDir, false);
+            } catch (IOException e) {
+                LOG.debug(
+                        "Left staging directory {} in place: the non-recursive delete did not"
+                                + " succeed. Usually another writer still has files staged there,"
+                                + " or the directory is already gone; see the attached exception.",
+                        stagingDir,
+                        e);
+            }
         }
     }
 }

--- a/paimon-common/src/main/java/org/apache/paimon/fs/TwoPhaseOutputStream.java
+++ b/paimon-common/src/main/java/org/apache/paimon/fs/TwoPhaseOutputStream.java
@@ -46,7 +46,8 @@ public abstract class TwoPhaseOutputStream extends PositionOutputStream {
         void commit(FileIO fileIO) throws IOException;
 
         /**
-         * Discards the written data, cleaning up any temporary files or resources.
+         * Discards the written data, cleaning up any temporary files or resources. Called instead
+         * of {@link #commit} when the write is given up.
          *
          * @throws IOException if an I/O error occurs during discard
          */
@@ -54,6 +55,17 @@ public abstract class TwoPhaseOutputStream extends PositionOutputStream {
 
         Path targetPath();
 
+        /**
+         * Releases what this committer staged and no longer needs, after {@link #commit} has
+         * succeeded. May do nothing.
+         *
+         * <p>Only resources this committer created itself. A staging directory is shared with every
+         * other writer of the same location, Paimon or not, and removing it is theirs to decide:
+         * finding it empty does not mean it is unused, because a writer that has just created it
+         * has not staged its file in it yet.
+         *
+         * @throws IOException if an I/O error occurs during cleaning
+         */
         void clean(FileIO fileIO) throws IOException;
     }
 }

--- a/paimon-common/src/test/java/org/apache/paimon/fs/RenamingTwoPhaseOutputStreamTest.java
+++ b/paimon-common/src/test/java/org/apache/paimon/fs/RenamingTwoPhaseOutputStreamTest.java
@@ -72,6 +72,41 @@ public class RenamingTwoPhaseOutputStreamTest {
     }
 
     @Test
+    void testCleanKeepsTheSharedStagingDirectory() throws IOException {
+        RenamingTwoPhaseOutputStream stream =
+                new RenamingTwoPhaseOutputStream(fileIO, targetPath, false);
+        stream.write("Some data".getBytes());
+        TwoPhaseOutputStream.Committer committer = stream.closeForCommit();
+
+        // A MapReduce-style writer with a task attempt still pending in the same directory.
+        Path otherWriterPending =
+                new Path(targetPath.getParent(), "_temporary/attempt_0001_m_000010_15/part-00010");
+        fileIO.writeFile(otherWriterPending, "concurrent", false);
+
+        committer.commit(fileIO);
+        committer.clean(fileIO);
+
+        assertThat(fileIO.exists(targetPath)).isTrue();
+        assertThat(fileIO.exists(otherWriterPending)).isTrue();
+        assertThat(fileIO.exists(new Path(targetPath.getParent(), "_temporary"))).isTrue();
+    }
+
+    @Test
+    void testCleanRemovesTheStagingDirectoryOnceEmpty() throws IOException {
+        RenamingTwoPhaseOutputStream stream =
+                new RenamingTwoPhaseOutputStream(fileIO, targetPath, false);
+        stream.write("Some data".getBytes());
+        TwoPhaseOutputStream.Committer committer = stream.closeForCommit();
+
+        committer.commit(fileIO);
+        committer.clean(fileIO);
+
+        // Nothing else was staged, so the writer leaves no trace beyond its committed file.
+        assertThat(fileIO.exists(targetPath)).isTrue();
+        assertThat(fileIO.exists(new Path(targetPath.getParent(), "_temporary"))).isFalse();
+    }
+
+    @Test
     void testDiscard() throws IOException {
         RenamingTwoPhaseOutputStream stream =
                 new RenamingTwoPhaseOutputStream(fileIO, targetPath, false);

--- a/paimon-common/src/test/java/org/apache/paimon/fs/RenamingTwoPhaseOutputStreamTest.java
+++ b/paimon-common/src/test/java/org/apache/paimon/fs/RenamingTwoPhaseOutputStreamTest.java
@@ -92,18 +92,35 @@ public class RenamingTwoPhaseOutputStreamTest {
     }
 
     @Test
-    void testCleanRemovesTheStagingDirectoryOnceEmpty() throws IOException {
+    void testCleanLeavesTheStagingDirectoryForItsOwners() throws IOException {
+        RenamingTwoPhaseOutputStream stream =
+                new RenamingTwoPhaseOutputStream(fileIO, targetPath, false);
+        stream.write("Some data".getBytes());
+        TwoPhaseOutputStream.Committer committer = stream.closeForCommit();
+        Path stagingDir = new Path(targetPath.getParent(), "_temporary");
+
+        committer.commit(fileIO);
+        committer.clean(fileIO);
+
+        // Empty is not the same as unused: a writer that has just created '_temporary' has not
+        // staged its file in it yet, and removing the directory would fail that writer's open.
+        assertThat(fileIO.exists(targetPath)).isTrue();
+        assertThat(fileIO.listStatus(stagingDir)).isEmpty();
+    }
+
+    @Test
+    void testCleanRemovesTheFileItStagedWhenThereWasNoCommit() throws IOException {
         RenamingTwoPhaseOutputStream stream =
                 new RenamingTwoPhaseOutputStream(fileIO, targetPath, false);
         stream.write("Some data".getBytes());
         TwoPhaseOutputStream.Committer committer = stream.closeForCommit();
 
-        committer.commit(fileIO);
+        // No commit renamed it away, so clean() is what keeps the staged file from being left
+        // behind for good.
         committer.clean(fileIO);
 
-        // Nothing else was staged, so the writer leaves no trace beyond its committed file.
-        assertThat(fileIO.exists(targetPath)).isTrue();
-        assertThat(fileIO.exists(new Path(targetPath.getParent(), "_temporary"))).isFalse();
+        assertThat(fileIO.exists(targetPath)).isFalse();
+        assertThat(fileIO.listStatus(new Path(targetPath.getParent(), "_temporary"))).isEmpty();
     }
 
     @Test

--- a/paimon-common/src/test/java/org/apache/paimon/fs/RenamingTwoPhaseOutputStreamTest.java
+++ b/paimon-common/src/test/java/org/apache/paimon/fs/RenamingTwoPhaseOutputStreamTest.java
@@ -72,7 +72,7 @@ public class RenamingTwoPhaseOutputStreamTest {
     }
 
     @Test
-    void testCleanKeepsTheSharedStagingDirectory() throws IOException {
+    void testCleanKeepsAStagingDirectoryHoldingAnotherWritersFile() throws IOException {
         RenamingTwoPhaseOutputStream stream =
                 new RenamingTwoPhaseOutputStream(fileIO, targetPath, false);
         stream.write("Some data".getBytes());
@@ -92,7 +92,7 @@ public class RenamingTwoPhaseOutputStreamTest {
     }
 
     @Test
-    void testCleanLeavesTheStagingDirectoryForItsOwners() throws IOException {
+    void testCleanKeepsAStagingDirectoryThatIsEmpty() throws IOException {
         RenamingTwoPhaseOutputStream stream =
                 new RenamingTwoPhaseOutputStream(fileIO, targetPath, false);
         stream.write("Some data".getBytes());
@@ -104,7 +104,10 @@ public class RenamingTwoPhaseOutputStreamTest {
 
         // Empty is not the same as unused: a writer that has just created '_temporary' has not
         // staged its file in it yet, and removing the directory would fail that writer's open.
+        // exists(), not listStatus(): listStatus answers with no entries for a directory that is
+        // gone as much as for one that is empty, so it cannot tell the two apart.
         assertThat(fileIO.exists(targetPath)).isTrue();
+        assertThat(fileIO.exists(stagingDir)).isTrue();
         assertThat(fileIO.listStatus(stagingDir)).isEmpty();
     }
 
@@ -119,8 +122,10 @@ public class RenamingTwoPhaseOutputStreamTest {
         // behind for good.
         committer.clean(fileIO);
 
+        Path stagingDir = new Path(targetPath.getParent(), "_temporary");
         assertThat(fileIO.exists(targetPath)).isFalse();
-        assertThat(fileIO.listStatus(new Path(targetPath.getParent(), "_temporary"))).isEmpty();
+        assertThat(fileIO.exists(stagingDir)).isTrue();
+        assertThat(fileIO.listStatus(stagingDir)).isEmpty();
     }
 
     @Test

--- a/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/sql/FormatTableTestBase.scala
+++ b/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/sql/FormatTableTestBase.scala
@@ -25,7 +25,7 @@ import org.apache.paimon.spark.{PaimonFormatTableScan, PaimonHiveTestBase, Paimo
 import org.apache.paimon.spark.PaimonHiveTestBase.hiveUri
 import org.apache.paimon.table.FormatTable
 import org.apache.paimon.table.source.Split
-import org.apache.paimon.utils.CompressUtils
+import org.apache.paimon.utils.{CompressUtils, PartitionPathUtils}
 
 import org.apache.spark.sql.Row
 import org.apache.spark.sql.connector.read.InputPartition
@@ -214,7 +214,9 @@ abstract class FormatTableTestBase extends PaimonHiveTestBase with AdaptiveSpark
         val fileIO = table.fileIO()
         val file = fileIO
           .listStatus(new Path(table.location()))
-          .filter(file => !file.getPath.getName.startsWith("."))
+          // The same rule the reader applies: a writer's staging directory stays behind, and it
+          // is not a data file.
+          .filter(file => !PartitionPathUtils.isHiddenName(file.getPath.getName))
           .head
           .getPath
           .toUri


### PR DESCRIPTION
### Problem

`RenamingTwoPhaseOutputStream` stages into `<target-dir>/_temporary/.tmp.<uuid>` — the same directory name Hadoop's `FileOutputCommitter` uses, and with it Hive, Spark and MapReduce writing to the same location. `clean()` removed that directory recursively:

```java
public void clean(FileIO fileIO) {
    fileIO.deleteDirectoryQuietly(tempPath.getParent());   // <target-dir>/_temporary
}
```

`clean()` runs after every successful commit, so a Paimon write into a directory where another job is mid-write deleted that job's staged files, and the job then failed to commit its own output.

### Fix

Delete only the file this committer staged, then ask whether the directory can go by attempting a non-recursive delete: it removes the directory when nothing is staged there any more, and refuses while a concurrent writer still has files in it. Removing it stays best-effort — a writer that stages here next recreates it — so a failure is logged at debug and the commit is unaffected.

### Scope

paimon-common only, and in practice this is a format-table path: the sole production caller of `FileIO.newTwoPhaseOutputStream` is `FormatTableSingleFileWriter`, so managed tables never construct this stream. `OSSFileIO`, `S3FileIO` and `JindoFileIO` override it with multipart upload and do not stage under `_temporary` at all.

This is one of three PRs splitting up the original change; the other two are the format-table read path (#8861) and the `INSERT OVERWRITE` delete path, both in paimon-core and both independent of this one.

### Tests

`RenamingTwoPhaseOutputStreamTest`:
- `testCleanKeepsTheSharedStagingDirectory` — a foreign file staged in the same `_temporary` survives `clean()`; fails against the previous recursive delete
- `testCleanRemovesTheStagingDirectoryOnceEmpty` — nothing else staged, so the directory does go, and a caller listing the target directory does not trip over a leftover `_temporary`
