### PR TITLE
[parquet] Support boolean predicate push down for parquet

### DIFF
--- a/paimon-format/src/main/java/org/apache/parquet/filter2/predicate/ParquetFilters.java
+++ b/paimon-format/src/main/java/org/apache/parquet/filter2/predicate/ParquetFilters.java
@@ -326,6 +326,8 @@ public class ParquetFilters {
 
             // The literal has to speak whatever the file holds, not what the table declares.
             switch (pushdownTarget(fieldRef, fileSchema, caseSensitive).type) {
+                case BOOLEAN:
+                    return toBoolean(value);
                 case INT32:
                     return toInt(value);
                 case INT64:
@@ -340,6 +342,13 @@ public class ParquetFilters {
                 default:
                     throw new UnsupportedOperationException();
             }
+        }
+
+        private Comparable<?> toBoolean(Object value) {
+            if (value instanceof Boolean) {
+                return (Boolean) value;
+            }
+            throw new UnsupportedOperationException();
         }
 
         private Comparable<?> toInt(Object value) {

--- a/paimon-format/src/test/java/org/apache/paimon/format/parquet/ParquetFiltersTest.java
+++ b/paimon-format/src/test/java/org/apache/paimon/format/parquet/ParquetFiltersTest.java
@@ -23,6 +23,7 @@ import org.apache.paimon.data.Timestamp;
 import org.apache.paimon.predicate.Predicate;
 import org.apache.paimon.predicate.PredicateBuilder;
 import org.apache.paimon.types.BigIntType;
+import org.apache.paimon.types.BooleanType;
 import org.apache.paimon.types.DataField;
 import org.apache.paimon.types.DecimalType;
 import org.apache.paimon.types.DoubleType;
@@ -68,6 +69,28 @@ import java.util.stream.LongStream;
 import static org.assertj.core.api.Assertions.assertThat;
 
 class ParquetFiltersTest {
+
+    @Test
+    public void testBoolean() {
+        RowType rowType =
+                new RowType(Collections.singletonList(new DataField(0, "flag", new BooleanType())));
+        MessageType schema = ParquetSchemaConverter.convertToParquetMessageType(rowType);
+        PredicateBuilder builder = new PredicateBuilder(rowType);
+
+        test(schema, builder.isNull(0), "eq(flag, null)", true);
+
+        test(schema, builder.isNotNull(0), "noteq(flag, null)", true);
+
+        test(schema, builder.equal(0, true), "eq(flag, true)", true);
+
+        test(schema, builder.notEqual(0, false), "noteq(flag, false)", true);
+
+        test(
+                schema,
+                builder.in(0, Arrays.asList(true, false)),
+                "or(eq(flag, true), eq(flag, false))",
+                true);
+    }
 
     @Test
     public void testLong() {


### PR DESCRIPTION
### Purpose
 - ParquetFilters drops any predicate on boolean column. `toParquetObject` does not have bool conversion logic, the conversion throws an error and silently drops the filter. (hence pushdown of bool filter dos not work)
 - Convert Boolean literals so equality, inequality, and IN predicates on boolean columns push down to parquet.

### Tests
 - UT