### PR TITLE
[vector] Configure IVF-PQ batch table reuse

### DIFF
--- a/paimon-vector/pom.xml
+++ b/paimon-vector/pom.xml
@@ -32,7 +32,7 @@ under the License.
     <name>Paimon : Vector Index</name>
 
     <properties>
-        <paimon-vector-index-java.version>0.3.0</paimon-vector-index-java.version>
+        <paimon-vector-index-java.version>0.4.0-SNAPSHOT</paimon-vector-index-java.version>
     </properties>
 
     <dependencies>

--- a/paimon-vector/src/main/java/org/apache/paimon/vector/index/NativeVectorGlobalIndexReader.java
+++ b/paimon-vector/src/main/java/org/apache/paimon/vector/index/NativeVectorGlobalIndexReader.java
@@ -65,6 +65,7 @@ public class NativeVectorGlobalIndexReader implements GlobalIndexReader {
 
     private static final String NPROBE_PARAMETER = "ivf.nprobe";
     private static final String L_SEARCH_PARAMETER = "diskann.l_search";
+    private static final String IVF_PQ_BATCH_TABLE_REUSE_PARAMETER = "ivf_pq.batch_table_reuse";
     private static final int VECTOR_INDEX_MIN_SEEK_FOR_VECTOR_READS = 16 * 1024;
     private static final int VECTOR_INDEX_PARALLELISM_FOR_VECTOR_READS = 32;
 
@@ -151,6 +152,8 @@ public class NativeVectorGlobalIndexReader implements GlobalIndexReader {
         if (scope == null) {
             return emptyResults(n);
         }
+        VectorSearchParams searchParams =
+                batchSearchParams(batchVectorSearch.options(), scope.effectiveK);
 
         // Flatten query vectors into one contiguous array for a single native call.
         float[] queries = new float[n * dim];
@@ -160,15 +163,8 @@ public class NativeVectorGlobalIndexReader implements GlobalIndexReader {
 
         VectorSearchBatchResult batchResult =
                 scope.filterBytes != null
-                        ? vectorReader.searchBatch(
-                                queries,
-                                n,
-                                searchParams(batchVectorSearch.options(), scope.effectiveK),
-                                scope.filterBytes)
-                        : vectorReader.searchBatch(
-                                queries,
-                                n,
-                                searchParams(batchVectorSearch.options(), scope.effectiveK));
+                        ? vectorReader.searchBatch(queries, n, searchParams, scope.filterBytes)
+                        : vectorReader.searchBatch(queries, n, searchParams);
 
         // result i corresponds to vectors[i], matching input order.
         List<Optional<ScoredGlobalIndexResult>> results = new ArrayList<>(n);
@@ -298,6 +294,12 @@ public class NativeVectorGlobalIndexReader implements GlobalIndexReader {
             return VectorSearchParams.diskAnn(topK, lSearch);
         }
         return VectorSearchParams.automatic(topK);
+    }
+
+    static VectorSearchParams batchSearchParams(Map<String, String> parameters, int topK) {
+        VectorSearchParams searchParams = searchParams(parameters, topK);
+        String reuseMode = parameters.get(IVF_PQ_BATCH_TABLE_REUSE_PARAMETER);
+        return reuseMode == null ? searchParams : searchParams.withIvfPqBatchTableReuse(reuseMode);
     }
 
     private static Integer intParameter(Map<String, String> parameters, String key) {

--- a/paimon-vector/src/test/java/org/apache/paimon/vector/index/NativeVectorGlobalIndexTest.java
+++ b/paimon-vector/src/test/java/org/apache/paimon/vector/index/NativeVectorGlobalIndexTest.java
@@ -27,6 +27,7 @@ import org.apache.paimon.globalindex.ResultEntry;
 import org.apache.paimon.globalindex.ScoredGlobalIndexResult;
 import org.apache.paimon.globalindex.io.GlobalIndexFileReader;
 import org.apache.paimon.globalindex.io.GlobalIndexFileWriter;
+import org.apache.paimon.index.vector.IvfPqBatchTableReuseMode;
 import org.apache.paimon.index.vector.VectorSearchParams;
 import org.apache.paimon.options.Options;
 import org.apache.paimon.predicate.BatchVectorSearch;
@@ -253,6 +254,15 @@ public class NativeVectorGlobalIndexTest {
                 NativeVectorGlobalIndexReader.searchParams(
                         Collections.singletonMap("diskann.l_search", "80"), 10);
         assertThat(diskAnnParams.topK()).isEqualTo(10);
+    }
+
+    @Test
+    public void testIvfPqBatchTableReuseIsPropagatedToBatchSearchParams() {
+        VectorSearchParams params =
+                NativeVectorGlobalIndexReader.batchSearchParams(
+                        Collections.singletonMap("ivf_pq.batch_table_reuse", "on"), 10);
+
+        assertThat(params.ivfPqBatchTableReuse()).isEqualTo(IvfPqBatchTableReuseMode.ON);
     }
 
     @Test


### PR DESCRIPTION
## Summary

Allow batch vector searches to configure IVF-PQ list-table reuse through the `ivf_pq.batch_table_reuse` search option. The optimization itself is provided by apache/paimon-vector-index#65; this change only wires the option through Paimon.

## Changes

- update `paimon-vector-index-java` to `0.4.0-SNAPSHOT`
- apply `ivf_pq.batch_table_reuse` only to batch search parameters
- preserve the existing automatic, IVF `nprobe`, and DiskANN `l_search` parameter handling
- delegate reuse-mode parsing and validation to the vector-index Java API

## Testing

- `mvn -nsu -pl paimon-vector -DwildcardSuites=none -Dtest=NativeVectorGlobalIndexerFactoryTest,NativeVectorGlobalIndexTest,SeekableStreamVectorIndexInputTest test`
- `git diff --check`

## Notes

- Depends on apache/paimon-vector-index#65.
- The Apache `0.4.0-SNAPSHOT` repository artifact may need its next publication before CI can compile against the newly merged API.