### PR TITLE
[fs] Force CVE-patched commons-lang3 and snappy-java in hadoop-shaded-3.4

### DIFF
--- a/paimon-filesystems/paimon-hadoop-shaded-3.4/pom.xml
+++ b/paimon-filesystems/paimon-hadoop-shaded-3.4/pom.xml
@@ -44,6 +44,18 @@
                 <artifactId>commons-beanutils</artifactId>
                 <version>${commons.beanutils.version}</version>
             </dependency>
+            <dependency>
+                <!-- Bumped for security purposes (CVE-2025-48924); aligns bundled version with NOTICE -->
+                <groupId>org.apache.commons</groupId>
+                <artifactId>commons-lang3</artifactId>
+                <version>3.18.0</version>
+            </dependency>
+            <dependency>
+                <!-- Bumped for security purposes; aligns bundled version with NOTICE -->
+                <groupId>org.xerial.snappy</groupId>
+                <artifactId>snappy-java</artifactId>
+                <version>${snappy.version}</version>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 

--- a/paimon-filesystems/paimon-hadoop-shaded-3.4/src/main/resources/META-INF/NOTICE
+++ b/paimon-filesystems/paimon-hadoop-shaded-3.4/src/main/resources/META-INF/NOTICE
@@ -20,7 +20,7 @@ This project bundles the following dependencies under the Apache Software Licens
 - commons-logging:commons-logging:1.1.3
 - org.apache.commons:commons-compress:1.21
 - org.apache.commons:commons-configuration2:2.1.1
-- org.apache.commons:commons-lang3:3.12.0
+- org.apache.commons:commons-lang3:3.18.0
 - org.apache.commons:commons-text:1.4
 - org.apache.hadoop.thirdparty:hadoop-shaded-guava:1.4.0
 - org.apache.hadoop.thirdparty:hadoop-shaded-protobuf_3_25:1.4.0


### PR DESCRIPTION

### Purpose

fix #8933

- `hadoop-common:3.4.2` pulls `commons-lang3:3.17.0` (CVE-2025-48924) and `snappy-java:1.1.10.4` into the shaded jar, unrelocated.
- #6781 raised seven filesystem NOTICE files to 3.18.0 but skipped this module (created two months earlier) and added no pom override. NOTICE already declares `snappy-java:1.1.10.8` while 1.1.10.4 ships.
- Pin both in `dependencyManagement`, mirroring the merged sibling fix #8560.
- NOTICE line 23 is corrected too; #8560 needed no NOTICE change because the sibling entry was already right.
- `paimon-azure-impl` and `paimon-s3-impl` re-bundle this module with `<include>*:*</include>`, so the classes reach published artifacts.

### Tests

- No test added — the module has no Java sources and this is not a runtime change.
- `mvn -pl paimon-filesystems/paimon-hadoop-shaded-3.4 -DfailIfNoTests=false clean install` — BUILD SUCCESS (JDK 11).
- `dependency:tree` before `3.17.0` / `1.1.10.4`, after `3.18.0` / `1.1.10.8`; shade log confirms both in the jar.

