### PR TITLE
[filesystem][s3] Fix multipart part upload missing SSE-C encryption parameters

### DIFF
--- a/paimon-filesystems/paimon-s3-impl/src/main/java/org/apache/paimon/s3/S3MultiPartUpload.java
+++ b/paimon-filesystems/paimon-s3-impl/src/main/java/org/apache/paimon/s3/S3MultiPartUpload.java
@@ -18,6 +18,7 @@
 
 package org.apache.paimon.s3;
 
+import org.apache.paimon.annotation.VisibleForTesting;
 import org.apache.paimon.fs.MultiPartUploadStore;
 
 import org.apache.hadoop.conf.Configuration;
@@ -89,16 +90,27 @@ public class S3MultiPartUpload
             String objectName, String uploadId, int partNumber, File file, int byteLength)
             throws IOException {
         UploadPartRequest request =
-                UploadPartRequest.builder()
-                        .bucket(s3a.getBucket())
-                        .key(objectName)
-                        .uploadId(uploadId)
-                        .partNumber(partNumber)
-                        .contentLength((long) byteLength)
-                        .build();
+                newUploadPartRequest(objectName, uploadId, partNumber, byteLength);
         RequestBody body = RequestBody.fromBytes(Files.readAllBytes(file.toPath()));
         UploadPartResponse response = s3accessHelper.uploadPart(request, body, null);
         return CompletedPart.builder().partNumber(partNumber).eTag(response.eTag()).build();
+    }
+
+    /**
+     * Builds the part request through the S3A request factory, the same way the multipart upload is
+     * initiated. Hand-assembling the request would drop the SSE-C encryption parameters, which S3
+     * requires on every part when the upload was initiated with a customer-provided key.
+     *
+     * <p>{@code isLastPart} is always {@code false}: the caller does not know in advance which part
+     * is the last one, and the factory only uses the flag to set {@code sdkPartType}, which the
+     * hand-assembled request never set either.
+     */
+    @VisibleForTesting
+    UploadPartRequest newUploadPartRequest(
+            String objectName, String uploadId, int partNumber, int byteLength) throws IOException {
+        return s3accessHelper
+                .newUploadPartRequestBuilder(objectName, uploadId, partNumber, false, byteLength)
+                .build();
     }
 
     @Override

--- a/paimon-filesystems/paimon-s3-impl/src/test/java/org/apache/paimon/s3/S3MultiPartUploadTest.java
+++ b/paimon-filesystems/paimon-s3-impl/src/test/java/org/apache/paimon/s3/S3MultiPartUploadTest.java
@@ -1,0 +1,105 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.s3;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.s3a.S3AFileSystem;
+import org.junit.jupiter.api.Test;
+import software.amazon.awssdk.services.s3.model.UploadPartRequest;
+
+import java.io.IOException;
+import java.net.URI;
+import java.util.Base64;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests for the {@link UploadPartRequest} built by {@link S3MultiPartUpload}. No S3 backend is
+ * contacted: {@code fs.s3a.bucket.probe=0} makes {@link S3AFileSystem#initialize} skip the bucket
+ * existence check, so the request factory can be exercised offline.
+ */
+class S3MultiPartUploadTest {
+
+    private static final String BUCKET = "paimon-test-bucket";
+    private static final String OBJECT_NAME = "path/to/object";
+    private static final String UPLOAD_ID = "test-upload-id";
+
+    @Test
+    void testUploadPartRequestCarriesSseCustomerParameters() throws Exception {
+        Configuration conf = baseConfiguration();
+        conf.set("fs.s3a.encryption.algorithm", "SSE-C");
+        conf.set("fs.s3a.encryption.key", sseCustomerKey());
+
+        UploadPartRequest request = newUploadPartRequest(conf);
+
+        assertThat(request.sseCustomerAlgorithm()).isEqualTo("AES256");
+        assertThat(request.sseCustomerKey()).isNotNull();
+        assertThat(request.sseCustomerKeyMD5()).isNotNull();
+    }
+
+    @Test
+    void testUploadPartRequestWithoutEncryption() throws Exception {
+        UploadPartRequest request = newUploadPartRequest(baseConfiguration());
+
+        assertThat(request.sseCustomerAlgorithm()).isNull();
+        assertThat(request.sseCustomerKey()).isNull();
+        assertThat(request.sseCustomerKeyMD5()).isNull();
+    }
+
+    @Test
+    void testUploadPartRequestKeepsPartCoordinates() throws Exception {
+        UploadPartRequest request = newUploadPartRequest(baseConfiguration());
+
+        assertThat(request.bucket()).isEqualTo(BUCKET);
+        assertThat(request.key()).isEqualTo(OBJECT_NAME);
+        assertThat(request.uploadId()).isEqualTo(UPLOAD_ID);
+        assertThat(request.partNumber()).isEqualTo(3);
+        assertThat(request.contentLength()).isEqualTo(1024L);
+        assertThat(request.sdkPartType()).isNull();
+    }
+
+    private static UploadPartRequest newUploadPartRequest(Configuration conf) throws IOException {
+        try (S3AFileSystem fs = new S3AFileSystem()) {
+            fs.initialize(URI.create("s3a://" + BUCKET + "/"), conf);
+            S3MultiPartUpload upload = new S3MultiPartUpload(fs, conf);
+            return upload.newUploadPartRequest(OBJECT_NAME, UPLOAD_ID, 3, 1024);
+        }
+    }
+
+    private static Configuration baseConfiguration() {
+        Configuration conf = new Configuration(false);
+        // Never reach the network: no bucket probe, dummy credentials and an unroutable endpoint.
+        conf.setInt("fs.s3a.bucket.probe", 0);
+        conf.set("fs.s3a.endpoint", "http://localhost:1");
+        conf.set("fs.s3a.endpoint.region", "us-east-1");
+        conf.set("fs.s3a.path.style.access", "true");
+        conf.set("fs.s3a.access.key", "dummy-access-key");
+        conf.set("fs.s3a.secret.key", "dummy-secret-key");
+        return conf;
+    }
+
+    /** A 256-bit key, base64 encoded, as required by {@code fs.s3a.encryption.key} for SSE-C. */
+    private static String sseCustomerKey() {
+        byte[] key = new byte[32];
+        for (int i = 0; i < key.length; i++) {
+            key[i] = (byte) i;
+        }
+        return Base64.getEncoder().encodeToString(key);
+    }
+}


### PR DESCRIPTION
### Purpose

fix #8968

- `S3MultiPartUpload.uploadPart()` hand-assembles the `UploadPartRequest`, bypassing the S3A request factory that `startMultiPartUpload()` already uses.
- SSE-C requires identical encryption parameters on every part, so S3 rejects the part upload (HTTP 400). SSE-S3/SSE-KMS/DSSE-KMS are unaffected.
- `closeForCommit()` uploads a part unconditionally, so every non-empty format table file is affected regardless of size. Normal table writes go through S3A's `S3ABlockOutputStream`, which already uses the factory.
- Also relaxes the per-part timeout from the 60s client-level default to the intended 15 minutes.
- Regression from #7187, which kept the helper for initiate/complete/abort.

### Tests

- Added `S3MultiPartUploadTest`: the built request carries the SSE-C parameters, none without encryption, part coordinates unchanged. The SSE-C assertion fails against the hand-assembled request.
- `mvn -pl paimon-filesystems/paimon-s3-impl -Dtest='!S3FileIOTest' clean install` — 3 tests passed. `S3FileIOTest` needs Docker/MinIO — covered by CI.
