### PR TITLE
[spark] Stabilize Spark E2E output validation

### DIFF
--- a/paimon-e2e-tests/src/test/java/org/apache/paimon/tests/SparkE2eTest.java
+++ b/paimon-e2e-tests/src/test/java/org/apache/paimon/tests/SparkE2eTest.java
@@ -36,6 +36,8 @@ import static org.junit.jupiter.api.condition.JRE.JAVA_11;
 public class SparkE2eTest extends E2eReaderTestBase {
 
     private static final Logger LOG = LoggerFactory.getLogger(SparkE2eTest.class);
+    private static final String COARSE_GRAINED_SCHEDULER_SHUTDOWN_ERROR =
+            "ERROR Utils: Uncaught exception in thread dispatcher-CoarseGrainedScheduler";
 
     public SparkE2eTest() {
         super(false, false, true);
@@ -75,11 +77,23 @@ public class SparkE2eTest extends E2eReaderTestBase {
                         LOG.info(execResult.getStderr());
                         throw new AssertionError("Failed when running spark sql.");
                     }
-                    return Arrays.stream(execResult.getStdout().split("\n"))
+                    String stdout =
+                            stripCoarseGrainedSchedulerShutdownError(execResult.getStdout());
+                    return Arrays.stream(stdout.split("\n"))
                                     .filter(s -> !s.contains("WARN"))
                                     .collect(Collectors.joining("\n"))
                             + "\n";
                 });
+    }
+
+    private static String stripCoarseGrainedSchedulerShutdownError(String stdout) {
+        int errorIndex = stdout.indexOf(COARSE_GRAINED_SCHEDULER_SHUTDOWN_ERROR);
+        if (errorIndex < 0) {
+            return stdout;
+        }
+
+        int errorLineStart = stdout.lastIndexOf('\n', errorIndex);
+        return errorLineStart < 0 ? "" : stdout.substring(0, errorLineStart);
     }
 
     private ContainerState getSpark() {


### PR DESCRIPTION
### Purpose
   Spark may emit a CoarseGrainedScheduler shutdown error to stdout after a
  successful query, causing the error stack trace to be compared as query output.
  Strip this known shutdown error and its trailing stack trace before validating
  the query result.
  
<img width="2226" height="1184" alt="image" src="https://github.com/user-attachments/assets/24f3ce88-445f-4e76-93a1-285d000614cd" />

### Tests
  - SparkE2eTest#testFlinkWriteAndSparkRead