### PR TITLE
[flink] Support skipping update-time expired partitions in compaction

### DIFF
--- a/docs/docs/maintenance/dedicated-compaction.mdx
+++ b/docs/docs/maintenance/dedicated-compaction.mdx
@@ -454,16 +454,15 @@ Example: compact historical partitions for tables in database
 
 ## Skip Expired Partitions in Compaction Job
 
-When [partition expiration](./manage-partitions#expiring-partitions) is configured with
-`partition.expiration-strategy = values-time`, a compaction job may waste resources compacting
-partitions that are already expired and will soon be deleted.
+When [partition expiration](./manage-partitions#expiring-partitions) is configured, a compaction job
+may waste resources compacting partitions that are already expired and will soon be deleted.
 
 You can set `compaction.skip-expired-partitions = true` to make the compaction job skip these
 already-expired partitions, avoiding unnecessary compaction work on data that will be deleted shortly.
 
 :::info
 
-This option requires `partition.expiration-strategy = values-time` to be configured on the table.
+This option supports both `values-time` and `update-time` partition expiration strategies.
 It only supports primary key tables with fixed or dynamic bucket mode. Unaware bucket (append-only) tables
 and `compact_database` in `combined` mode are not supported — the option will be silently ignored in those cases.
 

--- a/docs/generated/core_configuration.html
+++ b/docs/generated/core_configuration.html
@@ -426,7 +426,7 @@ under the License.
             <td><h5>compaction.skip-expired-partitions</h5></td>
             <td style="word-wrap: break-word;">false</td>
             <td>Boolean</td>
-            <td>Whether to skip compacting partitions that are already expired according to 'partition.expiration-time'. Only effective when 'partition.expiration-time' is set and 'partition.expiration-strategy' is 'values-time'. Note: even when this option is enabled, expired partitions may still be deleted during the compaction commit phase as a side effect of partition expiration triggered by committing the remaining active partitions.</td>
+            <td>Whether to skip compacting partitions that are already expired according to 'partition.expiration-time'. Only effective when 'partition.expiration-time' is set. Note: even when this option is enabled, expired partitions may still be deleted during the compaction commit phase as a side effect of partition expiration triggered by committing the remaining active partitions.</td>
         </tr>
         <tr>
             <td><h5>compaction.small-file-ratio</h5></td>

--- a/paimon-api/src/main/java/org/apache/paimon/CoreOptions.java
+++ b/paimon-api/src/main/java/org/apache/paimon/CoreOptions.java
@@ -1397,8 +1397,7 @@ public class CoreOptions implements Serializable {
                     .withDescription(
                             "Whether to skip compacting partitions that are already expired "
                                     + "according to 'partition.expiration-time'. "
-                                    + "Only effective when 'partition.expiration-time' is set "
-                                    + "and 'partition.expiration-strategy' is 'values-time'. "
+                                    + "Only effective when 'partition.expiration-time' is set. "
                                     + "Note: even when this option is enabled, expired partitions "
                                     + "may still be deleted during the compaction commit phase "
                                     + "as a side effect of partition expiration triggered by "

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/source/CompactorSourceBuilder.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/source/CompactorSourceBuilder.java
@@ -36,6 +36,7 @@ import org.apache.paimon.types.RowType;
 import org.apache.paimon.utils.Preconditions;
 
 import org.apache.flink.api.common.eventtime.WatermarkStrategy;
+import org.apache.flink.api.common.functions.FilterFunction;
 import org.apache.flink.api.connector.source.Source;
 import org.apache.flink.streaming.api.datastream.DataStreamSource;
 import org.apache.flink.streaming.api.datastream.SingleOutputStreamOperator;
@@ -45,6 +46,7 @@ import org.apache.flink.table.runtime.typeutils.InternalTypeInfo;
 
 import javax.annotation.Nullable;
 
+import java.io.Serializable;
 import java.time.Duration;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
@@ -171,17 +173,25 @@ public class CompactorSourceBuilder {
             }
             dataStream = new DataStreamSource<>(filterStream);
         }
+        return applySkipExpiredPartitionsFilter(dataStream, compactBucketsTable);
+    }
+
+    private DataStreamSource<RowData> applySkipExpiredPartitionsFilter(
+            DataStreamSource<RowData> dataStream, CompactBucketsTable compactBucketsTable) {
         CoreOptions coreOptions = table.coreOptions();
-        if (coreOptions.compactionSkipExpiredPartitions()
-                && coreOptions.partitionExpireTime() != null
-                && CoreOptions.PartitionExpireStrategy.VALUES_TIME
-                        .toString()
-                        .equals(coreOptions.partitionExpireStrategy())) {
+        if (!coreOptions.compactionSkipExpiredPartitions()
+                || coreOptions.partitionExpireTime() == null) {
+            return dataStream;
+        }
+
+        Duration expireTime = coreOptions.partitionExpireTime();
+        String strategy = coreOptions.partitionExpireStrategy();
+        SingleOutputStreamOperator<RowData> filterStream;
+        if (CoreOptions.PartitionExpireStrategy.VALUES_TIME.toString().equals(strategy)) {
             RowType partitionType = table.schema().logicalPartitionType();
-            Duration expireTime = coreOptions.partitionExpireTime();
             PartitionValuesTimeExpireStrategy expireStrategy =
                     new PartitionValuesTimeExpireStrategy(coreOptions, partitionType);
-            SingleOutputStreamOperator<RowData> filterStream =
+            filterStream =
                     dataStream.filter(
                             rowData -> {
                                 LocalDateTime expireDateTime =
@@ -189,12 +199,24 @@ public class CompactorSourceBuilder {
                                 BinaryRow partition = deserializeBinaryRow(rowData.getBinary(1));
                                 return !expireStrategy.isExpired(expireDateTime, partition);
                             });
-            if (parallelism != null) {
-                filterStream.setParallelism(parallelism);
+        } else if (CoreOptions.PartitionExpireStrategy.UPDATE_TIME.toString().equals(strategy)) {
+            if (isContinuous) {
+                filterStream =
+                        dataStream.filter(
+                                new UpdateTimePartitionFilter(
+                                        expireTime, () -> getPartitionInfo(compactBucketsTable)));
+            } else {
+                final Map<BinaryRow, Long> partitionInfo = getPartitionInfo(compactBucketsTable);
+                filterStream =
+                        dataStream.filter(
+                                rowData -> shouldKeepPartition(rowData, expireTime, partitionInfo));
             }
-            dataStream = new DataStreamSource<>(filterStream);
+        } else {
+            return dataStream;
         }
-        return dataStream;
+
+        filterStream.setParallelism(dataStream.getParallelism());
+        return new DataStreamSource<>(filterStream);
     }
 
     private Map<String, String> streamingCompactOptions() {
@@ -295,12 +317,61 @@ public class CompactorSourceBuilder {
         }
     }
 
-    private Map<BinaryRow, Long> getPartitionInfo(CompactBucketsTable table) {
+    private static Map<BinaryRow, Long> getPartitionInfo(CompactBucketsTable table) {
         List<PartitionEntry> partitions = table.newSnapshotReader().partitionEntries();
 
         return partitions.stream()
                 .collect(
                         Collectors.toMap(
                                 PartitionEntry::partition, PartitionEntry::lastFileCreationTime));
+    }
+
+    private static boolean shouldKeepPartition(
+            RowData rowData, Duration expireTime, Map<BinaryRow, Long> partitionInfo) {
+        long expireMilli =
+                LocalDateTime.now()
+                        .minus(expireTime)
+                        .atZone(ZoneId.systemDefault())
+                        .toInstant()
+                        .toEpochMilli();
+        BinaryRow partition = deserializeBinaryRow(rowData.getBinary(1));
+        Long lastUpdateTime = partitionInfo.get(partition);
+        return shouldKeepPartition(lastUpdateTime, expireMilli);
+    }
+
+    static boolean shouldKeepPartition(@Nullable Long lastUpdateTime, long expireMilli) {
+        return lastUpdateTime == null || lastUpdateTime >= expireMilli;
+    }
+
+    @FunctionalInterface
+    interface PartitionInfoLoader extends Serializable {
+
+        Map<BinaryRow, Long> load();
+    }
+
+    static class UpdateTimePartitionFilter implements FilterFunction<RowData> {
+
+        private static final long serialVersionUID = 1L;
+
+        private final Duration expireTime;
+        private final PartitionInfoLoader partitionInfoLoader;
+
+        private transient long cachedSnapshotId = Long.MIN_VALUE;
+        private transient Map<BinaryRow, Long> partitionInfo;
+
+        UpdateTimePartitionFilter(Duration expireTime, PartitionInfoLoader partitionInfoLoader) {
+            this.expireTime = expireTime;
+            this.partitionInfoLoader = partitionInfoLoader;
+        }
+
+        @Override
+        public boolean filter(RowData rowData) {
+            long snapshotId = rowData.getLong(0);
+            if (partitionInfo == null || cachedSnapshotId != snapshotId) {
+                partitionInfo = partitionInfoLoader.load();
+                cachedSnapshotId = snapshotId;
+            }
+            return shouldKeepPartition(rowData, expireTime, partitionInfo);
+        }
     }
 }

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/action/CompactActionITCase.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/action/CompactActionITCase.java
@@ -24,6 +24,7 @@ import org.apache.paimon.Snapshot;
 import org.apache.paimon.data.BinaryRow;
 import org.apache.paimon.data.BinaryString;
 import org.apache.paimon.data.InternalRow;
+import org.apache.paimon.data.Timestamp;
 import org.apache.paimon.flink.FlinkConnectorOptions;
 import org.apache.paimon.fs.Path;
 import org.apache.paimon.fs.local.LocalFileIO;
@@ -1001,6 +1002,74 @@ public class CompactActionITCase extends CompactActionITCaseBase {
 
     @Test
     @Timeout(60)
+    public void testSkipExpiredPartitionsWithUpdateTime() throws Exception {
+        String expiredPartition = "expired";
+        String activePartition = "active";
+
+        Map<String, String> tableOptions = new HashMap<>();
+        tableOptions.put(CoreOptions.WRITE_ONLY.key(), "true");
+        tableOptions.put(CoreOptions.PARTITION_EXPIRATION_TIME.key(), "7 d");
+        tableOptions.put(
+                CoreOptions.PARTITION_EXPIRATION_STRATEGY.key(),
+                CoreOptions.PartitionExpireStrategy.UPDATE_TIME.toString());
+        // Prevent partition expiration from running during the compact commit.
+        tableOptions.put(CoreOptions.PARTITION_EXPIRATION_CHECK_INTERVAL.key(), "999 d");
+
+        FileStoreTable table =
+                prepareTable(
+                        Collections.singletonList("dt"),
+                        Arrays.asList("dt", "k"),
+                        Collections.emptyList(),
+                        tableOptions);
+
+        long expiredCreationTime = System.currentTimeMillis() - Duration.ofDays(30).toMillis();
+        writeDataWithCreationTime(
+                0L,
+                expiredPartition,
+                expiredCreationTime,
+                rowData(1, 100, 15, BinaryString.fromString(expiredPartition)),
+                rowData(1, 100, 15, BinaryString.fromString(activePartition)));
+        writeDataWithCreationTime(
+                1L,
+                expiredPartition,
+                expiredCreationTime,
+                rowData(2, 100, 15, BinaryString.fromString(expiredPartition)),
+                rowData(2, 100, 15, BinaryString.fromString(activePartition)));
+
+        checkLatestSnapshot(table, 2, Snapshot.CommitKind.APPEND);
+
+        CompactAction action =
+                createAction(
+                        CompactAction.class,
+                        "compact",
+                        "--warehouse",
+                        warehouse,
+                        "--database",
+                        database,
+                        "--table",
+                        tableName,
+                        "--table_conf",
+                        CoreOptions.COMPACTION_SKIP_EXPIRED_PARTITIONS.key() + "=true");
+        StreamExecutionEnvironment env = streamExecutionEnvironmentBuilder().batchMode().build();
+        action.withStreamExecutionEnvironment(env).build();
+        env.execute();
+
+        checkLatestSnapshot(table, 3, Snapshot.CommitKind.COMPACT);
+
+        List<DataSplit> splits = table.newSnapshotReader().read().dataSplits();
+        for (DataSplit split : splits) {
+            String partition = split.partition().getString(0).toString();
+            if (partition.equals(activePartition)) {
+                assertThat(split.dataFiles()).hasSize(1);
+            } else {
+                assertThat(partition).isEqualTo(expiredPartition);
+                assertThat(split.dataFiles()).hasSize(2);
+            }
+        }
+    }
+
+    @Test
+    @Timeout(60)
     public void testNotSkipExpiredPartitionsByDefault() throws Exception {
         String expiredDt =
                 LocalDate.now().minusDays(30).format(DateTimeFormatter.ofPattern("yyyyMMdd"));
@@ -1055,6 +1124,58 @@ public class CompactActionITCase extends CompactActionITCaseBase {
         for (DataSplit split : splits) {
             assertThat(split.dataFiles().size()).isEqualTo(1);
         }
+    }
+
+    private void writeDataWithCreationTime(
+            long commitIdentifier, String partition, long creationTime, InternalRow... data)
+            throws Exception {
+        for (InternalRow row : data) {
+            write.write(row);
+        }
+        List<CommitMessage> commitMessages = write.prepareCommit(true, commitIdentifier);
+        commitMessages.stream()
+                .map(CommitMessageImpl.class::cast)
+                .filter(message -> message.partition().getString(0).toString().equals(partition))
+                .forEach(
+                        message -> {
+                            List<DataFileMeta> newFiles =
+                                    new ArrayList<>(message.newFilesIncrement().newFiles());
+                            message.newFilesIncrement().newFiles().clear();
+                            message.newFilesIncrement()
+                                    .newFiles()
+                                    .addAll(
+                                            newFiles.stream()
+                                                    .map(
+                                                            file ->
+                                                                    copyWithCreationTime(
+                                                                            file, creationTime))
+                                                    .collect(Collectors.toList()));
+                        });
+        commit.commit(commitIdentifier, commitMessages);
+    }
+
+    private static DataFileMeta copyWithCreationTime(DataFileMeta file, long creationTime) {
+        return DataFileMeta.create(
+                file.fileName(),
+                file.fileSize(),
+                file.rowCount(),
+                file.minKey(),
+                file.maxKey(),
+                file.keyStats(),
+                file.valueStats(),
+                file.minSequenceNumber(),
+                file.maxSequenceNumber(),
+                file.schemaId(),
+                file.level(),
+                file.extraFiles(),
+                Timestamp.fromEpochMillis(creationTime),
+                file.deleteRowCount().orElse(null),
+                file.embeddedIndex(),
+                file.fileSource().orElse(null),
+                file.valueStatsCols(),
+                file.externalPath().orElse(null),
+                file.firstRowId(),
+                file.writeCols());
     }
 
     private void setFirstRowId(List<CommitMessage> commitables, long firstRowId) {

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/source/CompactorSourceBuilderTest.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/source/CompactorSourceBuilderTest.java
@@ -26,13 +26,17 @@ import org.apache.paimon.io.DataFileMeta;
 import org.apache.paimon.options.Options;
 import org.apache.paimon.table.source.DataSplit;
 
+import org.apache.flink.table.data.GenericRowData;
 import org.junit.jupiter.api.Test;
 
+import java.time.Duration;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
 
+import static org.apache.paimon.utils.SerializationUtils.serializeBinaryRow;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -117,6 +121,36 @@ public class CompactorSourceBuilderTest {
                         dataFile("file-2", 25L));
 
         assertThat(CompactorSourceBuilder.bucketFileSize(split)).isEqualTo(35L);
+    }
+
+    @Test
+    public void testUpdateTimePartitionFilterRefreshesOncePerSnapshot() throws Exception {
+        AtomicInteger loadCount = new AtomicInteger();
+        Map<BinaryRow, Long> partitionInfo =
+                Collections.singletonMap(BinaryRow.EMPTY_ROW, Long.MAX_VALUE);
+        CompactorSourceBuilder.UpdateTimePartitionFilter filter =
+                new CompactorSourceBuilder.UpdateTimePartitionFilter(
+                        Duration.ofDays(1),
+                        () -> {
+                            loadCount.incrementAndGet();
+                            return partitionInfo;
+                        });
+
+        assertThat(filter.filter(compactBucketRow(1L))).isTrue();
+        assertThat(filter.filter(compactBucketRow(1L))).isTrue();
+        assertThat(filter.filter(compactBucketRow(2L))).isTrue();
+        assertThat(loadCount).hasValue(2);
+    }
+
+    @Test
+    public void testUpdateTimePartitionFilterKeepsExpirationBoundary() {
+        assertThat(CompactorSourceBuilder.shouldKeepPartition(100L, 100L)).isTrue();
+        assertThat(CompactorSourceBuilder.shouldKeepPartition(99L, 100L)).isFalse();
+        assertThat(CompactorSourceBuilder.shouldKeepPartition(null, 100L)).isTrue();
+    }
+
+    private static GenericRowData compactBucketRow(long snapshotId) {
+        return GenericRowData.of(snapshotId, serializeBinaryRow(BinaryRow.EMPTY_ROW));
     }
 
     private static Options optionsWithParallelism(int scanParallelism, int sinkParallelism) {


### PR DESCRIPTION
### Purpose
  Extend compaction.skip-expired-partitions to support the update-time
  partition expiration strategy. Refresh partition update metadata for each
  snapshot in streaming compaction while reusing it across rows from the same
  snapshot.

  Update the option documentation and generated configuration reference.

### Tests
  - CompactorSourceBuilderTest
  - CompactActionITCase#testSkipExpiredPartitionsWithUpdateTime