### PR TITLE
[fs] Align paimon-gs dependency scopes with sibling filesystem modules

### DIFF
--- a/paimon-filesystems/paimon-gs/pom.xml
+++ b/paimon-filesystems/paimon-gs/pom.xml
@@ -38,6 +38,7 @@
             <groupId>org.apache.paimon</groupId>
             <artifactId>paimon-common</artifactId>
             <version>${project.version}</version>
+            <scope>provided</scope>
         </dependency>
 
         <dependency>
@@ -52,6 +53,7 @@
             <artifactId>paimon-gs-impl</artifactId>
             <version>${project.version}</version>
             <scope>runtime</scope>
+            <optional>true</optional>
             <exclusions>
                 <exclusion>
                     <groupId>*</groupId>


### PR DESCRIPTION

### Purpose

fix #8937

- The published `paimon-gs` pom leaks `paimon-common` (and its transitives) at compile scope to Maven/Gradle consumers; on Maven Central, `paimon-gs-1.2.0.pom` has `compile` while `paimon-s3-1.2.0.pom` has `provided`.
- Mark `paimon-common` as `provided`, matching all 7 sibling filesystem loaders (s3/oss/obs/cosn/azure/jindo/jindodls) — the core classes are supplied by the Paimon engine bundle at runtime.
- Also mark the `paimon-gs-impl` runtime dependency `<optional>true</optional>`, matching the 5 PluginFileIO siblings.
- Both lines were dropped when #5238 copied the cosn pom.

### Tests

- Pom-only metadata change — no Java behavior to test, no test added.
- JDK 11 `mvn -pl paimon-filesystems/paimon-gs -am -DfailIfNoTests=false clean install` passed (BUILD SUCCESS, checkstyle/spotless/rat included).
- Verified the installed (dependency-reduced) `paimon-gs` pom now declares `paimon-common` with `<scope>provided</scope>` and no longer lists `paimon-gs-impl`.


