### PR TITLE
[core] Fix index source metadata compatibility

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/index/GlobalIndexMeta.java
+++ b/paimon-core/src/main/java/org/apache/paimon/index/GlobalIndexMeta.java
@@ -30,6 +30,7 @@ import javax.annotation.Nullable;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Objects;
 
 /** Schema for global index. */
 public class GlobalIndexMeta {
@@ -152,5 +153,31 @@ public class GlobalIndexMeta {
             names.add(rowType.getField(id).name());
         }
         return names;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        GlobalIndexMeta that = (GlobalIndexMeta) o;
+        return rowRangeStart == that.rowRangeStart
+                && rowRangeEnd == that.rowRangeEnd
+                && indexFieldId == that.indexFieldId
+                && Arrays.equals(extraFieldIds, that.extraFieldIds)
+                && Arrays.equals(indexMeta, that.indexMeta)
+                && Arrays.equals(sourceMeta, that.sourceMeta);
+    }
+
+    @Override
+    public int hashCode() {
+        int result = Objects.hash(rowRangeStart, rowRangeEnd, indexFieldId);
+        result = 31 * result + Arrays.hashCode(extraFieldIds);
+        result = 31 * result + Arrays.hashCode(indexMeta);
+        result = 31 * result + Arrays.hashCode(sourceMeta);
+        return result;
     }
 }

--- a/paimon-core/src/main/java/org/apache/paimon/index/IndexFileMeta.java
+++ b/paimon-core/src/main/java/org/apache/paimon/index/IndexFileMeta.java
@@ -152,12 +152,14 @@ public class IndexFileMeta {
                 && fileSize == that.fileSize
                 && rowCount == that.rowCount
                 && Objects.equals(dvRanges, that.dvRanges)
-                && Objects.equals(externalPath, that.externalPath);
+                && Objects.equals(externalPath, that.externalPath)
+                && Objects.equals(globalIndexMeta, that.globalIndexMeta);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(indexType, fileName, fileSize, rowCount, dvRanges, externalPath);
+        return Objects.hash(
+                indexType, fileName, fileSize, rowCount, dvRanges, externalPath, globalIndexMeta);
     }
 
     @Override

