### PR TITLE
[docs] Add dls:// to the supported filesystems table

### DIFF
--- a/docs/docs/maintenance/filesystems.mdx
+++ b/docs/docs/maintenance/filesystems.mdx
@@ -48,6 +48,7 @@ FileSystem pluggable jars for user to query tables from Spark/Hive side.
 | Microsoft Azure Storage      | abfs://    | Y         |                                                                        |
 | Huawei OBS                   | obs://     | Y         |                                                                        |
 | Google Cloud Storage         | gs://      | Y         |                                                                        |
+| Aliyun OSS-HDFS (DLS)        | dls://     | Y         | Requires `paimon-jindodls` and `paimon-jindo` jars, and the Jindo SDK in the environment (see [OSS](#oss)) |
 
 ## Dependency
 


### PR DESCRIPTION

### Purpose

fix #8954

- Add a `dls://` row to the "Supported FileSystems" table in `docs/docs/maintenance/filesystems.mdx`.
- `JindoDLSLoader.getScheme()` returns `"dls"` and is registered in `META-INF/services/org.apache.paimon.fs.FileIOLoader`; `paimon-jindodls` 1.4.1/1.4.2 are on Maven Central, yet `grep -rn "dls" docs/` matched nothing.
- The Description column names the required jars and the environment-supplied Jindo SDK, and links to the [OSS](#oss) section that already documents that model for Jindo Fs.
- Loader added in #7145, moved to `paimon-jindodls` in #7263.

### Tests

- Docs-only change, no behavior change — no test added.
- One added line; the table's column count and separator style are unchanged.
- `yarn build` in `docs/` passes locally; also covered by CI (`.github/workflows/docs-tests.yml`).

