### PR TITLE
[common] Fix input stream leak in FileIndexFormat.Reader constructor

### DIFF
--- a/paimon-common/src/main/java/org/apache/paimon/fileindex/FileIndexFormat.java
+++ b/paimon-common/src/main/java/org/apache/paimon/fileindex/FileIndexFormat.java
@@ -243,8 +243,10 @@ public final class FileIndexFormat {
         public Reader(SeekableInputStream seekableInputStream, RowType fileRowType) {
             this.seekableInputStream = seekableInputStream;
             DataInputStream dataInputStream = new DataInputStream(seekableInputStream);
-            fileRowType.getFields().forEach(field -> this.fields.put(field.name(), field));
+            boolean success = false;
             try {
+                fileRowType.getFields().forEach(field -> this.fields.put(field.name(), field));
+
                 long magic = dataInputStream.readLong();
                 if (magic != MAGIC) {
                     throw new RuntimeException("This file is not file index file.");
@@ -279,10 +281,15 @@ public final class FileIndexFormat {
                         }
                     }
                 }
+                success = true;
             } catch (IOException e) {
-                IOUtils.closeQuietly(seekableInputStream);
                 throw new RuntimeException(
                         "Exception happens while construct file index reader.", e);
+            } finally {
+                // a throwing constructor hands out no reference to close
+                if (!success) {
+                    IOUtils.closeQuietly(seekableInputStream);
+                }
             }
         }
 

--- a/paimon-common/src/test/java/org/apache/paimon/fileindex/FileIndexFormatFormatTest.java
+++ b/paimon-common/src/test/java/org/apache/paimon/fileindex/FileIndexFormatFormatTest.java
@@ -27,8 +27,11 @@ import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import java.io.ByteArrayOutputStream;
+import java.io.EOFException;
 import java.io.IOException;
