### PR TITLE
[filesystem][obs] Remove access key and secret from required options in OBSLoader

### DIFF
--- a/paimon-filesystems/paimon-obs/src/main/java/org/apache/paimon/obs/OBSLoader.java
+++ b/paimon-filesystems/paimon-obs/src/main/java/org/apache/paimon/obs/OBSLoader.java
@@ -57,8 +57,6 @@ public class OBSLoader implements FileIOLoader {
     public List<String[]> requiredOptions() {
         List<String[]> options = new ArrayList<>();
         options.add(new String[] {"fs.obs.endpoint"});
-        options.add(new String[] {"fs.obs.access.key", "fs.obs.access-key"});
-        options.add(new String[] {"fs.obs.secret.key", "fs.obs.secret-key"});
         return options;
     }
 

--- a/paimon-filesystems/paimon-obs/src/test/java/org/apache/paimon/obs/OBSLoaderTest.java
+++ b/paimon-filesystems/paimon-obs/src/test/java/org/apache/paimon/obs/OBSLoaderTest.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.obs;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Tests for {@link OBSLoader}. */
+public class OBSLoaderTest {
+
+    @Test
+    public void testScheme() {
+        assertThat(new OBSLoader().getScheme()).isEqualTo("obs");
+    }
+
+    /**
+     * The OBS loader must only require the endpoint, which OBSA reads without a default. Access key
+     * / secret key are optional so that credential-less authentication (ECS agency and other {@code
+     * fs.obs.security.provider} chains) routes through the bundled OBS plugin instead of being
+     * gated out and falling back to another {@code FileIO}.
+     */
+    @Test
+    public void testDoesNotRequireCredentials() {
+        List<String> keys = new ArrayList<>();
+        for (String[] group : new OBSLoader().requiredOptions()) {
+            keys.addAll(Arrays.asList(group));
+        }
+        assertThat(keys).containsExactly("fs.obs.endpoint");
+    }
+}


### PR DESCRIPTION
### Purpose

fix #8957

- Required options are a selection gate: declaring `fs.obs.access.key`/`fs.obs.secret.key` makes `FileIO.get()` discard `OBSLoader` for catalogs without static credentials.
- The `HadoopFileIO` fallback cannot resolve `OBSFileSystem` (plugin-only classloader), so `obs://` fails with `UnsupportedSchemeException`.
- hadoop-huaweicloud authenticates without static keys: `DefaultOBSClientFactory` builds an `ObsClient` from the `fs.obs.security.provider` `IObsCredentialsProvider` when both are empty.
- Mirrors #8679, which removed the same gate from `S3Loader`.
- `fs.obs.endpoint` stays required — `DefaultOBSClientFactory` reads it without a default.

### Tests

- Added `OBSLoaderTest#testScheme` and `#testDoesNotRequireCredentials`, asserting required options flatten to exactly `fs.obs.endpoint`.
- `mvn -pl paimon-filesystems/paimon-obs -DfailIfNoTests=false clean install` on JDK 11: 2 tests passed.
- No end-to-end test against a real OBS backend — the build has no OBS emulator. Coverage is the loader's required-options contract only.

