### PR TITLE
[core] Drop concurrently-built global indexes at materialize-deletion compaction

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/append/dataevolution/DataEvolutionCompactGlobalIndexDropper.java
+++ b/paimon-core/src/main/java/org/apache/paimon/append/dataevolution/DataEvolutionCompactGlobalIndexDropper.java
@@ -59,12 +59,20 @@ class DataEvolutionCompactGlobalIndexDropper {
             return Collections.emptyList();
         }
 
+        // Scan at the latest snapshot, not the compaction's base: a global index
+        // built concurrently and committed after this compaction planned still
+        // references pre-materialization row-ids and must be dropped too.
+        Snapshot scanSnapshot = table.snapshotManager().latestSnapshot();
+        if (scanSnapshot == null) {
+            scanSnapshot = snapshot;
+        }
+
         Map<Pair<BinaryRow, Integer>, List<IndexFileMeta>> deletedIndexes = new LinkedHashMap<>();
         for (IndexManifestEntry entry :
                 table.store()
                         .newIndexFileHandler()
                         .scan(
-                                snapshot,
+                                scanSnapshot,
                                 e ->
                                         partitions.contains(e.partition())
                                                 && e.indexFile().globalIndexMeta() != null)) {


### PR DESCRIPTION
### Purpose

`DataEvolutionCompactGlobalIndexDropper` drops global indexes that a
`materialize-deletion` compaction invalidates (the compaction renumbers row-ids,
so pre-materialization indexes become stale). It scanned the compaction's **base**
snapshot for indexes to drop. A global index built concurrently and committed
**after** the compaction planned still encodes pre-materialization row-ids, but is
not visible at the base snapshot, so it survives — and a later vector search
resolves its stale row-ids against renumbered data.

Latent on master today (index build on DV tables is currently blocked); reachable
once Lumina indexes on DV tables are allowed. Self-contained; submitted
independently.

### Change

Scan the **latest** snapshot for stale indexes instead of the compaction base, so
concurrently-committed indexes are also dropped (falling back to the base snapshot
when no newer one exists).