+import java.nio.ByteBuffer;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
@@ -104,5 +107,102 @@ public class FileIndexFormatFormatTest {
         Assertions.assertThat(fileIndexFormatList.size()).isEqualTo(1);
         Assertions.assertThat(new ArrayList<>(fileIndexFormatList).get(0))
                 .isEqualTo(EmptyFileIndexReader.INSTANCE);
+    }
+
+    @Test
+    public void testReaderClosesStreamOnBadMagic() throws IOException {
+        byte[] indexBytes = validIndexBytes();
+        // overwrite the magic
+        ByteBuffer.wrap(indexBytes).putLong(0, 0L);
+        CloseTrackingSeekableStream stream = new CloseTrackingSeekableStream(indexBytes);
+
+        Assertions.assertThatThrownBy(() -> createReader(stream))
+                .isInstanceOf(RuntimeException.class)
+                .hasMessage("This file is not file index file.");
+        Assertions.assertThat(stream.closeCount()).isEqualTo(1);
+    }
+
+    @Test
+    public void testReaderClosesStreamOnUnsupportedVersion() throws IOException {
+        byte[] indexBytes = validIndexBytes();
+        // overwrite the version, which follows the 8 bytes long magic
+        ByteBuffer.wrap(indexBytes).putInt(8, 2);
+        CloseTrackingSeekableStream stream = new CloseTrackingSeekableStream(indexBytes);
+
+        Assertions.assertThatThrownBy(() -> createReader(stream))
+                .isInstanceOf(RuntimeException.class)
+                .hasMessageContaining("This index file is version of 2");
+        Assertions.assertThat(stream.closeCount()).isEqualTo(1);
+    }
+
+    @Test
+    public void testReaderClosesStreamOnCorruptedHeadLength() throws IOException {
+        byte[] indexBytes = validIndexBytes();
+        // overwrite the head length, which follows the magic and the version
+        ByteBuffer.wrap(indexBytes).putInt(12, 0);
+        CloseTrackingSeekableStream stream = new CloseTrackingSeekableStream(indexBytes);
+
+        // a corrupted head length fails outside the IOException path
+        Assertions.assertThatThrownBy(() -> createReader(stream))
+                .isInstanceOf(NegativeArraySizeException.class);
+        Assertions.assertThat(stream.closeCount()).isEqualTo(1);
+    }
+
+    @Test
+    public void testReaderClosesStreamOnTruncatedHead() throws IOException {
+        byte[] indexBytes = validIndexBytes();
+        Assertions.assertThat(indexBytes.length).isGreaterThan(20);
+        CloseTrackingSeekableStream stream =
+                new CloseTrackingSeekableStream(Arrays.copyOf(indexBytes, 20));
+
+        Assertions.assertThatThrownBy(() -> createReader(stream))
+                .isInstanceOf(RuntimeException.class)
+                .hasMessage("Exception happens while construct file index reader.")
+                .hasCauseInstanceOf(EOFException.class);
+        Assertions.assertThat(stream.closeCount()).isEqualTo(1);
+    }
+
+    @Test
+    public void testReaderKeepsStreamOpenOnSuccess() throws IOException {
+        CloseTrackingSeekableStream stream = new CloseTrackingSeekableStream(validIndexBytes());
+
+        FileIndexFormat.Reader reader = createReader(stream);
+        Assertions.assertThat(stream.closeCount()).isEqualTo(0);
+
+        reader.close();
+        Assertions.assertThat(stream.closeCount()).isEqualTo(1);
+    }
+
+    private static FileIndexFormat.Reader createReader(CloseTrackingSeekableStream stream) {
+        return FileIndexFormat.createReader(stream, RowType.builder().build());
+    }
+
+    private static byte[] validIndexBytes() throws IOException {
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        Map<String, Map<String, byte[]>> indexes = new HashMap<>();
+        indexes.computeIfAbsent("a", a -> new HashMap<>()).put("bloom", randomBytes(64));
+        try (FileIndexFormat.Writer writer = FileIndexFormat.createWriter(baos)) {
+            writer.writeColumnIndexes(indexes);
+        }
+        return baos.toByteArray();
+    }
+
+    private static class CloseTrackingSeekableStream extends ByteArraySeekableStream {
+
+        private int closeCount;
+
+        private CloseTrackingSeekableStream(byte[] buf) {
+            super(buf);
+        }
+
+        private int closeCount() {
+            return closeCount;
+        }
+
+        @Override
+        public void close() throws IOException {
+            closeCount++;
+            super.close();
+        }
     }
 }


### PR DESCRIPTION
### Purpose

Closes #8765.

`FileIndexFormat.Reader` takes ownership of the `SeekableInputStream` and parses the file header in its constructor. The magic and version checks throw `RuntimeException`, but the only `catch` handled `IOException`, so those paths left the stream open. A throwing constructor hands out no reference, so the caller's try-with-resources never binds and `Reader.close()` never runs.

It is reachable in production: `FileIndexEvaluator.createFileIndexPredicate` and `FileIndexProcessor` pass `fileIO.newInputStream(path)` straight into the constructor for the separate `.index` file, so a corrupt index file, or one written by a newer Paimon version, leaks one descriptor per attempt. The scan path passes the embedded index as `byte[]` and is unaffected.

The fix guards the constructor with a success flag and closes the stream from `finally` when parsing did not complete. Widening the catch to `IOException | RuntimeException`, as the issue suggests, does not compile: the constructor does not declare `throws IOException`, so precise rethrow rejects `throw e`. Wrapping everything into a new `RuntimeException` would instead bury `This file is not file index file.` in the cause. The `finally` form keeps the type, message and cause of every exception unchanged, and also covers the `OutOfMemoryError` a garbage `headLength` can trigger.

### Tests

Five tests in `FileIndexFormatFormatTest`, on a `ByteArraySeekableStream` subclass that counts `close()` calls: bad magic, unsupported version and corrupted head length (these three fail on master), truncated head (the `IOException` branch, where asserting exactly one close also guards against double close), and successful construction (the constructor leaves the stream open and `Reader.close()` closes it once).