### PR TITLE
[python][ray] Reuse pinned bucket-join split plans

### DIFF
--- a/docs/docs/pypaimon/ray-data.md
+++ b/docs/docs/pypaimon/ray-data.md
@@ -580,11 +580,13 @@ print(metrics)   # {"num_updated": 50}
 - Partition columns cannot be updated (in-place rewrite can't move a row across partitions).
 - Deletion-vectors-enabled tables are not supported yet: a DV-deleted row still lives
   in its data file, so it can't be told apart from a live row without reading the target.
-- Incremental commits are not atomic across the whole operation. If a group fails,
+- Incremental commits are not atomic across the whole operation. Ordinary exceptions
+  raised while applying a group are reported as results so other groups can finish;
   completed groups are flushed before the error is raised.
-- Incremental mode reports group exceptions as results so other groups can finish.
-  Ray task retry options in `ray_remote_args` do not retry these exceptions; a
-  transient group failure can therefore leave a partial update.
+- Ray task retry options in `ray_remote_args` do not retry group exceptions reported
+  as results, so a transient group failure can leave a partial update. Worker loss and
+  other task-level failures which bypass Python exception handling may still lose
+  results buffered by that task.
 
 ## Read By Row Id
 

--- a/docs/docs/pypaimon/ray-data.md
+++ b/docs/docs/pypaimon/ray-data.md
@@ -553,9 +553,22 @@ metrics = update_by_row_id(
     source=ray_dataset,          # ray.data.Dataset / pa.Table / pandas, carrying _ROW_ID
     catalog_options={"warehouse": "/path/to/warehouse"},
     update_cols=["feature"],     # non-blob columns to overwrite
-    max_groups_per_commit=64,    # optional incremental commit window
 )
 print(metrics)   # {"num_updated": 50}
+```
+
+The default is one atomic commit. To explicitly opt into non-atomic,
+incremental commits:
+
+```python
+metrics = update_by_row_id(
+    target="database_name.table_name",
+    source=ray_dataset,
+    catalog_options={"warehouse": "/path/to/warehouse"},
+    update_cols=["feature"],
+    commit_mode="incremental",
+    max_groups_per_commit=64,
+)
 ```
 
 **Parameters:**
@@ -567,8 +580,10 @@ print(metrics)   # {"num_updated": 50}
 - `num_partitions`: parallelism for grouping the update rows by target file;
   defaults to `max(1, cluster_cpus * 2)`.
 - `ray_remote_args`: Ray remote options applied to the update tasks.
-- `max_groups_per_commit`: optional positive number of completed target file groups
-  per commit. By default, all groups are committed together.
+- `commit_mode`: `"atomic"` (default) commits all groups together.
+  `"incremental"` explicitly opts into non-atomic, windowed commits.
+- `max_groups_per_commit`: required in incremental mode; positive number of
+  completed target file groups per commit. It is rejected in atomic mode.
 
 **Returns:** `{"num_updated": <rows>}`.
 
@@ -580,13 +595,15 @@ print(metrics)   # {"num_updated": 50}
 - Partition columns cannot be updated (in-place rewrite can't move a row across partitions).
 - Deletion-vectors-enabled tables are not supported yet: a DV-deleted row still lives
   in its data file, so it can't be told apart from a live row without reading the target.
-- Incremental commits are not atomic across the whole operation. Ordinary exceptions
-  raised while applying a group are reported as results so other groups can finish;
-  completed groups are flushed before the error is raised.
-- Ray task retry options in `ray_remote_args` do not retry group exceptions reported
-  as results, so a transient group failure can leave a partial update. Worker loss and
-  other task-level failures which bypass Python exception handling may still lose
-  results buffered by that task.
+- Incremental commits are not atomic across the whole operation. Commits completed
+  before a later failure remain visible.
+- A duplicate `_ROW_ID` within a target file group is a deterministic validation
+  error. In incremental mode it is reported as a result so successful groups can
+  finish and be committed before the error is raised.
+- Other application and I/O exceptions propagate to Ray and remain subject to the
+  retry options in `ray_remote_args`. If retries are exhausted, earlier incremental
+  commits remain visible. Worker loss may also discard successful results still
+  buffered in the failed Ray task.
 
 ## Read By Row Id
 

--- a/docs/docs/pypaimon/ray-data.md
+++ b/docs/docs/pypaimon/ray-data.md
@@ -571,19 +571,83 @@ metrics = update_by_row_id(
 )
 ```
 
+To resume a multi-day job after a driver restart, use a replayable Paimon
+source with a bounded source-offset checkpoint:
+
+```python
+import pyarrow as pa
+
+from pypaimon.ray import PaimonOffsetSource, update_by_row_id
+
+
+def build_updates(dataset):
+    def transform(batch):
+        return pa.table({
+            "_ROW_ID": batch["_ROW_ID"],
+            "feature": compute_feature(batch["raw_feature"]),
+        })
+
+    return dataset.map_batches(transform, batch_format="pyarrow")
+
+
+source = PaimonOffsetSource(
+    "database_name.table_name",
+    projection=["_ROW_ID", "raw_feature"],
+    transform=build_updates,
+    rows_per_unit=1_000_000,
+    units_per_checkpoint=1,
+)
+
+metrics = update_by_row_id(
+    target="database_name.table_name",
+    source=source,
+    catalog_options={"warehouse": "/path/to/warehouse"},
+    update_cols=["feature"],
+    commit_mode="incremental",
+    operation_id="feature-backfill-2026-07",
+)
+```
+
+The source snapshot is retained by an internal tag. Each unit window is read,
+transformed, and committed atomically with its next offset. A retry with the
+same `operation_id` starts at that offset, so completed source windows are not
+read or computed again. The checkpoint contains a fixed-size source plan and
+one offset; it does not grow with the number of updated target files.
+The source may be the target's pinned pre-update snapshot, as above, or an
+existing upstream Paimon table; no staging table is required.
+The final metadata marker validates concurrent rewrites and records
+`complete=true` before the call returns.
+
+`transform` must be deterministic and window-local. Global aggregations,
+joins, or other state spanning source windows are not checkpointed. If a
+separate source can contain repeated target `_ROW_ID` values, deduplicate it
+upstream; an existing primary-key source table is one option.
+`max_groups_per_commit` is not used with
+`PaimonOffsetSource`; `rows_per_unit` and `units_per_checkpoint` control the
+replay window instead. External target overwrites and deletes are rejected
+while the operation is active. Row slicing applies to append and
+data-evolution sources; other table types use their planned scan splits as
+units.
+
 **Parameters:**
-- `source`: a `ray.data.Dataset`, `pyarrow.Table`, or `pandas.DataFrame` carrying the
-  target `_ROW_ID` and every column in `update_cols`; extra columns are ignored, and
-  values are cast to the target column types. A table-name source is not accepted: a
-  table's system `_ROW_ID` is its own and cannot address the target's rows.
+- `source`: a `ray.data.Dataset`, `pyarrow.Table`, `pandas.DataFrame`, or
+  `PaimonOffsetSource` producing the target `_ROW_ID` and every column in
+  `update_cols`; extra columns are ignored, and values are cast to the target
+  column types. A plain table-name source is not accepted: a table's system
+  `_ROW_ID` is its own and cannot address the target's rows.
 - `update_cols`: the non-blob columns to overwrite. Must be non-empty.
 - `num_partitions`: parallelism for grouping the update rows by target file;
   defaults to `max(1, cluster_cpus * 2)`.
 - `ray_remote_args`: Ray remote options applied to the update tasks.
 - `commit_mode`: `"atomic"` (default) commits all groups together.
   `"incremental"` explicitly opts into non-atomic, windowed commits.
-- `max_groups_per_commit`: required in incremental mode; positive number of
-  completed target file groups per commit. It is rejected in atomic mode.
+- `max_groups_per_commit`: required for an incremental Dataset source; positive
+  number of completed target file groups per commit. It is rejected in atomic
+  mode and with `PaimonOffsetSource`.
+- `operation_id`: required with `PaimonOffsetSource`. It identifies one
+  immutable update input and its durable progress across driver restarts. Do
+  not run two callers concurrently with the same id or reuse an id for another
+  source or `update_cols`.
 
 **Returns:** `{"num_updated": <rows>}`.
 
@@ -604,6 +668,17 @@ metrics = update_by_row_id(
   retry options in `ray_remote_args`. If retries are exhausted, earlier incremental
   commits remain visible. Worker loss may also discard successful results still
   buffered in the failed Ray task.
+- Keep the checkpoint until a successful result has been acknowledged. Afterwards
+  it can be removed explicitly:
+  ```python
+  from pypaimon.ray import delete_update_by_row_id_checkpoint
+
+  delete_update_by_row_id_checkpoint(
+      "database_name.table_name",
+      {"warehouse": "/path/to/warehouse"},
+      "feature-backfill-2026-07",
+  )
+  ```
 
 ## Read By Row Id
 

--- a/docs/docs/pypaimon/ray-data.md
+++ b/docs/docs/pypaimon/ray-data.md
@@ -553,6 +553,7 @@ metrics = update_by_row_id(
     source=ray_dataset,          # ray.data.Dataset / pa.Table / pandas, carrying _ROW_ID
     catalog_options={"warehouse": "/path/to/warehouse"},
     update_cols=["feature"],     # non-blob columns to overwrite
+    max_groups_per_commit=64,    # optional incremental commit window
 )
 print(metrics)   # {"num_updated": 50}
 ```
@@ -566,6 +567,8 @@ print(metrics)   # {"num_updated": 50}
 - `num_partitions`: parallelism for grouping the update rows by target file;
   defaults to `max(1, cluster_cpus * 2)`.
 - `ray_remote_args`: Ray remote options applied to the update tasks.
+- `max_groups_per_commit`: optional positive number of completed target file groups
+  per commit. By default, all groups are committed together.
 
 **Returns:** `{"num_updated": <rows>}`.
 
@@ -577,6 +580,11 @@ print(metrics)   # {"num_updated": 50}
 - Partition columns cannot be updated (in-place rewrite can't move a row across partitions).
 - Deletion-vectors-enabled tables are not supported yet: a DV-deleted row still lives
   in its data file, so it can't be told apart from a live row without reading the target.
+- Incremental commits are not atomic across the whole operation. If a group fails,
+  completed groups are flushed before the error is raised.
+- Incremental mode reports group exceptions as results so other groups can finish.
+  Ray task retry options in `ray_remote_args` do not retry these exceptions; a
+  transient group failure can therefore leave a partial update.
 
 ## Read By Row Id
 

--- a/paimon-python/pypaimon/ray/__init__.py
+++ b/paimon-python/pypaimon/ray/__init__.py
@@ -28,7 +28,11 @@ from pypaimon.ray.data_evolution_merge_transform import (
     target_col,
     lit,
 )
-from pypaimon.ray.update_by_row_id import update_by_row_id
+from pypaimon.ray.update_by_row_id import (
+    delete_update_by_row_id_checkpoint,
+    update_by_row_id,
+)
+from pypaimon.ray.offset_source import PaimonOffsetSource
 from pypaimon.ray.read_by_row_id import read_by_row_id
 
 __all__ = [
@@ -39,6 +43,8 @@ __all__ = [
     "range_join",
     "merge_into",
     "update_by_row_id",
+    "PaimonOffsetSource",
+    "delete_update_by_row_id_checkpoint",
     "read_by_row_id",
     "WhenMatched",
     "WhenNotMatched",

--- a/paimon-python/pypaimon/ray/bucket_join.py
+++ b/paimon-python/pypaimon/ray/bucket_join.py
@@ -58,27 +58,187 @@ def _plan_splits_by_bucket(table_id, catalog_options, projection, expected_total
     """
     table = _get_table(table_id, catalog_options)  # fresh, latest schema
     schema_id = table.table_schema.id
-    # Pin the guard and the split plan to one snapshot, else a commit between the two
-    # manifest reads could slip stale-bucket files past the guard.
+    # Pin the guard and the split plan to one snapshot.
     if pin_latest_snapshot(table) is None:
         return {}, schema_id
+    return _plan_table_splits_by_bucket(
+        table, projection, expected_total_buckets)
+
+
+def _plan_table_splits_by_bucket(
+        table, projection, expected_total_buckets):
+    """Plan an already snapshot-pinned table by bucket."""
+    schema_id = table.table_schema.id
     rb = table.new_read_builder()
-    scan = (rb.with_projection(projection) if projection is not None else rb).new_scan()
+    scan = (
+        rb.with_projection(projection)
+        if projection is not None else rb
+    ).new_scan()
     # Guard against a rescaled table (old files under a different total_buckets, which
     # splits -- bucket only -- can't tell apart); read the entries once for it.
     fs = scan.file_scanner
     entries = fs.plan_files()
-    stale = {e.total_buckets for e in entries if e.total_buckets != expected_total_buckets}
+    stale = {
+        e.total_buckets
+        for e in entries
+        if e.total_buckets != expected_total_buckets
+    }
     if stale:
         raise ValueError(
-            f"bucket_join needs {table_id} fully in bucket count {expected_total_buckets}, "
-            f"but files exist under {sorted(stale)} (rescale in progress); rewrite first.")
+            f"bucket_join needs {table.identifier} fully in bucket count "
+            f"{expected_total_buckets}, but files exist under "
+            f"{sorted(stale)} (rescale in progress); rewrite first.")
     # Reuse those entries: scan.plan() re-reads plan_files() (append/pk) otherwise.
     fs.plan_files = lambda: entries
     by_bucket = {}
     for s in scan.plan().splits():
         by_bucket.setdefault(s.bucket, []).append(s)
     return by_bucket, schema_id
+
+
+def _validate_bucket_join(
+        left,
+        right,
+        ltable,
+        rtable,
+        on,
+        left_projection,
+        right_projection,
+        join_type):
+    on_cols = _norm(on)
+    lcount, lkey, lfunc = _bucketing(ltable)
+    rcount, rkey, rfunc = _bucketing(rtable)
+
+    if ltable.partition_keys or rtable.partition_keys:
+        raise ValueError(
+            "bucket_join does not support partitioned tables yet; got "
+            "partition keys {}={}, {}={}.".format(
+                left, ltable.partition_keys, right, rtable.partition_keys))
+    if not lcount or lcount <= 0 or not rcount or rcount <= 0:
+        raise ValueError(
+            "bucket_join requires both tables to be fixed-bucket "
+            "(bucket > 0); got {}={}, {}={}.".format(
+                left, lcount, right, rcount))
+    if lcount != rcount:
+        raise ValueError(
+            "bucket_join requires the same bucket count; "
+            "{}={}, {}={}.".format(left, lcount, right, rcount))
+    if lkey != rkey:
+        raise ValueError(
+            "bucket_join requires the same bucket-key; "
+            "{}={}, {}={}.".format(left, lkey, right, rkey))
+    if lfunc != rfunc:
+        raise ValueError(
+            "bucket_join requires the same bucket-function.type; "
+            "{}={}, {}={}.".format(left, lfunc, right, rfunc))
+    if on_cols != lkey:
+        raise ValueError(
+            "bucket_join requires the join key to be the bucket-key {}; "
+            "got on={}. Equal keys only co-locate by bucket when joining "
+            "on the bucket-key (the comparison is order-sensitive for "
+            "composite keys).".format(lkey, on_cols))
+
+    key_type_mismatch = [
+        (c, _key_type(ltable, c), _key_type(rtable, c))
+        for c in on_cols
+        if _key_type(ltable, c) != _key_type(rtable, c)
+    ]
+    if key_type_mismatch:
+        raise ValueError(
+            "bucket_join requires the bucket-key columns to have the same "
+            "type on both sides; mismatched (column, left, right): {}."
+            .format(key_type_mismatch))
+    if join_type != "inner":
+        raise ValueError(
+            "bucket_join currently supports only join_type='inner'; got "
+            "{!r}.".format(join_type))
+
+    if (left_projection is not None
+            and not set(on_cols) <= set(left_projection)):
+        raise ValueError(
+            "left_projection must include the join key {}; got {}."
+            .format(on_cols, left_projection))
+    if (right_projection is not None
+            and not set(on_cols) <= set(right_projection)):
+        raise ValueError(
+            "right_projection must include the join key {}; got {}."
+            .format(on_cols, right_projection))
+    lcols = (
+        left_projection
+        if left_projection is not None else ltable.field_names)
+    rcols = (
+        right_projection
+        if right_projection is not None else rtable.field_names)
+    collisions = sorted((set(lcols) & set(rcols)) - set(on_cols))
+    if collisions:
+        raise ValueError(
+            "bucket_join sides must not share columns other than the join "
+            "key {}; both have {}. Project or rename them away."
+            .format(on_cols, collisions))
+    return on_cols, lcount
+
+
+def _bucket_join_from_split_plans(
+        left,
+        right,
+        catalog_options,
+        on_cols,
+        left_projection,
+        right_projection,
+        join_type,
+        left_by_bucket,
+        right_by_bucket,
+        left_schema_id,
+        right_schema_id,
+        ray_remote_args=None):
+    import ray
+
+    def _join_bucket(left_splits, right_splits):
+        left_t = _read_splits(
+            left,
+            catalog_options,
+            left_projection,
+            left_splits,
+            left_schema_id,
+        )
+        right_t = _read_splits(
+            right,
+            catalog_options,
+            right_projection,
+            right_splits,
+            right_schema_id,
+        )
+        return left_t.join(right_t, keys=on_cols, join_type=join_type)
+
+    remote_fn = (
+        ray.remote(**ray_remote_args)(_join_bucket)
+        if ray_remote_args else ray.remote(_join_bucket)
+    )
+    buckets = sorted(set(left_by_bucket) & set(right_by_bucket))
+    if not buckets:
+        empty = _read_splits(
+            left,
+            catalog_options,
+            left_projection,
+            [],
+            left_schema_id,
+        ).join(
+            _read_splits(
+                right,
+                catalog_options,
+                right_projection,
+                [],
+                right_schema_id,
+            ),
+            keys=on_cols,
+            join_type=join_type,
+        )
+        return ray.data.from_arrow(empty)
+    refs = [
+        remote_fn.remote(left_by_bucket[b], right_by_bucket[b])
+        for b in buckets
+    ]
+    return ray.data.from_arrow_refs(refs)
 
 
 def _read_splits(table_id, catalog_options, projection, splits, schema_id):
@@ -108,93 +268,36 @@ def bucket_join(
             "bucket_join needs a Ray version with ray.data.from_arrow_refs; "
             f"installed ray is {ray.__version__}.")
 
-    on_cols = _norm(on)
     cat = CatalogFactory.create(catalog_options)
     ltable, rtable = cat.get_table(left), cat.get_table(right)
-    lcount, lkey, lfunc = _bucketing(ltable)
-    rcount, rkey, rfunc = _bucketing(rtable)
-
-    if ltable.partition_keys or rtable.partition_keys:
-        # Bucket numbers are per-partition, so the same bucket id lives in every
-        # partition -- grouping splits by bucket alone would join across partitions.
-        # Supporting this needs grouping by (partition, bucket); not done yet.
-        raise ValueError(
-            "bucket_join does not support partitioned tables yet; got partition keys "
-            f"{left}={ltable.partition_keys}, {right}={rtable.partition_keys}.")
-    if not lcount or lcount <= 0 or not rcount or rcount <= 0:
-        raise ValueError(
-            "bucket_join requires both tables to be fixed-bucket (bucket > 0); "
-            f"got {left}={lcount}, {right}={rcount}.")
-    if lcount != rcount:
-        raise ValueError(
-            f"bucket_join requires the same bucket count; {left}={lcount}, {right}={rcount}.")
-    if lkey != rkey:
-        raise ValueError(
-            f"bucket_join requires the same bucket-key; {left}={lkey}, {right}={rkey}.")
-    if lfunc != rfunc:
-        # Different bucket functions hash the same key to different buckets.
-        raise ValueError(
-            f"bucket_join requires the same bucket-function.type; {left}={lfunc}, {right}={rfunc}.")
-    if on_cols != lkey:
-        raise ValueError(
-            f"bucket_join requires the join key to be the bucket-key {lkey}; got on={on_cols}. "
-            "Equal keys only co-locate by bucket when joining on the bucket-key "
-            "(the comparison is order-sensitive for composite keys).")
-    # Same name isn't enough: differing key types (INT vs BIGINT) can hash apart and
-    # silently drop matches (types compared without nullability).
-    key_type_mismatch = [
-        (c, _key_type(ltable, c), _key_type(rtable, c))
-        for c in on_cols
-        if _key_type(ltable, c) != _key_type(rtable, c)
-    ]
-    if key_type_mismatch:
-        raise ValueError(
-            "bucket_join requires the bucket-key columns to have the same type on both "
-            f"sides; mismatched (column, left, right): {key_type_mismatch}.")
-    if join_type != "inner":
-        # Outer joins would need the union of buckets (a bucket missing on one side
-        # still emits rows); only inner is correct with the per-bucket intersection.
-        raise ValueError(f"bucket_join currently supports only join_type='inner'; got {join_type!r}.")
-
-    # The join key must survive projection on both sides, or ``Table.join`` has no key.
-    if left_projection is not None and not set(on_cols) <= set(left_projection):
-        raise ValueError(
-            f"left_projection must include the join key {on_cols}; got {left_projection}.")
-    if right_projection is not None and not set(on_cols) <= set(right_projection):
-        raise ValueError(
-            f"right_projection must include the join key {on_cols}; got {right_projection}.")
-    # The two sides must not share non-key columns, or pyarrow's join collides on them.
-    # Check up front (against the projected columns) instead of failing inside a task.
-    lcols = left_projection if left_projection is not None else ltable.field_names
-    rcols = right_projection if right_projection is not None else rtable.field_names
-    collisions = sorted((set(lcols) & set(rcols)) - set(on_cols))
-    if collisions:
-        raise ValueError(
-            f"bucket_join sides must not share columns other than the join key {on_cols}; "
-            f"both have {collisions}. Project or rename them away.")
+    on_cols, bucket_count = _validate_bucket_join(
+        left,
+        right,
+        ltable,
+        rtable,
+        on,
+        left_projection,
+        right_projection,
+        join_type,
+    )
 
     # Plan each side's manifest once (driver-side, split metadata only -- the join
     # results stay distributed below), then dispatch per-bucket splits to the tasks.
     left_by_bucket, l_schema_id = _plan_splits_by_bucket(
-        left, catalog_options, left_projection, lcount)
+        left, catalog_options, left_projection, bucket_count)
     right_by_bucket, r_schema_id = _plan_splits_by_bucket(
-        right, catalog_options, right_projection, rcount)
-
-    def _join_bucket(left_splits, right_splits):
-        left_t = _read_splits(left, catalog_options, left_projection, left_splits, l_schema_id)
-        right_t = _read_splits(right, catalog_options, right_projection, right_splits, r_schema_id)
-        return left_t.join(right_t, keys=on_cols, join_type=join_type)
-
-    # ``@ray.remote()`` (empty parens) is rejected by Ray, so wrap conditionally.
-    remote_fn = ray.remote(**ray_remote_args)(_join_bucket) if ray_remote_args else ray.remote(_join_bucket)
-    # Inner join: only buckets present on both sides can match.
-    buckets = sorted(set(left_by_bucket) & set(right_by_bucket))
-    if not buckets:
-        # No shared bucket: empty result, but keep the join schema (join two empties).
-        empty = _read_splits(left, catalog_options, left_projection, [], l_schema_id).join(
-            _read_splits(right, catalog_options, right_projection, [], r_schema_id),
-            keys=on_cols, join_type=join_type)
-        return ray.data.from_arrow(empty)
-    # Keep each bucket's result as a distributed object ref -- never pulled into the driver.
-    refs = [remote_fn.remote(left_by_bucket[b], right_by_bucket[b]) for b in buckets]
-    return ray.data.from_arrow_refs(refs)
+        right, catalog_options, right_projection, bucket_count)
+    return _bucket_join_from_split_plans(
+        left,
+        right,
+        catalog_options,
+        on_cols,
+        left_projection,
+        right_projection,
+        join_type,
+        left_by_bucket,
+        right_by_bucket,
+        l_schema_id,
+        r_schema_id,
+        ray_remote_args,
+    )

--- a/paimon-python/pypaimon/ray/data_evolution_merge_join.py
+++ b/paimon-python/pypaimon/ray/data_evolution_merge_join.py
@@ -562,7 +562,7 @@ def distributed_update_apply(
 
     captured_table = table
     captured_cols = cols
-    capture_group_errors = on_group_result is not None
+    capture_group_validation_errors = on_group_result is not None
 
     def _group_result(msgs_blob, n_updated, row_ids_blob, error):
         return pa.Table.from_pydict({
@@ -581,33 +581,31 @@ def distributed_update_apply(
                 "error": pa.array([], type=pa.string()),
             })
 
-        try:
-            if (
-                pc.count_distinct(group.column(row_id_name)).as_py()
-                != group.num_rows
-            ):
-                raise ValueError(
-                    "MERGE matched multiple source rows to the same "
-                    "target _ROW_ID. Deduplicate the source before "
-                    "merging."
-                )
-
-            for_update = group.drop_columns([frid_col])
-            row_ids = (
-                for_update.column(row_id_name).to_pylist()
-                if collect_row_ids else []
+        if (
+            pc.count_distinct(group.column(row_id_name)).as_py()
+            != group.num_rows
+        ):
+            error = ValueError(
+                "MERGE matched multiple source rows to the same "
+                "target _ROW_ID. Deduplicate the source before "
+                "merging."
             )
-            worker = TableUpdateByRowId(
-                captured_table,
-                "_merge_into_shard_" + uuid.uuid4().hex[:8],
-                BATCH_COMMIT_IDENTIFIER,
-                _precomputed_files_info=ray.get(precomputed_info_ref),
-            )
-            msgs = worker.update_columns(for_update, list(captured_cols))
-        except Exception as error:
-            if not capture_group_errors:
-                raise
+            if not capture_group_validation_errors:
+                raise error
             return _group_result(b"", 0, b"", _group_error_text(error))
+
+        for_update = group.drop_columns([frid_col])
+        row_ids = (
+            for_update.column(row_id_name).to_pylist()
+            if collect_row_ids else []
+        )
+        worker = TableUpdateByRowId(
+            captured_table,
+            "_merge_into_shard_" + uuid.uuid4().hex[:8],
+            BATCH_COMMIT_IDENTIFIER,
+            _precomputed_files_info=ray.get(precomputed_info_ref),
+        )
+        msgs = worker.update_columns(for_update, list(captured_cols))
 
         return _group_result(
             pickle.dumps(msgs),

--- a/paimon-python/pypaimon/ray/data_evolution_merge_join.py
+++ b/paimon-python/pypaimon/ray/data_evolution_merge_join.py
@@ -639,6 +639,8 @@ def distributed_update_apply(
         for blob, n, row_ids_blob, error in zip(
                 message_blobs, updated_counts, row_id_blobs, errors):
             if error is not None:
+                # Keep the first failure as the primary error, but continue
+                # draining results so successful groups can still be committed.
                 if group_error is None:
                     group_error = error
                 continue

--- a/paimon-python/pypaimon/ray/data_evolution_merge_join.py
+++ b/paimon-python/pypaimon/ray/data_evolution_merge_join.py
@@ -59,6 +59,16 @@ def _map_kwargs(
     return kwargs
 
 
+def _sorted_range_membership(values, starts, ends):
+    import numpy as np
+
+    indices = np.searchsorted(ends, values, side="left")
+    matches = np.zeros(len(values), dtype=bool)
+    positions = np.flatnonzero(indices < len(starts))
+    matches[positions] = starts[indices[positions]] <= values[positions]
+    return matches
+
+
 def _resolve_source_projection(
     clauses: List[_NormalizedClause],
     source_on: Sequence[str],
@@ -460,7 +470,7 @@ def distributed_update_apply(
     ray_remote_args: Optional[Dict[str, Any]] = None,
     base_snapshot_id: Optional[int] = None,
     collect_row_ids: bool = False,
-    on_group_result: Optional[Callable[[list, int, list], None]] = None,
+    on_group_result: Optional[Callable[[list, int, list, list], None]] = None,
 ) -> Tuple[list, int, list]:
     import numpy as np
     import pickle
@@ -471,6 +481,9 @@ def distributed_update_apply(
 
     from pypaimon.snapshot.snapshot import BATCH_COMMIT_IDENTIFIER
     from pypaimon.table.special_fields import SpecialFields
+    from pypaimon.write.commit.conflict_detection import (
+        row_id_file_signature,
+    )
     from pypaimon.write.table_update_by_row_id import TableUpdateByRowId
 
     row_id_name = SpecialFields.ROW_ID.name
@@ -537,10 +550,8 @@ def distributed_update_apply(
                 "or matched rows come from a different table."
             )
         rids = rid_col.to_numpy(zero_copy_only=False)
-        # Check each row_id belongs to a valid range (vectorized).
-        in_range = np.zeros(len(rids), dtype=bool)
-        for s, e in zip(range_starts, range_ends):
-            in_range |= (rids >= s) & (rids <= e)
+        in_range = _sorted_range_membership(
+            rids, range_starts, range_ends)
         if not in_range.all():
             bad = rids[~in_range][0]
             raise ValueError(
@@ -562,13 +573,20 @@ def distributed_update_apply(
 
     captured_table = table
     captured_cols = cols
-    capture_group_validation_errors = on_group_result is not None
+    capture_group_errors = on_group_result is not None
 
-    def _group_result(msgs_blob, n_updated, row_ids_blob, error):
+    def _group_result(
+            msgs_blob,
+            n_updated,
+            row_ids_blob,
+            planned_files_blob,
+            error):
         return pa.Table.from_pydict({
             "msgs_blob": pa.array([msgs_blob], type=pa.binary()),
             "n_updated": pa.array([n_updated], type=pa.int64()),
             "row_ids_blob": pa.array([row_ids_blob], type=pa.binary()),
+            "planned_files_blob": pa.array(
+                [planned_files_blob], type=pa.binary()),
             "error": pa.array([error], type=pa.string()),
         })
 
@@ -578,39 +596,52 @@ def distributed_update_apply(
                 "msgs_blob": pa.array([], type=pa.binary()),
                 "n_updated": pa.array([], type=pa.int64()),
                 "row_ids_blob": pa.array([], type=pa.binary()),
+                "planned_files_blob": pa.array([], type=pa.binary()),
                 "error": pa.array([], type=pa.string()),
             })
 
-        if (
-            pc.count_distinct(group.column(row_id_name)).as_py()
-            != group.num_rows
-        ):
-            error = ValueError(
-                "MERGE matched multiple source rows to the same "
-                "target _ROW_ID. Deduplicate the source before "
-                "merging."
-            )
-            if not capture_group_validation_errors:
-                raise error
-            return _group_result(b"", 0, b"", _group_error_text(error))
+        try:
+            if (
+                pc.count_distinct(group.column(row_id_name)).as_py()
+                != group.num_rows
+            ):
+                raise ValueError(
+                    "MERGE matched multiple source rows to the same "
+                    "target _ROW_ID. Deduplicate the source before "
+                    "merging."
+                )
 
-        for_update = group.drop_columns([frid_col])
-        row_ids = (
-            for_update.column(row_id_name).to_pylist()
-            if collect_row_ids else []
-        )
-        worker = TableUpdateByRowId(
-            captured_table,
-            "_merge_into_shard_" + uuid.uuid4().hex[:8],
-            BATCH_COMMIT_IDENTIFIER,
-            _precomputed_files_info=ray.get(precomputed_info_ref),
-        )
-        msgs = worker.update_columns(for_update, list(captured_cols))
+            for_update = group.drop_columns([frid_col])
+            row_ids = (
+                for_update.column(row_id_name).to_pylist()
+                if collect_row_ids else []
+            )
+            files_info = ray.get(precomputed_info_ref)
+            first_row_id = group.column(frid_col)[0].as_py()
+            split, target_files = files_info.first_row_id_index[first_row_id]
+            planned_file_signatures = [
+                row_id_file_signature(
+                    split.partition, split.bucket, data_file)
+                for data_file in target_files
+            ]
+            worker = TableUpdateByRowId(
+                captured_table,
+                "_merge_into_shard_" + uuid.uuid4().hex[:8],
+                BATCH_COMMIT_IDENTIFIER,
+                _precomputed_files_info=files_info,
+            )
+            msgs = worker.update_columns(for_update, list(captured_cols))
+        except Exception as error:
+            if not capture_group_errors:
+                raise
+            return _group_result(
+                b"", 0, b"", b"", _group_error_text(error))
 
         return _group_result(
             pickle.dumps(msgs),
             for_update.num_rows,
             pickle.dumps(row_ids),
+            pickle.dumps(planned_file_signatures),
             None,
         )
 
@@ -630,12 +661,18 @@ def distributed_update_apply(
         message_blobs = batch.column("msgs_blob").to_pylist()
         updated_counts = batch.column("n_updated").to_pylist()
         errors = batch.column("error").to_pylist()
+        planned_file_blobs = (
+            batch.column("planned_files_blob").to_pylist())
         row_id_blobs = (
             batch.column("row_ids_blob").to_pylist()
             if collect_row_ids else [None] * len(message_blobs)
         )
-        for blob, n, row_ids_blob, error in zip(
-                message_blobs, updated_counts, row_id_blobs, errors):
+        for blob, n, row_ids_blob, planned_files_blob, error in zip(
+                message_blobs,
+                updated_counts,
+                row_id_blobs,
+                planned_file_blobs,
+                errors):
             if error is not None:
                 # Keep the first failure as the primary error, but continue
                 # draining results so successful groups can still be committed.
@@ -646,10 +683,17 @@ def distributed_update_apply(
             group_row_ids = (
                 pickle.loads(row_ids_blob) if collect_row_ids else []
             )
+            planned_file_signatures = pickle.loads(
+                planned_files_blob)
             if on_group_result is None:
                 all_msgs.extend(group_msgs)
             else:
-                on_group_result(group_msgs, n, group_row_ids)
+                on_group_result(
+                    group_msgs,
+                    n,
+                    group_row_ids,
+                    planned_file_signatures,
+                )
             num_updated += n
             if collect_row_ids:
                 action_row_ids.extend(group_row_ids)

--- a/paimon-python/pypaimon/ray/data_evolution_merge_join.py
+++ b/paimon-python/pypaimon/ray/data_evolution_merge_join.py
@@ -16,7 +16,7 @@
 # limitations under the License.
 ################################################################################
 
-from typing import Any, Dict, List, Optional, Sequence, Tuple
+from typing import Any, Callable, Dict, List, Optional, Sequence, Tuple
 
 import pyarrow as pa
 
@@ -30,6 +30,21 @@ from pypaimon.ray.data_evolution_merge_transform import (
     vectorized_insert_transform,
     vectorized_matched_transform,
 )
+
+
+class GroupApplyError(RuntimeError):
+    """A file group failed after other groups may have completed."""
+
+
+def _group_error_text(error: BaseException) -> str:
+    import traceback
+
+    return "update_by_row_id file group failed: {}: {}\n{}".format(
+        type(error).__name__,
+        str(error),
+        "".join(traceback.format_exception(
+            type(error), error, error.__traceback__)),
+    )
 
 
 def _map_kwargs(
@@ -445,6 +460,7 @@ def distributed_update_apply(
     ray_remote_args: Optional[Dict[str, Any]] = None,
     base_snapshot_id: Optional[int] = None,
     collect_row_ids: bool = False,
+    on_group_result: Optional[Callable[[list, int, list], None]] = None,
 ) -> Tuple[list, int, list]:
     import numpy as np
     import pickle
@@ -546,6 +562,15 @@ def distributed_update_apply(
 
     captured_table = table
     captured_cols = cols
+    capture_group_errors = on_group_result is not None
+
+    def _group_result(msgs_blob, n_updated, row_ids_blob, error):
+        return pa.Table.from_pydict({
+            "msgs_blob": pa.array([msgs_blob], type=pa.binary()),
+            "n_updated": pa.array([n_updated], type=pa.int64()),
+            "row_ids_blob": pa.array([row_ids_blob], type=pa.binary()),
+            "error": pa.array([error], type=pa.string()),
+        })
 
     def _apply_group(group: pa.Table) -> pa.Table:
         if group.num_rows == 0:
@@ -553,39 +578,43 @@ def distributed_update_apply(
                 "msgs_blob": pa.array([], type=pa.binary()),
                 "n_updated": pa.array([], type=pa.int64()),
                 "row_ids_blob": pa.array([], type=pa.binary()),
+                "error": pa.array([], type=pa.string()),
             })
 
-        if (
-            pc.count_distinct(group.column(row_id_name)).as_py()
-            != group.num_rows
-        ):
-            raise ValueError(
-                "MERGE matched multiple source rows to the same "
-                "target _ROW_ID. Deduplicate the source before "
-                "merging."
-            )
+        try:
+            if (
+                pc.count_distinct(group.column(row_id_name)).as_py()
+                != group.num_rows
+            ):
+                raise ValueError(
+                    "MERGE matched multiple source rows to the same "
+                    "target _ROW_ID. Deduplicate the source before "
+                    "merging."
+                )
 
-        for_update = group.drop_columns([frid_col])
-        row_ids = (
-            for_update.column(row_id_name).to_pylist()
-            if collect_row_ids else []
+            for_update = group.drop_columns([frid_col])
+            row_ids = (
+                for_update.column(row_id_name).to_pylist()
+                if collect_row_ids else []
+            )
+            worker = TableUpdateByRowId(
+                captured_table,
+                "_merge_into_shard_" + uuid.uuid4().hex[:8],
+                BATCH_COMMIT_IDENTIFIER,
+                _precomputed_files_info=ray.get(precomputed_info_ref),
+            )
+            msgs = worker.update_columns(for_update, list(captured_cols))
+        except Exception as error:
+            if not capture_group_errors:
+                raise
+            return _group_result(b"", 0, b"", _group_error_text(error))
+
+        return _group_result(
+            pickle.dumps(msgs),
+            for_update.num_rows,
+            pickle.dumps(row_ids),
+            None,
         )
-        worker = TableUpdateByRowId(
-            captured_table,
-            "_merge_into_shard_" + uuid.uuid4().hex[:8],
-            BATCH_COMMIT_IDENTIFIER,
-            _precomputed_files_info=ray.get(precomputed_info_ref),
-        )
-        msgs = worker.update_columns(for_update, list(captured_cols))
-        return pa.Table.from_pydict({
-            "msgs_blob": [pickle.dumps(msgs)],
-            "n_updated": pa.array(
-                [for_update.num_rows], type=pa.int64()
-            ),
-            "row_ids_blob": pa.array(
-                [pickle.dumps(row_ids)], type=pa.binary()
-            ),
-        })
 
     # One group per target data file; bounded by file count and num_partitions.
     group_partitions = max(
@@ -598,14 +627,34 @@ def distributed_update_apply(
     all_msgs: list = []
     num_updated = 0
     action_row_ids = []
+    group_error = None
     for batch in msgs_ds.iter_batches(batch_format="pyarrow"):
-        for blob in batch.column("msgs_blob").to_pylist():
-            all_msgs.extend(pickle.loads(blob))
-        for n in batch.column("n_updated").to_pylist():
+        message_blobs = batch.column("msgs_blob").to_pylist()
+        updated_counts = batch.column("n_updated").to_pylist()
+        errors = batch.column("error").to_pylist()
+        row_id_blobs = (
+            batch.column("row_ids_blob").to_pylist()
+            if collect_row_ids else [None] * len(message_blobs)
+        )
+        for blob, n, row_ids_blob, error in zip(
+                message_blobs, updated_counts, row_id_blobs, errors):
+            if error is not None:
+                if group_error is None:
+                    group_error = error
+                continue
+            group_msgs = pickle.loads(blob)
+            group_row_ids = (
+                pickle.loads(row_ids_blob) if collect_row_ids else []
+            )
+            if on_group_result is None:
+                all_msgs.extend(group_msgs)
+            else:
+                on_group_result(group_msgs, n, group_row_ids)
             num_updated += n
-        if collect_row_ids:
-            for blob in batch.column("row_ids_blob").to_pylist():
-                action_row_ids.extend(pickle.loads(blob))
+            if collect_row_ids:
+                action_row_ids.extend(group_row_ids)
+    if group_error is not None:
+        raise GroupApplyError(group_error)
     return all_msgs, num_updated, action_row_ids
 
 

--- a/paimon-python/pypaimon/ray/offset_source.py
+++ b/paimon-python/pypaimon/ray/offset_source.py
@@ -1,0 +1,325 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+"""Replayable Paimon source for resumable Ray updates."""
+
+import hashlib
+import marshal
+import pickle
+from typing import Any, Callable, Dict, List, Optional
+
+__all__ = ["PaimonOffsetSource"]
+
+
+class PaimonOffsetSource:
+    """A snapshot-pinned Paimon source processed in offset units.
+
+    ``transform`` is rebuilt for every window. It must be deterministic and
+    must not depend on rows from another window. Append and data-evolution
+    sources are sliced by ``rows_per_unit``; other sources use scan splits.
+    """
+
+    def __init__(
+            self,
+            table_identifier: str,
+            *,
+            projection: Optional[List[str]] = None,
+            filter=None,
+            transform: Optional[Callable[[Any], Any]] = None,
+            snapshot_id: Optional[int] = None,
+            rows_per_unit: int = 1_000_000,
+            units_per_checkpoint: int = 1,
+            ray_remote_args: Optional[Dict[str, Any]] = None,
+            concurrency: Optional[int] = None,
+            override_num_blocks: Optional[int] = None,
+            **read_args):
+        if not isinstance(table_identifier, str) or not table_identifier:
+            raise ValueError("table_identifier is required.")
+        if (isinstance(rows_per_unit, bool)
+                or not isinstance(rows_per_unit, int)
+                or rows_per_unit <= 0):
+            raise ValueError(
+                "rows_per_unit must be a positive integer.")
+        if (isinstance(units_per_checkpoint, bool)
+                or not isinstance(units_per_checkpoint, int)
+                or units_per_checkpoint <= 0):
+            raise ValueError(
+                "units_per_checkpoint must be a positive integer.")
+        if transform is not None and not callable(transform):
+            raise ValueError("transform must be callable.")
+        if snapshot_id is not None and (
+                isinstance(snapshot_id, bool)
+                or not isinstance(snapshot_id, int)
+                or snapshot_id <= 0):
+            raise ValueError("snapshot_id must be a positive integer.")
+        self.table_identifier = table_identifier
+        self.projection = (
+            list(projection) if projection is not None else None)
+        self.filter = filter
+        self.transform = transform
+        self.snapshot_id = snapshot_id
+        self.rows_per_unit = rows_per_unit
+        self.units_per_checkpoint = units_per_checkpoint
+        self.ray_remote_args = (
+            dict(ray_remote_args) if ray_remote_args is not None else None)
+        self.concurrency = concurrency
+        self.override_num_blocks = override_num_blocks
+        self.read_args = dict(read_args)
+
+    def _resolve_snapshot_id(
+            self,
+            catalog,
+            checkpoint_plan=None,
+            retained_snapshot_id=None):
+        checkpoint_snapshot_id = (
+            checkpoint_plan.get("snapshot_id")
+            if checkpoint_plan is not None else None)
+        if (checkpoint_plan is not None
+                and checkpoint_plan.get("table") != self.table_identifier):
+            raise ValueError(
+                "PaimonOffsetSource does not match the saved checkpoint.")
+        snapshot_ids = {
+            snapshot_id
+            for snapshot_id in (
+                self.snapshot_id,
+                checkpoint_snapshot_id,
+                retained_snapshot_id,
+            )
+            if snapshot_id is not None
+        }
+        if len(snapshot_ids) > 1:
+            raise ValueError(
+                "PaimonOffsetSource snapshot_id differs from its checkpoint.")
+        snapshot_id = (
+            self.snapshot_id
+            or checkpoint_snapshot_id
+            or retained_snapshot_id
+        )
+        if snapshot_id is None:
+            latest = (
+                catalog.get_table(self.table_identifier)
+                .snapshot_manager()
+                .get_latest_snapshot()
+            )
+            snapshot_id = latest.id if latest is not None else None
+        return snapshot_id
+
+    def _bind(
+            self,
+            catalog,
+            checkpoint_plan=None,
+            tag_name=None,
+            retained_snapshot_id=None):
+        from pypaimon.common.options.core_options import CoreOptions
+        from pypaimon.read.read_builder import ReadBuilder
+
+        table = catalog.get_table(self.table_identifier)
+        snapshot_id = self._resolve_snapshot_id(
+            catalog, checkpoint_plan, retained_snapshot_id)
+
+        if tag_name is not None:
+            table = table.copy({
+                CoreOptions.SCAN_TAG_NAME.key(): tag_name,
+            })
+        elif snapshot_id is not None:
+            table = table.copy({
+                CoreOptions.SCAN_SNAPSHOT_ID.key(): str(snapshot_id),
+            })
+
+        read_builder = ReadBuilder(table)
+        if self.filter is not None:
+            read_builder = read_builder.with_filter(self.filter)
+        if self.projection is not None:
+            read_builder = read_builder.with_projection(self.projection)
+
+        read_type = read_builder.read_type()
+        nested_name_paths = read_builder._nested_name_paths()
+        splits = read_builder.new_scan().plan().splits()
+        units = _build_offset_units(table, splits, self.rows_per_unit)
+        fingerprint = self._fingerprint(snapshot_id, units, read_type)
+        plan = {
+            "kind": "paimon-units-v1",
+            "table": self.table_identifier,
+            "snapshot_id": snapshot_id,
+            "fingerprint": fingerprint,
+            "num_units": len(units),
+            "rows_per_unit": self.rows_per_unit,
+            "units_per_checkpoint": self.units_per_checkpoint,
+        }
+        if checkpoint_plan is not None and plan != checkpoint_plan:
+            raise ValueError(
+                "PaimonOffsetSource does not match the saved checkpoint.")
+        return _BoundPaimonOffsetSource(
+            self, table, units, read_type, nested_name_paths, plan)
+
+    def _fingerprint(self, snapshot_id, units, read_type):
+        transform_identity = self._transform_identity()
+        payload = (
+            self.table_identifier,
+            snapshot_id,
+            self.projection,
+            self.filter,
+            transform_identity,
+            read_type,
+            units,
+            self.concurrency,
+            self.override_num_blocks,
+            sorted(self.read_args.items()),
+        )
+        return hashlib.sha256(
+            pickle.dumps(payload, protocol=4)).hexdigest()
+
+    def _transform_identity(self):
+        if self.transform is None:
+            return None
+        try:
+            import ray.cloudpickle as cloudpickle
+
+            encoded = cloudpickle.dumps(self.transform)
+        except Exception:
+            function = getattr(
+                self.transform, "__func__", self.transform)
+            code = getattr(function, "__code__", None)
+            if code is None:
+                call = getattr(self.transform, "__call__", None)
+                function = getattr(call, "__func__", call)
+                code = getattr(function, "__code__", None)
+            if code is None:
+                raise ValueError(
+                    "PaimonOffsetSource transform must be a Python "
+                    "function or a serializable callable.")
+            encoded = pickle.dumps((
+                getattr(function, "__module__", None),
+                getattr(function, "__qualname__", None),
+                marshal.dumps(code),
+                repr(getattr(function, "__defaults__", None)),
+                repr(getattr(function, "__kwdefaults__", None)),
+            ), protocol=4)
+        return hashlib.sha256(encoded).hexdigest()
+
+
+def _build_offset_units(table, splits, rows_per_unit):
+    from pypaimon.globalindex.indexed_split import IndexedSplit
+    from pypaimon.read.sliced_split import SlicedSplit
+    from pypaimon.read.split import DataSplit
+    from pypaimon.utils.range import Range
+
+    units = []
+    for split in splits:
+        if not isinstance(split, DataSplit):
+            units.append(split)
+            continue
+
+        if (table.options.data_evolution_enabled()
+                and all(data_file.first_row_id is not None
+                        for data_file in split.files)):
+            ranges = Range.sort_and_merge_overlap(
+                [data_file.row_id_range() for data_file in split.files],
+                True,
+                True,
+            )
+            for row_range in ranges:
+                for start in range(
+                        row_range.from_, row_range.to + 1, rows_per_unit):
+                    end = min(
+                        start + rows_per_unit - 1, row_range.to)
+                    units.append(IndexedSplit(
+                        split, [Range(start, end)]))
+            continue
+
+        if table.is_primary_key_table:
+            units.append(split)
+            continue
+
+        deletion_files = split.data_deletion_files
+        for index, data_file in enumerate(split.files):
+            deletion_file = (
+                deletion_files[index]
+                if deletion_files is not None else None)
+            single = DataSplit(
+                [data_file],
+                split.partition,
+                split.bucket,
+                raw_convertible=split.raw_convertible,
+                data_deletion_files=(
+                    [deletion_file]
+                    if deletion_file is not None else None),
+                snapshot_id=split.snapshot_id,
+            )
+            for start in range(0, data_file.row_count, rows_per_unit):
+                end = min(start + rows_per_unit, data_file.row_count)
+                if start == 0 and end == data_file.row_count:
+                    units.append(single)
+                else:
+                    units.append(SlicedSplit(
+                        single,
+                        {data_file.file_name: (start, end)},
+                    ))
+    return units
+
+
+class _BoundPaimonOffsetSource:
+
+    def __init__(
+            self,
+            source,
+            table,
+            units,
+            read_type,
+            nested_name_paths,
+            plan):
+        self.source = source
+        self.table = table
+        self.units = units
+        self.read_type = read_type
+        self.nested_name_paths = nested_name_paths
+        self.plan = plan
+
+    @property
+    def num_units(self):
+        return len(self.units)
+
+    def windows(self, next_offset):
+        step = self.source.units_per_checkpoint
+        for start in range(next_offset, self.num_units, step):
+            yield start, min(start + step, self.num_units)
+
+    def read_window(self, start, end):
+        import ray.data
+
+        from pypaimon.read.datasource.ray_datasource import RayDatasource
+        from pypaimon.read.datasource.split_provider import (
+            PreResolvedSplitProvider,
+        )
+
+        provider = PreResolvedSplitProvider(
+            self.table,
+            self.units[start:end],
+            self.read_type,
+            predicate=self.source.filter,
+            nested_name_paths=self.nested_name_paths,
+        )
+        dataset = ray.data.read_datasource(
+            RayDatasource(provider),
+            ray_remote_args=self.source.ray_remote_args,
+            concurrency=self.source.concurrency,
+            override_num_blocks=self.source.override_num_blocks,
+            **self.source.read_args,
+        )
+        if self.source.transform is not None:
+            dataset = self.source.transform(dataset)
+        return dataset

--- a/paimon-python/pypaimon/ray/update_by_row_id.py
+++ b/paimon-python/pypaimon/ray/update_by_row_id.py
@@ -51,7 +51,7 @@ __all__ = [
 
 logger = logging.getLogger(__name__)
 
-_CHECKPOINT_PROPERTY = "pypaimon.ray.update-by-row-id.checkpoint"
+_CHECKPOINT_PROPERTY = "data-evolution.update-by-row-id.checkpoint"
 _CHECKPOINT_TAG_PREFIX = "_pypaimon_ray_update_"
 _OFFSET_CHECKPOINT_VERSION = 2
 _OFFSET_CHECKPOINT_MODE = "source-offset"

--- a/paimon-python/pypaimon/ray/update_by_row_id.py
+++ b/paimon-python/pypaimon/ray/update_by_row_id.py
@@ -59,6 +59,7 @@ def update_by_row_id(
     update_cols: List[str],
     num_partitions: Optional[int] = None,
     ray_remote_args: Optional[Dict[str, Any]] = None,
+    commit_mode: str = "atomic",
     max_groups_per_commit: Optional[int] = None,
 ) -> Dict[str, int]:
     """Update ``update_cols`` of a data-evolution table by ``_ROW_ID``.
@@ -70,12 +71,12 @@ def update_by_row_id(
     ``ray >= 2.50`` and a target with ``data-evolution.enabled`` + ``row-tracking.enabled``.
 
     By default, all file groups are committed atomically. Set
-    ``max_groups_per_commit`` to commit completed groups in smaller windows.
-    Ordinary exceptions raised while applying a group are returned as results
-    in incremental mode, so completed groups are flushed before the error is
-    raised and Ray task retry options in ``ray_remote_args`` do not retry the
-    group. Worker loss and other task-level failures which bypass Python
-    exception handling may still lose results buffered by that task.
+    ``commit_mode="incremental"`` together with ``max_groups_per_commit`` to
+    commit completed groups in smaller windows. Incremental mode is not atomic:
+    commits made before a later failure remain visible. Deterministic duplicate
+    ``_ROW_ID`` errors are returned as group results so completed groups can be
+    flushed first. Other application errors propagate to Ray and remain subject
+    to the retry options in ``ray_remote_args``.
 
     Returns ``{"num_updated": <rows>}``.
     """
@@ -86,6 +87,14 @@ def update_by_row_id(
     _require_ray_join()
     if not update_cols:
         raise ValueError("update_cols must be non-empty.")
+    if commit_mode not in ("atomic", "incremental"):
+        raise ValueError("commit_mode must be 'atomic' or 'incremental'.")
+    if commit_mode == "atomic" and max_groups_per_commit is not None:
+        raise ValueError(
+            "max_groups_per_commit requires commit_mode='incremental'.")
+    if commit_mode == "incremental" and max_groups_per_commit is None:
+        raise ValueError(
+            "commit_mode='incremental' requires max_groups_per_commit.")
     if max_groups_per_commit is not None:
         if (isinstance(max_groups_per_commit, bool)
                 or not isinstance(max_groups_per_commit, int)
@@ -158,7 +167,7 @@ def update_by_row_id(
         return {"num_updated": 0}
     incremental_committer = (
         _IncrementalUpdateCommitter(table, max_groups_per_commit)
-        if max_groups_per_commit is not None else None
+        if commit_mode == "incremental" else None
     )
     try:
         apply_kwargs = {

--- a/paimon-python/pypaimon/ray/update_by_row_id.py
+++ b/paimon-python/pypaimon/ray/update_by_row_id.py
@@ -71,9 +71,11 @@ def update_by_row_id(
 
     By default, all file groups are committed atomically. Set
     ``max_groups_per_commit`` to commit completed groups in smaller windows.
-    If a group fails, completed groups are flushed before the error is raised.
-    Group exceptions are returned as results in incremental mode, so Ray task
-    retry options in ``ray_remote_args`` do not retry them.
+    Ordinary exceptions raised while applying a group are returned as results
+    in incremental mode, so completed groups are flushed before the error is
+    raised and Ray task retry options in ``ray_remote_args`` do not retry the
+    group. Worker loss and other task-level failures which bypass Python
+    exception handling may still lose results buffered by that task.
 
     Returns ``{"num_updated": <rows>}``.
     """
@@ -205,14 +207,23 @@ class _IncrementalUpdateCommitter:
         self._table_commit = None
         self._next_commit_identifier = 1
         self._commit_failed = False
+        self._deferred_commit_error = None
 
     def add_group(self, commit_messages, _num_updated, _row_ids) -> None:
         self._pending_messages.extend(commit_messages)
         self._pending_groups += 1
-        if self._pending_groups >= self._max_groups_per_commit:
-            self._commit_pending()
+        if (self._deferred_commit_error is None
+                and self._pending_groups >= self._max_groups_per_commit):
+            try:
+                self._commit_pending()
+            except Exception as error:
+                # Keep draining materialized Ray results so their staged files
+                # are known to the driver and can be aborted by the caller.
+                self._deferred_commit_error = error
 
     def finish(self) -> None:
+        if self._deferred_commit_error is not None:
+            raise self._deferred_commit_error
         self._commit_pending()
 
     def _commit_pending(self) -> None:

--- a/paimon-python/pypaimon/ray/update_by_row_id.py
+++ b/paimon-python/pypaimon/ray/update_by_row_id.py
@@ -23,7 +23,10 @@ shuffle join (unlike ``merge_into(on=["_ROW_ID"])``, which reads and joins the w
 target). Pairs with ``bucket_join``, which produces the row ids.
 """
 
+import hashlib
+import json
 import logging
+import time
 from typing import Any, Dict, List, Optional
 
 import pyarrow as pa
@@ -41,9 +44,18 @@ from pypaimon.ray.data_evolution_merge_join import (
 from pypaimon.ray.data_evolution_merge_transform import build_update_schema
 from pypaimon.schema.data_types import is_blob_file_field
 
-__all__ = ["update_by_row_id"]
+__all__ = [
+    "update_by_row_id",
+    "delete_update_by_row_id_checkpoint",
+]
 
 logger = logging.getLogger(__name__)
+
+_CHECKPOINT_PROPERTY = "pypaimon.ray.update-by-row-id.checkpoint"
+_CHECKPOINT_TAG_PREFIX = "_pypaimon_ray_update_"
+_OFFSET_CHECKPOINT_VERSION = 2
+_OFFSET_CHECKPOINT_MODE = "source-offset"
+_CHECKPOINT_TAG_UPDATE_ATTEMPTS = 3
 
 
 def _blob_col_names(table: "FileStoreTable") -> set:
@@ -61,6 +73,7 @@ def update_by_row_id(
     ray_remote_args: Optional[Dict[str, Any]] = None,
     commit_mode: str = "atomic",
     max_groups_per_commit: Optional[int] = None,
+    operation_id: Optional[str] = None,
 ) -> Dict[str, int]:
     """Update ``update_cols`` of a data-evolution table by ``_ROW_ID``.
 
@@ -70,21 +83,28 @@ def update_by_row_id(
     the target is never fully read and there is no join against it. Requires
     ``ray >= 2.50`` and a target with ``data-evolution.enabled`` + ``row-tracking.enabled``.
 
+    A :class:`PaimonOffsetSource` pins its source snapshot and commits one unit
+    window at a time. Its checkpoint stores only the next source offset.
+
     By default, all file groups are committed atomically. Set
     ``commit_mode="incremental"`` together with ``max_groups_per_commit`` to
     commit completed groups in smaller windows. Incremental mode is not atomic:
     commits made before a later failure remain visible. Deterministic duplicate
     ``_ROW_ID`` errors are returned as group results so completed groups can be
     flushed first. Other application errors propagate to Ray and remain subject
-    to the retry options in ``ray_remote_args``.
+    to the retry options in ``ray_remote_args``. A ``PaimonOffsetSource`` also
+    requires a stable ``operation_id`` so a later invocation can resume from its
+    durable source offset.
 
     Returns ``{"num_updated": <rows>}``.
     """
     from pypaimon.catalog.catalog_factory import CatalogFactory
+    from pypaimon.ray.offset_source import PaimonOffsetSource
     from pypaimon.schema.data_types import PyarrowFieldParser
     from pypaimon.table.special_fields import SpecialFields
 
     _require_ray_join()
+    offset_source = isinstance(source, PaimonOffsetSource)
     if not update_cols:
         raise ValueError("update_cols must be non-empty.")
     if commit_mode not in ("atomic", "incremental"):
@@ -92,18 +112,38 @@ def update_by_row_id(
     if commit_mode == "atomic" and max_groups_per_commit is not None:
         raise ValueError(
             "max_groups_per_commit requires commit_mode='incremental'.")
-    if commit_mode == "incremental" and max_groups_per_commit is None:
+    if (commit_mode == "incremental"
+            and max_groups_per_commit is None
+            and not offset_source):
         raise ValueError(
             "commit_mode='incremental' requires max_groups_per_commit.")
+    if offset_source and operation_id is None:
+        raise ValueError("PaimonOffsetSource requires operation_id.")
+    if operation_id is not None and not offset_source:
+        raise ValueError("operation_id requires a PaimonOffsetSource.")
+    if operation_id is not None:
+        if not isinstance(operation_id, str) or not operation_id.strip():
+            raise ValueError("operation_id must be a non-empty string.")
+        if len(operation_id) > 256:
+            raise ValueError("operation_id must contain at most 256 characters.")
     if max_groups_per_commit is not None:
         if (isinstance(max_groups_per_commit, bool)
                 or not isinstance(max_groups_per_commit, int)
                 or max_groups_per_commit <= 0):
             raise ValueError("max_groups_per_commit must be a positive integer.")
+    if offset_source:
+        if commit_mode != "incremental":
+            raise ValueError(
+                "PaimonOffsetSource requires commit_mode='incremental'.")
+        if max_groups_per_commit is not None:
+            raise ValueError(
+                "PaimonOffsetSource uses units_per_checkpoint instead of "
+                "max_groups_per_commit.")
     update_cols = list(dict.fromkeys(update_cols))  # de-dup, keep order
     num_partitions = _resolve_num_partitions(num_partitions)
 
-    table = CatalogFactory.create(catalog_options).get_table(target)
+    catalog = CatalogFactory.create(catalog_options)
+    table = catalog.get_table(target)
     if not table.options.data_evolution_enabled():
         raise ValueError(
             f"update_by_row_id requires 'data-evolution.enabled'='true' on '{target}'.")
@@ -132,6 +172,18 @@ def update_by_row_id(
                 f"update_by_row_id cannot update partition column {col!r}; "
                 "cross-partition row movement is not supported.")
 
+    if offset_source:
+        return _update_from_offset_source(
+            target,
+            source,
+            catalog,
+            table,
+            update_cols,
+            num_partitions,
+            ray_remote_args,
+            operation_id,
+        )
+
     if isinstance(source, str):
         # A table's system _ROW_ID is its own, independent of the target's, so a
         # table-name source can't address target rows. Require in-memory data that
@@ -157,18 +209,23 @@ def update_by_row_id(
     update_ds = source_ds.map_batches(_project_cast, batch_format="pyarrow")
 
     base = table.snapshot_manager().get_latest_snapshot()
-    # Without deletion vectors (rejected above), total_record_count is the live row
-    # count, so 0 means the target is empty (never written, or emptied by overwrite).
-    if base is None or base.total_record_count == 0:
-        # Every source row id is foreign; don't silently no-op non-empty input.
-        if update_ds.limit(1).count() > 0:
-            raise ValueError(
-                f"target '{target}' has no rows; every _ROW_ID in the source is foreign.")
-        return {"num_updated": 0}
     incremental_committer = (
         _IncrementalUpdateCommitter(table, max_groups_per_commit)
         if commit_mode == "incremental" else None
     )
+    # Without deletion vectors (rejected above), total_record_count is the live row
+    # count, so 0 means the target is empty (never written, or emptied by overwrite).
+    if base is None or base.total_record_count == 0:
+        # Every source row id is foreign; don't silently no-op non-empty input.
+        try:
+            if update_ds.limit(1).count() > 0:
+                raise ValueError(
+                    f"target '{target}' has no rows; every _ROW_ID in the "
+                    "source is foreign.")
+            return {"num_updated": 0}
+        finally:
+            if incremental_committer is not None:
+                incremental_committer.close()
     try:
         apply_kwargs = {
             "num_partitions": num_partitions,
@@ -206,6 +263,313 @@ def update_by_row_id(
     return {"num_updated": num_updated}
 
 
+def _update_from_offset_source(
+        target,
+        source,
+        catalog,
+        table,
+        update_cols,
+        num_partitions,
+        ray_remote_args,
+        operation_id):
+    from pypaimon.schema.data_types import PyarrowFieldParser
+    from pypaimon.table.special_fields import SpecialFields
+
+    initial_snapshot = table.snapshot_manager().get_latest_snapshot()
+    if initial_snapshot is None or initial_snapshot.total_record_count == 0:
+        raise ValueError(
+            "PaimonOffsetSource requires a non-empty target table.")
+
+    commit_user = _operation_commit_user(operation_id)
+    checkpoint_tags = _operation_checkpoint_tags(operation_id)
+    loaded = _load_offset_operation_checkpoint(
+        catalog,
+        target,
+        table,
+        operation_id,
+        update_cols,
+        commit_user,
+        checkpoint_tags,
+    )
+    saved_plan = (
+        loaded[1]["source"]
+        if loaded is not None and loaded[1] is not None
+        else None)
+    source_tag = _operation_source_tag(operation_id, target)
+    retained_source = _get_checkpoint_tag(
+        catalog, source.table_identifier, source_tag)
+    retained_snapshot_id = (
+        retained_source.snapshot.id
+        if retained_source is not None else None)
+    source_snapshot_id = source._resolve_snapshot_id(
+        catalog, saved_plan, retained_snapshot_id)
+    if source_snapshot_id is None:
+        raise ValueError(
+            "PaimonOffsetSource requires a source snapshot.")
+    bound_source = source._bind(
+        catalog,
+        checkpoint_plan=saved_plan,
+        tag_name=source_tag if retained_source is not None else None,
+        retained_snapshot_id=retained_snapshot_id,
+    )
+    if source_snapshot_id is not None:
+        _ensure_source_tag(
+            catalog,
+            source.table_identifier,
+            source_tag,
+            source_snapshot_id,
+        )
+    committer = _OffsetUpdateCommitter(
+        table,
+        catalog,
+        target,
+        operation_id,
+        update_cols,
+        bound_source.plan,
+        initial_snapshot,
+        loaded,
+    )
+    if committer.next_offset > bound_source.num_units:
+        committer.close()
+        raise RuntimeError(
+            "Offset checkpoint is beyond the source unit count.")
+
+    rid = SpecialFields.ROW_ID.name
+    target_pa = PyarrowFieldParser.from_paimon_schema(
+        table.table_schema.fields)
+    update_schema = build_update_schema(target_pa, update_cols, rid)
+
+    try:
+        for _, end in bound_source.windows(committer.next_offset):
+            source_ds = bound_source.read_window(
+                committer.next_offset, end)
+
+            def _project_cast(batch: pa.Table) -> pa.Table:
+                missing = [
+                    col for col in [rid] + update_cols
+                    if col not in batch.column_names
+                ]
+                if missing:
+                    raise ValueError(
+                        "source is missing columns {}; it must carry {} and {}."
+                        .format(missing, rid, update_cols))
+                return batch.select(
+                    [rid] + update_cols).cast(update_schema)
+
+            update_ds = source_ds.map_batches(
+                _project_cast, batch_format="pyarrow")
+
+            latest = table.snapshot_manager().get_latest_snapshot()
+            if latest is None:
+                raise RuntimeError(
+                    "Target has no snapshot before offset update.")
+
+            messages = []
+            planned_file_signatures = set()
+
+            def _collect_group(
+                    group_messages,
+                    _group_num_updated,
+                    _row_ids,
+                    group_file_signatures):
+                messages.extend(group_messages)
+                planned_file_signatures.update(group_file_signatures)
+
+            try:
+                _, num_updated, _ = distributed_update_apply(
+                    update_ds,
+                    table,
+                    update_cols,
+                    num_partitions=num_partitions,
+                    ray_remote_args=ray_remote_args,
+                    base_snapshot_id=latest.id,
+                    on_group_result=_collect_group,
+                )
+            except Exception as error:
+                _abort_pending_update_messages(table, messages)
+                _reraise_inner(error)
+            committer.commit_window(
+                messages,
+                num_updated,
+                end,
+                planned_file_signatures,
+            )
+        committer.finish()
+        return {"num_updated": committer.num_updated}
+    finally:
+        committer.close()
+
+
+class _OffsetUpdateCommitter:
+
+    def __init__(
+            self,
+            table,
+            catalog,
+            target,
+            operation_id,
+            update_cols,
+            source_plan,
+            initial_snapshot,
+            checkpoint):
+        self._table = table
+        self._catalog = catalog
+        self._target = target
+        self._operation_id = operation_id
+        self._update_cols = list(update_cols)
+        self._source_plan = dict(source_plan)
+        self._commit_user = _operation_commit_user(operation_id)
+        self._checkpoint_tags = _operation_checkpoint_tags(operation_id)
+        self._table_commit = None
+
+        initialize = checkpoint is None
+        if checkpoint is not None:
+            snapshot, state = checkpoint
+            self._checkpoint_snapshot = snapshot
+            if state is None:
+                initialize = True
+                self._next_offset = 0
+                self._num_updated = 0
+                self._complete = False
+                self._next_commit_identifier = 1
+            else:
+                if state["source"] != self._source_plan:
+                    raise ValueError(
+                        "PaimonOffsetSource does not match the saved checkpoint.")
+                self._next_offset = state["next_offset"]
+                self._num_updated = state["num_updated"]
+                self._complete = state["complete"]
+                self._next_commit_identifier = (
+                    snapshot.commit_identifier + 1)
+        else:
+            self._checkpoint_snapshot = initial_snapshot
+            self._next_offset = 0
+            self._num_updated = 0
+            self._complete = False
+            self._next_commit_identifier = 1
+
+        try:
+            builder = table.new_stream_write_builder()
+            builder.commit_user = self._commit_user
+            self._table_commit = builder.new_commit()
+            if initialize:
+                self._commit_initial_checkpoint()
+        except Exception:
+            self.close()
+            raise
+
+    @property
+    def next_offset(self):
+        return self._next_offset
+
+    @property
+    def num_updated(self):
+        return self._num_updated
+
+    def _commit_initial_checkpoint(self):
+        self._commit_checkpoint(
+            [],
+            0,
+            0,
+            set(),
+            complete=False,
+        )
+
+    def commit_window(
+            self,
+            messages,
+            num_updated,
+            next_offset,
+            planned_file_signatures):
+        if next_offset <= self._next_offset:
+            raise RuntimeError("Source checkpoint offset did not advance.")
+        self._commit_checkpoint(
+            messages,
+            next_offset,
+            self._num_updated + num_updated,
+            planned_file_signatures,
+            complete=False,
+        )
+        self._next_offset = next_offset
+        self._num_updated += num_updated
+        logger.info(
+            "Committed source offsets through %d for operation %s.",
+            next_offset,
+            self._operation_id,
+        )
+
+    def finish(self):
+        if self._complete:
+            return
+        self._commit_checkpoint(
+            [],
+            self._next_offset,
+            self._num_updated,
+            set(),
+            complete=True,
+        )
+        self._complete = True
+
+    def _commit_checkpoint(
+            self,
+            messages,
+            next_offset,
+            num_updated,
+            planned_file_signatures,
+            complete):
+        properties = _offset_checkpoint_properties(
+            self._operation_id,
+            self._table.table_schema.id,
+            self._update_cols,
+            self._source_plan,
+            next_offset,
+            num_updated,
+            complete,
+        )
+        commit_identifier = self._next_commit_identifier
+        ranges = _row_id_ranges_from_messages(messages)
+        self._table_commit.protect_from_external_rewrites(
+            self._checkpoint_snapshot, self._commit_user)
+        self._table_commit.protect_planned_row_id_files(
+            ranges, planned_file_signatures)
+        self._table_commit.with_snapshot_properties(properties)
+        if messages:
+            self._table_commit.commit(messages, commit_identifier)
+        else:
+            self._table_commit.commit_metadata(commit_identifier)
+        snapshot = _find_offset_operation_snapshot(
+            self._table,
+            self._commit_user,
+            commit_identifier,
+            self._checkpoint_snapshot.id,
+        )
+        if snapshot is None:
+            raise RuntimeError(
+                "Committed offset checkpoint snapshot cannot be found.")
+        _store_operation_checkpoint(
+            self._catalog,
+            self._target,
+            self._checkpoint_tags,
+            snapshot,
+        )
+
+        self._checkpoint_snapshot = snapshot
+        self._next_commit_identifier += 1
+
+    def close(self):
+        if self._table_commit is None:
+            return
+        try:
+            self._table_commit.close()
+        except Exception as error:
+            logger.warning(
+                "Failed to close offset update commit: %s",
+                error,
+                exc_info=error,
+            )
+        self._table_commit = None
+
+
 class _IncrementalUpdateCommitter:
 
     def __init__(self, table, max_groups_per_commit: int):
@@ -218,7 +582,12 @@ class _IncrementalUpdateCommitter:
         self._commit_failed = False
         self._deferred_commit_error = None
 
-    def add_group(self, commit_messages, _num_updated, _row_ids) -> None:
+    def add_group(
+            self,
+            commit_messages,
+            _num_updated,
+            _row_ids,
+            _planned_file_signatures=()) -> None:
         self._pending_messages.extend(commit_messages)
         self._pending_groups += 1
         if (self._deferred_commit_error is None
@@ -277,6 +646,385 @@ class _IncrementalUpdateCommitter:
                 close_error,
                 exc_info=close_error,
             )
+
+
+def delete_update_by_row_id_checkpoint(
+        target: str,
+        catalog_options: Dict[str, str],
+        operation_id: str) -> bool:
+    """Delete a completed incremental update's durable resume checkpoint."""
+    from pypaimon.catalog.catalog_factory import CatalogFactory
+
+    if not isinstance(operation_id, str) or not operation_id.strip():
+        raise ValueError("operation_id must be a non-empty string.")
+    catalog = CatalogFactory.create(catalog_options)
+    deleted = False
+    checkpoint_tags = _operation_checkpoint_tags(operation_id)
+    source_table = None
+    offset_snapshots = []
+    for checkpoint_tag in checkpoint_tags:
+        tagged = _get_checkpoint_tag(catalog, target, checkpoint_tag)
+        if (tagged is not None
+                and _has_offset_checkpoint_state(tagged.snapshot)):
+            offset_snapshots.append(tagged.snapshot)
+    if not offset_snapshots:
+        table = catalog.get_table(target)
+        snapshot_manager = table.snapshot_manager()
+        latest = snapshot_manager.get_latest_snapshot()
+        if latest is not None:
+            earliest = snapshot_manager.try_get_earliest_snapshot(latest.id)
+            commit_user = _operation_commit_user(operation_id)
+            for snapshot_id in range(
+                    latest.id, earliest.id - 1, -1):
+                snapshot = snapshot_manager.get_snapshot_by_id(snapshot_id)
+                if (snapshot is not None
+                        and snapshot.commit_user == commit_user
+                        and _has_offset_checkpoint_state(snapshot)):
+                    offset_snapshots.append(snapshot)
+                    break
+    if offset_snapshots:
+        offset_snapshot = max(
+            offset_snapshots, key=lambda snapshot: snapshot.id)
+        source_table = _offset_checkpoint_state(
+            offset_snapshot)["source"].get("table")
+
+    for checkpoint_tag in checkpoint_tags:
+        deleted = (
+            _delete_checkpoint_tag(
+                catalog, target, checkpoint_tag, ignore_missing=True)
+            or deleted
+        )
+    if source_table:
+        deleted = (
+            _delete_checkpoint_tag(
+                catalog,
+                source_table,
+                _operation_source_tag(operation_id, target),
+                ignore_missing=True,
+            )
+            or deleted
+        )
+    return deleted
+
+
+def _operation_digest(operation_id):
+    return hashlib.sha256(operation_id.encode("utf-8")).hexdigest()[:32]
+
+
+def _operation_commit_user(operation_id):
+    return "pypaimon-ray-update-" + _operation_digest(operation_id)
+
+
+def _operation_checkpoint_tags(operation_id):
+    base = _CHECKPOINT_TAG_PREFIX + _operation_digest(operation_id)
+    return base + "_0", base + "_1"
+
+
+def _operation_source_tag(operation_id, target):
+    return (
+        _CHECKPOINT_TAG_PREFIX
+        + _operation_digest(target + "\0" + operation_id)
+        + "_source"
+    )
+
+
+def _offset_checkpoint_properties(
+        operation_id,
+        schema_id,
+        update_cols,
+        source_plan,
+        next_offset,
+        num_updated,
+        complete):
+    state = {
+        "version": _OFFSET_CHECKPOINT_VERSION,
+        "mode": _OFFSET_CHECKPOINT_MODE,
+        "operation_id": operation_id,
+        "schema_id": schema_id,
+        "update_cols": list(update_cols),
+        "source": dict(source_plan),
+        "next_offset": next_offset,
+        "num_updated": num_updated,
+        "complete": complete,
+    }
+    return {
+        _CHECKPOINT_PROPERTY: json.dumps(
+            state, sort_keys=True, separators=(",", ":"))
+    }
+
+
+def _offset_checkpoint_state(snapshot):
+    encoded = (snapshot.properties or {}).get(_CHECKPOINT_PROPERTY)
+    if encoded is None:
+        return None
+    try:
+        state = json.loads(encoded)
+    except Exception as error:
+        raise RuntimeError(
+            "Invalid source-offset checkpoint JSON.") from error
+    if (state.get("version") != _OFFSET_CHECKPOINT_VERSION
+            or state.get("mode") != _OFFSET_CHECKPOINT_MODE):
+        raise RuntimeError(
+            "operation_id belongs to a different checkpoint mode.")
+    required = {
+        "operation_id",
+        "schema_id",
+        "update_cols",
+        "source",
+        "next_offset",
+        "num_updated",
+        "complete",
+    }
+    if not required.issubset(state):
+        raise RuntimeError("Incomplete source-offset checkpoint.")
+    if not isinstance(state["source"], dict):
+        raise RuntimeError("Invalid source-offset checkpoint source.")
+    required_source = {
+        "kind",
+        "table",
+        "snapshot_id",
+        "fingerprint",
+        "num_units",
+        "rows_per_unit",
+        "units_per_checkpoint",
+    }
+    if not required_source.issubset(state["source"]):
+        raise RuntimeError("Incomplete source-offset checkpoint source.")
+    source = state["source"]
+    if (source["kind"] != "paimon-units-v1"
+            or not isinstance(source["table"], str)
+            or not isinstance(source["fingerprint"], str)
+            or isinstance(source["num_units"], bool)
+            or not isinstance(source["num_units"], int)
+            or source["num_units"] < 0
+            or isinstance(source["rows_per_unit"], bool)
+            or not isinstance(source["rows_per_unit"], int)
+            or source["rows_per_unit"] <= 0
+            or isinstance(source["units_per_checkpoint"], bool)
+            or not isinstance(source["units_per_checkpoint"], int)
+            or source["units_per_checkpoint"] <= 0
+            or (source["snapshot_id"] is not None
+                and (isinstance(source["snapshot_id"], bool)
+                     or not isinstance(source["snapshot_id"], int)
+                     or source["snapshot_id"] <= 0))):
+        raise RuntimeError("Invalid source-offset checkpoint source.")
+    for name in ("next_offset", "num_updated"):
+        value = state[name]
+        if (isinstance(value, bool)
+                or not isinstance(value, int)
+                or value < 0):
+            raise RuntimeError(
+                "Invalid source-offset checkpoint {}.".format(name))
+    if not isinstance(state["complete"], bool):
+        raise RuntimeError(
+            "Invalid source-offset checkpoint completion state.")
+    if (state["next_offset"] > source["num_units"]
+            or (state["complete"]
+                and state["next_offset"] != source["num_units"])):
+        raise RuntimeError(
+            "Invalid source-offset checkpoint progress.")
+    return state
+
+
+def _validate_offset_checkpoint_state(
+        snapshot,
+        operation_id,
+        update_cols,
+        schema_id,
+        state):
+    if state["operation_id"] != operation_id:
+        raise RuntimeError(
+            "Source-offset update operation id hash collision.")
+    if state["schema_id"] != schema_id:
+        raise RuntimeError(
+            "Target schema changed since source-offset operation "
+            "{!r} started.".format(operation_id))
+    if state["update_cols"] != list(update_cols):
+        raise ValueError(
+            "operation_id {!r} was already used with update_cols {}; "
+            "got {}.".format(
+                operation_id, state["update_cols"], list(update_cols)))
+    return state
+
+
+def _load_offset_operation_checkpoint(
+        catalog,
+        target,
+        table,
+        operation_id,
+        update_cols,
+        commit_user,
+        checkpoint_tags):
+    snapshot_manager = table.snapshot_manager()
+    latest = snapshot_manager.get_latest_snapshot()
+    tagged_snapshots = []
+    for checkpoint_tag in checkpoint_tags:
+        tagged = _get_checkpoint_tag(catalog, target, checkpoint_tag)
+        if tagged is not None:
+            tagged_snapshots.append(tagged.snapshot)
+
+    checkpoint_snapshot = (
+        max(tagged_snapshots, key=lambda snapshot: snapshot.id)
+        if tagged_snapshots else None)
+    if latest is not None:
+        if checkpoint_snapshot is not None:
+            lower_bound = checkpoint_snapshot.id + 1
+        else:
+            earliest = snapshot_manager.try_get_earliest_snapshot(latest.id)
+            lower_bound = earliest.id
+        for snapshot_id in range(latest.id, lower_bound - 1, -1):
+            snapshot = snapshot_manager.get_snapshot_by_id(snapshot_id)
+            if (snapshot is not None
+                    and snapshot.commit_user == commit_user
+                    and _has_offset_checkpoint_state(snapshot)):
+                checkpoint_snapshot = snapshot
+                break
+
+    if checkpoint_snapshot is None:
+        return None
+    state = _offset_checkpoint_state(checkpoint_snapshot)
+    if state is None:
+        return checkpoint_snapshot, None
+    if checkpoint_snapshot.commit_user != commit_user:
+        raise RuntimeError(
+            "Source-offset checkpoint tag belongs to another writer.")
+    state = _validate_offset_checkpoint_state(
+        checkpoint_snapshot,
+        operation_id,
+        update_cols,
+        table.table_schema.id,
+        state,
+    )
+    _store_operation_checkpoint(
+        catalog, target, checkpoint_tags, checkpoint_snapshot)
+    return checkpoint_snapshot, state
+
+
+def _find_offset_operation_snapshot(
+        table,
+        commit_user,
+        commit_identifier,
+        after_snapshot_id):
+    snapshot_manager = table.snapshot_manager()
+    latest = snapshot_manager.get_latest_snapshot()
+    if latest is None or latest.id <= after_snapshot_id:
+        return None
+    for snapshot_id in range(
+            latest.id, after_snapshot_id, -1):
+        snapshot = snapshot_manager.get_snapshot_by_id(snapshot_id)
+        if (snapshot is not None
+                and snapshot.commit_user == commit_user
+                and snapshot.commit_identifier == commit_identifier
+                and _has_offset_checkpoint_state(snapshot)):
+            return snapshot
+    return None
+
+
+def _store_operation_checkpoint(
+        catalog, target, checkpoint_tags, snapshot):
+    for attempt in range(_CHECKPOINT_TAG_UPDATE_ATTEMPTS):
+        try:
+            _store_operation_checkpoint_once(
+                catalog, target, checkpoint_tags, snapshot)
+            return
+        except Exception:
+            if attempt + 1 == _CHECKPOINT_TAG_UPDATE_ATTEMPTS:
+                raise
+            logger.warning(
+                "Retry resumable update checkpoint tag.",
+                exc_info=True,
+            )
+            time.sleep(0.1 * (2 ** attempt))
+
+
+def _store_operation_checkpoint_once(
+        catalog, target, checkpoint_tags, snapshot):
+    slot = snapshot.commit_identifier % 2
+    checkpoint_tag = checkpoint_tags[slot]
+    previous = _get_checkpoint_tag(catalog, target, checkpoint_tag)
+    if previous is None or previous.snapshot.id != snapshot.id:
+        if previous is not None:
+            _delete_checkpoint_tag(catalog, target, checkpoint_tag)
+        catalog.create_tag(
+            target, checkpoint_tag, snapshot_id=snapshot.id)
+    _delete_checkpoint_tag(
+        catalog, target, checkpoint_tags[1 - slot], ignore_missing=True)
+
+
+def _get_checkpoint_tag(catalog, target, checkpoint_tag):
+    from pypaimon.catalog.catalog_exception import TagNotExistException
+
+    try:
+        return catalog.get_tag(target, checkpoint_tag)
+    except TagNotExistException:
+        return None
+
+
+def _ensure_source_tag(
+        catalog, source_table, source_tag, snapshot_id):
+    previous = _get_checkpoint_tag(catalog, source_table, source_tag)
+    if previous is not None:
+        if previous.snapshot.id != snapshot_id:
+            raise ValueError(
+                "operation_id is already bound to another source snapshot.")
+        return
+    catalog.create_tag(
+        source_table, source_tag, snapshot_id=snapshot_id)
+
+
+def _delete_checkpoint_tag(
+        catalog, target, checkpoint_tag, ignore_missing=False):
+    from pypaimon.catalog.catalog_exception import TagNotExistException
+
+    try:
+        catalog.delete_tag(target, checkpoint_tag)
+        return True
+    except TagNotExistException:
+        if not ignore_missing:
+            raise
+        return False
+
+
+def _has_offset_checkpoint_state(snapshot):
+    if _CHECKPOINT_PROPERTY not in (snapshot.properties or {}):
+        return False
+    try:
+        state = json.loads(
+            snapshot.properties[_CHECKPOINT_PROPERTY])
+    except Exception:
+        return False
+    return (
+        state.get("version") == _OFFSET_CHECKPOINT_VERSION
+        and state.get("mode") == _OFFSET_CHECKPOINT_MODE
+    )
+
+
+def _merge_row_id_ranges(*range_groups):
+    from pypaimon.utils.range import Range
+
+    return Range.sort_and_merge_overlap(
+        [
+            row_range
+            for ranges in range_groups
+            for row_range in ranges
+        ],
+        True,
+        True,
+    )
+
+
+def _row_id_ranges_from_messages(messages):
+    ranges = []
+    for message in messages:
+        for data_file in message.new_files:
+            row_range = data_file.row_id_range()
+            if row_range is not None:
+                ranges.append(row_range)
+    merged = _merge_row_id_ranges(ranges)
+    if messages and not merged:
+        raise RuntimeError(
+            "Cannot checkpoint update messages without row-id ranges.")
+    return merged
 
 
 def _commit_update_messages(table, commit_messages) -> None:

--- a/paimon-python/pypaimon/ray/update_by_row_id.py
+++ b/paimon-python/pypaimon/ray/update_by_row_id.py
@@ -34,7 +34,10 @@ from pypaimon.ray.data_evolution_merge_into import (
     _require_ray_join,
     _resolve_num_partitions,
 )
-from pypaimon.ray.data_evolution_merge_join import distributed_update_apply
+from pypaimon.ray.data_evolution_merge_join import (
+    GroupApplyError,
+    distributed_update_apply,
+)
 from pypaimon.ray.data_evolution_merge_transform import build_update_schema
 from pypaimon.schema.data_types import is_blob_file_field
 
@@ -56,6 +59,7 @@ def update_by_row_id(
     update_cols: List[str],
     num_partitions: Optional[int] = None,
     ray_remote_args: Optional[Dict[str, Any]] = None,
+    max_groups_per_commit: Optional[int] = None,
 ) -> Dict[str, int]:
     """Update ``update_cols`` of a data-evolution table by ``_ROW_ID``.
 
@@ -64,6 +68,12 @@ def update_by_row_id(
     routed to the data file owning its row id and only those files are rewritten --
     the target is never fully read and there is no join against it. Requires
     ``ray >= 2.50`` and a target with ``data-evolution.enabled`` + ``row-tracking.enabled``.
+
+    By default, all file groups are committed atomically. Set
+    ``max_groups_per_commit`` to commit completed groups in smaller windows.
+    If a group fails, completed groups are flushed before the error is raised.
+    Group exceptions are returned as results in incremental mode, so Ray task
+    retry options in ``ray_remote_args`` do not retry them.
 
     Returns ``{"num_updated": <rows>}``.
     """
@@ -74,6 +84,11 @@ def update_by_row_id(
     _require_ray_join()
     if not update_cols:
         raise ValueError("update_cols must be non-empty.")
+    if max_groups_per_commit is not None:
+        if (isinstance(max_groups_per_commit, bool)
+                or not isinstance(max_groups_per_commit, int)
+                or max_groups_per_commit <= 0):
+            raise ValueError("max_groups_per_commit must be a positive integer.")
     update_cols = list(dict.fromkeys(update_cols))  # de-dup, keep order
     num_partitions = _resolve_num_partitions(num_partitions)
 
@@ -139,20 +154,109 @@ def update_by_row_id(
             raise ValueError(
                 f"target '{target}' has no rows; every _ROW_ID in the source is foreign.")
         return {"num_updated": 0}
+    incremental_committer = (
+        _IncrementalUpdateCommitter(table, max_groups_per_commit)
+        if max_groups_per_commit is not None else None
+    )
     try:
+        apply_kwargs = {
+            "num_partitions": num_partitions,
+            "ray_remote_args": ray_remote_args,
+            "base_snapshot_id": base.id,
+        }
+        if incremental_committer is not None:
+            apply_kwargs["on_group_result"] = incremental_committer.add_group
         msgs, num_updated, _ = distributed_update_apply(
-            update_ds, table, update_cols,
-            num_partitions=num_partitions,
-            ray_remote_args=ray_remote_args,
-            base_snapshot_id=base.id,
+            update_ds, table, update_cols, **apply_kwargs
         )
+        if incremental_committer is not None:
+            incremental_committer.finish()
+    except GroupApplyError:
+        if incremental_committer is not None:
+            try:
+                incremental_committer.finish()
+            except Exception:
+                incremental_committer.abort_pending()
+                raise
+        raise
     except Exception as e:
+        if incremental_committer is not None:
+            incremental_committer.abort_pending()
+            if incremental_committer._commit_failed:
+                raise
         _reraise_inner(e)
         raise  # _reraise_inner always raises; keeps msgs/num_updated defined for linters
+    finally:
+        if incremental_committer is not None:
+            incremental_committer.close()
 
-    if msgs:
+    if incremental_committer is None and msgs:
         _commit_update_messages(table, msgs)
     return {"num_updated": num_updated}
+
+
+class _IncrementalUpdateCommitter:
+
+    def __init__(self, table, max_groups_per_commit: int):
+        self._table = table
+        self._max_groups_per_commit = max_groups_per_commit
+        self._pending_messages: list = []
+        self._pending_groups = 0
+        self._table_commit = None
+        self._next_commit_identifier = 1
+        self._commit_failed = False
+
+    def add_group(self, commit_messages, _num_updated, _row_ids) -> None:
+        self._pending_messages.extend(commit_messages)
+        self._pending_groups += 1
+        if self._pending_groups >= self._max_groups_per_commit:
+            self._commit_pending()
+
+    def finish(self) -> None:
+        self._commit_pending()
+
+    def _commit_pending(self) -> None:
+        if self._pending_groups == 0:
+            return
+        if not self._pending_messages:
+            self._pending_groups = 0
+            return
+
+        try:
+            if self._table_commit is None:
+                self._table_commit = (
+                    self._table.new_stream_write_builder().new_commit()
+                )
+
+            messages = self._pending_messages
+            self._pending_messages = []
+            self._pending_groups = 0
+            commit_identifier = self._next_commit_identifier
+            self._table_commit.commit(messages, commit_identifier)
+        except Exception:
+            self._commit_failed = True
+            raise
+        self._next_commit_identifier += 1
+
+    def abort_pending(self) -> None:
+        if not self._pending_messages:
+            return
+        messages = self._pending_messages
+        self._pending_messages = []
+        self._pending_groups = 0
+        _abort_pending_update_messages(self._table, messages)
+
+    def close(self) -> None:
+        if self._table_commit is None:
+            return
+        try:
+            self._table_commit.close()
+        except Exception as close_error:
+            logger.warning(
+                "Failed to close incremental update_by_row_id commit: %s",
+                close_error,
+                exc_info=close_error,
+            )
 
 
 def _commit_update_messages(table, commit_messages) -> None:

--- a/paimon-python/pypaimon/tests/file_store_commit_test.py
+++ b/paimon-python/pypaimon/tests/file_store_commit_test.py
@@ -59,6 +59,19 @@ class TestFileStoreCommit(unittest.TestCase):
             commit_user='test_user'
         )
 
+    def test_commit_metadata_allows_empty_snapshot(
+            self, mock_manifest_list_manager, mock_manifest_file_manager):
+        file_store_commit = self._create_file_store_commit()
+        file_store_commit._try_commit = Mock()
+
+        file_store_commit.commit_metadata(42)
+
+        kwargs = file_store_commit._try_commit.call_args.kwargs
+        self.assertEqual("APPEND", kwargs["commit_kind"])
+        self.assertEqual(42, kwargs["commit_identifier"])
+        self.assertEqual([], kwargs["commit_entries_plan"](None))
+        self.assertTrue(kwargs["allow_empty"])
+
     def test_generate_partition_statistics_single_partition_single_file(
             self, mock_manifest_list_manager, mock_manifest_file_manager):
         """Test partition statistics generation with single partition and single file."""

--- a/paimon-python/pypaimon/tests/ray_update_by_row_id_test.py
+++ b/paimon-python/pypaimon/tests/ray_update_by_row_id_test.py
@@ -130,6 +130,222 @@ class RayUpdateByRowIdTest(unittest.TestCase):
         self.assertEqual(got[21], 999)
         self.assertTrue(all(v == 0 for k, v in got.items() if k != 21))
 
+    def test_incrementally_commits_file_group_windows(self):
+        from pypaimon.write.table_commit import StreamTableCommit
+
+        target = self._create()
+        chunks = [[start, start + 1] for start in range(10, 60, 10)]
+        for chunk in chunks:
+            self._write(target, pa.Table.from_pydict(
+                {"id": chunk, "name": ["x", "x"], "age": [0, 0]},
+                schema=self.pa_schema,
+            ))
+
+        table = self.catalog.get_table(target)
+        base_snapshot_id = table.snapshot_manager().get_latest_snapshot().id
+        row_ids = self._rowid_by_id(target)
+        updated_ids = [chunk[0] for chunk in chunks]
+        source = pa.table(
+            {
+                "_ROW_ID": [row_ids[row_id] for row_id in updated_ids],
+                "age": updated_ids,
+            },
+            schema=pa.schema([("_ROW_ID", pa.int64()), ("age", pa.int32())]),
+        )
+        commits = []
+        original_commit = StreamTableCommit.commit
+
+        def record_commit(stream_commit, messages, commit_identifier):
+            commits.append((len(messages), commit_identifier))
+            return original_commit(
+                stream_commit, messages, commit_identifier)
+
+        with mock.patch.object(StreamTableCommit, "commit", record_commit):
+            stats = update_by_row_id(
+                target,
+                ray.data.from_arrow(source).repartition(4),
+                self.catalog_options,
+                update_cols=["age"],
+                num_partitions=4,
+                max_groups_per_commit=2,
+            )
+
+        self.assertEqual({"num_updated": 5}, stats)
+        self.assertEqual([(2, 1), (2, 2), (1, 3)], commits)
+        self.assertEqual(
+            base_snapshot_id + 3,
+            table.snapshot_manager().get_latest_snapshot().id,
+        )
+        result = self._read(target).sort_by("id").to_pydict()
+        ages = dict(zip(result["id"], result["age"]))
+        self.assertEqual(
+            {row_id: row_id for row_id in updated_ids},
+            {row_id: ages[row_id] for row_id in updated_ids},
+        )
+
+    def test_group_failure_preserves_completed_groups(self):
+        for max_groups, expected_snapshots in [(1, 2), (5, 1)]:
+            with self.subTest(max_groups_per_commit=max_groups):
+                target = self._create()
+                for row_id in range(1, 4):
+                    self._write(target, pa.Table.from_pydict(
+                        {"id": [row_id], "name": ["a"], "age": [0]},
+                        schema=self.pa_schema,
+                    ))
+
+                table = self.catalog.get_table(target)
+                base_snapshot_id = (
+                    table.snapshot_manager().get_latest_snapshot().id
+                )
+                row_ids = self._rowid_by_id(target)
+                source = pa.table(
+                    {
+                        "_ROW_ID": [
+                            row_ids[1], row_ids[2], row_ids[3], row_ids[3],
+                        ],
+                        "age": [100, 200, 300, 301],
+                    },
+                    schema=pa.schema([
+                        ("_ROW_ID", pa.int64()),
+                        ("age", pa.int32()),
+                    ]),
+                )
+
+                with self.assertRaisesRegex(RuntimeError, "Deduplicate"):
+                    update_by_row_id(
+                        target,
+                        ray.data.from_arrow(source),
+                        self.catalog_options,
+                        update_cols=["age"],
+                        num_partitions=1,
+                        max_groups_per_commit=max_groups,
+                    )
+
+                self.assertEqual(
+                    base_snapshot_id + expected_snapshots,
+                    table.snapshot_manager().get_latest_snapshot().id,
+                )
+                self.assertEqual(
+                    [100, 200, 0],
+                    self._read(target).sort_by("id")["age"].to_pylist(),
+                )
+
+    def test_atomic_group_failure_commits_nothing(self):
+        target = self._create()
+        for row_id in range(1, 4):
+            self._write(target, pa.Table.from_pydict(
+                {"id": [row_id], "name": ["a"], "age": [0]},
+                schema=self.pa_schema,
+            ))
+
+        table = self.catalog.get_table(target)
+        base_snapshot_id = table.snapshot_manager().get_latest_snapshot().id
+        row_ids = self._rowid_by_id(target)
+        source = pa.table(
+            {
+                "_ROW_ID": [
+                    row_ids[1], row_ids[2], row_ids[3], row_ids[3],
+                ],
+                "age": [100, 200, 300, 301],
+            },
+            schema=pa.schema([
+                ("_ROW_ID", pa.int64()),
+                ("age", pa.int32()),
+            ]),
+        )
+
+        with self.assertRaisesRegex(ValueError, "Deduplicate"):
+            update_by_row_id(
+                target,
+                ray.data.from_arrow(source),
+                self.catalog_options,
+                update_cols=["age"],
+                num_partitions=1,
+            )
+
+        self.assertEqual(
+            base_snapshot_id,
+            table.snapshot_manager().get_latest_snapshot().id,
+        )
+        self.assertEqual(
+            [0, 0, 0],
+            self._read(target).sort_by("id")["age"].to_pylist(),
+        )
+
+    def test_incremental_committer_batches_and_aborts_pending_groups(self):
+        import importlib
+
+        module = importlib.import_module("pypaimon.ray.update_by_row_id")
+        commits = []
+        aborted = []
+        close_calls = []
+
+        class FakeCommit:
+            def commit(self, messages, commit_identifier):
+                commits.append((list(messages), commit_identifier))
+
+            def close(self):
+                close_calls.append(True)
+
+        class FakeBuilder:
+            def new_commit(self):
+                return FakeCommit()
+
+        class FakeTable:
+            def new_stream_write_builder(self):
+                return FakeBuilder()
+
+        committer = module._IncrementalUpdateCommitter(FakeTable(), 2)
+        with mock.patch.object(
+                module,
+                "_abort_pending_update_messages",
+                side_effect=lambda table, messages: aborted.append(list(messages))):
+            committer.add_group(["group-1"], 1, [])
+            committer.add_group(["group-2"], 1, [])
+            committer.add_group(["group-3"], 1, [])
+            committer.abort_pending()
+            committer.close()
+
+        self.assertEqual(
+            [(["group-1", "group-2"], 1)],
+            commits,
+        )
+        self.assertEqual([["group-3"]], aborted)
+        self.assertEqual([True], close_calls)
+
+    def test_incremental_commit_failure_does_not_abort_unknown_outcome(self):
+        import importlib
+
+        module = importlib.import_module("pypaimon.ray.update_by_row_id")
+        aborted = []
+
+        class FakeCommit:
+            def commit(self, messages, commit_identifier):
+                raise RuntimeError("commit failed")
+
+            def close(self):
+                pass
+
+        class FakeBuilder:
+            def new_commit(self):
+                return FakeCommit()
+
+        class FakeTable:
+            def new_stream_write_builder(self):
+                return FakeBuilder()
+
+        committer = module._IncrementalUpdateCommitter(FakeTable(), 1)
+        with mock.patch.object(
+                module,
+                "_abort_pending_update_messages",
+                side_effect=lambda table, messages: aborted.append(list(messages))):
+            with self.assertRaisesRegex(RuntimeError, "commit failed"):
+                committer.add_group(["group-1"], 1, [])
+            committer.abort_pending()
+            committer.close()
+
+        self.assertEqual([], aborted)
+
     def test_pins_base_snapshot_for_conflict_detection(self):
         # The update pins its base snapshot and threads it to distributed_update_apply,
         # which uses it for commit-time conflict detection against concurrent writers.
@@ -182,6 +398,20 @@ class RayUpdateByRowIdTest(unittest.TestCase):
         self.assertEqual(recorder["commit_calls"], 1)
         self.assertEqual(recorder["abort_calls"], 0)
         self.assertEqual(recorder["close_calls"], 1)
+
+    def test_incremental_driver_commit_failure_is_not_unwrapped(self):
+        retry_error = ValueError("retry failed")
+        commit_error = RuntimeError("commit failed")
+        commit_error.__cause__ = retry_error
+
+        with self.assertRaises(RuntimeError) as raised:
+            self._run_with_fake_commit(
+                commit_error=commit_error,
+                incremental=True,
+            )
+
+        self.assertIs(commit_error, raised.exception)
+        self.assertIs(retry_error, raised.exception.__cause__)
 
     def test_close_failure_after_success_warns_and_returns_stats(self):
         close_error = RuntimeError("close failed")
@@ -324,8 +554,30 @@ class RayUpdateByRowIdTest(unittest.TestCase):
         with self.assertRaises(ValueError):
             update_by_row_id(target, src, self.catalog_options, update_cols=[])
 
+    def test_rejects_invalid_max_groups_per_commit(self):
+        target = self._create()
+        self._write(target, pa.Table.from_pydict(
+            {"id": [1], "name": ["a"], "age": [1]}, schema=self.pa_schema))
+        source = pa.table(
+            {"_ROW_ID": [0], "age": [9]},
+            schema=pa.schema([("_ROW_ID", pa.int64()), ("age", pa.int32())]),
+        )
+
+        for value in [0, -1, True, 1.5, "2"]:
+            with self.subTest(value=value):
+                with self.assertRaisesRegex(
+                        ValueError, "must be a positive integer"):
+                    update_by_row_id(
+                        target,
+                        source,
+                        self.catalog_options,
+                        update_cols=["age"],
+                        max_groups_per_commit=value,
+                    )
+
     def _run_with_fake_commit(self, *, recorder=None, new_commit_errors=None,
-                              commit_error=None, close_error=None):
+                              commit_error=None, close_error=None,
+                              incremental=False):
         import importlib
 
         m = importlib.import_module("pypaimon.ray.update_by_row_id")
@@ -354,7 +606,7 @@ class RayUpdateByRowIdTest(unittest.TestCase):
                 return False
 
         class FakeCommit:
-            def commit(self, msgs):
+            def commit(self, msgs, *args):
                 recorder["commit_calls"] += 1
                 recorder["commit_msgs"] = list(msgs)
                 if recorder["commit_error"] is not None:
@@ -396,6 +648,9 @@ class RayUpdateByRowIdTest(unittest.TestCase):
             def new_batch_write_builder(self):
                 return FakeWriteBuilder()
 
+            def new_stream_write_builder(self):
+                return FakeWriteBuilder()
+
         class FakeCatalog:
             def get_table(self, target):
                 return FakeTable()
@@ -410,6 +665,13 @@ class RayUpdateByRowIdTest(unittest.TestCase):
         parser_path = (
             "pypaimon.schema.data_types.PyarrowFieldParser.from_paimon_schema"
         )
+
+        def fake_apply(*args, **kwargs):
+            if incremental:
+                kwargs["on_group_result"](recorder["msgs"], 3, [])
+                return [], 3, []
+            return recorder["msgs"], 3, []
+
         with mock.patch(
                 "pypaimon.catalog.catalog_factory.CatalogFactory.create",
                 return_value=FakeCatalog()), \
@@ -425,12 +687,13 @@ class RayUpdateByRowIdTest(unittest.TestCase):
                                ("age", pa.int32()),
                            ])), \
                 mock.patch.object(m, "distributed_update_apply",
-                                  return_value=(recorder["msgs"], 3, [])):
+                                  side_effect=fake_apply):
             recorder["result"] = m.update_by_row_id(
                 "default.fake",
                 FakeSource(),
                 self.catalog_options,
                 update_cols=["age"],
+                max_groups_per_commit=1 if incremental else None,
             )
         return recorder
 

--- a/paimon-python/pypaimon/tests/ray_update_by_row_id_test.py
+++ b/paimon-python/pypaimon/tests/ray_update_by_row_id_test.py
@@ -177,6 +177,7 @@ class RayUpdateByRowIdTest(unittest.TestCase):
                 self.catalog_options,
                 update_cols=["age"],
                 num_partitions=4,
+                commit_mode="incremental",
                 max_groups_per_commit=2,
             )
 
@@ -228,6 +229,7 @@ class RayUpdateByRowIdTest(unittest.TestCase):
                         self.catalog_options,
                         update_cols=["age"],
                         num_partitions=1,
+                        commit_mode="incremental",
                         max_groups_per_commit=max_groups,
                     )
 
@@ -398,6 +400,7 @@ class RayUpdateByRowIdTest(unittest.TestCase):
                     self.catalog_options,
                     update_cols=["age"],
                     num_partitions=1,
+                    commit_mode="incremental",
                     max_groups_per_commit=1,
                 )
 
@@ -637,8 +640,46 @@ class RayUpdateByRowIdTest(unittest.TestCase):
                         source,
                         self.catalog_options,
                         update_cols=["age"],
+                        commit_mode="incremental",
                         max_groups_per_commit=value,
                     )
+
+    def test_requires_explicit_incremental_commit_mode(self):
+        target = self._create()
+        self._write(target, pa.Table.from_pydict(
+            {"id": [1], "name": ["a"], "age": [1]}, schema=self.pa_schema))
+        source = pa.table(
+            {"_ROW_ID": [0], "age": [9]},
+            schema=pa.schema([("_ROW_ID", pa.int64()), ("age", pa.int32())]),
+        )
+
+        with self.assertRaisesRegex(
+                ValueError, "requires commit_mode='incremental'"):
+            update_by_row_id(
+                target,
+                source,
+                self.catalog_options,
+                update_cols=["age"],
+                max_groups_per_commit=1,
+            )
+        with self.assertRaisesRegex(
+                ValueError, "requires max_groups_per_commit"):
+            update_by_row_id(
+                target,
+                source,
+                self.catalog_options,
+                update_cols=["age"],
+                commit_mode="incremental",
+            )
+        with self.assertRaisesRegex(
+                ValueError, "must be 'atomic' or 'incremental'"):
+            update_by_row_id(
+                target,
+                source,
+                self.catalog_options,
+                update_cols=["age"],
+                commit_mode="unknown",
+            )
 
     def _run_with_fake_commit(self, *, recorder=None, new_commit_errors=None,
                               commit_error=None, close_error=None,
@@ -758,6 +799,7 @@ class RayUpdateByRowIdTest(unittest.TestCase):
                 FakeSource(),
                 self.catalog_options,
                 update_cols=["age"],
+                commit_mode="incremental" if incremental else "atomic",
                 max_groups_per_commit=1 if incremental else None,
             )
         return recorder

--- a/paimon-python/pypaimon/tests/ray_update_by_row_id_test.py
+++ b/paimon-python/pypaimon/tests/ray_update_by_row_id_test.py
@@ -30,7 +30,11 @@ pypaimon = pytest.importorskip("pypaimon")
 ray = pytest.importorskip("ray")
 
 from pypaimon import CatalogFactory, Schema
-from pypaimon.ray import update_by_row_id
+from pypaimon.ray import (
+    PaimonOffsetSource,
+    delete_update_by_row_id_checkpoint,
+    update_by_row_id,
+)
 
 
 class RayUpdateByRowIdTest(unittest.TestCase):
@@ -62,16 +66,31 @@ class RayUpdateByRowIdTest(unittest.TestCase):
             pass
         shutil.rmtree(cls.tempdir, ignore_errors=True)
 
-    def _create(self, options=None):
+    def _create(self, options=None, partition_keys=None):
         name = f"default.u_{uuid.uuid4().hex[:8]}"
         opts = self.de_options if options is None else options
         self.catalog.create_table(
-            name, Schema.from_pyarrow_schema(self.pa_schema, options=opts), False)
+            name,
+            Schema.from_pyarrow_schema(
+                self.pa_schema,
+                partition_keys=partition_keys,
+                options=opts,
+            ),
+            False,
+        )
         return name
 
     def _write(self, target, data):
         t = self.catalog.get_table(target)
         wb = t.new_batch_write_builder()
+        w = wb.new_write()
+        w.write_arrow(data)
+        wb.new_commit().commit(w.prepare_commit())
+        w.close()
+
+    def _overwrite(self, target, partition, data):
+        t = self.catalog.get_table(target)
+        wb = t.new_batch_write_builder().overwrite(partition)
         w = wb.new_write()
         w.write_arrow(data)
         wb.new_commit().commit(w.prepare_commit())
@@ -87,6 +106,48 @@ class RayUpdateByRowIdTest(unittest.TestCase):
     def _rowid_by_id(self, target):
         tab = self._read(target, ["_ROW_ID", "id"])
         return dict(zip(tab.column("id").to_pylist(), tab.column("_ROW_ID").to_pylist()))
+
+    @staticmethod
+    def _offset_age_source(target):
+        def transform(dataset):
+            def to_updates(batch):
+                return pa.table(
+                    {
+                        "_ROW_ID": batch["_ROW_ID"],
+                        "age": pa.compute.add(batch["id"], 100),
+                    },
+                    schema=pa.schema([
+                        ("_ROW_ID", pa.int64()),
+                        ("age", pa.int32()),
+                    ]),
+                )
+
+            return dataset.map_batches(
+                to_updates, batch_format="pyarrow")
+
+        return PaimonOffsetSource(
+            target,
+            projection=["_ROW_ID", "id"],
+            transform=transform,
+            rows_per_unit=1,
+            units_per_checkpoint=1,
+        )
+
+    def test_offset_source_fingerprints_unserializable_closure(self):
+        import threading
+
+        lock = threading.Lock()
+
+        def transform(dataset):
+            lock.locked()
+            return dataset
+
+        source = PaimonOffsetSource(
+            "default.source", transform=transform)
+        self.assertEqual(
+            source._transform_identity(),
+            source._transform_identity(),
+        )
 
     @staticmethod
     def _data_files_under(table):
@@ -121,6 +182,578 @@ class RayUpdateByRowIdTest(unittest.TestCase):
         back = self._read(target).sort_by("id").to_pydict()
         self.assertEqual(back["age"], [10, 999, 30, 40, 888, 60])
         self.assertEqual(back["name"], [f"n{i}" for i in range(1, 7)])  # untouched
+
+    def test_offset_source_resumes_from_next_unit(self):
+        import importlib
+
+        module = importlib.import_module(
+            "pypaimon.ray.update_by_row_id")
+        offset_module = importlib.import_module(
+            "pypaimon.ray.offset_source")
+
+        target = self._create()
+        for value in range(4):
+            self._write(target, pa.Table.from_pydict(
+                {
+                    "id": [value],
+                    "name": ["x"],
+                    "age": [0],
+                },
+                schema=self.pa_schema,
+            ))
+
+        operation_id = "offset-resume-" + uuid.uuid4().hex
+        original_read = offset_module._BoundPaimonOffsetSource.read_window
+        first_reads = []
+
+        def fail_second_window(bound, start, end):
+            first_reads.append(start)
+            if start == 1:
+                raise RuntimeError("stop after first source window")
+            return original_read(bound, start, end)
+
+        with mock.patch.object(
+                offset_module._BoundPaimonOffsetSource,
+                "read_window",
+                fail_second_window):
+            with self.assertRaisesRegex(
+                    RuntimeError, "stop after first source window"):
+                update_by_row_id(
+                    target,
+                    self._offset_age_source(target),
+                    self.catalog_options,
+                    update_cols=["age"],
+                    num_partitions=1,
+                    commit_mode="incremental",
+                    operation_id=operation_id,
+                )
+
+        self.assertEqual([0, 1], first_reads)
+        checkpoint_tags = module._operation_checkpoint_tags(operation_id)
+        tagged = [
+            module._get_checkpoint_tag(
+                self.catalog, target, checkpoint_tag)
+            for checkpoint_tag in checkpoint_tags
+        ]
+        checkpoint = max(
+            (tag.snapshot for tag in tagged if tag is not None),
+            key=lambda snapshot: snapshot.id,
+        )
+        self.assertEqual(
+            1, module._offset_checkpoint_state(checkpoint)["next_offset"])
+
+        resumed_reads = []
+
+        def record_window(bound, start, end):
+            resumed_reads.append(start)
+            return original_read(bound, start, end)
+
+        with mock.patch.object(
+                offset_module._BoundPaimonOffsetSource,
+                "read_window",
+                record_window):
+            stats = update_by_row_id(
+                target,
+                self._offset_age_source(target),
+                self.catalog_options,
+                update_cols=["age"],
+                num_partitions=1,
+                commit_mode="incremental",
+                operation_id=operation_id,
+            )
+
+        self.assertEqual({"num_updated": 4}, stats)
+        self.assertEqual([1, 2, 3], resumed_reads)
+        self.assertEqual(
+            [100, 101, 102, 103],
+            self._read(target).sort_by("id")["age"].to_pylist(),
+        )
+
+        table = self.catalog.get_table(target)
+        commit_user = module._operation_commit_user(operation_id)
+        latest = table.snapshot_manager().get_latest_snapshot()
+        checkpoint_properties = []
+        for snapshot_id in range(1, latest.id + 1):
+            snapshot = table.snapshot_manager().get_snapshot_by_id(
+                snapshot_id)
+            if (snapshot is not None
+                    and snapshot.commit_user == commit_user):
+                checkpoint_properties.append(
+                    snapshot.properties[module._CHECKPOINT_PROPERTY])
+        self.assertEqual(6, len(checkpoint_properties))
+        self.assertTrue(all(
+            len(encoded) < 2048
+            and "completed_ranges" not in encoded
+            for encoded in checkpoint_properties
+        ))
+        final_state = module._offset_checkpoint_state(latest)
+        self.assertEqual(4, final_state["next_offset"])
+        self.assertTrue(final_state["complete"])
+
+        completed_snapshot_id = latest.id
+        self.assertEqual(
+            {"num_updated": 4},
+            update_by_row_id(
+                target,
+                self._offset_age_source(target),
+                self.catalog_options,
+                update_cols=["age"],
+                num_partitions=1,
+                commit_mode="incremental",
+                operation_id=operation_id,
+            ),
+        )
+        self.assertEqual(
+            completed_snapshot_id,
+            table.snapshot_manager().get_latest_snapshot().id,
+        )
+
+        source_tag = module._operation_source_tag(operation_id, target)
+        self.assertIsNotNone(
+            module._get_checkpoint_tag(
+                self.catalog, target, source_tag))
+        self.assertTrue(delete_update_by_row_id_checkpoint(
+            target, self.catalog_options, operation_id))
+        self.assertIsNone(
+            module._get_checkpoint_tag(
+                self.catalog, target, source_tag))
+
+    def test_offset_source_reads_separate_table(self):
+        import importlib
+
+        module = importlib.import_module(
+            "pypaimon.ray.update_by_row_id")
+
+        target = self._create()
+        self._write(target, pa.Table.from_pydict(
+            {
+                "id": [0, 1, 2],
+                "name": ["x", "x", "x"],
+                "age": [0, 0, 0],
+            },
+            schema=self.pa_schema,
+        ))
+        row_ids = self._rowid_by_id(target)
+
+        source_schema = pa.schema([
+            ("target_row_id", pa.int64()),
+            ("new_age", pa.int32()),
+        ])
+        source_table = "default.s_" + uuid.uuid4().hex[:8]
+        self.catalog.create_table(
+            source_table,
+            Schema.from_pyarrow_schema(source_schema),
+            False,
+        )
+        self._write(source_table, pa.Table.from_pydict(
+            {
+                "target_row_id": [
+                    row_ids[value] for value in range(3)],
+                "new_age": [
+                    value + 100 for value in range(3)],
+            },
+            schema=source_schema,
+        ))
+
+        def transform(dataset):
+            def to_updates(batch):
+                return pa.table({
+                    "_ROW_ID": batch["target_row_id"],
+                    "age": batch["new_age"],
+                })
+
+            return dataset.map_batches(
+                to_updates, batch_format="pyarrow")
+
+        source = PaimonOffsetSource(
+            source_table,
+            projection=["target_row_id", "new_age"],
+            transform=transform,
+            rows_per_unit=1,
+            units_per_checkpoint=1,
+        )
+        operation_id = "offset-upstream-" + uuid.uuid4().hex
+        self.assertEqual(
+            {"num_updated": 3},
+            update_by_row_id(
+                target,
+                source,
+                self.catalog_options,
+                update_cols=["age"],
+                num_partitions=1,
+                commit_mode="incremental",
+                operation_id=operation_id,
+            ),
+        )
+        self.assertEqual(
+            [100, 101, 102],
+            self._read(target).sort_by("id")["age"].to_pylist(),
+        )
+        target_table = self.catalog.get_table(target)
+        commit_user = module._operation_commit_user(operation_id)
+        snapshot_manager = target_table.snapshot_manager()
+        operation_snapshots = []
+        for snapshot_id in range(
+                1, snapshot_manager.get_latest_snapshot().id + 1):
+            snapshot = snapshot_manager.get_snapshot_by_id(snapshot_id)
+            if snapshot is not None and snapshot.commit_user == commit_user:
+                operation_snapshots.append(snapshot)
+        self.assertEqual(5, len(operation_snapshots))
+
+        source_tag = module._operation_source_tag(operation_id, target)
+        self.assertIsNotNone(module._get_checkpoint_tag(
+            self.catalog, source_table, source_tag))
+        self.assertTrue(delete_update_by_row_id_checkpoint(
+            target, self.catalog_options, operation_id))
+        self.assertIsNone(module._get_checkpoint_tag(
+            self.catalog, source_table, source_tag))
+
+    def test_offset_window_failure_commits_no_partial_group(self):
+        import importlib
+
+        from pypaimon.ray.data_evolution_merge_join import GroupApplyError
+
+        module = importlib.import_module(
+            "pypaimon.ray.update_by_row_id")
+
+        target = self._create(partition_keys=["id"])
+        for value in range(2):
+            self._write(target, pa.Table.from_pydict(
+                {
+                    "id": [value],
+                    "name": ["x"],
+                    "age": [0],
+                },
+                schema=self.pa_schema,
+            ))
+        table = self.catalog.get_table(target)
+        base_snapshot_id = table.snapshot_manager().get_latest_snapshot().id
+        files_before = self._data_files_under(table)
+        operation_id = "offset-atomic-" + uuid.uuid4().hex
+        failure_marker = tempfile.NamedTemporaryFile(delete=False)
+        failure_marker_path = failure_marker.name
+        failure_marker.close()
+        self.addCleanup(
+            lambda: os.path.exists(failure_marker_path)
+            and os.unlink(failure_marker_path))
+
+        def transform(dataset):
+            def to_updates(batch):
+                row_ids = batch["_ROW_ID"].to_pylist()
+                ages = [value + 100 for value in batch["id"].to_pylist()]
+                if os.path.exists(failure_marker_path) and 101 in ages:
+                    row_ids.append(row_ids[-1])
+                    ages.append(ages[-1])
+                return pa.table({
+                    "_ROW_ID": row_ids,
+                    "age": ages,
+                }, schema=pa.schema([
+                    ("_ROW_ID", pa.int64()),
+                    ("age", pa.int32()),
+                ]))
+
+            return dataset.map_batches(
+                to_updates, batch_format="pyarrow")
+
+        source = PaimonOffsetSource(
+            target,
+            projection=["_ROW_ID", "id"],
+            transform=transform,
+            rows_per_unit=1,
+            units_per_checkpoint=2,
+        )
+
+        with self.assertRaisesRegex(GroupApplyError, "Deduplicate"):
+            update_by_row_id(
+                target,
+                source,
+                self.catalog_options,
+                update_cols=["age"],
+                num_partitions=1,
+                commit_mode="incremental",
+                operation_id=operation_id,
+            )
+
+        self.assertEqual(files_before, self._data_files_under(table))
+        self.assertEqual(
+            base_snapshot_id + 1,
+            table.snapshot_manager().get_latest_snapshot().id,
+        )
+        checkpoint_tag = next(
+            tag for tag in (
+                module._get_checkpoint_tag(
+                    self.catalog, target, checkpoint_tag)
+                for checkpoint_tag in
+                module._operation_checkpoint_tags(operation_id)
+            )
+            if tag is not None
+        )
+        self.assertEqual(
+            0,
+            module._offset_checkpoint_state(
+                checkpoint_tag.snapshot)["next_offset"],
+        )
+        self.assertEqual(
+            [0, 0],
+            self._read(target).sort_by("id")["age"].to_pylist(),
+        )
+
+        os.unlink(failure_marker_path)
+        self.assertEqual(
+            {"num_updated": 2},
+            update_by_row_id(
+                target,
+                source,
+                self.catalog_options,
+                update_cols=["age"],
+                num_partitions=1,
+                commit_mode="incremental",
+                operation_id=operation_id,
+            ),
+        )
+        self.assertEqual(
+            [100, 101],
+            self._read(target).sort_by("id")["age"].to_pylist(),
+        )
+
+    def test_offset_resume_rejects_external_overwrite(self):
+        import importlib
+
+        from pypaimon.write.commit.conflict_detection import (
+            CommitConflictError,
+        )
+
+        module = importlib.import_module(
+            "pypaimon.ray.update_by_row_id")
+        offset_module = importlib.import_module(
+            "pypaimon.ray.offset_source")
+
+        target = self._create(partition_keys=["id"])
+        for value in range(3):
+            self._write(target, pa.Table.from_pydict(
+                {
+                    "id": [value],
+                    "name": ["x"],
+                    "age": [0],
+                },
+                schema=self.pa_schema,
+            ))
+        operation_id = "offset-overwrite-" + uuid.uuid4().hex
+        original_read = offset_module._BoundPaimonOffsetSource.read_window
+
+        def fail_second_window(bound, start, end):
+            if start == 1:
+                raise RuntimeError("pause before overwrite")
+            return original_read(bound, start, end)
+
+        with mock.patch.object(
+                offset_module._BoundPaimonOffsetSource,
+                "read_window",
+                fail_second_window):
+            with self.assertRaisesRegex(
+                    RuntimeError, "pause before overwrite"):
+                update_by_row_id(
+                    target,
+                    self._offset_age_source(target),
+                    self.catalog_options,
+                    update_cols=["age"],
+                    num_partitions=1,
+                    commit_mode="incremental",
+                    operation_id=operation_id,
+                )
+
+        self._overwrite(
+            target,
+            {"id": 0},
+            pa.Table.from_pydict(
+                {
+                    "id": [0],
+                    "name": ["external"],
+                    "age": [999],
+                },
+                schema=self.pa_schema,
+            ),
+        )
+        table = self.catalog.get_table(target)
+        files_before_retry = self._data_files_under(table)
+
+        with self.assertRaisesRegex(
+                CommitConflictError, "Concurrent rewrite"):
+            update_by_row_id(
+                target,
+                self._offset_age_source(target),
+                self.catalog_options,
+                update_cols=["age"],
+                num_partitions=1,
+                commit_mode="incremental",
+                operation_id=operation_id,
+            )
+
+        self.assertEqual(
+            files_before_retry, self._data_files_under(table))
+        state = max(
+            (
+                module._get_checkpoint_tag(
+                    self.catalog, target, checkpoint_tag).snapshot
+                for checkpoint_tag in
+                module._operation_checkpoint_tags(operation_id)
+                if module._get_checkpoint_tag(
+                    self.catalog, target, checkpoint_tag) is not None
+            ),
+            key=lambda snapshot: snapshot.id,
+        )
+        self.assertEqual(
+            1, module._offset_checkpoint_state(state)["next_offset"])
+        back = self._read(target).sort_by("id").to_pydict()
+        self.assertEqual(["external", "x", "x"], back["name"])
+        self.assertEqual([999, 0, 0], back["age"])
+
+    def test_offset_final_marker_rejects_late_overwrite(self):
+        import importlib
+
+        from pypaimon.write.commit.conflict_detection import (
+            CommitConflictError,
+        )
+
+        module = importlib.import_module(
+            "pypaimon.ray.update_by_row_id")
+        target = self._create(partition_keys=["id"])
+        self._write(target, pa.Table.from_pydict(
+            {
+                "id": [0],
+                "name": ["x"],
+                "age": [0],
+            },
+            schema=self.pa_schema,
+        ))
+        operation_id = "offset-final-overwrite-" + uuid.uuid4().hex
+        original_finish = module._OffsetUpdateCommitter.finish
+        overwrite_done = False
+
+        def overwrite_before_finish(committer):
+            nonlocal overwrite_done
+            if not overwrite_done:
+                overwrite_done = True
+                self._overwrite(
+                    target,
+                    {"id": 0},
+                    pa.Table.from_pydict(
+                        {
+                            "id": [0],
+                            "name": ["external"],
+                            "age": [999],
+                        },
+                        schema=self.pa_schema,
+                    ),
+                )
+            return original_finish(committer)
+
+        with mock.patch.object(
+                module._OffsetUpdateCommitter,
+                "finish",
+                overwrite_before_finish):
+            with self.assertRaisesRegex(
+                    CommitConflictError, "Concurrent rewrite"):
+                update_by_row_id(
+                    target,
+                    self._offset_age_source(target),
+                    self.catalog_options,
+                    update_cols=["age"],
+                    num_partitions=1,
+                    commit_mode="incremental",
+                    operation_id=operation_id,
+                )
+
+        checkpoint = max(
+            (
+                module._get_checkpoint_tag(
+                    self.catalog, target, checkpoint_tag).snapshot
+                for checkpoint_tag in
+                module._operation_checkpoint_tags(operation_id)
+                if module._get_checkpoint_tag(
+                    self.catalog, target, checkpoint_tag) is not None
+            ),
+            key=lambda snapshot: snapshot.id,
+        )
+        state = module._offset_checkpoint_state(checkpoint)
+        self.assertEqual(1, state["next_offset"])
+        self.assertFalse(state["complete"])
+        back = self._read(target).to_pydict()
+        self.assertEqual(["external"], back["name"])
+        self.assertEqual([999], back["age"])
+
+    def test_offset_checkpoint_recovers_without_updated_tag(self):
+        import importlib
+
+        module = importlib.import_module(
+            "pypaimon.ray.update_by_row_id")
+
+        target = self._create(partition_keys=["id"])
+        for value in range(2):
+            self._write(target, pa.Table.from_pydict(
+                {
+                    "id": [value],
+                    "name": ["x"],
+                    "age": [0],
+                },
+                schema=self.pa_schema,
+            ))
+        operation_id = "offset-tag-failure-" + uuid.uuid4().hex
+        original_store = module._store_operation_checkpoint
+        store_calls = 0
+
+        def fail_initial_tag(*args, **kwargs):
+            nonlocal store_calls
+            store_calls += 1
+            if store_calls == 1:
+                raise RuntimeError("checkpoint tag unavailable")
+            return original_store(*args, **kwargs)
+
+        with mock.patch.object(
+                module,
+                "_store_operation_checkpoint",
+                fail_initial_tag):
+            with self.assertRaisesRegex(
+                    RuntimeError, "checkpoint tag unavailable"):
+                update_by_row_id(
+                    target,
+                    self._offset_age_source(target),
+                    self.catalog_options,
+                    update_cols=["age"],
+                    num_partitions=1,
+                    commit_mode="incremental",
+                    operation_id=operation_id,
+                )
+
+        table = self.catalog.get_table(target)
+        checkpoint_snapshot_id = (
+            table.snapshot_manager().get_latest_snapshot().id)
+        self.assertEqual(
+            0,
+            module._offset_checkpoint_state(
+                table.snapshot_manager().get_latest_snapshot()
+            )["next_offset"],
+        )
+        self.assertEqual(
+            {"num_updated": 2},
+            update_by_row_id(
+                target,
+                self._offset_age_source(target),
+                self.catalog_options,
+                update_cols=["age"],
+                num_partitions=1,
+                commit_mode="incremental",
+                operation_id=operation_id,
+            ),
+        )
+        self.assertEqual(
+            checkpoint_snapshot_id + 3,
+            table.snapshot_manager().get_latest_snapshot().id,
+        )
+        self.assertEqual(
+            [100, 101],
+            self._read(target).sort_by("id")["age"].to_pylist(),
+        )
 
     def test_updates_correct_row_across_files(self):
         # A _ROW_ID owned by a middle data file must update only that row.
@@ -679,6 +1312,35 @@ class RayUpdateByRowIdTest(unittest.TestCase):
                 self.catalog_options,
                 update_cols=["age"],
                 commit_mode="unknown",
+            )
+
+    def test_operation_id_requires_offset_source(self):
+        target = self._create()
+        self._write(target, pa.Table.from_pydict(
+            {"id": [1], "name": ["a"], "age": [1]},
+            schema=self.pa_schema))
+        source = pa.table(
+            {"_ROW_ID": [0], "age": [9]},
+            schema=pa.schema([("_ROW_ID", pa.int64()), ("age", pa.int32())]),
+        )
+
+        with self.assertRaisesRegex(ValueError, "requires a PaimonOffsetSource"):
+            update_by_row_id(
+                target,
+                source,
+                self.catalog_options,
+                update_cols=["age"],
+                commit_mode="incremental",
+                max_groups_per_commit=1,
+                operation_id="raw-source",
+            )
+        with self.assertRaisesRegex(ValueError, "requires operation_id"):
+            update_by_row_id(
+                target,
+                PaimonOffsetSource(target),
+                self.catalog_options,
+                update_cols=["age"],
+                commit_mode="incremental",
             )
 
     def _run_with_fake_commit(self, *, recorder=None, new_commit_errors=None,

--- a/paimon-python/pypaimon/tests/ray_update_by_row_id_test.py
+++ b/paimon-python/pypaimon/tests/ray_update_by_row_id_test.py
@@ -88,6 +88,16 @@ class RayUpdateByRowIdTest(unittest.TestCase):
         tab = self._read(target, ["_ROW_ID", "id"])
         return dict(zip(tab.column("id").to_pylist(), tab.column("_ROW_ID").to_pylist()))
 
+    @staticmethod
+    def _data_files_under(table):
+        table_path = table.file_io.to_filesystem_path(table.table_path)
+        return {
+            os.path.join(root, file_name)
+            for root, _, files in os.walk(table_path)
+            for file_name in files
+            if file_name.endswith(".parquet")
+        }
+
     def test_update_by_row_id_basic(self):
         target = self._create()
         self._write(target, pa.Table.from_pydict(
@@ -313,14 +323,16 @@ class RayUpdateByRowIdTest(unittest.TestCase):
         self.assertEqual([["group-3"]], aborted)
         self.assertEqual([True], close_calls)
 
-    def test_incremental_commit_failure_does_not_abort_unknown_outcome(self):
+    def test_incremental_commit_failure_aborts_later_groups(self):
         import importlib
 
         module = importlib.import_module("pypaimon.ray.update_by_row_id")
         aborted = []
+        commit_calls = []
 
         class FakeCommit:
             def commit(self, messages, commit_identifier):
+                commit_calls.append((list(messages), commit_identifier))
                 raise RuntimeError("commit failed")
 
             def close(self):
@@ -339,12 +351,65 @@ class RayUpdateByRowIdTest(unittest.TestCase):
                 module,
                 "_abort_pending_update_messages",
                 side_effect=lambda table, messages: aborted.append(list(messages))):
+            committer.add_group(["group-1"], 1, [])
+            committer.add_group(["group-2"], 1, [])
             with self.assertRaisesRegex(RuntimeError, "commit failed"):
-                committer.add_group(["group-1"], 1, [])
+                committer.finish()
             committer.abort_pending()
             committer.close()
 
-        self.assertEqual([], aborted)
+        self.assertEqual([(["group-1"], 1)], commit_calls)
+        self.assertEqual([["group-2"]], aborted)
+
+    def test_incremental_commit_conflict_aborts_buffered_group_files(self):
+        from pypaimon.write.commit.conflict_detection import CommitConflictError
+        from pypaimon.write.file_store_commit import FileStoreCommit
+
+        target = self._create()
+        for row_id in range(1, 4):
+            self._write(target, pa.Table.from_pydict(
+                {"id": [row_id], "name": ["a"], "age": [0]},
+                schema=self.pa_schema,
+            ))
+
+        table = self.catalog.get_table(target)
+        base_snapshot_id = table.snapshot_manager().get_latest_snapshot().id
+        files_before = self._data_files_under(table)
+        row_ids = self._rowid_by_id(target)
+        source = pa.table(
+            {
+                "_ROW_ID": [row_ids[1], row_ids[2], row_ids[3]],
+                "age": [100, 200, 300],
+            },
+            schema=pa.schema([
+                ("_ROW_ID", pa.int64()),
+                ("age", pa.int32()),
+            ]),
+        )
+
+        with mock.patch.object(
+                FileStoreCommit,
+                "commit",
+                side_effect=CommitConflictError("forced conflict")):
+            with self.assertRaisesRegex(CommitConflictError, "forced conflict"):
+                update_by_row_id(
+                    target,
+                    ray.data.from_arrow(source),
+                    self.catalog_options,
+                    update_cols=["age"],
+                    num_partitions=1,
+                    max_groups_per_commit=1,
+                )
+
+        self.assertEqual(files_before, self._data_files_under(table))
+        self.assertEqual(
+            base_snapshot_id,
+            table.snapshot_manager().get_latest_snapshot().id,
+        )
+        self.assertEqual(
+            [0, 0, 0],
+            self._read(target).sort_by("id")["age"].to_pylist(),
+        )
 
     def test_pins_base_snapshot_for_conflict_detection(self):
         # The update pins its base snapshot and threads it to distributed_update_apply,

--- a/paimon-python/pypaimon/tests/table_commit_test.py
+++ b/paimon-python/pypaimon/tests/table_commit_test.py
@@ -100,3 +100,10 @@ class TestTableCommitEmptyOverwrite(unittest.TestCase):
             commit_messages=[],
             commit_identifier=42,
         )
+
+    def test_stream_commit_metadata(self):
+        commit, mock_fsc = self._create_commit(StreamTableCommit)
+
+        commit.commit_metadata(42)
+
+        mock_fsc.commit_metadata.assert_called_once_with(42)

--- a/paimon-python/pypaimon/tests/write/conflict_detection_test.py
+++ b/paimon-python/pypaimon/tests/write/conflict_detection_test.py
@@ -26,9 +26,11 @@ from pypaimon.manifest.schema.data_file_meta import DataFileMeta
 from pypaimon.manifest.schema.manifest_entry import ManifestEntry
 from pypaimon.schema.data_types import AtomicType, DataField
 from pypaimon.table.row.generic_row import GenericRow
+from pypaimon.utils.range import Range
 from pypaimon.write.commit.conflict_detection import (
     ConflictDetection,
     RowIdColumnConflictChecker,
+    row_id_file_signature,
 )
 
 
@@ -314,10 +316,14 @@ class TestOverwriteConflictDetection(unittest.TestCase):
 
 class _FakeSnapshot:
 
-    def __init__(self, snapshot_id, commit_kind, next_row_id=None):
+    def __init__(self, snapshot_id, commit_kind, next_row_id=None,
+                 commit_user="external", schema_id=0, uuid=None):
         self.id = snapshot_id
         self.commit_kind = commit_kind
         self.next_row_id = next_row_id
+        self.commit_user = commit_user
+        self.schema_id = schema_id
+        self.uuid = uuid
 
 
 class _FakeSnapshotManager:
@@ -331,9 +337,12 @@ class _FakeSnapshotManager:
 
 class _FakeCommitScanner:
 
-    def __init__(self, entries_by_snapshot_id, raw_entries_by_snapshot_id=None):
+    def __init__(self, entries_by_snapshot_id, raw_entries_by_snapshot_id=None,
+                 range_entries=None, deleting_snapshot_ids=None):
         self._by_id = entries_by_snapshot_id
         self._raw_by_id = raw_entries_by_snapshot_id or {}
+        self._range_entries = range_entries or []
+        self._deleting_snapshot_ids = set(deleting_snapshot_ids or [])
 
     def read_incremental_entries_from_changed_partitions(self, snapshot, _):
         return self._by_id.get(snapshot.id, [])
@@ -341,11 +350,21 @@ class _FakeCommitScanner:
     def read_incremental_raw_entries_from_changed_partitions(self, snapshot, _):
         return self._raw_by_id.get(snapshot.id, self._by_id.get(snapshot.id, []))
 
+    def read_entries_for_row_id_ranges(self, snapshot, _):
+        return self._range_entries
+
+    def snapshot_deletes_files(self, snapshot):
+        return snapshot.id in self._deleting_snapshot_ids
+
 
 class _FakeTable:
 
-    def __init__(self, schema_manager):
+    def __init__(self, schema_manager, snapshot_manager=None):
         self.schema_manager = schema_manager
+        self._snapshot_manager = snapshot_manager
+
+    def snapshot_manager(self):
+        return self._snapshot_manager
 
 
 class TestCheckRowIdFromSnapshot(unittest.TestCase):
@@ -416,6 +435,67 @@ class TestCheckRowIdFromSnapshot(unittest.TestCase):
                     [check_snap, compact_snap], {2: compact_entries})
                 self.assertIsNone(
                     detection.check_row_id_from_snapshot(compact_snap, delta))
+
+
+class TestResumableRowIdCommitGuards(unittest.TestCase):
+
+    @staticmethod
+    def _detection(snapshots, scanner):
+        snapshot_manager = _FakeSnapshotManager(snapshots)
+        return ConflictDetection(
+            data_evolution_enabled=True,
+            snapshot_manager=snapshot_manager,
+            manifest_list_manager=None,
+            table=_FakeTable(
+                _FakeSchemaManager([_DEFAULT_SCHEMA]), snapshot_manager),
+            commit_scanner=scanner,
+        )
+
+    def test_rejects_external_rewrite_after_checkpoint(self):
+        checkpoint = _FakeSnapshot(
+            1, "APPEND", commit_user="operation")
+        overwrite = _FakeSnapshot(2, "OVERWRITE")
+        detection = self._detection(
+            [checkpoint, overwrite], _FakeCommitScanner({}))
+        detection.protect_from_external_rewrites(
+            checkpoint, "operation")
+
+        result = detection.check_external_rewrites(overwrite)
+
+        self.assertIsNotNone(result)
+        self.assertIn("Concurrent rewrite", str(result))
+
+    def test_allows_own_snapshots_and_external_appends(self):
+        checkpoint = _FakeSnapshot(
+            1, "APPEND", commit_user="operation")
+        own = _FakeSnapshot(
+            2, "APPEND", commit_user="operation")
+        append = _FakeSnapshot(3, "APPEND")
+        detection = self._detection(
+            [checkpoint, own, append], _FakeCommitScanner({}))
+        detection.protect_from_external_rewrites(
+            checkpoint, "operation")
+
+        self.assertIsNone(detection.check_external_rewrites(append))
+
+    def test_rejects_changed_planned_files(self):
+        expected = _make_entry(
+            "expected", first_row_id=0, row_count=10)
+        scanner = _FakeCommitScanner(
+            {}, range_entries=[_make_entry(
+                "replacement", first_row_id=0, row_count=10)])
+        detection = self._detection([], scanner)
+        detection.protect_planned_row_id_files(
+            [Range(0, 9)],
+            {row_id_file_signature(
+                expected.partition, expected.bucket, expected.file)},
+        )
+
+        result = detection.check_planned_row_id_files(
+            _FakeSnapshot(1, "APPEND"))
+
+        self.assertIsNotNone(result)
+        self.assertIn("Target files changed", str(result))
 
 
 class TestRowIdColumnConflictChecker(unittest.TestCase):

--- a/paimon-python/pypaimon/write/commit/commit_scanner.py
+++ b/paimon-python/pypaimon/write/commit/commit_scanner.py
@@ -18,6 +18,8 @@
 """
 Manifest entries scanner for commit operations.
 """
+import bisect
+import os
 from typing import Optional, List
 
 from pypaimon.common.predicate_builder import PredicateBuilder
@@ -25,8 +27,51 @@ from pypaimon.manifest.index_manifest_file import IndexManifestFile
 from pypaimon.manifest.manifest_file_manager import ManifestFileManager
 from pypaimon.manifest.manifest_list_manager import ManifestListManager
 from pypaimon.manifest.schema.manifest_entry import ManifestEntry
-from pypaimon.read.scanner.file_scanner import FileScanner
+from pypaimon.read.scanner.file_scanner import (
+    FileScanner,
+    _filter_manifest_files_by_row_ranges,
+)
 from pypaimon.snapshot.snapshot import Snapshot
+from pypaimon.utils.range import Range
+
+
+class _RowIdRangeScope:
+    """Table-global row-id ranges for planned update files."""
+
+    def __init__(self, row_id_ranges):
+        self.ranges = Range.sort_and_merge_overlap(
+            list(row_id_ranges or []), True, True)
+        self._range_ends = [row_range.to for row_range in self.ranges]
+
+    def is_empty(self):
+        return not self.ranges
+
+    def matches_record(self, record):
+        file_dict = record.get("_FILE")
+        if file_dict is None:
+            return False
+        first_row_id = file_dict.get("_FIRST_ROW_ID")
+        row_count = file_dict.get("_ROW_COUNT")
+        if first_row_id is None or row_count is None:
+            return False
+        return self.matches_values(
+            int(first_row_id),
+            int(first_row_id) + int(row_count) - 1,
+        )
+
+    def matches_entry(self, entry):
+        row_range = entry.file.row_id_range()
+        return (
+            row_range is not None
+            and self.matches_values(row_range.from_, row_range.to)
+        )
+
+    def matches_values(self, from_, to):
+        index = bisect.bisect_left(self._range_ends, from_)
+        return (
+            index < len(self.ranges)
+            and self.ranges[index].from_ <= to
+        )
 
 
 class CommitScanner:
@@ -73,6 +118,36 @@ class CommitScanner:
         return FileScanner(
             self.table, lambda: ([], None), partition_predicate=partition_filter
         ).read_manifest_entries(all_manifests)
+
+    def read_entries_for_row_id_ranges(
+            self,
+            snapshot: Optional[Snapshot],
+            row_id_ranges):
+        """Read live entries intersecting table-global row-id ranges."""
+        if snapshot is None:
+            return []
+
+        scope = _RowIdRangeScope(row_id_ranges)
+        if scope.is_empty():
+            return []
+
+        manifest_files = self.manifest_list_manager.read_all(snapshot)
+        manifest_files = _filter_manifest_files_by_row_ranges(
+            manifest_files, scope.ranges)
+        max_workers = self.table.options.scan_manifest_parallelism(
+            os.cpu_count() or 8)
+        return ManifestFileManager(self.table).read_entries_parallel(
+            manifest_files,
+            manifest_entry_filter=scope.matches_entry,
+            max_workers=max_workers,
+            early_record_filter=scope.matches_record,
+        )
+
+    def snapshot_deletes_files(self, snapshot: Snapshot) -> bool:
+        return any(
+            manifest.num_deleted_files > 0
+            for manifest in self.manifest_list_manager.read_delta(snapshot)
+        )
 
     def read_incremental_entries_from_changed_partitions(self,
                                                          snapshot: Snapshot,

--- a/paimon-python/pypaimon/write/commit/conflict_detection.py
+++ b/paimon-python/pypaimon/write/commit/conflict_detection.py
@@ -170,6 +170,27 @@ class RowIdExistenceConflict(RuntimeError):
                 entry.bucket))
 
 
+def row_id_file_signature(partition, bucket, data_file):
+    values = (
+        tuple(partition.values)
+        if hasattr(partition, "values") else tuple(partition)
+    )
+    return (
+        values,
+        bucket,
+        data_file.level,
+        data_file.file_name,
+        tuple(data_file.extra_files) if data_file.extra_files else (),
+        data_file.embedded_index,
+        data_file.external_path,
+        data_file.first_row_id,
+        data_file.row_count,
+        data_file.schema_id,
+        tuple(data_file.write_cols)
+        if data_file.write_cols is not None else None,
+    )
+
+
 class ConflictDetection:
     """Detects conflicts between base and delta files during commit."""
 
@@ -180,7 +201,87 @@ class ConflictDetection:
         self.manifest_list_manager = manifest_list_manager
         self.table = table
         self._row_id_check_from_snapshot = None
+        self._planned_row_id_ranges = []
+        self._planned_row_id_signatures = set()
+        self._rewrite_checkpoint = None
+        self._rewrite_commit_user = None
         self.commit_scanner = commit_scanner
+
+    def protect_from_external_rewrites(
+            self, checkpoint_snapshot, commit_user):
+        self._rewrite_checkpoint = checkpoint_snapshot
+        self._rewrite_commit_user = commit_user
+
+    def check_external_rewrites(self, latest_snapshot):
+        checkpoint = self._rewrite_checkpoint
+        if checkpoint is None:
+            return None
+        if latest_snapshot is None or latest_snapshot.id < checkpoint.id:
+            return RuntimeError(
+                "Offset checkpoint is no longer in the snapshot lineage.")
+        if latest_snapshot.id == checkpoint.id:
+            if self._same_snapshot(checkpoint, latest_snapshot):
+                return None
+            return RuntimeError("Offset checkpoint snapshot was replaced.")
+
+        snapshot_manager = self.table.snapshot_manager()
+        for snapshot_id in range(checkpoint.id + 1, latest_snapshot.id + 1):
+            snapshot = snapshot_manager.get_snapshot_by_id(snapshot_id)
+            if snapshot is None:
+                return RuntimeError(
+                    "Cannot validate external rewrites because snapshot "
+                    "{} expired.".format(snapshot_id))
+            if snapshot.commit_user == self._rewrite_commit_user:
+                continue
+            if snapshot.schema_id != checkpoint.schema_id:
+                return RuntimeError(
+                    "Target schema changed during the offset update.")
+            if snapshot.commit_kind == "COMPACT":
+                continue
+            if (snapshot.commit_kind == "OVERWRITE"
+                    or self.commit_scanner.snapshot_deletes_files(snapshot)):
+                return RuntimeError(
+                    "Concurrent rewrite landed during the offset update.")
+        return None
+
+    def protect_planned_row_id_files(
+            self, row_id_ranges, file_signatures):
+        self._planned_row_id_ranges = Range.sort_and_merge_overlap(
+            list(row_id_ranges or []), True, True)
+        self._planned_row_id_signatures = set(file_signatures or [])
+
+    def clear_planned_row_id_files(self):
+        self._planned_row_id_ranges = []
+        self._planned_row_id_signatures = set()
+
+    def check_planned_row_id_files(self, latest_snapshot):
+        if not self._planned_row_id_ranges:
+            return None
+        latest_entries = self.commit_scanner.read_entries_for_row_id_ranges(
+            latest_snapshot, self._planned_row_id_ranges)
+        if (self._row_id_entry_signatures(latest_entries)
+                != self._planned_row_id_signatures):
+            return RuntimeError(
+                "Target files changed after the resumable update group "
+                "was planned.")
+        return None
+
+    @staticmethod
+    def _same_snapshot(left, right):
+        if left is None or right is None:
+            return left is right
+        if left.uuid is not None or right.uuid is not None:
+            return left.id == right.id and left.uuid == right.uuid
+        return left == right
+
+    @staticmethod
+    def _row_id_entry_signatures(entries):
+        return {
+            row_id_file_signature(
+                entry.partition, entry.bucket, entry.file)
+            for entry in entries
+            if entry.kind == 0
+        }
 
     def should_be_overwrite_commit(self, append_file_entries=None, append_index_files=None):
         for entry in append_file_entries or []:

--- a/paimon-python/pypaimon/write/file_store_commit.py
+++ b/paimon-python/pypaimon/write/file_store_commit.py
@@ -109,6 +109,7 @@ class FileStoreCommit:
         self.table: FileStoreTable = table
         self.commit_user = commit_user
         self.commit_callbacks: List[CommitCallback] = commit_callbacks if commit_callbacks is not None else []
+        self.snapshot_properties = {}
 
         self.snapshot_manager = table.snapshot_manager()
         self.manifest_file_manager = ManifestFileManager(table)
@@ -142,6 +143,27 @@ class FileStoreCommit:
 
         table_rollback = table.catalog_environment.catalog_table_rollback()
         self.rollback = CommitRollback(table_rollback) if table_rollback is not None else None
+
+    def with_snapshot_properties(self, properties):
+        self.snapshot_properties = dict(properties or {})
+
+    def protect_planned_row_id_files(
+            self, row_id_ranges, file_signatures):
+        self.conflict_detection.protect_planned_row_id_files(
+            row_id_ranges, file_signatures)
+
+    def protect_from_external_rewrites(
+            self, checkpoint_snapshot, commit_user):
+        self.conflict_detection.protect_from_external_rewrites(
+            checkpoint_snapshot, commit_user)
+
+    def commit_metadata(self, commit_identifier: int):
+        self._try_commit(
+            commit_kind="APPEND",
+            commit_identifier=commit_identifier,
+            commit_entries_plan=lambda _snapshot: [],
+            allow_empty=True,
+        )
 
     def commit(self, commit_messages: List[CommitMessage], commit_identifier: int):
         """Commit the given commit messages in normal append mode."""
@@ -373,7 +395,7 @@ class FileStoreCommit:
     def _try_commit(self, commit_kind, commit_identifier, commit_entries_plan,
                     detect_conflicts=False, allow_rollback=False, index_deletes=None,
                     index_adds=None, changelog_entries=None,
-                    hash_index_base_snapshot=None):
+                    hash_index_base_snapshot=None, allow_empty=False):
 
         retry_count = 0
         retry_result = None
@@ -389,7 +411,10 @@ class FileStoreCommit:
 
             # No entries to commit (e.g. drop_partitions with no matching data): skip commit
             # to avoid creating manifest/snapshot with empty partition_stats (causes read errors).
-            if not commit_entries and not index_deletes and not index_adds:
+            if (not allow_empty
+                    and not commit_entries
+                    and not index_deletes
+                    and not index_adds):
                 break
 
             result = self._try_commit_once(
@@ -411,6 +436,7 @@ class FileStoreCommit:
                 self.conflict_detection._row_id_check_from_snapshot = (
                     latest_snapshot.id
                 )
+                self.conflict_detection.clear_planned_row_id_files()
                 # No snapshot commit was attempted for the conflicting files,
                 # so the rewritten attempt is still deterministic.
                 retry_result = None
@@ -479,6 +505,14 @@ class FileStoreCommit:
         start_millis = int(time.time() * 1000)
         if self._is_duplicate_commit(retry_result, latest_snapshot, commit_identifier, commit_kind):
             return SuccessResult()
+
+        rewrite_conflict = (
+            self.conflict_detection.check_external_rewrites(latest_snapshot))
+        if rewrite_conflict is not None:
+            if retry_result is None or retry_result.exception is None:
+                raise CommitConflictError(
+                    str(rewrite_conflict)) from rewrite_conflict
+            raise rewrite_conflict
 
         latest_snapshot_id = latest_snapshot.id if latest_snapshot else 0
         if (
@@ -568,6 +602,15 @@ class FileStoreCommit:
                 # callers do not delete files which a snapshot may reference.
                 raise conflict_exception
 
+        planned_conflict = (
+            self.conflict_detection.check_planned_row_id_files(
+                latest_snapshot))
+        if planned_conflict is not None:
+            if retry_result is None or retry_result.exception is None:
+                raise CommitConflictError(
+                    str(planned_conflict)) from planned_conflict
+            raise planned_conflict
+
         # Apply row tracking logic after conflict detection (matches Java ordering)
         row_tracking_enabled = self.table.options.row_tracking_enabled()
         next_row_id = None
@@ -646,6 +689,7 @@ class FileStoreCommit:
                 time_millis=int(time.time() * 1000),
                 next_row_id=next_row_id,
                 index_manifest=index_manifest,
+                properties=self.snapshot_properties,
             )
             # Generate partition statistics for the commit
             statistics = self._generate_partition_statistics(commit_entries)

--- a/paimon-python/pypaimon/write/table_commit.py
+++ b/paimon-python/pypaimon/write/table_commit.py
@@ -61,6 +61,22 @@ class TableCommit:
         """Register a callback to be invoked after each successful commit."""
         self._commit_callbacks.append(callback)
 
+    def with_snapshot_properties(self, properties):
+        self.file_store_commit.with_snapshot_properties(properties)
+        return self
+
+    def protect_planned_row_id_files(
+            self, row_id_ranges, file_signatures):
+        self.file_store_commit.protect_planned_row_id_files(
+            row_id_ranges, file_signatures)
+        return self
+
+    def protect_from_external_rewrites(
+            self, checkpoint_snapshot, commit_user):
+        self.file_store_commit.protect_from_external_rewrites(
+            checkpoint_snapshot, commit_user)
+        return self
+
     def _commit(self, commit_messages: List[CommitMessage], commit_identifier: int = BATCH_COMMIT_IDENTIFIER):
         non_empty_messages = [msg for msg in commit_messages if not msg.is_empty()]
 
@@ -146,3 +162,6 @@ class StreamTableCommit(TableCommit):
 
     def commit(self, commit_messages: List[CommitMessage], commit_identifier: int):
         self._commit(commit_messages, commit_identifier)
+
+    def commit_metadata(self, commit_identifier: int):
+        self.file_store_commit.commit_metadata(commit_identifier)


### PR DESCRIPTION
Stacked on #8979. The effective diff after that PR is one file.

This refactors `bucket_join` into reusable validation, planning, and execution helpers so a resumable source can join snapshot-pinned, preplanned bucket splits. The public `bucket_join` behavior is unchanged.

Tests: `ray_bucket_join_test.py` (18 passed with Ray 2.56.1); project flake8 clean.