### PR TITLE
[hive] Support multiset type in hive reads

### DIFF
--- a/paimon-hive/paimon-hive-connector-common/src/main/java/org/apache/paimon/hive/objectinspector/PaimonObjectInspectorFactory.java
+++ b/paimon-hive/paimon-hive-connector-common/src/main/java/org/apache/paimon/hive/objectinspector/PaimonObjectInspectorFactory.java
@@ -24,7 +24,9 @@ import org.apache.paimon.types.CharType;
 import org.apache.paimon.types.DataField;
 import org.apache.paimon.types.DataType;
 import org.apache.paimon.types.DecimalType;
+import org.apache.paimon.types.IntType;
 import org.apache.paimon.types.MapType;
+import org.apache.paimon.types.MultisetType;
 import org.apache.paimon.types.RowType;
 import org.apache.paimon.types.TimeType;
 import org.apache.paimon.types.VarCharType;
@@ -89,6 +91,9 @@ public class PaimonObjectInspectorFactory {
             case MAP:
                 MapType mapType = (MapType) logicalType;
                 return new PaimonMapObjectInspector(mapType.getKeyType(), mapType.getValueType());
+            case MULTISET:
+                MultisetType multisetType = (MultisetType) logicalType;
+                return new PaimonMapObjectInspector(multisetType.getElementType(), new IntType());
             case ROW:
                 List<String> fieldComments =
                         ((RowType) logicalType)

--- a/paimon-hive/paimon-hive-connector-common/src/test/java/org/apache/paimon/hive/objectinspector/PaimonObjectInspectorFactoryTest.java
+++ b/paimon-hive/paimon-hive-connector-common/src/test/java/org/apache/paimon/hive/objectinspector/PaimonObjectInspectorFactoryTest.java
@@ -1,0 +1,71 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.hive.objectinspector;
+
+import org.apache.paimon.data.BinaryString;
+import org.apache.paimon.data.GenericMap;
+import org.apache.paimon.types.DataTypes;
+
+import org.apache.hadoop.hive.serde2.objectinspector.MapObjectInspector;
+import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspector;
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Tests for {@link PaimonObjectInspectorFactory}. */
+public class PaimonObjectInspectorFactoryTest {
+
+    @Test
+    public void testCreateMultisetObjectInspector() {
+        ObjectInspector oi =
+                PaimonObjectInspectorFactory.create(DataTypes.MULTISET(DataTypes.STRING()));
+
+        assertThat(oi.getCategory()).isEqualTo(ObjectInspector.Category.MAP);
+        assertThat(oi.getTypeName()).isEqualTo("map<string,int>");
+
+        MapObjectInspector mapOi = (MapObjectInspector) oi;
+        Map<BinaryString, Integer> javaMap = new HashMap<>();
+        javaMap.put(BinaryString.fromString("apple"), 2);
+        javaMap.put(BinaryString.fromString("banana"), 1);
+        GenericMap multisetData = new GenericMap(javaMap);
+
+        assertThat(mapOi.getMapSize(multisetData)).isEqualTo(2);
+        assertThat(mapOi.getMapValueElement(multisetData, BinaryString.fromString("apple")))
+                .isEqualTo(2);
+        assertThat(mapOi.getMapValueElement(multisetData, BinaryString.fromString("banana")))
+                .isEqualTo(1);
+    }
+
+    @Test
+    public void testCreateRowInspectorContainingMultiset() {
+        PaimonInternalRowObjectInspector inspector =
+                new PaimonInternalRowObjectInspector(
+                        Arrays.asList("id", "tags"),
+                        Arrays.asList(DataTypes.INT(), DataTypes.MULTISET(DataTypes.STRING())),
+                        Arrays.asList(null, null));
+
+        assertThat(inspector.getAllStructFieldRefs()).hasSize(2);
+        assertThat(inspector.getStructFieldRef("tags").getFieldObjectInspector().getTypeName())
+                .isEqualTo("map<string,int>");
+    }
+}


### PR DESCRIPTION
### Purpose
- Hive maps Paimon multiset to map type in table schema, but PaimonObjectInspectorFactory has no multiset support.
- This causes any hive query on a table containing a multiset column fails, even when selecting other columns.
- Create a `PaimonMapObjectInspector` with map type, similar to the internalMap layout to represent multiset types in Paimon today.

### Tests
 - UT