### PR TITLE
[spark] Fix mergedRecordSize truncation to zero

### DIFF
--- a/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/commands/PaimonAnalyzeTableColumnCommand.scala
+++ b/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/commands/PaimonAnalyzeTableColumnCommand.scala
@@ -70,7 +70,7 @@ case class PaimonAnalyzeTableColumnCommand(
 
     val totalRecordCount = currentSnapshot.totalRecordCount()
     checkState(totalRecordCount >= mergedRecordCount)
-    val mergedRecordSize = totalSize * (mergedRecordCount.toDouble / totalRecordCount).toLong
+    val mergedRecordSize = (totalSize.toDouble * mergedRecordCount / totalRecordCount).toLong
 
     // convert to paimon stats
     val tableSchema = table.schema()

--- a/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/sql/AnalyzeTableTestBase.scala
+++ b/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/sql/AnalyzeTableTestBase.scala
@@ -52,6 +52,26 @@ abstract class AnalyzeTableTestBase extends PaimonSparkTestBase {
     Assertions.assertTrue(stats.colStats().isEmpty)
   }
 
+  test("Paimon analyze: mergedRecordSize should not truncate to zero") {
+    spark.sql(s"""
+                 |CREATE TABLE T (id STRING, name STRING)
+                 |USING PAIMON
+                 |TBLPROPERTIES ('primary-key'='id')
+                 |""".stripMargin)
+
+    spark.sql(s"INSERT INTO T VALUES ('1', 'a')")
+    spark.sql(s"INSERT INTO T VALUES ('1', 'bb')")
+    spark.sql(s"INSERT INTO T VALUES ('1', 'ccc')")
+
+    spark.sql(s"ANALYZE TABLE T COMPUTE STATISTICS")
+
+    val stats = loadTable("T").statistics().get()
+    Assertions.assertEquals(1L, stats.mergedRecordCount().getAsLong)
+
+    Assertions.assertTrue(stats.mergedRecordSize().isPresent)
+    Assertions.assertTrue(stats.mergedRecordSize().getAsLong > 0)
+  }
+
   test("Paimon analyze: test statistic system table") {
     spark.sql(s"""
                  |CREATE TABLE T (id STRING, name STRING, i INT, l LONG)


### PR DESCRIPTION
### Purpose

`PaimonAnalyzeTableColumnCommand` computed `mergedRecordSize` as:

```scala
totalSize * (mergedRecordCount.toDouble / totalRecordCount).toLong
```

The .toLong was applied to the ratio before multiplying by totalSize. Since mergedRecordCount <= totalRecordCount, the ratio is always in [0, 1], so it gets truncated to 0 whenever mergedRecordCount < totalRecordCount (e.g. after updates on a primary-key table), making mergedRecordSize incorrectly 0 even though there is data.

### Tests

```bash
mvn -pl paimon-spark/paimon-spark-3.5 -am -Pfast-build -Pspark3 \
  -DwildcardSuites=org.apache.paimon.spark.sql.AnalyzeTableTest \
  -DfailIfNoTests=false -Dtest=none test -o
```