### PR TITLE
[spark] Cache blob field lookup in SparkInternalRow

### DIFF
--- a/paimon-api/src/main/java/org/apache/paimon/types/RowType.java
+++ b/paimon-api/src/main/java/org/apache/paimon/types/RowType.java
@@ -70,6 +70,8 @@ public final class RowType extends DataType {
     private transient volatile Map<Integer, DataField> laziedFieldIdToField;
     private transient volatile Map<Integer, Integer> laziedFieldIdToIndex;
 
+    private transient volatile Set<Integer> laziedBlobFieldIndices;
+
     public RowType(boolean isNullable, List<DataField> fields) {
         super(isNullable, DataTypeRoot.ROW);
         this.fields =
@@ -119,6 +121,22 @@ public final class RowType extends DataType {
             projection[i] = getFieldIndex(projectFields.get(i));
         }
         return projection;
+    }
+
+    /** Returns the indices of top-level BLOB fields. */
+    public Set<Integer> getBlobFieldIndices() {
+        Set<Integer> blobFieldIndices = this.laziedBlobFieldIndices;
+        if (blobFieldIndices == null) {
+            Set<Integer> indices = new HashSet<>();
+            for (int i = 0; i < fields.size(); i++) {
+                if (fields.get(i).type().getTypeRoot() == DataTypeRoot.BLOB) {
+                    indices.add(i);
+                }
+            }
+            blobFieldIndices = Collections.unmodifiableSet(indices);
+            this.laziedBlobFieldIndices = blobFieldIndices;
+        }
+        return blobFieldIndices;
     }
 
     public boolean containsField(String fieldName) {

--- a/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/data/SparkInternalRow.scala
+++ b/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/data/SparkInternalRow.scala
@@ -18,13 +18,12 @@
 
 package org.apache.paimon.spark.data
 
-import org.apache.paimon.shade.guava30.com.google.common.cache.{CacheBuilder, CacheLoader, LoadingCache}
-import org.apache.paimon.types.{DataTypeRoot, RowType}
+import org.apache.paimon.types.RowType
 
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.paimon.shims.SparkShimLoader
 
-import scala.collection.mutable
+import scala.collection.JavaConverters._
 
 abstract class SparkInternalRow extends InternalRow {
   def replace(row: org.apache.paimon.data.InternalRow): SparkInternalRow
@@ -34,39 +33,20 @@ abstract class SparkInternalRow extends InternalRow {
 
 object SparkInternalRow {
 
-  private val blobFieldsCache: LoadingCache[RowType, Set[Int]] =
-    CacheBuilder
-      .newBuilder()
-      .weakKeys()
-      .build(new CacheLoader[RowType, Set[Int]] {
-        override def load(rowType: RowType): Set[Int] = findBlobFields(rowType)
-      })
-
   def create(rowType: RowType): SparkInternalRow = {
     create(rowType, blobAsDescriptor = false)
   }
 
   def create(rowType: RowType, blobAsDescriptor: Boolean): SparkInternalRow = {
-    val blobs = blobFields(rowType)
-    if (blobs.nonEmpty) {
-      SparkShimLoader.shim.createSparkInternalRowWithBlob(rowType, blobs, blobAsDescriptor)
-    } else {
+    val blobFieldIndices = rowType.getBlobFieldIndices
+    if (blobFieldIndices.isEmpty) {
       SparkShimLoader.shim.createSparkInternalRow(rowType).withBlobAsDescriptor(blobAsDescriptor)
+    } else {
+      SparkShimLoader.shim.createSparkInternalRowWithBlob(
+        rowType,
+        blobFieldIndices.asScala.map(_.intValue()).toSet,
+        blobAsDescriptor)
     }
-  }
-
-  private def blobFields(rowType: RowType): Set[Int] = blobFieldsCache.getUnchecked(rowType)
-
-  private def findBlobFields(rowType: RowType): Set[Int] = {
-    var i: Int = 0
-    val blobFields = new mutable.HashSet[Int]()
-    while (i < rowType.getFieldCount) {
-      if (rowType.getTypeAt(i).getTypeRoot.equals(DataTypeRoot.BLOB)) {
-        blobFields.add(i)
-      }
-      i += 1
-    }
-    blobFields.toSet
   }
 
 }

--- a/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/data/SparkInternalRow.scala
+++ b/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/data/SparkInternalRow.scala
@@ -23,6 +23,8 @@ import org.apache.paimon.types.{DataTypeRoot, RowType}
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.paimon.shims.SparkShimLoader
 
+import java.util.IdentityHashMap
+
 import scala.collection.mutable
 
 abstract class SparkInternalRow extends InternalRow {
@@ -32,6 +34,8 @@ abstract class SparkInternalRow extends InternalRow {
 }
 
 object SparkInternalRow {
+
+  private val blobFieldsCache = new IdentityHashMap[RowType, Set[Int]]()
 
   def create(rowType: RowType): SparkInternalRow = {
     create(rowType, blobAsDescriptor = false)
@@ -46,7 +50,18 @@ object SparkInternalRow {
     }
   }
 
-  private def blobFields(rowType: RowType): Set[Int] = {
+  private def blobFields(rowType: RowType): Set[Int] = blobFieldsCache.synchronized {
+    val cached = blobFieldsCache.get(rowType)
+    if (cached != null) {
+      cached
+    } else {
+      val fields = findBlobFields(rowType)
+      blobFieldsCache.put(rowType, fields)
+      fields
+    }
+  }
+
+  private def findBlobFields(rowType: RowType): Set[Int] = {
     var i: Int = 0
     val blobFields = new mutable.HashSet[Int]()
     while (i < rowType.getFieldCount) {

--- a/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/data/SparkInternalRow.scala
+++ b/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/data/SparkInternalRow.scala
@@ -18,12 +18,11 @@
 
 package org.apache.paimon.spark.data
 
+import org.apache.paimon.shade.guava30.com.google.common.cache.{CacheBuilder, CacheLoader, LoadingCache}
 import org.apache.paimon.types.{DataTypeRoot, RowType}
 
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.paimon.shims.SparkShimLoader
-
-import java.util.IdentityHashMap
 
 import scala.collection.mutable
 
@@ -35,7 +34,13 @@ abstract class SparkInternalRow extends InternalRow {
 
 object SparkInternalRow {
 
-  private val blobFieldsCache = new IdentityHashMap[RowType, Set[Int]]()
+  private val blobFieldsCache: LoadingCache[RowType, Set[Int]] =
+    CacheBuilder
+      .newBuilder()
+      .weakKeys()
+      .build(new CacheLoader[RowType, Set[Int]] {
+        override def load(rowType: RowType): Set[Int] = findBlobFields(rowType)
+      })
 
   def create(rowType: RowType): SparkInternalRow = {
     create(rowType, blobAsDescriptor = false)
@@ -50,16 +55,7 @@ object SparkInternalRow {
     }
   }
 
-  private def blobFields(rowType: RowType): Set[Int] = blobFieldsCache.synchronized {
-    val cached = blobFieldsCache.get(rowType)
-    if (cached != null) {
-      cached
-    } else {
-      val fields = findBlobFields(rowType)
-      blobFieldsCache.put(rowType, fields)
-      fields
-    }
-  }
+  private def blobFields(rowType: RowType): Set[Int] = blobFieldsCache.getUnchecked(rowType)
 
   private def findBlobFields(rowType: RowType): Set[Int] = {
     var i: Int = 0

--- a/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/data/SparkInternalRowTest.scala
+++ b/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/data/SparkInternalRowTest.scala
@@ -36,20 +36,48 @@ class SparkInternalRowTest extends SparkFunSuite {
     SparkInternalRow.create(rowType)
 
     assert(getTypeRootCount.get() == 10)
+    assert(rowType.getBlobFieldIndices.asScala == Set(3, 7))
+  }
+
+  test("cache blob field lookup per row type instance") {
+    val getTypeRootCount = new AtomicInteger()
+    val first = newRowType(getTypeRootCount)
+    val second = newRowType(getTypeRootCount)
+
+    assert(first == second)
+    SparkInternalRow.create(first)
+    SparkInternalRow.create(second)
+
+    assert(getTypeRootCount.get() == 20)
+  }
+
+  test("blob field indices are immutable") {
+    val rowType = newRowType(new AtomicInteger())
+
+    intercept[UnsupportedOperationException] {
+      rowType.getBlobFieldIndices.add(1)
+    }
   }
 
   private def newRowType(getTypeRootCount: AtomicInteger): RowType = {
-    new RowType(
-      (0 until 10)
-        .map(i => new DataField(i, s"f$i", new CountingBinaryType(getTypeRootCount)))
-        .asJava)
+    new RowType((0 until 10).map {
+      i =>
+        val dataType =
+          if (i == 3 || i == 7) {
+            new CountingBinaryType(getTypeRootCount, DataTypeRoot.BLOB)
+          } else {
+            new CountingBinaryType(getTypeRootCount, DataTypeRoot.BINARY)
+          }
+        new DataField(i, s"f$i", dataType)
+    }.asJava)
   }
 
-  private class CountingBinaryType(getTypeRootCount: AtomicInteger) extends BinaryType {
+  private class CountingBinaryType(getTypeRootCount: AtomicInteger, typeRoot: DataTypeRoot)
+    extends BinaryType {
 
     override def getTypeRoot: DataTypeRoot = {
       getTypeRootCount.incrementAndGet()
-      super.getTypeRoot
+      typeRoot
     }
   }
 }

--- a/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/data/SparkInternalRowTest.scala
+++ b/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/data/SparkInternalRowTest.scala
@@ -1,0 +1,55 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.spark.data
+
+import org.apache.paimon.types.{BinaryType, DataField, DataTypeRoot, RowType}
+
+import org.apache.spark.SparkFunSuite
+
+import java.util.concurrent.atomic.AtomicInteger
+
+import scala.collection.JavaConverters._
+
+class SparkInternalRowTest extends SparkFunSuite {
+
+  test("cache blob field lookup for reused row type") {
+    val getTypeRootCount = new AtomicInteger()
+    val rowType = newRowType(getTypeRootCount)
+
+    SparkInternalRow.create(rowType)
+    SparkInternalRow.create(rowType)
+
+    assert(getTypeRootCount.get() == 10)
+  }
+
+  private def newRowType(getTypeRootCount: AtomicInteger): RowType = {
+    new RowType(
+      (0 until 10)
+        .map(i => new DataField(i, s"f$i", new CountingBinaryType(getTypeRootCount)))
+        .asJava)
+  }
+
+  private class CountingBinaryType(getTypeRootCount: AtomicInteger) extends BinaryType {
+
+    override def getTypeRoot: DataTypeRoot = {
+      getTypeRootCount.incrementAndGet()
+      super.getTypeRoot
+    }
+  }
+}


### PR DESCRIPTION
### What is the purpose of the change

This PR optimizes `SparkInternalRow.create(rowType)` for very wide nested `RowType`s.

When Spark reads a Paimon table containing a wide struct, for example a struct with tens of thousands of fields, nested struct conversion can repeatedly create `SparkInternalRow` wrappers. Before this change, each creation scanned all fields in the `RowType` to find BLOB fields.

In production, executor threads can spend a significant amount of time in the following stack:

```text
org.apache.paimon.types.RowType.getFieldCount
org.apache.paimon.spark.data.SparkInternalRow$.blobFields
org.apache.paimon.spark.data.SparkInternalRow$.create
org.apache.paimon.spark.DataConverter.fromPaimon
org.apache.paimon.spark.AbstractSparkInternalRow.getStruct
```

This repeated scan is expensive for very wide structs.

### Brief change log

- Cache BLOB field lookup results in `SparkInternalRow`.
- Use `IdentityHashMap[RowType, Set[Int]]` so cache lookup does not call `RowType.hashCode` or `RowType.equals`, which may also traverse wide schemas.
- Add a regression test to verify that repeated `SparkInternalRow.create(rowType)` calls for the same `RowType` scan the fields only once.

### Verifying this change

This change added tests and can be verified as follows:

```bash
mvn -pl paimon-spark/paimon-spark-ut -am -Pfast-build -Pspark3 \
  -DfailIfNoTests=false \
  -DwildcardSuites=org.apache.paimon.spark.data.SparkInternalRowTest \
  -Dtest=none test
```

Result:

```text
BUILD SUCCESS
```
