### PR TITLE
[cdc] Support PostgreSQL uuid type in postgres sync

### DIFF
--- a/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/action/cdc/postgres/PostgresTypeUtils.java
+++ b/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/action/cdc/postgres/PostgresTypeUtils.java
@@ -70,6 +70,7 @@ public class PostgresTypeUtils {
     private static final String PG_CHARACTER_VARYING_ARRAY = "_varchar";
     private static final String PG_JSON = "json";
     private static final String PG_ENUM = "enum";
+    private static final String PG_UUID = "uuid";
 
     public static DataType toDataType(
             String typeName,
@@ -159,6 +160,7 @@ public class PostgresTypeUtils {
             case PG_TEXT:
             case PG_JSON:
             case PG_ENUM:
+            case PG_UUID:
                 return DataTypes.STRING();
             case PG_TEXT_ARRAY:
                 return DataTypes.ARRAY(DataTypes.STRING());

--- a/paimon-flink/paimon-flink-cdc/src/test/java/org/apache/paimon/flink/action/cdc/postgres/PostgresSyncTableActionITCase.java
+++ b/paimon-flink/paimon-flink-cdc/src/test/java/org/apache/paimon/flink/action/cdc/postgres/PostgresSyncTableActionITCase.java
@@ -365,6 +365,7 @@ public class PostgresSyncTableActionITCase extends PostgresActionITCaseBase {
                             DataTypes.STRING(), // _text
                             DataTypes.BYTES(), // _bin
                             DataTypes.STRING(), // _json
+                            DataTypes.STRING(), // _uuid
                             DataTypes.ARRAY(DataTypes.STRING()) // _array
                         },
                         new String[] {
@@ -398,6 +399,7 @@ public class PostgresSyncTableActionITCase extends PostgresActionITCaseBase {
                             "_text",
                             "_bin",
                             "_json",
+                            "_uuid",
                             "_array",
                         });
         FileStoreTable table = getFileStoreTable();
@@ -423,6 +425,7 @@ public class PostgresSyncTableActionITCase extends PostgresActionITCaseBase {
                                 + "Paimon    , Apache Paimon, Apache Paimon PostgreSQL Test Data, "
                                 + "[98, 121, 116, 101, 115], "
                                 + "{\"a\": \"b\"}, "
+                                + "123e4567-e89b-12d3-a456-426655440000, "
                                 + "[item1, item2]"
                                 + "]",
                         "+I["
@@ -442,6 +445,7 @@ public class PostgresSyncTableActionITCase extends PostgresActionITCaseBase {
                                 + "NULL, NULL, "
                                 + "NULL, NULL, "
                                 + "NULL, NULL, "
+                                + "NULL, "
                                 + "NULL, "
                                 + "NULL, "
                                 + "NULL"

--- a/paimon-flink/paimon-flink-cdc/src/test/java/org/apache/paimon/flink/action/cdc/postgres/PostgresTypeUtilsTest.java
+++ b/paimon-flink/paimon-flink-cdc/src/test/java/org/apache/paimon/flink/action/cdc/postgres/PostgresTypeUtilsTest.java
@@ -83,4 +83,14 @@ public class PostgresTypeUtilsTest {
         assertThat(PostgresTypeUtils.toDataType("_numeric", 0, 0, EMPTY))
                 .isEqualTo(DataTypes.ARRAY(DataTypes.DECIMAL(DecimalType.MAX_PRECISION, 18)));
     }
+
+    /**
+     * Debezium emits {@code uuid} values as plain strings ({@code io.debezium.data.Uuid}), so the
+     * type maps to {@code STRING} preserving the canonical text representation.
+     */
+    @Test
+    public void testUuidMapsToString() {
+        assertThat(PostgresTypeUtils.toDataType("uuid", null, null, EMPTY))
+                .isEqualTo(DataTypes.STRING());
+    }
 }

--- a/paimon-flink/paimon-flink-cdc/src/test/resources/postgres/sync_table_setup.sql
+++ b/paimon-flink/paimon-flink-cdc/src/test/resources/postgres/sync_table_setup.sql
@@ -105,6 +105,8 @@ CREATE TABLE all_types_table (
     _bin BYTEA,
     -- json
     _json JSON,
+    -- UUID
+    _uuid UUID,
     _array VARCHAR[],
     PRIMARY KEY (_id)
 );
@@ -129,7 +131,7 @@ INSERT INTO all_types_table (
     _time, _time0,
     _char, _varchar, _text,
     _bin,
-    _json,
+    _json, _uuid,
     _array
 ) VALUES (
     1, 1.1,
@@ -148,7 +150,7 @@ INSERT INTO all_types_table (
     '10:13:23'::TIME, '10:13:23'::TIME,
     'Paimon', 'Apache Paimon', 'Apache Paimon PostgreSQL Test Data',
     'bytes',
-    '{"a": "b"}'::JSON,
+    '{"a": "b"}'::JSON, '123e4567-e89b-12d3-a456-426655440000'::UUID,
     ARRAY['item1', 'item2']::VARCHAR[]
     ), (
     2, 2.2,
@@ -167,7 +169,7 @@ INSERT INTO all_types_table (
     NULL, NULL,
     NULL, NULL, NULL,
     NULL,
-    NULL,
+    NULL, NULL,
     NULL
     );
 


### PR DESCRIPTION
### Purpose
 - Postgres sync when the source has UUID type.
 - Debezium already emits uuid values as plain strings.
 - Map the uuid type to string to support the same.

### Tests
 - UT