### PR TITLE
[core] Only require the <db>.db warehouse layout for catalog-storage Iceberg metadata

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/iceberg/IcebergCommitCallback.java
+++ b/paimon-core/src/main/java/org/apache/paimon/iceberg/IcebergCommitCallback.java
@@ -192,13 +192,6 @@ public class IcebergCommitCallback implements CommitCallback, TagCallback {
         IcebergOptions.StorageType storageType =
                 table.coreOptions().toConfiguration().get(IcebergOptions.METADATA_ICEBERG_STORAGE);
 
-        if (!dbPath.getName().endsWith(dbSuffix)) {
-            throw new UnsupportedOperationException(
-                    String.format(
-                            "Storage type %s can only be used on Paimon tables in a Paimon warehouse.",
-                            storageType.name()));
-        }
-
         IcebergOptions.StorageLocation storageLocation =
                 table.coreOptions()
                         .toConfiguration()
@@ -207,8 +200,23 @@ public class IcebergCommitCallback implements CommitCallback, TagCallback {
 
         switch (storageLocation) {
             case TABLE_LOCATION:
+                // Iceberg metadata is written beside the table, under the database's own location,
+                // so no warehouse (<db>.db) layout is required. This lets the table register in any
+                // catalog, including a database whose location is not a Paimon warehouse path (e.g.
+                // an externally-provisioned / cross-account catalog database).
                 return dbPath;
             case CATALOG_STORAGE:
+                // Catalog-storage derives a warehouse-relative iceberg/<db>/ path by stripping the
+                // ".db" suffix, so it only applies under the Paimon <db>.db warehouse layout.
+                if (!dbPath.getName().endsWith(dbSuffix)) {
+                    throw new UnsupportedOperationException(
+                            String.format(
+                                    "Storage type %s with catalog-location Iceberg metadata requires a "
+                                            + "Paimon warehouse database (a <db>.db location); set "
+                                            + "metadata.iceberg.storage-location=table-location for a "
+                                            + "database with a non-warehouse location.",
+                                    storageType.name()));
+                }
                 String dbName =
                         dbPath.getName()
                                 .substring(0, dbPath.getName().length() - dbSuffix.length());

--- a/paimon-core/src/test/java/org/apache/paimon/iceberg/IcebergCommitCallbackTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/iceberg/IcebergCommitCallbackTest.java
@@ -38,6 +38,7 @@ import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
@@ -162,6 +163,38 @@ public class IcebergCommitCallbackTest {
         Path result = IcebergCommitCallback.catalogDatabasePath(mockTable);
 
         assertThat(result.toString()).isEqualTo(expectedPath);
+    }
+
+    @Test
+    void testCatalogDatabasePathTableLocationAllowsNonWarehouseDatabase() {
+        // A database whose location is not a Paimon <db>.db warehouse path (e.g. an externally
+        // provisioned / cross-account catalog database).
+        when(mockTable.location()).thenReturn(new Path("s3://bucket/ingest/mydb/mytable"));
+        when(mockConfig.get(IcebergOptions.METADATA_ICEBERG_STORAGE))
+                .thenReturn(IcebergOptions.StorageType.REST_CATALOG);
+        when(mockConfig.getOptional(IcebergOptions.METADATA_ICEBERG_STORAGE_LOCATION))
+                .thenReturn(Optional.of(IcebergOptions.StorageLocation.TABLE_LOCATION));
+
+        // table-location writes Iceberg metadata beside the table, so the database path is used
+        // as-is with no <db>.db requirement.
+        assertThat(IcebergCommitCallback.catalogDatabasePath(mockTable).toString())
+                .isEqualTo("s3://bucket/ingest/mydb");
+    }
+
+    @Test
+    void testCatalogDatabasePathCatalogStorageRejectsNonWarehouseDatabase() {
+        when(mockTable.location()).thenReturn(new Path("s3://bucket/ingest/mydb/mytable"));
+        when(mockConfig.get(IcebergOptions.METADATA_ICEBERG_STORAGE))
+                .thenReturn(IcebergOptions.StorageType.REST_CATALOG);
+        when(mockConfig.getOptional(IcebergOptions.METADATA_ICEBERG_STORAGE_LOCATION))
+                .thenReturn(Optional.of(IcebergOptions.StorageLocation.CATALOG_STORAGE));
+
+        // catalog-storage derives a warehouse-relative iceberg/<db>/ path by stripping ".db", so a
+        // non-".db" database is still rejected (with a message pointing at the table-location fix).
+        assertThatThrownBy(() -> IcebergCommitCallback.catalogDatabasePath(mockTable))
+                .isInstanceOf(UnsupportedOperationException.class)
+                .hasMessageContaining("requires a Paimon warehouse database")
+                .hasMessageContaining("table-location");
     }
 
     private static Stream<Arguments> provideMetadataPathsWithStorageType() {


### PR DESCRIPTION
### Problem
catalogDatabasePath() rejected any database whose location does not end in '.db' before checking the storage location, so metadata.iceberg.storage-location =table-location which writes Iceberg metadata beside the table and does not need the warehouse layout, was also rejected for databases with a non-warehouse location (e.g. an externally-provisioned or cross-account catalog database).

### Fix
Move the '.db' guard into the catalog-storage branch, which is the only path that derives a warehouse-relative iceberg/<db>/ location by stripping the '.db' suffix. table-location now returns the database path as-is with no layout requirement; catalog-storage still requires '.db' and gives a clearer message.

### Tests
Adds unit tests covering a non-warehouse database under both storage locations.

Closes #8910
