### PR TITLE
[filesystem] Fix nested META-INF/versions in filesystem impl jars

### DIFF
--- a/paimon-filesystems/paimon-azure-impl/pom.xml
+++ b/paimon-filesystems/paimon-azure-impl/pom.xml
@@ -146,6 +146,12 @@
                                     <fileset dir="${project.build.directory}/temporary">
                                         <include name="*"/>
                                     </fileset>
+                                    <patternset>
+                                        <!-- exclude the jar's own META-INF, otherwise multi-release
+                                             metadata gets nested under META-INF/versions/11 and tools
+                                             like JaCoCo fail on duplicate class names -->
+                                        <exclude name="META-INF/**"/>
+                                    </patternset>
                                 </unzip>
                             </target>
                         </configuration>
@@ -177,7 +183,6 @@
                                         <exclude>mime.types</exclude>
                                         <exclude>mozilla/**</exclude>
                                         <exclude>META-INF/maven/**</exclude>
-                                        <exclude>META-INF/versions/11/META-INF/maven/**</exclude>
                                         <exclude>META-INF/LICENSE.txt</exclude>
                                     </excludes>
                                 </filter>

--- a/paimon-filesystems/paimon-cosn-impl/pom.xml
+++ b/paimon-filesystems/paimon-cosn-impl/pom.xml
@@ -155,6 +155,12 @@
                                     <fileset dir="${project.build.directory}/temporary">
                                         <include name="*"/>
                                     </fileset>
+                                    <patternset>
+                                        <!-- exclude the jar's own META-INF, otherwise multi-release
+                                             metadata gets nested under META-INF/versions/11 and tools
+                                             like JaCoCo fail on duplicate class names -->
+                                        <exclude name="META-INF/**"/>
+                                    </patternset>
                                 </unzip>
                             </target>
                         </configuration>
@@ -187,7 +193,6 @@
                                         <exclude>mime.types</exclude>
                                         <exclude>mozilla/**</exclude>
                                         <exclude>META-INF/maven/**</exclude>
-                                        <exclude>META-INF/versions/11/META-INF/maven/**</exclude>
                                         <exclude>META-INF/LICENSE.txt</exclude>
                                     </excludes>
                                 </filter>

--- a/paimon-filesystems/paimon-gs-impl/pom.xml
+++ b/paimon-filesystems/paimon-gs-impl/pom.xml
@@ -272,6 +272,12 @@
                                     <fileset dir="${project.build.directory}/temporary">
                                         <include name="*"/>
                                     </fileset>
+                                    <patternset>
+                                        <!-- exclude the jar's own META-INF, otherwise multi-release
+                                             metadata gets nested under META-INF/versions/11 and tools
+                                             like JaCoCo fail on duplicate class names -->
+                                        <exclude name="META-INF/**"/>
+                                    </patternset>
                                 </unzip>
                             </target>
                         </configuration>
@@ -303,7 +309,6 @@
                                         <exclude>mime.types</exclude>
                                         <exclude>mozilla/**</exclude>
                                         <exclude>META-INF/maven/**</exclude>
-                                        <exclude>META-INF/versions/11/META-INF/maven/**</exclude>
                                         <exclude>META-INF/LICENSE.txt</exclude>
                                     </excludes>
                                 </filter>

--- a/paimon-filesystems/paimon-oss-impl/pom.xml
+++ b/paimon-filesystems/paimon-oss-impl/pom.xml
@@ -162,6 +162,12 @@
                                     <fileset dir="${project.build.directory}/temporary">
                                         <include name="*"/>
                                     </fileset>
+                                    <patternset>
+                                        <!-- exclude the jar's own META-INF, otherwise multi-release
+                                             metadata gets nested under META-INF/versions/11 and tools
+                                             like JaCoCo fail on duplicate class names -->
+                                        <exclude name="META-INF/**"/>
+                                    </patternset>
                                 </unzip>
                             </target>
                         </configuration>
@@ -194,7 +200,6 @@
                                         <exclude>mime.types</exclude>
                                         <exclude>mozilla/**</exclude>
                                         <exclude>META-INF/maven/**</exclude>
-                                        <exclude>META-INF/versions/11/META-INF/maven/**</exclude>
                                         <exclude>META-INF/LICENSE.txt</exclude>
                                     </excludes>
                                 </filter>

--- a/paimon-filesystems/paimon-s3-impl/pom.xml
+++ b/paimon-filesystems/paimon-s3-impl/pom.xml
@@ -260,6 +260,12 @@
                                     <fileset dir="${project.build.directory}/temporary">
                                         <include name="*"/>
                                     </fileset>
+                                    <patternset>
+                                        <!-- exclude the jar's own META-INF, otherwise multi-release
+                                             metadata gets nested under META-INF/versions/11 and tools
+                                             like JaCoCo fail on duplicate class names -->
+                                        <exclude name="META-INF/**"/>
+                                    </patternset>
                                 </unzip>
                             </target>
                         </configuration>
@@ -291,7 +297,6 @@
                                         <exclude>mime.types</exclude>
                                         <exclude>mozilla/**</exclude>
                                         <exclude>META-INF/maven/**</exclude>
-                                        <exclude>META-INF/versions/11/META-INF/maven/**</exclude>
                                         <exclude>META-INF/LICENSE.txt</exclude>
                                     </excludes>
                                 </filter>

--- a/tools/ci/paimon-ci-tools/src/main/java/org/apache/paimon/tools/ci/licensecheck/JarFileChecker.java
+++ b/tools/ci/paimon-ci-tools/src/main/java/org/apache/paimon/tools/ci/licensecheck/JarFileChecker.java
@@ -81,6 +81,8 @@ public class JarFileChecker {
                     getNumLicenseFilesOutsideMetaInfDirectory(file, fileSystem.getPath("/"));
 
             numSevereIssues += getFilesWithIncompatibleLicenses(file, fileSystem.getPath("/"));
+
+            numSevereIssues += getNumNestedMetaInfDirectories(file, fileSystem.getPath("/"));
         }
         return numSevereIssues;
     }
@@ -215,7 +217,6 @@ public class JarFileChecker {
                             path ->
                                     !pathStartsWith(
                                             path, "/META-INF/maven/javax.xml.bind/jaxb-api"))
-                    .filter(path -> !isJavaxManifest(jar, path))
                     // dual-licensed under GPL 2 and EPL 2.0
                     // contained in sql-avro-confluent-registry
                     .filter(path -> !pathStartsWith(path, "/org/glassfish/jersey/internal"))
@@ -306,6 +307,27 @@ public class JarFileChecker {
         }
     }
 
+    private static int getNumNestedMetaInfDirectories(Path jar, Path jarRoot) throws IOException {
+        // a nested META-INF below META-INF/versions indicates that another jar was
+        // unpacked/shaded as-is into the multi-release directory; the nested multi-release
+        // metadata is not resolvable at runtime and breaks tools scanning the unpacked
+        // classes (e.g., JaCoCo fails on duplicate class names)
+        final Pattern nestedMetaInf = Pattern.compile("^/?META-INF/versions/[^/]+/META-INF/?$");
+        try (Stream<Path> files = Files.walk(jarRoot)) {
+            final List<String> filesWithIssues =
+                    files.map(Path::toString)
+                            .filter(path -> nestedMetaInf.matcher(path).matches())
+                            .collect(Collectors.toList());
+            for (String fileWithIssue : filesWithIssues) {
+                LOG.error(
+                        "Jar file {} contains a nested META-INF directory in a multi-release directory: {}",
+                        jar,
+                        fileWithIssue);
+            }
+            return filesWithIssues.size();
+        }
+    }
+
     private static String getFileName(Path path) {
         return path.getFileName().toString().toLowerCase();
     }
@@ -314,24 +336,8 @@ public class JarFileChecker {
         return file.startsWith(file.getFileSystem().getPath(path));
     }
 
-    private static boolean equals(Path file, String path) {
-        return file.equals(file.getFileSystem().getPath(path));
-    }
-
     private static boolean isNoClassFile(Path file) {
         return !getFileName(file).endsWith(".class");
-    }
-
-    private static boolean isJavaxManifest(Path jar, Path potentialManifestFile) {
-        try {
-            return equals(potentialManifestFile, "/META-INF/versions/11/META-INF/MANIFEST.MF")
-                    && readFile(potentialManifestFile).contains("Specification-Title: jaxb-api");
-        } catch (IOException e) {
-            throw new RuntimeException(
-                    String.format(
-                            "Error while reading file %s from jar %s.", potentialManifestFile, jar),
-                    e);
-        }
     }
 
     private static String readFile(Path file) throws IOException {

--- a/tools/ci/paimon-ci-tools/src/test/java/org/apache/paimon/tools/ci/licensecheck/JarFileCheckerTest.java
+++ b/tools/ci/paimon-ci-tools/src/test/java/org/apache/paimon/tools/ci/licensecheck/JarFileCheckerTest.java
@@ -298,6 +298,47 @@ class JarFileCheckerTest {
                 .isEqualTo(0);
     }
 
+    @Test
+    void testRejectedOnNestedMetaInfInMultiReleaseDirectory(@TempDir Path tempDir)
+            throws Exception {
+        assertThat(
+                        JarFileChecker.checkJar(
+                                createJar(
+                                        tempDir,
+                                        Entry.fileEntry(VALID_NOTICE_CONTENTS, VALID_NOTICE_PATH),
+                                        Entry.fileEntry(VALID_LICENSE_CONTENTS, VALID_LICENSE_PATH),
+                                        Entry.fileEntry(
+                                                "Manifest-Version: 1.0",
+                                                Arrays.asList(
+                                                        "META-INF",
+                                                        "versions",
+                                                        "11",
+                                                        "META-INF",
+                                                        "MANIFEST.MF")))))
+                .isEqualTo(1);
+    }
+
+    @Test
+    void testAcceptedOnRegularMultiReleaseContent(@TempDir Path tempDir) throws Exception {
+        assertThat(
+                        JarFileChecker.checkJar(
+                                createJar(
+                                        tempDir,
+                                        Entry.fileEntry(VALID_NOTICE_CONTENTS, VALID_NOTICE_PATH),
+                                        Entry.fileEntry(VALID_LICENSE_CONTENTS, VALID_LICENSE_PATH),
+                                        Entry.fileEntry(
+                                                "some java 11 resource",
+                                                Arrays.asList(
+                                                        "META-INF",
+                                                        "versions",
+                                                        "11",
+                                                        "javax",
+                                                        "xml",
+                                                        "bind",
+                                                        "Messages.properties")))))
+                .isEqualTo(0);
+    }
+
     private static class Entry {
         final String contents;
         final List<String> path;


### PR DESCRIPTION
### Purpose

The filesystem impl modules (`paimon-oss-impl`, `paimon-s3-impl`, `paimon-azure-impl`, `paimon-cosn-impl`, `paimon-gs-impl`) unpack the whole `jaxb-api` jar into `target/classes/META-INF/versions/11`. Since `jaxb-api` is itself a multi-release jar, its own `META-INF` tree gets nested into the output, producing malformed entries such as:

```
META-INF/versions/11/javax/xml/bind/ModuleUtil.class
META-INF/versions/11/META-INF/versions/9/javax/xml/bind/ModuleUtil.class   <- nested
META-INF/versions/11/META-INF/MANIFEST.MF
META-INF/versions/11/META-INF/LICENSE.txt
```

Both `ModuleUtil.class` entries have the same internal class name `javax/xml/bind/ModuleUtil` but different bytecode. Any tool that scans the unpacked classes directory chokes on the duplicate. For example, JaCoCo fails with:

```
java.io.IOException: Error while analyzing .../META-INF/versions/11/javax/xml/bind/ModuleUtil.class
Caused by: java.lang.IllegalStateException: Can't add different class with same name: javax/xml/bind/ModuleUtil
```

The nesting has existed since #2658 but only surfaced after #8832 started shading `META-INF/versions/11/**` from `paimon-oss-impl` into `paimon-jindo`, propagating the malformed entries into that jar as well.

### Changes

- Exclude the jar's own `META-INF/**` when unzipping `jaxb-api` into `META-INF/versions/11`. The nested `META-INF/versions/9` variants were never resolvable at runtime anyway (nested multi-release directories are not a thing), so there is no functional change. The now-unnecessary `META-INF/versions/11/META-INF/maven/**` shade exclude is removed along with it.
- `JarFileChecker` now rejects any `META-INF` directory nested below `META-INF/versions/*`, so a regression fails the license check CI. The `isJavaxManifest` whitelist that existed to tolerate the nested jaxb manifest is removed since the path no longer occurs.

### Tests

- Rebuilt all five impl modules plus `paimon-jindo`: no `META-INF/versions/11/META-INF/**` entries remain and the 121 `META-INF/versions/11/javax/**` classes are intact; JaCoCo `Analyzer.analyzeAll` on the unpacked jar contents now passes (previously threw the exception above).
- Added `JarFileCheckerTest#testRejectedOnNestedMetaInfInMultiReleaseDirectory` and `#testAcceptedOnRegularMultiReleaseContent`.