### PR TITLE
[hive] Strip newline characters from Glue column comments

### DIFF
--- a/paimon-hive/paimon-hive-catalog/src/main/java/org/apache/paimon/iceberg/IcebergHiveMetadataCommitter.java
+++ b/paimon-hive/paimon-hive-catalog/src/main/java/org/apache/paimon/iceberg/IcebergHiveMetadataCommitter.java
@@ -271,7 +271,13 @@ public class IcebergHiveMetadataCommitter implements IcebergMetadataCommitter {
 
     @VisibleForTesting
     static String normalizeColumnComment(@Nullable String comment) {
-        if (comment == null || comment.length() <= HIVE_COLUMN_COMMENT_MAX_LENGTH) {
+        if (comment == null) {
+            return comment;
+        }
+
+        comment = comment.replace('\n', ' ').replace('\r', ' ');
+
+        if (comment.length() <= HIVE_COLUMN_COMMENT_MAX_LENGTH) {
             return comment;
         }
 

--- a/paimon-hive/paimon-hive-catalog/src/test/java/org/apache/paimon/iceberg/IcebergHiveMetadataCommitterTest.java
+++ b/paimon-hive/paimon-hive-catalog/src/test/java/org/apache/paimon/iceberg/IcebergHiveMetadataCommitterTest.java
@@ -39,6 +39,15 @@ class IcebergHiveMetadataCommitterTest {
         assertThat(IcebergHiveMetadataCommitter.normalizeColumnComment(longComment))
                 .hasSize(255)
                 .isEqualTo(repeat('b', 252) + "...");
+
+        assertThat(IcebergHiveMetadataCommitter.normalizeColumnComment("line1\nline2\r\nline3"))
+                .isEqualTo("line1 line2  line3");
+
+        assertThat(
+                        IcebergHiveMetadataCommitter.normalizeColumnComment(
+                                "first\n" + repeat('c', 253)))
+                .hasSize(255)
+                .endsWith("...");
     }
 
     private static String repeat(char c, int count) {


### PR DESCRIPTION
Closes #8917

### What

Normalize Glue column comments by replacing newline characters with spaces before the 255-character length check. Short multiline comments now get sanitized instead of returning early with raw newlines.

### Why

AWS Glue rejects column comments containing newline characters. The previous implementation only truncated long comments and skipped newline cleanup for short ones, which made short multiline comments fail validation.

### Tests

- Added coverage for newline-containing short and long comments in IcebergHiveMetadataCommitterTest
- Verified with mvn -pl paimon-hive/paimon-hive-catalog -am -Pfast-build -DfailIfNoTests=false -DwildcardSuites=none -Dtest=IcebergHiveMetadataCommitterTest test

The targeted Maven run passed.
