### PR TITLE
[obs] Add listFilesIterative implementation in HadoopCompliantFileIO

### DIFF
--- a/paimon-filesystems/paimon-obs-impl/src/main/java/org/apache/paimon/obs/HadoopCompliantFileIO.java
+++ b/paimon-filesystems/paimon-obs-impl/src/main/java/org/apache/paimon/obs/HadoopCompliantFileIO.java
@@ -22,6 +22,7 @@ import org.apache.paimon.fs.FileIO;
 import org.apache.paimon.fs.FileStatus;
 import org.apache.paimon.fs.Path;
 import org.apache.paimon.fs.PositionOutputStream;
+import org.apache.paimon.fs.RemoteIterator;
 import org.apache.paimon.fs.SeekableInputStream;
 
 import org.apache.hadoop.fs.FSDataInputStream;
@@ -77,6 +78,26 @@ public abstract class HadoopCompliantFileIO implements FileIO {
             }
         }
         return statuses;
+    }
+
+    @Override
+    public RemoteIterator<FileStatus> listFilesIterative(Path path, boolean recursive)
+            throws IOException {
+        org.apache.hadoop.fs.Path hadoopPath = path(path);
+        org.apache.hadoop.fs.RemoteIterator<org.apache.hadoop.fs.LocatedFileStatus> hadoopIter =
+                getFileSystem(hadoopPath).listFiles(hadoopPath, recursive);
+        return new RemoteIterator<FileStatus>() {
+            @Override
+            public boolean hasNext() throws IOException {
+                return hadoopIter.hasNext();
+            }
+
+            @Override
+            public FileStatus next() throws IOException {
+                org.apache.hadoop.fs.FileStatus hadoopStatus = hadoopIter.next();
+                return new HadoopFileStatus(hadoopStatus);
+            }
+        };
     }
 
     @Override


### PR DESCRIPTION
### Purpose

fix #8959

- Override `listFilesIterative(Path, boolean)` in `org.apache.paimon.obs.HadoopCompliantFileIO` to delegate to Hadoop `OBSFileSystem.listFiles(path, recursive)`, so recursive listing uses OBSA's bulk listing instead of the `FileIO` default's one `listStatus` per directory.
- Parity gap: `oss`, `s3`, `jindo` and core `HadoopFileIO` already have this override. Ported verbatim from `oss`, identical to jindo `0cc45257a`.
- Returned set is unchanged (files only). Order becomes flat instead of BFS, and `FileNotFoundException` for a missing path surfaces eagerly — matching core/oss/s3/jindo.

### Tests

- No test added: this module has no `src/test` and OBS has no local emulator. Precedent: gs #8559 (same class) and jindo `0cc45257a` merged without tests.
- `mvn -pl paimon-filesystems/paimon-obs-impl -DfailIfNoTests=false clean install` — BUILD SUCCESS (checkstyle, spotless, enforcer).
