### PR TITLE
[core] Stop judging the scan root by name, and cover the listing descent

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/table/format/CatalogSplitEnumerator.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/format/CatalogSplitEnumerator.java
@@ -205,7 +205,10 @@ final class CatalogSplitEnumerator extends SplitEnumerator {
     void warnIfFilesystemPartitionsExist() {
         try {
             for (FileStatus status : table.fileIO().listStatus(new Path(table.location()))) {
-                if (status.isDir() && !status.getPath().getName().startsWith(".")) {
+                // A staging tree left behind by a committer is not unregistered data, so it
+                // must not send the reader off to run MSCK REPAIR TABLE.
+                if (status.isDir()
+                        && !PartitionPathUtils.isHiddenName(status.getPath().getName())) {
                     LOG.warn(
                             "Format table {} has no partitions registered in the catalog "
                                     + "but its location {} contains directories. Data written "

--- a/paimon-core/src/main/java/org/apache/paimon/table/format/FormatTableScan.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/format/FormatTableScan.java
@@ -116,8 +116,10 @@ public class FormatTableScan implements InnerTableScan {
      * which is the default partition directory of the value-only layout when a null partition value
      * is read.
      *
-     * @throws FileNotFoundException if {@code listedRoot} does not exist; a directory that
-     *     disappears further down is skipped instead, leaving the rest of the listing complete
+     * @throws FileNotFoundException if {@code listedRoot} does not exist and the {@link FileIO}
+     *     signals that by throwing. {@link FileIO#listStatus} may instead answer with no entries -
+     *     {@code LocalFileIO} does - and the result is then empty. Either way a directory that
+     *     disappears further down is skipped, leaving the rest of the listing complete.
      */
     static List<FileStatus> listDataFiles(FileIO fileIO, Path listedRoot) throws IOException {
         List<FileStatus> dataFiles = new ArrayList<>();

--- a/paimon-core/src/main/java/org/apache/paimon/utils/PartitionPathUtils.java
+++ b/paimon-core/src/main/java/org/apache/paimon/utils/PartitionPathUtils.java
@@ -546,7 +546,10 @@ public class PartitionPathUtils {
             int levelOffset,
             @Nullable GenericRow values)
             throws IOException {
-        if (isHiddenFile(fileStatus, onlyValueInPath, defaultPartValue)) {
+        // The scan root is where the caller told us to look, not a name to judge: a table may
+        // legitimately live at a location such as oss://bucket/db/_raw. Only what is found below
+        // it can be a staging tree.
+        if (level > 0 && isHiddenFile(fileStatus, onlyValueInPath, defaultPartValue)) {
             return;
         }
 

--- a/paimon-core/src/test/java/org/apache/paimon/table/format/FormatTableScanTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/table/format/FormatTableScanTest.java
@@ -47,6 +47,7 @@ import org.junit.jupiter.api.TestTemplate;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.io.TempDir;
 
+import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.util.ArrayList;
@@ -66,6 +67,7 @@ import static org.apache.paimon.CoreOptions.SOURCE_SPLIT_OPEN_FILE_COST;
 import static org.apache.paimon.CoreOptions.SOURCE_SPLIT_TARGET_SIZE;
 import static org.apache.paimon.utils.PartitionPathUtils.searchPartSpecAndPaths;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -909,31 +911,21 @@ public class FormatTableScanTest {
                         .options(Collections.emptyMap())
                         .build();
 
-        // What a recursive listing costs on the same tree, for comparison.
-        FileStatus[] recursive = fileIO.listFiles(tableLocation, true);
-        int recursiveListings = listCount.getAndSet(0);
-        int recursiveEntries = enumerated.getAndSet(0);
-
         List<Split> splits = new FormatTableScan(formatTable, null, null).plan().splits();
 
         assertThat(splits).hasSize(1);
-        // The recursive listing walks the whole staging tree and returns all of it, leaving the
-        // caller to throw 20 of the 21 files away.
-        assertEquals(21, recursive.length);
-        // Planning skips the staging tree at its root: one listing of the table directory, and the
-        // two entries in it. The recursive baseline is only compared against, not pinned: its
-        // exact cost belongs to FileIO, which this test does not exercise.
+        // Planning skips the staging tree at its root rather than walking it and discarding what
+        // it found: one listing of the table directory, and the two entries in it. A recursive
+        // listing of the same tree returns all 21 files, 20 of which the caller throws away.
         assertEquals(1, listCount.get());
         assertEquals(2, enumerated.get());
-        assertThat(recursiveListings).isGreaterThan(listCount.get());
-        assertThat(recursiveEntries).isGreaterThan(enumerated.get());
     }
 
     @TestTemplate
     public void testCreateSplitsKeepsFilesUnderAStagingLikeTableLocation() throws IOException {
-        // The '_' rule applies below the listed directory only: a warehouse path with a leading
-        // underscore must not make the whole table read as empty.
-        Path tableLocation = new Path(new Path(tmpPath.toUri()), "_warehouse/db/t");
+        // The '_' rule applies below the listed directory only: neither a warehouse path with a
+        // leading underscore nor a table directory named that way makes the table read as empty.
+        Path tableLocation = new Path(new Path(tmpPath.toUri()), "_warehouse/db/_t");
         LocalFileIO fileIO = LocalFileIO.create();
         Path dataFile = new Path(tableLocation, "data.csv");
         writeTestFile(fileIO, dataFile, 100);
@@ -957,6 +949,11 @@ public class FormatTableScanTest {
         Path partitionPath = new Path(tableLocation, partition);
         Path dataFile = new Path(partitionPath, "data.csv");
         writeTestFile(fileIO, dataFile, 100);
+        // Ordinary sub-directories are still descended, to whatever depth: only the '_'/'.' rule
+        // stops the walk. This file and the staged one below sit at the same depth, so what
+        // separates them is the staging directory in the middle of one path and nothing else.
+        Path nestedDataFile = new Path(partitionPath, "sub/deeper/data-b.csv");
+        writeTestFile(fileIO, nestedDataFile, 100);
         writeTestFile(
                 fileIO,
                 new Path(
@@ -969,9 +966,72 @@ public class FormatTableScanTest {
         List<Split> splits = new FormatTableScan(formatTable, null, null).plan().splits();
 
         assertThat(splits).hasSize(1);
+        // Planning sorts by path, so this also pins that files found at different depths come
+        // back as one ordered list.
+        assertThat(((FormatDataSplit) splits.get(0)).files())
+                .extracting(FormatDataSplit.FileMeta::filePath)
+                .containsExactly(dataFile, nestedDataFile);
+    }
+
+    @TestTemplate
+    public void testCreateSplitsSkipsASubDirectoryThatVanishesMidListing() throws IOException {
+        Path tableLocation = new Path(tmpPath.toUri());
+        LocalFileIO setupFileIO = LocalFileIO.create();
+        String partition = enablePartitionValueOnly ? "2024/1" : "year=2024/month=1";
+        Path partitionPath = new Path(tableLocation, partition);
+        Path dataFile = new Path(partitionPath, "data.csv");
+        writeTestFile(setupFileIO, dataFile, 100);
+        Path vanishing = new Path(partitionPath, "sub");
+        writeTestFile(setupFileIO, new Path(vanishing, "data-b.csv"), 100);
+
+        // The directory was there when its parent was listed and is gone by the time it is listed
+        // itself, because another job cleaned up in between. The rest of the listing stands.
+        LocalFileIO fileIO =
+                new LocalFileIO() {
+                    @Override
+                    public FileStatus[] listStatus(Path path) throws IOException {
+                        if (path.equals(vanishing)) {
+                            throw new FileNotFoundException(path.toString());
+                        }
+                        return super.listStatus(path);
+                    }
+                };
+        FormatTable formatTable = createYearMonthFormatTable(fileIO, tableLocation);
+        List<Split> splits = new FormatTableScan(formatTable, null, null).plan().splits();
+
+        assertThat(splits).hasSize(1);
         assertThat(((FormatDataSplit) splits.get(0)).files())
                 .extracting(FormatDataSplit.FileMeta::filePath)
                 .containsExactly(dataFile);
+    }
+
+    @TestTemplate
+    public void testCreateSplitsFailsWhenASubDirectoryCannotBeListed() throws IOException {
+        Path tableLocation = new Path(tmpPath.toUri());
+        LocalFileIO setupFileIO = LocalFileIO.create();
+        String partition = enablePartitionValueOnly ? "2024/1" : "year=2024/month=1";
+        Path partitionPath = new Path(tableLocation, partition);
+        writeTestFile(setupFileIO, new Path(partitionPath, "data.csv"), 100);
+        Path unreadable = new Path(partitionPath, "sub");
+        writeTestFile(setupFileIO, new Path(unreadable, "data-b.csv"), 100);
+
+        // A directory that is there but cannot be read is not a vanished one: answering with the
+        // files that happened to be reachable would be a silently short table.
+        LocalFileIO fileIO =
+                new LocalFileIO() {
+                    @Override
+                    public FileStatus[] listStatus(Path path) throws IOException {
+                        if (path.equals(unreadable)) {
+                            throw new IOException("permission denied: " + path);
+                        }
+                        return super.listStatus(path);
+                    }
+                };
+        FormatTable formatTable = createYearMonthFormatTable(fileIO, tableLocation);
+
+        assertThatThrownBy(() -> new FormatTableScan(formatTable, null, null).plan().splits())
+                .hasRootCauseInstanceOf(IOException.class)
+                .hasRootCauseMessage("permission denied: " + unreadable);
     }
 
     @TestTemplate

--- a/paimon-core/src/test/java/org/apache/paimon/table/format/FormatTableScanTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/table/format/FormatTableScanTest.java
@@ -1061,6 +1061,30 @@ public class FormatTableScanTest {
     }
 
     @TestTemplate
+    public void testReadsAPartitionedTableWhoseOwnDirectoryNameIsHidden() throws IOException {
+        // A table may live at a location whose last component starts with '_' - a migration or
+        // scratch directory, a name a catalog generated. That is where the caller told us to
+        // look, not a name to judge: judging it found no partitions at all, so the table read as
+        // empty with nothing raised, while the same directory read fine as an unpartitioned one.
+        Path tableLocation = new Path(new Path(tmpPath.toUri()), "db/_t");
+        LocalFileIO fileIO = LocalFileIO.create();
+        String partition = enablePartitionValueOnly ? "2024/1" : "year=2024/month=1";
+        Path dataFile = new Path(new Path(tableLocation, partition), "data.csv");
+        writeTestFile(fileIO, dataFile, 100);
+        // The root and nothing below it: a staging tree standing where a partition directory
+        // would is still skipped.
+        writeTestFile(fileIO, new Path(tableLocation, "_temporary/attempt/part-00010.csv"), 100);
+
+        FormatTable formatTable = createYearMonthFormatTable(fileIO, tableLocation);
+        List<Split> splits = new FormatTableScan(formatTable, null, null).plan().splits();
+
+        assertThat(splits).hasSize(1);
+        assertThat(((FormatDataSplit) splits.get(0)).files())
+                .extracting(FormatDataSplit.FileMeta::filePath)
+                .containsExactly(dataFile);
+    }
+
+    @TestTemplate
     public void testCreateSplitsWithEmptyDirectory() throws IOException {
         Path tableLocation = new Path(tmpPath.toUri());
         LocalFileIO fileIO = LocalFileIO.create();


### PR DESCRIPTION
Follow-up to #8861. That PR wrote down a contract — *only entries below the listed root are judged by the `'_'` / `'.'` rule, never the root itself* — and this closes the two places where the code does not yet keep it, plus the coverage hole that let the listing's descent go untested.

### The scan root is still judged during partition discovery

`PartitionPathUtils.listStatusRecursively` applies the rule at every level, and level 0 is the scan root itself, built by `getFileStatusRecurse` from the table location:

```java
fileStatus = fileIO.getFileStatus(path);                    // the table location
listStatusRecursively(fileIO, fileStatus, 0, expectLevel, ...);
    -> if (isHiddenFile(fileStatus, ...)) { return; }        // judges the location's own name
```

A format table at a location ending in `_raw` therefore finds no partitions at all — **zero splits, no exception, no warning** — while the same directory reads fine when the table is declared unpartitioned, because that path goes through `createSplits`. Locations like that are ordinary: migrations, scratch areas, generated catalog paths. It is the expensive kind of failure, since a downstream job does not error, it computes on nothing.

The root is where the caller told us to look; only what is found below it can be a staging tree. The rule now applies from level 1 down, which is what `FormatTableScan.listDataFiles` already does, so the two halves of the read path answer the same way.

### The descent had no test

Every test of the new listing covered only its negative half — a hidden directory is skipped. Mutating `collectDataFiles` so it never descends:

```java
if (child.isDir()) {
    continue;                      // was: directories.add(child.getPath());
}
```

left the whole format-table suite green. The half that returns the files of an ordinary sub-directory — and the sort merging what different depths found — was unpinned, although it is the behaviour the previous `fileIO.listFiles(path, true)` had. A guard widened to "never descend" makes whole subtrees of committed data disappear from a read, silently.

`testCreateSplitsSkipsStagingFilesInsidePartitions` now stages a committed file two non-hidden levels below the partition, at the same depth as the staged one, so the staging directory in the middle of one path is the only thing separating them.

The failure contract was unpinned for the same reason: with no non-hidden sub-directory in any fixture, the descent's `catch` never ran, so widening it from `FileNotFoundException` to `IOException` also left the suite green. Two tests now separate the halves — a directory that vanishes between its parent's listing and its own is skipped; one that cannot be read fails loudly.

### Two claims corrected

- **`@throws FileNotFoundException` for a missing `listedRoot`** is the `FileIO`'s choice, not this method's: `LocalFileIO.listStatus` answers with no entries for a missing path, so the result is simply empty. The javadoc says that now instead of promising the throw.
- **`testCreateSplitsKeepsFilesUnderAStagingLikeTableLocation`** claimed a table directory may sit under a leading-underscore path, but named the listed root `t` while production only inspects the root's own name — no implementation could fail it. The root is now `_t`, and its partitioned counterpart is the new test above.

### Two smaller ones

- `testStagingTreesAreNotEnumerated` measured `FileIO.listFiles(path, true)` as a baseline, a path planning no longer calls, so no change to the code under test could turn those three assertions red — and they contradicted the comment two lines above them. Dropped; the exact counts already carry the claim.
- `warnIfFilesystemPartitionsExist` still excluded only `.`-prefixed directories, so a leftover staging tree told the reader to run `MSCK REPAIR TABLE` for data that does not exist. It now uses `PartitionPathUtils.isHiddenName`.

### Verification

| mutation | before | after |
| --- | --- | --- |
| `collectDataFiles`: never descend | suite green | `testCreateSplitsSkipsStagingFilesInsidePartitions` fails, both layouts |
| descent `catch (FileNotFoundException)` → `catch (IOException)` | suite green | `testCreateSplitsFailsWhenASubDirectoryCannotBeListed` fails, both layouts |
| `level > 0 &&` guard reverted | suite green | `testReadsAPartitionedTableWhoseOwnDirectoryNameIsHidden` fails, both layouts |

`listStatusRecursively` is private and reached only through `searchPartSpecAndPaths`, whose production callers are `FileSystemSplitEnumerator` and the Spark `FormatTablePartitionRepair` procedure — both format-table paths; managed tables do not use it.

143 tests pass across `FormatTableScanTest`, `CatalogManagedPartitionScanTest`, `FormatTableCommitTest`, `PartitionPathUtilsTest`, `FormatTableWriteTest`, `FormatReadBuilderTest`, `FormatTableCompatibilityTest` and `FormatDataSplitTest`; spotless and checkstyle clean.
