### PR TITLE
Use repository secrets for PyPI publishing

### DIFF
--- a/.github/workflows/release-python-publish.yml
+++ b/.github/workflows/release-python-publish.yml
@@ -20,6 +20,11 @@ name: Release PyPaimon Publish
 
 on:
   workflow_call:
+    secrets:
+      TEST_PYPI_API_TOKEN:
+        required: true
+      PYPI_API_TOKEN:
+        required: true
 
 concurrency:
   group: release-python-publish-${{ github.ref }}
@@ -35,8 +40,6 @@ jobs:
     if: >-
       github.repository == 'apache/paimon' &&
       startsWith(github.ref, 'refs/tags/')
-    environment:
-      name: ${{ contains(github.ref_name, '-rc') && 'testpypi' || 'pypi' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -127,3 +127,6 @@ jobs:
       (needs.java.result == 'success' ||
        needs.validation.outputs.release_kind == 'final')
     uses: ./.github/workflows/release-python-publish.yml
+    secrets:
+      TEST_PYPI_API_TOKEN: ${{ secrets.TEST_PYPI_API_TOKEN }}
+      PYPI_API_TOKEN: ${{ secrets.PYPI_API_TOKEN }}

--- a/docs/docs/project/creating-a-release.md
+++ b/docs/docs/project/creating-a-release.md
@@ -96,15 +96,11 @@ release blocker.
 
 The Java jobs use `-Dgpg.skip=true` and never receive Nexus credentials or a
 GPG private key. Their artifacts are build evidence, not the Maven staging
-repositories used for the vote. The Python RC job uses the protected
-`testpypi` environment to publish `PYPAIMON_VERSIONrcRC_NUMBER` to TestPyPI.
-The final job uses the separate protected `pypi` environment.
-
-Configure both environments with an RM approval and a deployment policy which
-allows only the corresponding signed release tags. Store
-`TEST_PYPI_API_TOKEN` only in `testpypi` and `PYPI_API_TOKEN` only in `pypi`.
-Do not store either token as a repository or organization secret, and do not
-pass unrelated secrets to the reusable publishing workflow.
+repositories used for the vote. The Python RC job uses the
+`TEST_PYPI_API_TOKEN` repository Actions secret to publish
+`PYPAIMON_VERSIONrcRC_NUMBER` to TestPyPI. The final job uses the
+`PYPI_API_TOKEN` repository Actions secret to publish to PyPI. The release
+workflow passes only these two secrets to the reusable publishing workflow.
 
 ## One-time RM setup
 
@@ -122,12 +118,9 @@ Before managing the first release:
    GitHub Actions.
 5. Confirm access to the ASF distribution SVN repository, Apache Nexus,
    TestPyPI, and PyPI.
-6. Create the protected GitHub environments `testpypi` and `pypi`. Configure
-   required RM reviewers and release-tag deployment policies, store only the
-   matching token in each environment, and remove any repository- or
-   organization-level copies of those tokens.
-7. Verify that the Python release secrets are configured without printing
-   their values in an Actions log.
+6. Verify that the repository Actions secrets `TEST_PYPI_API_TOKEN` and
+   `PYPI_API_TOKEN` are configured without printing their values in an Actions
+   log.
 
 ```shell
 gpg --list-secret-keys --keyid-format LONG
@@ -445,8 +438,8 @@ svn mv -m "Release PyPaimon ${PYPAIMON_VERSION}" \
    is still closed and has the exact artifact tree approved by the vote.
 2. Release those exact closed repositories to Maven Central. Do not run Maven
    deploy again.
-3. Approve the protected `pypi` promotion job for the final tag. It must build
-   `pypaimon==PYPAIMON_VERSION` from the approved tag commit and must not change
+3. Confirm that the final tag's PyPI publish job builds
+   `pypaimon==PYPAIMON_VERSION` from the approved tag commit and does not change
    project source.
 4. Verify Maven Central and PyPI before announcing the release.
 


### PR DESCRIPTION
## What changed

- Declare the TestPyPI and PyPI tokens required by the reusable publishing workflow.
- Pass only `TEST_PYPI_API_TOKEN` and `PYPI_API_TOKEN` from the release orchestrator.
- Remove the `testpypi` and `pypi` environment bindings and update the release guide to describe repository Actions Secrets.

## Why

The repository-level Actions Secrets already exist, but reusable workflows do not receive caller secrets automatically. The previous workflow also documented and selected environment-level secrets instead of using the repository secrets directly.

## Impact

RC tags publish PyPaimon to TestPyPI with `TEST_PYPI_API_TOKEN`, while final tags publish to PyPI with `PYPI_API_TOKEN`. No package build behavior changes.

## Validation

- Parsed both changed workflow YAML files successfully.
- Ran `git diff --check`.
- Passed the repository pre-push secret-leak check.
