### PR TITLE
[rest] Preserve custom catalog for dependency reads

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/table/CatalogEnvironment.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/CatalogEnvironment.java
@@ -232,7 +232,9 @@ public class CatalogEnvironment implements Serializable {
         }
 
         Options dependencyOptions = new Options(options.toMap());
-        dependencyOptions.set(METASTORE, RESTCatalogFactory.IDENTIFIER);
+        if (!dependencyOptions.contains(METASTORE)) {
+            dependencyOptions.set(METASTORE, RESTCatalogFactory.IDENTIFIER);
+        }
         dependencyOptions.set(
                 READ_VIA_OPTION, RESTUtil.encodeString(JsonSerdeUtil.toFlatJson(identifier)));
         return CatalogContext.create(

--- a/paimon-core/src/test/java/org/apache/paimon/table/CatalogEnvironmentTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/table/CatalogEnvironmentTest.java
@@ -104,6 +104,19 @@ class CatalogEnvironmentTest {
     }
 
     @Test
+    void testDependencyReadContextPreservesCustomRestMetastore() {
+        Options options = new Options();
+        options.set(METASTORE, "custom-rest");
+        CatalogContext context = CatalogContext.create(options);
+        CatalogEnvironment environment = restEnvironment(Identifier.create("db", "table"), context);
+
+        CatalogContext dependencyContext = environment.dependencyReadContext();
+
+        assertThat(dependencyContext).isNotSameAs(context);
+        assertThat(dependencyContext.options().get(METASTORE)).isEqualTo("custom-rest");
+    }
+
+    @Test
     void testAppendTableUsesDependencyReadContext() {
         CatalogEnvironment environment = mock(CatalogEnvironment.class);
         when(environment.dependencyReadContext()).thenReturn(CatalogContext.create(new Options()));


### PR DESCRIPTION
## Purpose

Follow up on the post-merge review of #8823 and preserve custom REST Catalog
implementations during dependency reads.

## Root cause

Dependency reads may reconstruct a catalog through `CatalogFactory` using a
derived `CatalogContext`. #8823 populated `metastore=rest` so directly
constructed REST catalogs without a metastore option would not fall back to the
filesystem catalog.

That fallback was applied unconditionally, so a custom REST Catalog such as
`metastore=custom-rest` was replaced with the built-in REST Catalog identifier.

## Changes

- Preserve an explicitly configured metastore identifier.
- Set `metastore=rest` only when the derived context has no metastore option.
- Add a regression test for a custom REST metastore identifier.

Directly constructed built-in REST catalogs continue to receive the `rest`
fallback, while custom REST Catalog factories are reconstructed through their
original identifier.

## Validation

- `mvn -pl paimon-core -am -Pfast-build -DfailIfNoTests=false -DwildcardSuites=none '-Dtest=CatalogEnvironmentTest,BlobDescriptorReaderFactoryTest,MockRESTCatalogTest#testReadViaHeaderOnDependencyTableAndDataTokenRequests' test`
  (11 tests passed)
- `mvn -pl paimon-core -DskipTests test-compile`
- `git diff --check`
