### PR TITLE
[oss] Update bundled NOTICE for the aliyun-sdk-oss 3.17.4 upgrade

### DIFF
--- a/paimon-filesystems/paimon-oss-impl/src/main/resources/META-INF/NOTICE
+++ b/paimon-filesystems/paimon-oss-impl/src/main/resources/META-INF/NOTICE
@@ -8,20 +8,20 @@ This project bundles the following dependencies under the Apache Software Licens
 
 - org.apache.hadoop:hadoop-common:3.3.4
 - org.apache.hadoop.thirdparty:hadoop-shaded-protobuf_3_7:1.1.1
-- com.aliyun.oss:aliyun-sdk-oss:3.13.2
+- com.aliyun.oss:aliyun-sdk-oss:3.17.4
 - com.aliyun:aliyun-java-sdk-core:4.5.10
 - com.aliyun:aliyun-java-sdk-kms:2.11.0
 - com.aliyun:aliyun-java-sdk-ram:3.1.0
 - com.google.code.gson:gson:2.8.6
-- commons-codec:commons-codec:1.9
+- commons-codec:commons-codec:1.11
 - commons-logging:commons-logging:1.1.3
 - io.opentracing:opentracing-api:0.33.0
 - io.opentracing:opentracing-noop:0.33.0
 - io.opentracing:opentracing-util:0.33.0
 - org.apache.hadoop:hadoop-aliyun:3.3.4
-- org.apache.httpcomponents:httpclient:4.4.1
-- org.apache.httpcomponents:httpcore:4.4.1
-- org.codehaus.jettison:jettison:1.1
+- org.apache.httpcomponents:httpclient:4.5.13
+- org.apache.httpcomponents:httpcore:4.4.13
+- org.codehaus.jettison:jettison:1.5.4
 - org.ini4j:ini4j:0.5.4
 - stax:stax-api:1.0.1
 - org.apache.hadoop:hadoop-annotations:3.3.4
@@ -57,7 +57,7 @@ You find it under licenses/LICENSE.jacoco.
 This project bundles the following dependencies under the JDOM license.
 You find it under licenses/LICENSE.jdom.
 
-- org.jdom:jdom2:2.0.6
+- org.jdom:jdom2:2.0.6.1
 
 This project bundles the following dependencies under the MIT (https://opensource.org/licenses/MIT).
 You find them under licenses/LICENSE.checker-framework-qualifiers and licenses/LICENSE.animal-sniffer.


### PR DESCRIPTION

### Purpose

fix #8966

- #8832 raised `fs.oss.sdk.version` to 3.17.4 without updating the module's bundled `META-INF/NOTICE`, so the shaded `paimon-oss` jar declares six versions it no longer ships.
- Corrects `aliyun-sdk-oss` 3.17.4, `commons-codec` 1.11, `httpclient` 4.5.13, `httpcore` 4.4.13, `jettison` 1.5.4, `jdom2` 2.0.6.1 — no other lines touched.
- `commons-logging` stays at 1.1.3: Maven resolves 1.2, but the shade plugin's first-wins ordering bundles hadoop-shaded's 1.1.3 classes.
- Same shape as #7383, #6781.

### Tests

- Resource-only change, no test added.
- `mvn -pl paimon-filesystems/paimon-oss-impl -DskipTests package` prints exactly these six:
```
Including com.aliyun.oss:aliyun-sdk-oss:jar:3.17.4 in the shaded jar.
Including org.apache.httpcomponents:httpclient:jar:4.5.13 in the shaded jar.
Including org.apache.httpcomponents:httpcore:jar:4.4.13 in the shaded jar.
Including commons-codec:commons-codec:jar:1.11 in the shaded jar.
Including org.jdom:jdom2:jar:2.0.6.1 in the shaded jar.
Including org.codehaus.jettison:jettison:jar:1.5.4 in the shaded jar.
```
- `mvn -pl paimon-filesystems/paimon-oss-impl -DfailIfNoTests=false clean install` (JDK 11): BUILD SUCCESS, 15 `OSSFileIOTest` tests passed, checkstyle and spotless green.


