### PR TITLE
[core] Fix error classification for invalid bucket key

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/schema/SchemaValidation.java
+++ b/paimon-core/src/main/java/org/apache/paimon/schema/SchemaValidation.java
@@ -1197,7 +1197,7 @@ public class SchemaValidation {
         int bucket = options.bucket();
         if (bucket == -1) {
             if (options.toMap().get(BUCKET_KEY.key()) != null) {
-                throw new RuntimeException(
+                throw new IllegalArgumentException(
                         "Cannot define 'bucket-key' with bucket = -1, please remove the 'bucket-key' setting or specify a bucket number.");
             }
 

--- a/paimon-core/src/test/java/org/apache/paimon/schema/SchemaValidationTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/schema/SchemaValidationTest.java
@@ -1595,6 +1595,17 @@ class SchemaValidationTest {
     }
 
     @Test
+    public void testBucketKeyWithDynamicBucket() {
+        Map<String, String> options = new HashMap<>();
+        options.put(CoreOptions.BUCKET_KEY.key(), "f1");
+
+        assertThatThrownBy(() -> validateTableSchemaExec(options))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage(
+                        "Cannot define 'bucket-key' with bucket = -1, please remove the 'bucket-key' setting or specify a bucket number.");
+    }
+
+    @Test
     public void testMergeOnReadIgnoredWhenDvDisabled() {
         Map<String, String> options = new HashMap<>();
         options.put("deletion-vectors.merge-on-read", "true");


### PR DESCRIPTION
### Purpose

A CREATE TABLE request that configures bucket-key together with bucket = -1 is invalid. SchemaValidation currently reports this deterministic validation failure as a plain RuntimeException.

In the REST Catalog deployment where we encountered this issue, the server fallback mapped the RuntimeException to HTTP 503. The Paimon REST client retried the request, and the authentication layer then rejected the retry with SignatureNonceUsed. Users therefore saw a secondary nonce error instead of the actual invalid table configuration, while a non-retryable request error was treated as transient.

The REST Catalog OpenAPI defines HTTP 400 for illegal create-table requests, and REST servers map IllegalArgumentException to that response. This change uses IllegalArgumentException for this validation so the original configuration error can be returned as a non-retryable bad request.

### Changes

- Throw IllegalArgumentException when bucket-key is configured with bucket = -1.
- Add a regression test that verifies the exception type and original validation message.

### Tests

- mvn -pl paimon-core -Pfast-build -DwildcardSuites=none -Dtest=SchemaValidationTest test
- 51 tests passed.