### PR TITLE
[python][ray] Handle existing empty merge targets

### DIFF
--- a/paimon-python/pypaimon/ray/data_evolution_merge_into.py
+++ b/paimon-python/pypaimon/ray/data_evolution_merge_into.py
@@ -281,6 +281,8 @@ def _build_datasets(
     # snapshot the caller observed; otherwise concurrent commits in between
     # would mix data from different snapshots.
     base_snapshot_id = base_snapshot.id if base_snapshot is not None else None
+    target_empty = (
+        base_snapshot is None or base_snapshot.total_record_count == 0)
 
     update_ds = None
     delete_ds = None
@@ -317,7 +319,7 @@ def _build_datasets(
     # Mirror Spark: matched/not-matched run as two independent joins
     # (inner / left_anti). One unified left_outer join would force
     # joined.materialize() to feed both branches, which can OOM on large merges.
-    if matched_specs and base_snapshot is not None:
+    if matched_specs and not target_empty:
         update_cols_union = _union_update_cols(matched_specs)
         if update_cols_union:
             update_ds = build_matched_update_ds(
@@ -362,7 +364,7 @@ def _build_datasets(
             catalog_options=ctx.catalog_options,
             num_partitions=num_partitions,
             snapshot_id=base_snapshot_id,
-            target_empty=base_snapshot is None,
+            target_empty=target_empty,
             ray_remote_args=ray_remote_args,
         )
 

--- a/paimon-python/pypaimon/tests/ray_data_evolution_merge_into_test.py
+++ b/paimon-python/pypaimon/tests/ray_data_evolution_merge_into_test.py
@@ -505,6 +505,39 @@ class RayDataEvolutionMergeIntoTest(unittest.TestCase):
         self.assertEqual(out['name'], ['a', 'b', 'c'])
         self.assertEqual(out['age'], [10, 20, 30])
 
+    def test_update_and_insert_into_existing_empty_snapshot(self):
+        target = self._create_table()
+        self._write(target, self._source(ids=(1,)))
+        write_builder = (
+            self.catalog.get_table(target).new_batch_write_builder().overwrite())
+        writer = write_builder.new_write()
+        writer.write_arrow(pa.Table.from_pydict(
+            {
+                'id': pa.array([], type=pa.int32()),
+                'name': pa.array([], type=pa.string()),
+                'age': pa.array([], type=pa.int32()),
+            },
+            schema=self.pa_schema,
+        ))
+        write_builder.new_commit().commit(writer.prepare_commit())
+        writer.close()
+
+        metrics = merge_into(
+            target=target,
+            source=self._source(ids=(1, 2)),
+            catalog_options=self.catalog_options,
+            on=['id'],
+            when_matched=[WhenMatched.update('*')],
+            when_not_matched=[WhenNotMatched(insert='*')],
+            num_partitions=_TEST_NUM_PARTITIONS,
+        )
+
+        self.assertEqual([1, 2], self._read_sorted(target)['id'])
+        self.assertEqual(
+            {'num_matched': 0, 'num_inserted': 2, 'num_unchanged': 0},
+            metrics,
+        )
+
     def test_multi_source_match_raises_by_default(self):
         # One target row matched by several source rows: the winning value is
         # undefined (Spark DE's checkCardinality=false), so we refuse by default.


### PR DESCRIPTION
### Purpose

Treat a target with an existing zero-row snapshot as empty in Ray `merge_into`. This skips matched processing and sends all eligible source rows through the not-matched insert path.

### Tests

- Existing empty snapshot with matched update and not-matched insert
- Empty target insert and matched-update regressions
- Flake8, py_compile, and diff checks