--- a/paimon-core/src/main/java/org/apache/paimon/index/IndexFileMetaSerializer.java
+++ b/paimon-core/src/main/java/org/apache/paimon/index/IndexFileMetaSerializer.java
@@ -73,10 +73,7 @@ public class IndexFileMetaSerializer extends ObjectSerializer<IndexFileMeta> {
             int[] extralFields =
                     globalIndexRow.isNullAt(3) ? null : globalIndexRow.getArray(3).toIntArray();
             byte[] indexMeta = globalIndexRow.isNullAt(4) ? null : globalIndexRow.getBinary(4);
-            byte[] sourceMeta =
-                    globalIndexRow.getFieldCount() <= 5 || globalIndexRow.isNullAt(5)
-                            ? null
-                            : globalIndexRow.getBinary(5);
+            byte[] sourceMeta = globalIndexRow.isNullAt(5) ? null : globalIndexRow.getBinary(5);
             globalIndexMeta =
                     new GlobalIndexMeta(
                             rowRangeStart,

--- a/paimon-core/src/main/java/org/apache/paimon/index/IndexFileMetaV4Deserializer.java
+++ b/paimon-core/src/main/java/org/apache/paimon/index/IndexFileMetaV4Deserializer.java
@@ -1,0 +1,111 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.index;
+
+import org.apache.paimon.data.InternalRow;
+import org.apache.paimon.data.serializer.InternalRowSerializer;
+import org.apache.paimon.data.serializer.InternalSerializers;
+import org.apache.paimon.io.DataInputView;
+import org.apache.paimon.types.ArrayType;
+import org.apache.paimon.types.BigIntType;
+import org.apache.paimon.types.DataField;
+import org.apache.paimon.types.DataTypes;
+import org.apache.paimon.types.IntType;
+import org.apache.paimon.types.RowType;
+
+import java.io.IOException;
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.apache.paimon.index.IndexFileMetaSerializer.rowArrayDataToDvMetas;
+import static org.apache.paimon.utils.SerializationUtils.newStringType;
+
+/** Deserializer for {@link IndexFileMeta} in commit message version 11. */
+public class IndexFileMetaV4Deserializer implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    private static final RowType GLOBAL_INDEX_SCHEMA =
+            new RowType(
+                    true,
+                    Arrays.asList(
+                            new DataField(0, "_ROW_RANGE_START", new BigIntType(false)),
+                            new DataField(1, "_ROW_RANGE_END", new BigIntType(false)),
+                            new DataField(2, "_INDEX_FIELD_ID", new IntType(false)),
+                            new DataField(
+                                    3, "_EXTRA_FIELD_IDS", DataTypes.ARRAY(new IntType(false))),
+                            new DataField(4, "_INDEX_META", DataTypes.BYTES())));
+
+    public static final RowType SCHEMA =
+            new RowType(
+                    false,
+                    Arrays.asList(
+                            new DataField(0, "_INDEX_TYPE", newStringType(false)),
+                            new DataField(1, "_FILE_NAME", newStringType(false)),
+                            new DataField(2, "_FILE_SIZE", new BigIntType(false)),
+                            new DataField(3, "_ROW_COUNT", new BigIntType(false)),
+                            new DataField(
+                                    4,
+                                    "_DELETIONS_VECTORS_RANGES",
+                                    new ArrayType(true, DeletionVectorMeta.SCHEMA)),
+                            new DataField(5, "_EXTERNAL_PATH", newStringType(true)),
+                            new DataField(6, "_GLOBAL_INDEX", GLOBAL_INDEX_SCHEMA)));
+
+    private final InternalRowSerializer rowSerializer;
+
+    public IndexFileMetaV4Deserializer() {
+        this.rowSerializer = InternalSerializers.create(SCHEMA);
+    }
+
+    private IndexFileMeta fromRow(InternalRow row) {
+        GlobalIndexMeta globalIndexMeta = null;
+        if (!row.isNullAt(6)) {
+            InternalRow globalIndexRow = row.getRow(6, GLOBAL_INDEX_SCHEMA.getFieldCount());
+            long rowRangeStart = globalIndexRow.getLong(0);
+            long rowRangeEnd = globalIndexRow.getLong(1);
+            int indexFieldId = globalIndexRow.getInt(2);
+            int[] extraFields =
+                    globalIndexRow.isNullAt(3) ? null : globalIndexRow.getArray(3).toIntArray();
+            byte[] indexMeta = globalIndexRow.isNullAt(4) ? null : globalIndexRow.getBinary(4);
+            globalIndexMeta =
+                    new GlobalIndexMeta(
+                            rowRangeStart, rowRangeEnd, indexFieldId, extraFields, indexMeta);
+        }
+
+        return new IndexFileMeta(
+                row.getString(0).toString(),
+                row.getString(1).toString(),
+                row.getLong(2),
+                row.getLong(3),
+                row.isNullAt(4) ? null : rowArrayDataToDvMetas(row.getArray(4)),
+                row.isNullAt(5) ? null : row.getString(5).toString(),
+                globalIndexMeta);
+    }
+
+    public List<IndexFileMeta> deserializeList(DataInputView source) throws IOException {
+        int size = source.readInt();
+        List<IndexFileMeta> records = new ArrayList<>(size);
+        for (int i = 0; i < size; i++) {
+            records.add(fromRow(rowSerializer.deserialize(source)));
+        }
+        return records;
+    }
+}

--- a/paimon-core/src/main/java/org/apache/paimon/manifest/IndexManifestEntrySerializer.java
+++ b/paimon-core/src/main/java/org/apache/paimon/manifest/IndexManifestEntrySerializer.java
@@ -43,7 +43,7 @@ public class IndexManifestEntrySerializer extends VersionedObjectSerializer<Inde
 
     @Override
     public int getVersion() {
-        return 1;
+        return 2;
     }
 
     @Override
@@ -77,13 +77,13 @@ public class IndexManifestEntrySerializer extends VersionedObjectSerializer<Inde
 
     @Override
     public IndexManifestEntry convertFrom(int version, InternalRow row) {
-        if (version != 1) {
+        if (version < 1 || version > 2) {
             throw new UnsupportedOperationException("Unsupported version: " + version);
         }
 
         GlobalIndexMeta globalIndexMeta = null;
         if (!row.isNullAt(9)) {
-            InternalRow globalIndexRow = row.getRow(9, 6);
+            InternalRow globalIndexRow = row.getRow(9, version == 1 ? 5 : 6);
             long rowRangeStart = globalIndexRow.getLong(0);
             long rowRangeEnd = globalIndexRow.getLong(1);
             int indexFieldId = globalIndexRow.getInt(2);
@@ -91,9 +91,7 @@ public class IndexManifestEntrySerializer extends VersionedObjectSerializer<Inde
                     globalIndexRow.isNullAt(3) ? null : globalIndexRow.getArray(3).toIntArray();
             byte[] indexMeta = globalIndexRow.isNullAt(4) ? null : globalIndexRow.getBinary(4);
             byte[] sourceMeta =
-                    globalIndexRow.getFieldCount() <= 5 || globalIndexRow.isNullAt(5)
-                            ? null
-                            : globalIndexRow.getBinary(5);
+                    version == 1 || globalIndexRow.isNullAt(5) ? null : globalIndexRow.getBinary(5);
             globalIndexMeta =
                     new GlobalIndexMeta(
                             rowRangeStart,

--- a/paimon-core/src/main/java/org/apache/paimon/table/sink/CommitMessageSerializer.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/sink/CommitMessageSerializer.java
@@ -25,6 +25,7 @@ import org.apache.paimon.index.IndexFileMetaSerializer;
 import org.apache.paimon.index.IndexFileMetaV1Deserializer;
 import org.apache.paimon.index.IndexFileMetaV2Deserializer;
 import org.apache.paimon.index.IndexFileMetaV3Deserializer;
+import org.apache.paimon.index.IndexFileMetaV4Deserializer;
 import org.apache.paimon.io.CompactIncrement;
 import org.apache.paimon.io.DataFileMeta;
 import org.apache.paimon.io.DataFileMeta08Serializer;
@@ -51,7 +52,7 @@ import static org.apache.paimon.utils.SerializationUtils.serializeBinaryRow;
 /** {@link VersionedSerializer} for {@link CommitMessage}. */
 public class CommitMessageSerializer implements VersionedSerializer<CommitMessage> {
 
-    public static final int CURRENT_VERSION = 11;
+    public static final int CURRENT_VERSION = 12;
 
     private final DataFileMetaSerializer dataFileSerializer;
     private final IndexFileMetaSerializer indexEntrySerializer;
@@ -64,6 +65,7 @@ public class CommitMessageSerializer implements VersionedSerializer<CommitMessag
     private IndexFileMetaV1Deserializer indexEntryV1Deserializer;
     private IndexFileMetaV2Deserializer indexEntryV2Deserializer;
     private IndexFileMetaV3Deserializer indexEntryV3Deserializer;
+    private IndexFileMetaV4Deserializer indexEntryV4Deserializer;
 
     public CommitMessageSerializer() {
         this.dataFileSerializer = new DataFileMetaSerializer();
@@ -217,8 +219,13 @@ public class CommitMessageSerializer implements VersionedSerializer<CommitMessag
 
     private IOExceptionSupplier<List<IndexFileMeta>> indexEntryDeserializer(
             int version, DataInputView view) {
-        if (version >= 11) {
+        if (version >= 12) {
             return () -> indexEntrySerializer.deserializeList(view);
+        } else if (version == 11) {
+            if (indexEntryV4Deserializer == null) {
+                indexEntryV4Deserializer = new IndexFileMetaV4Deserializer();
+            }
+            return () -> indexEntryV4Deserializer.deserializeList(view);
         } else if (version >= 9) {
             if (indexEntryV3Deserializer == null) {
                 indexEntryV3Deserializer = new IndexFileMetaV3Deserializer();

--- a/paimon-core/src/test/java/org/apache/paimon/index/IndexFileMetaSerializerTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/index/IndexFileMetaSerializerTest.java
@@ -51,6 +51,28 @@ public class IndexFileMetaSerializerTest extends ObjectSerializerTestBase<IndexF
         assertThat(restored.indexMeta()).containsExactly(3, 4);
     }
 
+    @Test
+    void testEqualityIncludesGlobalIndexMeta() {
+        IndexFileMeta first =
+                globalIndexFile(
+                        new GlobalIndexMeta(
+                                0, 9, 7, new int[] {8}, new byte[] {3}, new byte[] {1}));
+        IndexFileMeta equal =
+                globalIndexFile(
+                        new GlobalIndexMeta(
+                                0, 9, 7, new int[] {8}, new byte[] {3}, new byte[] {1}));
+        IndexFileMeta different =
+                globalIndexFile(
+                        new GlobalIndexMeta(
+                                0, 9, 7, new int[] {8}, new byte[] {3}, new byte[] {2}));
+
+        assertThat(first).isEqualTo(equal).hasSameHashCodeAs(equal).isNotEqualTo(different);
+    }
+
+    private static IndexFileMeta globalIndexFile(GlobalIndexMeta globalIndexMeta) {
+        return new IndexFileMeta("ivf-pq", "index-file", 100, 10, globalIndexMeta, null);
+    }
+
     @Override
     protected ObjectSerializer<IndexFileMeta> serializer() {
         return new IndexFileMetaSerializer();

--- a/paimon-core/src/test/java/org/apache/paimon/manifest/IndexManifestEntrySerializerTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/manifest/IndexManifestEntrySerializerTest.java
@@ -21,13 +21,20 @@ package org.apache.paimon.manifest;
 import org.apache.paimon.data.BinaryRow;
 import org.apache.paimon.data.GenericRow;
 import org.apache.paimon.data.InternalRow;
+import org.apache.paimon.data.JoinedRow;
+import org.apache.paimon.data.serializer.InternalRowSerializer;
+import org.apache.paimon.data.serializer.InternalSerializers;
 import org.apache.paimon.index.GlobalIndexMeta;
 import org.apache.paimon.index.IndexFileMeta;
+import org.apache.paimon.io.DataOutputViewStreamWrapper;
 import org.apache.paimon.utils.ObjectSerializer;
 import org.apache.paimon.utils.ObjectSerializerTestBase;
+import org.apache.paimon.utils.VersionedObjectSerializer;
 
 import org.junit.jupiter.api.Test;
 
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
 import java.util.Random;
 
 import static org.apache.paimon.index.IndexFileMetaSerializerTest.randomIndexFile;
@@ -38,7 +45,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class IndexManifestEntrySerializerTest extends ObjectSerializerTestBase<IndexManifestEntry> {
 
     @Test
-    void testReadsGlobalIndexWithoutSourceMeta() {
+    void testReadsGlobalIndexWithoutSourceMeta() throws IOException {
         IndexManifestEntrySerializer serializer = new IndexManifestEntrySerializer();
         IndexManifestEntry entry =
                 new IndexManifestEntry(
@@ -53,18 +60,55 @@ public class IndexManifestEntrySerializerTest extends ObjectSerializerTestBase<I
                                 new GlobalIndexMeta(0, 9, 7, null, new byte[] {1}),
                                 null));
         GenericRow serialized = (GenericRow) serializer.convertTo(entry);
-        serialized.setField(9, GenericRow.of(0L, 9L, 7, null, new byte[] {1}));
+        InternalRowSerializer legacyGlobalIndexSerializer =
+                InternalSerializers.create(
+                        GlobalIndexMeta.SCHEMA.copy(
+                                GlobalIndexMeta.SCHEMA.getFields().subList(0, 5)));
+        BinaryRow legacyGlobalIndexRow =
+                legacyGlobalIndexSerializer
+                        .toBinaryRow(GenericRow.of(0L, 9L, 7, null, new byte[] {1}))
+                        .copy();
+        serialized.setField(9, legacyGlobalIndexRow);
 
-        InternalRow globalIndexRow = serialized.getRow(9, 5);
-        assertThat(globalIndexRow.getFieldCount()).isEqualTo(5);
+        InternalRow version1Row = new JoinedRow().replace(GenericRow.of(1), serialized);
+        InternalRowSerializer versionedRowSerializer =
+                InternalSerializers.create(
+                        VersionedObjectSerializer.versionType(IndexManifestEntry.SCHEMA));
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        versionedRowSerializer.serialize(version1Row, new DataOutputViewStreamWrapper(out));
+
         GlobalIndexMeta restored =
-                serializer
-                        .convertFrom(serializer.getVersion(), serialized)
-                        .indexFile()
-                        .globalIndexMeta();
+                serializer.deserializeFromBytes(out.toByteArray()).indexFile().globalIndexMeta();
 
         assertThat(restored.indexMeta()).containsExactly(1);
         assertThat(restored.sourceMeta()).isNull();
+    }
+
+    @Test
+    void testGlobalIndexSourceMetaRoundTrip() throws IOException {
+        IndexManifestEntrySerializer serializer = new IndexManifestEntrySerializer();
+        IndexManifestEntry entry =
+                new IndexManifestEntry(
+                        FileKind.ADD,
+                        BinaryRow.EMPTY_ROW,
+                        0,
+                        new IndexFileMeta(
+                                "ivf-pq",
+                                "index-file",
+                                100,
+                                10,
+                                new GlobalIndexMeta(
+                                        0, 9, 7, null, new byte[] {3, 4}, new byte[] {1, 2}),
+                                null));
+
+        GlobalIndexMeta restored =
+                serializer
+                        .deserializeFromBytes(serializer.serializeToBytes(entry))
+                        .indexFile()
+                        .globalIndexMeta();
+
+        assertThat(restored.indexMeta()).containsExactly(3, 4);
+        assertThat(restored.sourceMeta()).containsExactly(1, 2);
     }
 
     @Override

--- a/paimon-core/src/test/java/org/apache/paimon/manifest/ManifestCommittableSerializerCompatibilityTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/manifest/ManifestCommittableSerializerCompatibilityTest.java
@@ -83,7 +83,8 @@ public class ManifestCommittableSerializerCompatibilityTest {
                         Arrays.asList("asdf", "qwer", "zxcv"));
         List<DataFileMeta> dataFiles = Collections.singletonList(dataFile);
         GlobalIndexMeta globalIndexMeta =
-                new GlobalIndexMeta(1L, 2L, 3, new int[] {5, 6, 7}, new byte[] {0x23, 0x45});
+                new GlobalIndexMeta(
+                        1L, 2L, 3, new int[] {5, 6, 7}, new byte[] {0x23, 0x45}, new byte[] {0x67});
         IndexFileMeta hashIndexFile =
                 new IndexFileMeta(
                         "my_index_type",
@@ -133,6 +134,13 @@ public class ManifestCommittableSerializerCompatibilityTest {
         byte[] bytes = serializer.serialize(manifestCommittable);
         ManifestCommittable deserialized = serializer.deserialize(serializer.getVersion(), bytes);
         assertThat(deserialized).isEqualTo(manifestCommittable);
+        GlobalIndexMeta deserializedGlobalIndexMeta =
+                ((CommitMessageImpl) deserialized.fileCommittables().get(0))
+                        .newFilesIncrement()
+                        .newIndexFiles()
+                        .get(0)
+                        .globalIndexMeta();
+        assertThat(deserializedGlobalIndexMeta.sourceMeta()).containsExactly(0x67);
 
         byte[] oldBytes =
                 IOUtils.readFully(
@@ -142,6 +150,13 @@ public class ManifestCommittableSerializerCompatibilityTest {
                         true);
         deserialized = serializer.deserialize(5, oldBytes);
         assertThat(deserialized).isEqualTo(manifestCommittable);
+        deserializedGlobalIndexMeta =
+                ((CommitMessageImpl) deserialized.fileCommittables().get(0))
+                        .newFilesIncrement()
+                        .newIndexFiles()
+                        .get(0)
+                        .globalIndexMeta();
+        assertThat(deserializedGlobalIndexMeta.sourceMeta()).isNull();
     }
 
     @Test

--- a/paimon-core/src/test/java/org/apache/paimon/manifest/ManifestCommittableSerializerCompatibilityTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/manifest/ManifestCommittableSerializerCompatibilityTest.java
@@ -107,28 +107,8 @@ public class ManifestCommittableSerializerCompatibilityTest {
                         dvRanges,
                         "external_path");
 
-        CommitMessageImpl commitMessage =
-                new CommitMessageImpl(
-                        singleColumn("my_partition"),
-                        11,
-                        16,
-                        new DataIncrement(
-                                dataFiles,
-                                dataFiles,
-                                dataFiles,
-                                Collections.singletonList(hashIndexFile),
-                                Collections.singletonList(hashIndexFile)),
-                        new CompactIncrement(
-                                dataFiles,
-                                dataFiles,
-                                dataFiles,
-                                Collections.singletonList(devIndexFile),
-                                Collections.emptyList()));
-
         ManifestCommittable manifestCommittable =
-                new ManifestCommittable(5, 202020L, Collections.singletonList(commitMessage));
-        manifestCommittable.addProperty("k1", "v1");
-        manifestCommittable.addProperty("k2", "v2");
+                createManifestCommittable(dataFiles, hashIndexFile, devIndexFile);
 
         ManifestCommittableSerializer serializer = new ManifestCommittableSerializer();
         byte[] bytes = serializer.serialize(manifestCommittable);
@@ -149,7 +129,19 @@ public class ManifestCommittableSerializerCompatibilityTest {
                                 .getResourceAsStream("compatibility/" + fileName),
                         true);
         deserialized = serializer.deserialize(5, oldBytes);
-        assertThat(deserialized).isEqualTo(manifestCommittable);
+        GlobalIndexMeta legacyGlobalIndexMeta =
+                new GlobalIndexMeta(1L, 2L, 3, new int[] {5, 6, 7}, new byte[] {0x23, 0x45});
+        IndexFileMeta legacyHashIndexFile =
+                new IndexFileMeta(
+                        "my_index_type",
+                        "my_index_file",
+                        1024 * 100,
+                        1002,
+                        null,
+                        null,
+                        legacyGlobalIndexMeta);
+        assertThat(deserialized)
+                .isEqualTo(createManifestCommittable(dataFiles, legacyHashIndexFile, devIndexFile));
         deserializedGlobalIndexMeta =
                 ((CommitMessageImpl) deserialized.fileCommittables().get(0))
                         .newFilesIncrement()
@@ -157,6 +149,32 @@ public class ManifestCommittableSerializerCompatibilityTest {
                         .get(0)
                         .globalIndexMeta();
         assertThat(deserializedGlobalIndexMeta.sourceMeta()).isNull();
+    }
+
+    private static ManifestCommittable createManifestCommittable(
+            List<DataFileMeta> dataFiles, IndexFileMeta hashIndexFile, IndexFileMeta devIndexFile) {
+        CommitMessageImpl commitMessage =
+                new CommitMessageImpl(
+                        singleColumn("my_partition"),
+                        11,
+                        16,
+                        new DataIncrement(
+                                dataFiles,
+                                dataFiles,
+                                dataFiles,
+                                Collections.singletonList(hashIndexFile),
+                                Collections.singletonList(hashIndexFile)),
+                        new CompactIncrement(
+                                dataFiles,
+                                dataFiles,
+                                dataFiles,
+                                Collections.singletonList(devIndexFile),
+                                Collections.emptyList()));
+        ManifestCommittable manifestCommittable =
+                new ManifestCommittable(5, 202020L, Collections.singletonList(commitMessage));
+        manifestCommittable.addProperty("k1", "v1");
+        manifestCommittable.addProperty("k2", "v2");
+        return manifestCommittable;
     }
 
     @Test


### PR DESCRIPTION
## What changed

- Bump the commit message serializer to version 12 and route version 11 through a legacy five-field `GlobalIndexMeta` deserializer.
- Bump the index manifest entry serializer to version 2 and read version 1 entries with the original five-field nested row.
- Give `GlobalIndexMeta` value-based equality and include it in `IndexFileMeta.equals/hashCode`.
- Add binary regression coverage for old version 11 committables, current `sourceMeta` round trips, and metadata equality.

## Why

`sourceMeta` was added to the nested `GlobalIndexMeta` row without upgrading its enclosing serializer versions. Calling `getRow(..., 6)` constructs a `NestedRow` whose arity is always six, so `getFieldCount()` cannot identify older five-field data and bytes from the variable-length section can be misread as `sourceMeta`.

The compatibility test originally missed this corruption because `IndexFileMeta.equals` did not compare `globalIndexMeta`.

## Impact

Released five-field version 11 commit messages and version 1 index manifest entries now deserialize correctly with a null `sourceMeta`. New version 12/v2 data preserves `sourceMeta`. `IndexFileMeta` equality now distinguishes different global-index metadata and maintains the matching hash-code contract.

## Compatibility limitation

Commit `21d8e0ca59e` introduced `sourceMeta` on 2026-07-11 without changing the enclosing serializer versions. Builds based on that commit can therefore have written a six-field `GlobalIndexMeta` while still labeling commit messages as v11 and index manifest entries as v1.

This fix intentionally interprets every v11 commit message and v1 index manifest entry as the original five-field layout. It does **not** preserve `sourceMeta` from six-field v11/v1 data written by builds between `21d8e0ca59e` and this versioning fix. The remaining fields, including `indexMeta`, are preserved, but `sourceMeta` is read as null.

Affected primary-key vector, full-text, or sorted-index payloads may consequently be considered stale or rejected, and paths requiring source metadata can report that the index has no source metadata. Affected indexes should be rebuilt after upgrading. The reader does not attempt to distinguish the two physical layouts because they share the same enclosing version numbers.

## Tests

`mvn -o -pl paimon-core -am -DfailIfNoTests=false -DwildcardSuites=none -Dtest=ManifestCommittableSerializerCompatibilityTest,IndexManifestEntrySerializerTest,IndexFileMetaSerializerTest,CommitMessageSerializerTest test`

All 22 targeted tests passed, together with Checkstyle, Spotless, and Maven Enforcer checks.
