### PR TITLE
[python] Add commit support for resumable row-id updates

### DIFF
--- a/docs/docs/pypaimon/ray-data.md
+++ b/docs/docs/pypaimon/ray-data.md
@@ -580,11 +580,13 @@ print(metrics)   # {"num_updated": 50}
 - Partition columns cannot be updated (in-place rewrite can't move a row across partitions).
 - Deletion-vectors-enabled tables are not supported yet: a DV-deleted row still lives
   in its data file, so it can't be told apart from a live row without reading the target.
-- Incremental commits are not atomic across the whole operation. If a group fails,
+- Incremental commits are not atomic across the whole operation. Ordinary exceptions
+  raised while applying a group are reported as results so other groups can finish;
   completed groups are flushed before the error is raised.
-- Incremental mode reports group exceptions as results so other groups can finish.
-  Ray task retry options in `ray_remote_args` do not retry these exceptions; a
-  transient group failure can therefore leave a partial update.
+- Ray task retry options in `ray_remote_args` do not retry group exceptions reported
+  as results, so a transient group failure can leave a partial update. Worker loss and
+  other task-level failures which bypass Python exception handling may still lose
+  results buffered by that task.
 
 ## Read By Row Id
 

--- a/docs/docs/pypaimon/ray-data.md
+++ b/docs/docs/pypaimon/ray-data.md
@@ -553,9 +553,22 @@ metrics = update_by_row_id(
     source=ray_dataset,          # ray.data.Dataset / pa.Table / pandas, carrying _ROW_ID
     catalog_options={"warehouse": "/path/to/warehouse"},
     update_cols=["feature"],     # non-blob columns to overwrite
-    max_groups_per_commit=64,    # optional incremental commit window
 )
 print(metrics)   # {"num_updated": 50}
+```
+
+The default is one atomic commit. To explicitly opt into non-atomic,
+incremental commits:
+
+```python
+metrics = update_by_row_id(
+    target="database_name.table_name",
+    source=ray_dataset,
+    catalog_options={"warehouse": "/path/to/warehouse"},
+    update_cols=["feature"],
+    commit_mode="incremental",
+    max_groups_per_commit=64,
+)
 ```
 
 **Parameters:**
@@ -567,8 +580,10 @@ print(metrics)   # {"num_updated": 50}
 - `num_partitions`: parallelism for grouping the update rows by target file;
   defaults to `max(1, cluster_cpus * 2)`.
 - `ray_remote_args`: Ray remote options applied to the update tasks.
-- `max_groups_per_commit`: optional positive number of completed target file groups
-  per commit. By default, all groups are committed together.
+- `commit_mode`: `"atomic"` (default) commits all groups together.
+  `"incremental"` explicitly opts into non-atomic, windowed commits.
+- `max_groups_per_commit`: required in incremental mode; positive number of
+  completed target file groups per commit. It is rejected in atomic mode.
 
 **Returns:** `{"num_updated": <rows>}`.
 
@@ -580,13 +595,15 @@ print(metrics)   # {"num_updated": 50}
 - Partition columns cannot be updated (in-place rewrite can't move a row across partitions).
 - Deletion-vectors-enabled tables are not supported yet: a DV-deleted row still lives
   in its data file, so it can't be told apart from a live row without reading the target.
-- Incremental commits are not atomic across the whole operation. Ordinary exceptions
-  raised while applying a group are reported as results so other groups can finish;
-  completed groups are flushed before the error is raised.
-- Ray task retry options in `ray_remote_args` do not retry group exceptions reported
-  as results, so a transient group failure can leave a partial update. Worker loss and
-  other task-level failures which bypass Python exception handling may still lose
-  results buffered by that task.
+- Incremental commits are not atomic across the whole operation. Commits completed
+  before a later failure remain visible.
+- A duplicate `_ROW_ID` within a target file group is a deterministic validation
+  error. In incremental mode it is reported as a result so successful groups can
+  finish and be committed before the error is raised.
+- Other application and I/O exceptions propagate to Ray and remain subject to the
+  retry options in `ray_remote_args`. If retries are exhausted, earlier incremental
+  commits remain visible. Worker loss may also discard successful results still
+  buffered in the failed Ray task.
 
 ## Read By Row Id
 

--- a/docs/docs/pypaimon/ray-data.md
+++ b/docs/docs/pypaimon/ray-data.md
@@ -553,6 +553,7 @@ metrics = update_by_row_id(
     source=ray_dataset,          # ray.data.Dataset / pa.Table / pandas, carrying _ROW_ID
     catalog_options={"warehouse": "/path/to/warehouse"},
     update_cols=["feature"],     # non-blob columns to overwrite
+    max_groups_per_commit=64,    # optional incremental commit window
 )
 print(metrics)   # {"num_updated": 50}
 ```
@@ -566,6 +567,8 @@ print(metrics)   # {"num_updated": 50}
 - `num_partitions`: parallelism for grouping the update rows by target file;
   defaults to `max(1, cluster_cpus * 2)`.
 - `ray_remote_args`: Ray remote options applied to the update tasks.
+- `max_groups_per_commit`: optional positive number of completed target file groups
+  per commit. By default, all groups are committed together.
 
 **Returns:** `{"num_updated": <rows>}`.
 
@@ -577,6 +580,11 @@ print(metrics)   # {"num_updated": 50}
 - Partition columns cannot be updated (in-place rewrite can't move a row across partitions).
 - Deletion-vectors-enabled tables are not supported yet: a DV-deleted row still lives
   in its data file, so it can't be told apart from a live row without reading the target.
+- Incremental commits are not atomic across the whole operation. If a group fails,
+  completed groups are flushed before the error is raised.
+- Incremental mode reports group exceptions as results so other groups can finish.
+  Ray task retry options in `ray_remote_args` do not retry these exceptions; a
+  transient group failure can therefore leave a partial update.
 
 ## Read By Row Id
 

--- a/paimon-python/pypaimon/ray/data_evolution_merge_join.py
+++ b/paimon-python/pypaimon/ray/data_evolution_merge_join.py
@@ -562,7 +562,7 @@ def distributed_update_apply(
 
     captured_table = table
     captured_cols = cols
-    capture_group_errors = on_group_result is not None
+    capture_group_validation_errors = on_group_result is not None
 
     def _group_result(msgs_blob, n_updated, row_ids_blob, error):
         return pa.Table.from_pydict({
@@ -581,33 +581,31 @@ def distributed_update_apply(
                 "error": pa.array([], type=pa.string()),
             })
 
-        try:
-            if (
-                pc.count_distinct(group.column(row_id_name)).as_py()
-                != group.num_rows
-            ):
-                raise ValueError(
-                    "MERGE matched multiple source rows to the same "
-                    "target _ROW_ID. Deduplicate the source before "
-                    "merging."
-                )
-
-            for_update = group.drop_columns([frid_col])
-            row_ids = (
-                for_update.column(row_id_name).to_pylist()
-                if collect_row_ids else []
+        if (
+            pc.count_distinct(group.column(row_id_name)).as_py()
+            != group.num_rows
+        ):
+            error = ValueError(
+                "MERGE matched multiple source rows to the same "
+                "target _ROW_ID. Deduplicate the source before "
+                "merging."
             )
-            worker = TableUpdateByRowId(
-                captured_table,
-                "_merge_into_shard_" + uuid.uuid4().hex[:8],
-                BATCH_COMMIT_IDENTIFIER,
-                _precomputed_files_info=ray.get(precomputed_info_ref),
-            )
-            msgs = worker.update_columns(for_update, list(captured_cols))
-        except Exception as error:
-            if not capture_group_errors:
-                raise
+            if not capture_group_validation_errors:
+                raise error
             return _group_result(b"", 0, b"", _group_error_text(error))
+
+        for_update = group.drop_columns([frid_col])
+        row_ids = (
+            for_update.column(row_id_name).to_pylist()
+            if collect_row_ids else []
+        )
+        worker = TableUpdateByRowId(
+            captured_table,
+            "_merge_into_shard_" + uuid.uuid4().hex[:8],
+            BATCH_COMMIT_IDENTIFIER,
+            _precomputed_files_info=ray.get(precomputed_info_ref),
+        )
+        msgs = worker.update_columns(for_update, list(captured_cols))
 
         return _group_result(
             pickle.dumps(msgs),

--- a/paimon-python/pypaimon/ray/data_evolution_merge_join.py
+++ b/paimon-python/pypaimon/ray/data_evolution_merge_join.py
@@ -639,6 +639,8 @@ def distributed_update_apply(
         for blob, n, row_ids_blob, error in zip(
                 message_blobs, updated_counts, row_id_blobs, errors):
             if error is not None:
+                # Keep the first failure as the primary error, but continue
+                # draining results so successful groups can still be committed.
                 if group_error is None:
                     group_error = error
                 continue

--- a/paimon-python/pypaimon/ray/data_evolution_merge_join.py
+++ b/paimon-python/pypaimon/ray/data_evolution_merge_join.py
@@ -16,7 +16,7 @@
 # limitations under the License.
 ################################################################################
 
-from typing import Any, Dict, List, Optional, Sequence, Tuple
+from typing import Any, Callable, Dict, List, Optional, Sequence, Tuple
 
 import pyarrow as pa
 
@@ -30,6 +30,21 @@ from pypaimon.ray.data_evolution_merge_transform import (
     vectorized_insert_transform,
     vectorized_matched_transform,
 )
+
+
+class GroupApplyError(RuntimeError):
+    """A file group failed after other groups may have completed."""
+
+
+def _group_error_text(error: BaseException) -> str:
+    import traceback
+
+    return "update_by_row_id file group failed: {}: {}\n{}".format(
+        type(error).__name__,
+        str(error),
+        "".join(traceback.format_exception(
+            type(error), error, error.__traceback__)),
+    )
 
 
 def _map_kwargs(
@@ -445,6 +460,7 @@ def distributed_update_apply(
     ray_remote_args: Optional[Dict[str, Any]] = None,
     base_snapshot_id: Optional[int] = None,
     collect_row_ids: bool = False,
+    on_group_result: Optional[Callable[[list, int, list], None]] = None,
 ) -> Tuple[list, int, list]:
     import numpy as np
     import pickle
@@ -546,6 +562,15 @@ def distributed_update_apply(
 
     captured_table = table
     captured_cols = cols
+    capture_group_errors = on_group_result is not None
+
+    def _group_result(msgs_blob, n_updated, row_ids_blob, error):
+        return pa.Table.from_pydict({
+            "msgs_blob": pa.array([msgs_blob], type=pa.binary()),
+            "n_updated": pa.array([n_updated], type=pa.int64()),
+            "row_ids_blob": pa.array([row_ids_blob], type=pa.binary()),
+            "error": pa.array([error], type=pa.string()),
+        })
 
     def _apply_group(group: pa.Table) -> pa.Table:
         if group.num_rows == 0:
@@ -553,39 +578,43 @@ def distributed_update_apply(
                 "msgs_blob": pa.array([], type=pa.binary()),
                 "n_updated": pa.array([], type=pa.int64()),
                 "row_ids_blob": pa.array([], type=pa.binary()),
+                "error": pa.array([], type=pa.string()),
             })
 
-        if (
-            pc.count_distinct(group.column(row_id_name)).as_py()
-            != group.num_rows
-        ):
-            raise ValueError(
-                "MERGE matched multiple source rows to the same "
-                "target _ROW_ID. Deduplicate the source before "
-                "merging."
-            )
+        try:
+            if (
+                pc.count_distinct(group.column(row_id_name)).as_py()
+                != group.num_rows
+            ):
+                raise ValueError(
+                    "MERGE matched multiple source rows to the same "
+                    "target _ROW_ID. Deduplicate the source before "
+                    "merging."
+                )
 
-        for_update = group.drop_columns([frid_col])
-        row_ids = (
-            for_update.column(row_id_name).to_pylist()
-            if collect_row_ids else []
+            for_update = group.drop_columns([frid_col])
+            row_ids = (
+                for_update.column(row_id_name).to_pylist()
+                if collect_row_ids else []
+            )
+            worker = TableUpdateByRowId(
+                captured_table,
+                "_merge_into_shard_" + uuid.uuid4().hex[:8],
+                BATCH_COMMIT_IDENTIFIER,
+                _precomputed_files_info=ray.get(precomputed_info_ref),
+            )
+            msgs = worker.update_columns(for_update, list(captured_cols))
+        except Exception as error:
+            if not capture_group_errors:
+                raise
+            return _group_result(b"", 0, b"", _group_error_text(error))
+
+        return _group_result(
+            pickle.dumps(msgs),
+            for_update.num_rows,
+            pickle.dumps(row_ids),
+            None,
         )
-        worker = TableUpdateByRowId(
-            captured_table,
-            "_merge_into_shard_" + uuid.uuid4().hex[:8],
-            BATCH_COMMIT_IDENTIFIER,
-            _precomputed_files_info=ray.get(precomputed_info_ref),
-        )
-        msgs = worker.update_columns(for_update, list(captured_cols))
-        return pa.Table.from_pydict({
-            "msgs_blob": [pickle.dumps(msgs)],
-            "n_updated": pa.array(
-                [for_update.num_rows], type=pa.int64()
-            ),
-            "row_ids_blob": pa.array(
-                [pickle.dumps(row_ids)], type=pa.binary()
-            ),
-        })
 
     # One group per target data file; bounded by file count and num_partitions.
     group_partitions = max(
@@ -598,14 +627,34 @@ def distributed_update_apply(
     all_msgs: list = []
     num_updated = 0
     action_row_ids = []
+    group_error = None
     for batch in msgs_ds.iter_batches(batch_format="pyarrow"):
-        for blob in batch.column("msgs_blob").to_pylist():
-            all_msgs.extend(pickle.loads(blob))
-        for n in batch.column("n_updated").to_pylist():
+        message_blobs = batch.column("msgs_blob").to_pylist()
+        updated_counts = batch.column("n_updated").to_pylist()
+        errors = batch.column("error").to_pylist()
+        row_id_blobs = (
+            batch.column("row_ids_blob").to_pylist()
+            if collect_row_ids else [None] * len(message_blobs)
+        )
+        for blob, n, row_ids_blob, error in zip(
+                message_blobs, updated_counts, row_id_blobs, errors):
+            if error is not None:
+                if group_error is None:
+                    group_error = error
+                continue
+            group_msgs = pickle.loads(blob)
+            group_row_ids = (
+                pickle.loads(row_ids_blob) if collect_row_ids else []
+            )
+            if on_group_result is None:
+                all_msgs.extend(group_msgs)
+            else:
+                on_group_result(group_msgs, n, group_row_ids)
             num_updated += n
-        if collect_row_ids:
-            for blob in batch.column("row_ids_blob").to_pylist():
-                action_row_ids.extend(pickle.loads(blob))
+            if collect_row_ids:
+                action_row_ids.extend(group_row_ids)
+    if group_error is not None:
+        raise GroupApplyError(group_error)
     return all_msgs, num_updated, action_row_ids
 
 

--- a/paimon-python/pypaimon/ray/update_by_row_id.py
+++ b/paimon-python/pypaimon/ray/update_by_row_id.py
@@ -59,6 +59,7 @@ def update_by_row_id(
     update_cols: List[str],
     num_partitions: Optional[int] = None,
     ray_remote_args: Optional[Dict[str, Any]] = None,
+    commit_mode: str = "atomic",
     max_groups_per_commit: Optional[int] = None,
 ) -> Dict[str, int]:
     """Update ``update_cols`` of a data-evolution table by ``_ROW_ID``.
@@ -70,12 +71,12 @@ def update_by_row_id(
     ``ray >= 2.50`` and a target with ``data-evolution.enabled`` + ``row-tracking.enabled``.
 
     By default, all file groups are committed atomically. Set
-    ``max_groups_per_commit`` to commit completed groups in smaller windows.
-    Ordinary exceptions raised while applying a group are returned as results
-    in incremental mode, so completed groups are flushed before the error is
-    raised and Ray task retry options in ``ray_remote_args`` do not retry the
-    group. Worker loss and other task-level failures which bypass Python
-    exception handling may still lose results buffered by that task.
+    ``commit_mode="incremental"`` together with ``max_groups_per_commit`` to
+    commit completed groups in smaller windows. Incremental mode is not atomic:
+    commits made before a later failure remain visible. Deterministic duplicate
+    ``_ROW_ID`` errors are returned as group results so completed groups can be
+    flushed first. Other application errors propagate to Ray and remain subject
+    to the retry options in ``ray_remote_args``.
 
     Returns ``{"num_updated": <rows>}``.
     """
@@ -86,6 +87,14 @@ def update_by_row_id(
     _require_ray_join()
     if not update_cols:
         raise ValueError("update_cols must be non-empty.")
+    if commit_mode not in ("atomic", "incremental"):
+        raise ValueError("commit_mode must be 'atomic' or 'incremental'.")
+    if commit_mode == "atomic" and max_groups_per_commit is not None:
+        raise ValueError(
+            "max_groups_per_commit requires commit_mode='incremental'.")
+    if commit_mode == "incremental" and max_groups_per_commit is None:
+        raise ValueError(
+            "commit_mode='incremental' requires max_groups_per_commit.")
     if max_groups_per_commit is not None:
         if (isinstance(max_groups_per_commit, bool)
                 or not isinstance(max_groups_per_commit, int)
@@ -158,7 +167,7 @@ def update_by_row_id(
         return {"num_updated": 0}
     incremental_committer = (
         _IncrementalUpdateCommitter(table, max_groups_per_commit)
-        if max_groups_per_commit is not None else None
+        if commit_mode == "incremental" else None
     )
     try:
         apply_kwargs = {

--- a/paimon-python/pypaimon/ray/update_by_row_id.py
+++ b/paimon-python/pypaimon/ray/update_by_row_id.py
@@ -71,9 +71,11 @@ def update_by_row_id(
 
     By default, all file groups are committed atomically. Set
     ``max_groups_per_commit`` to commit completed groups in smaller windows.
-    If a group fails, completed groups are flushed before the error is raised.
-    Group exceptions are returned as results in incremental mode, so Ray task
-    retry options in ``ray_remote_args`` do not retry them.
+    Ordinary exceptions raised while applying a group are returned as results
+    in incremental mode, so completed groups are flushed before the error is
+    raised and Ray task retry options in ``ray_remote_args`` do not retry the
+    group. Worker loss and other task-level failures which bypass Python
+    exception handling may still lose results buffered by that task.
 
     Returns ``{"num_updated": <rows>}``.
     """
@@ -205,14 +207,23 @@ class _IncrementalUpdateCommitter:
         self._table_commit = None
         self._next_commit_identifier = 1
         self._commit_failed = False
+        self._deferred_commit_error = None
 
     def add_group(self, commit_messages, _num_updated, _row_ids) -> None:
         self._pending_messages.extend(commit_messages)
         self._pending_groups += 1
-        if self._pending_groups >= self._max_groups_per_commit:
-            self._commit_pending()
+        if (self._deferred_commit_error is None
+                and self._pending_groups >= self._max_groups_per_commit):
+            try:
+                self._commit_pending()
+            except Exception as error:
+                # Keep draining materialized Ray results so their staged files
+                # are known to the driver and can be aborted by the caller.
+                self._deferred_commit_error = error
 
     def finish(self) -> None:
+        if self._deferred_commit_error is not None:
+            raise self._deferred_commit_error
         self._commit_pending()
 
     def _commit_pending(self) -> None:

--- a/paimon-python/pypaimon/ray/update_by_row_id.py
+++ b/paimon-python/pypaimon/ray/update_by_row_id.py
@@ -34,7 +34,10 @@ from pypaimon.ray.data_evolution_merge_into import (
     _require_ray_join,
     _resolve_num_partitions,
 )
-from pypaimon.ray.data_evolution_merge_join import distributed_update_apply
+from pypaimon.ray.data_evolution_merge_join import (
+    GroupApplyError,
+    distributed_update_apply,
+)
 from pypaimon.ray.data_evolution_merge_transform import build_update_schema
 from pypaimon.schema.data_types import is_blob_file_field
 
@@ -56,6 +59,7 @@ def update_by_row_id(
     update_cols: List[str],
     num_partitions: Optional[int] = None,
     ray_remote_args: Optional[Dict[str, Any]] = None,
+    max_groups_per_commit: Optional[int] = None,
 ) -> Dict[str, int]:
     """Update ``update_cols`` of a data-evolution table by ``_ROW_ID``.
 
@@ -64,6 +68,12 @@ def update_by_row_id(
     routed to the data file owning its row id and only those files are rewritten --
     the target is never fully read and there is no join against it. Requires
     ``ray >= 2.50`` and a target with ``data-evolution.enabled`` + ``row-tracking.enabled``.
+
+    By default, all file groups are committed atomically. Set
+    ``max_groups_per_commit`` to commit completed groups in smaller windows.
+    If a group fails, completed groups are flushed before the error is raised.
+    Group exceptions are returned as results in incremental mode, so Ray task
+    retry options in ``ray_remote_args`` do not retry them.
 
     Returns ``{"num_updated": <rows>}``.
     """
@@ -74,6 +84,11 @@ def update_by_row_id(
     _require_ray_join()
     if not update_cols:
         raise ValueError("update_cols must be non-empty.")
+    if max_groups_per_commit is not None:
+        if (isinstance(max_groups_per_commit, bool)
+                or not isinstance(max_groups_per_commit, int)
+                or max_groups_per_commit <= 0):
+            raise ValueError("max_groups_per_commit must be a positive integer.")
     update_cols = list(dict.fromkeys(update_cols))  # de-dup, keep order
     num_partitions = _resolve_num_partitions(num_partitions)
 
@@ -139,20 +154,109 @@ def update_by_row_id(
             raise ValueError(
                 f"target '{target}' has no rows; every _ROW_ID in the source is foreign.")
         return {"num_updated": 0}
+    incremental_committer = (
+        _IncrementalUpdateCommitter(table, max_groups_per_commit)
+        if max_groups_per_commit is not None else None
+    )
     try:
+        apply_kwargs = {
+            "num_partitions": num_partitions,
+            "ray_remote_args": ray_remote_args,
+            "base_snapshot_id": base.id,
+        }
+        if incremental_committer is not None:
+            apply_kwargs["on_group_result"] = incremental_committer.add_group
         msgs, num_updated, _ = distributed_update_apply(
-            update_ds, table, update_cols,
-            num_partitions=num_partitions,
-            ray_remote_args=ray_remote_args,
-            base_snapshot_id=base.id,
+            update_ds, table, update_cols, **apply_kwargs
         )
+        if incremental_committer is not None:
+            incremental_committer.finish()
+    except GroupApplyError:
+        if incremental_committer is not None:
+            try:
+                incremental_committer.finish()
+            except Exception:
+                incremental_committer.abort_pending()
+                raise
+        raise
     except Exception as e:
+        if incremental_committer is not None:
+            incremental_committer.abort_pending()
+            if incremental_committer._commit_failed:
+                raise
         _reraise_inner(e)
         raise  # _reraise_inner always raises; keeps msgs/num_updated defined for linters
+    finally:
+        if incremental_committer is not None:
+            incremental_committer.close()
 
-    if msgs:
+    if incremental_committer is None and msgs:
         _commit_update_messages(table, msgs)
     return {"num_updated": num_updated}
+
+
+class _IncrementalUpdateCommitter:
+
+    def __init__(self, table, max_groups_per_commit: int):
+        self._table = table
+        self._max_groups_per_commit = max_groups_per_commit
+        self._pending_messages: list = []
+        self._pending_groups = 0
+        self._table_commit = None
+        self._next_commit_identifier = 1
+        self._commit_failed = False
+
+    def add_group(self, commit_messages, _num_updated, _row_ids) -> None:
+        self._pending_messages.extend(commit_messages)
+        self._pending_groups += 1
+        if self._pending_groups >= self._max_groups_per_commit:
+            self._commit_pending()
+
+    def finish(self) -> None:
+        self._commit_pending()
+
+    def _commit_pending(self) -> None:
+        if self._pending_groups == 0:
+            return
+        if not self._pending_messages:
+            self._pending_groups = 0
+            return
+
+        try:
+            if self._table_commit is None:
+                self._table_commit = (
+                    self._table.new_stream_write_builder().new_commit()
+                )
+
+            messages = self._pending_messages
+            self._pending_messages = []
+            self._pending_groups = 0
+            commit_identifier = self._next_commit_identifier
+            self._table_commit.commit(messages, commit_identifier)
+        except Exception:
+            self._commit_failed = True
+            raise
+        self._next_commit_identifier += 1
+
+    def abort_pending(self) -> None:
+        if not self._pending_messages:
+            return
+        messages = self._pending_messages
+        self._pending_messages = []
+        self._pending_groups = 0
+        _abort_pending_update_messages(self._table, messages)
+
+    def close(self) -> None:
+        if self._table_commit is None:
+            return
+        try:
+            self._table_commit.close()
+        except Exception as close_error:
+            logger.warning(
+                "Failed to close incremental update_by_row_id commit: %s",
+                close_error,
+                exc_info=close_error,
+            )
 
 
 def _commit_update_messages(table, commit_messages) -> None:

--- a/paimon-python/pypaimon/tests/file_store_commit_test.py
+++ b/paimon-python/pypaimon/tests/file_store_commit_test.py
@@ -573,6 +573,9 @@ class TestFileStoreCommit(unittest.TestCase):
             rewrite,
             AssertionError("rewrite retry budget was not enforced"),
         ])
+        refresh_guard = Mock()
+        file_store_commit.conflict_detection.refresh_planned_row_id_files = (
+            refresh_guard)
 
         with self.assertRaises(RuntimeError) as ctx:
             file_store_commit._try_commit(
@@ -583,6 +586,8 @@ class TestFileStoreCommit(unittest.TestCase):
 
         self.assertIn("with 1 retries", str(ctx.exception))
         self.assertEqual(2, file_store_commit._try_commit_once.call_count)
+        self.assertEqual(2, refresh_guard.call_count)
+        refresh_guard.assert_called_with(latest_snapshot)
         file_store_commit._commit_retry_wait.assert_called_once_with(0)
 
     @staticmethod

--- a/paimon-python/pypaimon/tests/file_store_commit_test.py
+++ b/paimon-python/pypaimon/tests/file_store_commit_test.py
@@ -59,6 +59,19 @@ class TestFileStoreCommit(unittest.TestCase):
             commit_user='test_user'
         )
 
+    def test_commit_metadata_allows_empty_snapshot(
+            self, mock_manifest_list_manager, mock_manifest_file_manager):
+        file_store_commit = self._create_file_store_commit()
+        file_store_commit._try_commit = Mock()
+
+        file_store_commit.commit_metadata(42)
+
+        kwargs = file_store_commit._try_commit.call_args.kwargs
+        self.assertEqual("APPEND", kwargs["commit_kind"])
+        self.assertEqual(42, kwargs["commit_identifier"])
+        self.assertEqual([], kwargs["commit_entries_plan"](None))
+        self.assertTrue(kwargs["allow_empty"])
+
     def test_generate_partition_statistics_single_partition_single_file(
             self, mock_manifest_list_manager, mock_manifest_file_manager):
         """Test partition statistics generation with single partition and single file."""

--- a/paimon-python/pypaimon/tests/file_store_commit_test.py
+++ b/paimon-python/pypaimon/tests/file_store_commit_test.py
@@ -24,6 +24,7 @@ from pypaimon.manifest.schema.data_file_meta import DataFileMeta
 from pypaimon.manifest.schema.manifest_entry import ManifestEntry
 from pypaimon.snapshot.snapshot_commit import PartitionStatistics
 from pypaimon.table.row.generic_row import GenericRow
+from pypaimon.utils.range import Range
 from pypaimon.write.commit.row_id_conflict_rewriter import RowIdRewriteResult
 from pypaimon.write.commit_message import CommitMessage
 from pypaimon.write.file_store_commit import (
@@ -71,6 +72,38 @@ class TestFileStoreCommit(unittest.TestCase):
         self.assertEqual(42, kwargs["commit_identifier"])
         self.assertEqual([], kwargs["commit_entries_plan"](None))
         self.assertTrue(kwargs["allow_empty"])
+
+    def test_success_clears_commit_context(
+            self, mock_manifest_list_manager, mock_manifest_file_manager):
+        file_store_commit = self._create_file_store_commit()
+        checkpoint = Mock()
+        file_store_commit.with_snapshot_properties({"offset": "1"})
+        file_store_commit.protect_planned_row_id_files(
+            [Range(0, 9)], {"file"})
+        file_store_commit.protect_from_external_rewrites(
+            checkpoint, "operation")
+
+        result = Mock()
+        result.is_success.return_value = True
+        file_store_commit._try_commit_once = Mock(return_value=result)
+        file_store_commit._try_commit(
+            commit_kind="APPEND",
+            commit_identifier=42,
+            commit_entries_plan=lambda _snapshot: [],
+            allow_empty=True,
+        )
+
+        self.assertEqual({}, file_store_commit.snapshot_properties)
+        self.assertEqual(
+            [], file_store_commit.conflict_detection._planned_row_id_ranges)
+        self.assertEqual(
+            set(),
+            file_store_commit.conflict_detection._planned_row_id_signatures,
+        )
+        self.assertIsNone(
+            file_store_commit.conflict_detection._rewrite_checkpoint)
+        self.assertIsNone(
+            file_store_commit.conflict_detection._rewrite_commit_user)
 
     def test_generate_partition_statistics_single_partition_single_file(
             self, mock_manifest_list_manager, mock_manifest_file_manager):

--- a/paimon-python/pypaimon/tests/ray_update_by_row_id_test.py
+++ b/paimon-python/pypaimon/tests/ray_update_by_row_id_test.py
@@ -130,6 +130,222 @@ class RayUpdateByRowIdTest(unittest.TestCase):
         self.assertEqual(got[21], 999)
         self.assertTrue(all(v == 0 for k, v in got.items() if k != 21))
 
+    def test_incrementally_commits_file_group_windows(self):
+        from pypaimon.write.table_commit import StreamTableCommit
+
+        target = self._create()
+        chunks = [[start, start + 1] for start in range(10, 60, 10)]
+        for chunk in chunks:
+            self._write(target, pa.Table.from_pydict(
+                {"id": chunk, "name": ["x", "x"], "age": [0, 0]},
+                schema=self.pa_schema,
+            ))
+
+        table = self.catalog.get_table(target)
+        base_snapshot_id = table.snapshot_manager().get_latest_snapshot().id
+        row_ids = self._rowid_by_id(target)
+        updated_ids = [chunk[0] for chunk in chunks]
+        source = pa.table(
+            {
+                "_ROW_ID": [row_ids[row_id] for row_id in updated_ids],
+                "age": updated_ids,
+            },
+            schema=pa.schema([("_ROW_ID", pa.int64()), ("age", pa.int32())]),
+        )
+        commits = []
+        original_commit = StreamTableCommit.commit
+
+        def record_commit(stream_commit, messages, commit_identifier):
+            commits.append((len(messages), commit_identifier))
+            return original_commit(
+                stream_commit, messages, commit_identifier)
+
+        with mock.patch.object(StreamTableCommit, "commit", record_commit):
+            stats = update_by_row_id(
+                target,
+                ray.data.from_arrow(source).repartition(4),
+                self.catalog_options,
+                update_cols=["age"],
+                num_partitions=4,
+                max_groups_per_commit=2,
+            )
+
+        self.assertEqual({"num_updated": 5}, stats)
+        self.assertEqual([(2, 1), (2, 2), (1, 3)], commits)
+        self.assertEqual(
+            base_snapshot_id + 3,
+            table.snapshot_manager().get_latest_snapshot().id,
+        )
+        result = self._read(target).sort_by("id").to_pydict()
+        ages = dict(zip(result["id"], result["age"]))
+        self.assertEqual(
+            {row_id: row_id for row_id in updated_ids},
+            {row_id: ages[row_id] for row_id in updated_ids},
+        )
+
+    def test_group_failure_preserves_completed_groups(self):
+        for max_groups, expected_snapshots in [(1, 2), (5, 1)]:
+            with self.subTest(max_groups_per_commit=max_groups):
+                target = self._create()
+                for row_id in range(1, 4):
+                    self._write(target, pa.Table.from_pydict(
+                        {"id": [row_id], "name": ["a"], "age": [0]},
+                        schema=self.pa_schema,
+                    ))
+
+                table = self.catalog.get_table(target)
+                base_snapshot_id = (
+                    table.snapshot_manager().get_latest_snapshot().id
+                )
+                row_ids = self._rowid_by_id(target)
+                source = pa.table(
+                    {
+                        "_ROW_ID": [
+                            row_ids[1], row_ids[2], row_ids[3], row_ids[3],
+                        ],
+                        "age": [100, 200, 300, 301],
+                    },
+                    schema=pa.schema([
+                        ("_ROW_ID", pa.int64()),
+                        ("age", pa.int32()),
+                    ]),
+                )
+
+                with self.assertRaisesRegex(RuntimeError, "Deduplicate"):
+                    update_by_row_id(
+                        target,
+                        ray.data.from_arrow(source),
+                        self.catalog_options,
+                        update_cols=["age"],
+                        num_partitions=1,
+                        max_groups_per_commit=max_groups,
+                    )
+
+                self.assertEqual(
+                    base_snapshot_id + expected_snapshots,
+                    table.snapshot_manager().get_latest_snapshot().id,
+                )
+                self.assertEqual(
+                    [100, 200, 0],
+                    self._read(target).sort_by("id")["age"].to_pylist(),
+                )
+
+    def test_atomic_group_failure_commits_nothing(self):
+        target = self._create()
+        for row_id in range(1, 4):
+            self._write(target, pa.Table.from_pydict(
+                {"id": [row_id], "name": ["a"], "age": [0]},
+                schema=self.pa_schema,
+            ))
+
+        table = self.catalog.get_table(target)
+        base_snapshot_id = table.snapshot_manager().get_latest_snapshot().id
+        row_ids = self._rowid_by_id(target)
+        source = pa.table(
+            {
+                "_ROW_ID": [
+                    row_ids[1], row_ids[2], row_ids[3], row_ids[3],
+                ],
+                "age": [100, 200, 300, 301],
+            },
+            schema=pa.schema([
+                ("_ROW_ID", pa.int64()),
+                ("age", pa.int32()),
+            ]),
+        )
+
+        with self.assertRaisesRegex(ValueError, "Deduplicate"):
+            update_by_row_id(
+                target,
+                ray.data.from_arrow(source),
+                self.catalog_options,
+                update_cols=["age"],
+                num_partitions=1,
+            )
+
+        self.assertEqual(
+            base_snapshot_id,
+            table.snapshot_manager().get_latest_snapshot().id,
+        )
+        self.assertEqual(
+            [0, 0, 0],
+            self._read(target).sort_by("id")["age"].to_pylist(),
+        )
+
+    def test_incremental_committer_batches_and_aborts_pending_groups(self):
+        import importlib
+
+        module = importlib.import_module("pypaimon.ray.update_by_row_id")
+        commits = []
+        aborted = []
+        close_calls = []
+
+        class FakeCommit:
+            def commit(self, messages, commit_identifier):
+                commits.append((list(messages), commit_identifier))
+
+            def close(self):
+                close_calls.append(True)
+
+        class FakeBuilder:
+            def new_commit(self):
+                return FakeCommit()
+
+        class FakeTable:
+            def new_stream_write_builder(self):
+                return FakeBuilder()
+
+        committer = module._IncrementalUpdateCommitter(FakeTable(), 2)
+        with mock.patch.object(
+                module,
+                "_abort_pending_update_messages",
+                side_effect=lambda table, messages: aborted.append(list(messages))):
+            committer.add_group(["group-1"], 1, [])
+            committer.add_group(["group-2"], 1, [])
+            committer.add_group(["group-3"], 1, [])
+            committer.abort_pending()
+            committer.close()
+
+        self.assertEqual(
+            [(["group-1", "group-2"], 1)],
+            commits,
+        )
+        self.assertEqual([["group-3"]], aborted)
+        self.assertEqual([True], close_calls)
+
+    def test_incremental_commit_failure_does_not_abort_unknown_outcome(self):
+        import importlib
+
+        module = importlib.import_module("pypaimon.ray.update_by_row_id")
+        aborted = []
+
+        class FakeCommit:
+            def commit(self, messages, commit_identifier):
+                raise RuntimeError("commit failed")
+
+            def close(self):
+                pass
+
+        class FakeBuilder:
+            def new_commit(self):
+                return FakeCommit()
+
+        class FakeTable:
+            def new_stream_write_builder(self):
+                return FakeBuilder()
+
+        committer = module._IncrementalUpdateCommitter(FakeTable(), 1)
+        with mock.patch.object(
+                module,
+                "_abort_pending_update_messages",
+                side_effect=lambda table, messages: aborted.append(list(messages))):
+            with self.assertRaisesRegex(RuntimeError, "commit failed"):
+                committer.add_group(["group-1"], 1, [])
+            committer.abort_pending()
+            committer.close()
+
+        self.assertEqual([], aborted)
+
     def test_pins_base_snapshot_for_conflict_detection(self):
         # The update pins its base snapshot and threads it to distributed_update_apply,
         # which uses it for commit-time conflict detection against concurrent writers.
@@ -182,6 +398,20 @@ class RayUpdateByRowIdTest(unittest.TestCase):
         self.assertEqual(recorder["commit_calls"], 1)
         self.assertEqual(recorder["abort_calls"], 0)
         self.assertEqual(recorder["close_calls"], 1)
+
+    def test_incremental_driver_commit_failure_is_not_unwrapped(self):
+        retry_error = ValueError("retry failed")
+        commit_error = RuntimeError("commit failed")
+        commit_error.__cause__ = retry_error
+
+        with self.assertRaises(RuntimeError) as raised:
+            self._run_with_fake_commit(
+                commit_error=commit_error,
+                incremental=True,
+            )
+
+        self.assertIs(commit_error, raised.exception)
+        self.assertIs(retry_error, raised.exception.__cause__)
 
     def test_close_failure_after_success_warns_and_returns_stats(self):
         close_error = RuntimeError("close failed")
@@ -324,8 +554,30 @@ class RayUpdateByRowIdTest(unittest.TestCase):
         with self.assertRaises(ValueError):
             update_by_row_id(target, src, self.catalog_options, update_cols=[])
 
+    def test_rejects_invalid_max_groups_per_commit(self):
+        target = self._create()
+        self._write(target, pa.Table.from_pydict(
+            {"id": [1], "name": ["a"], "age": [1]}, schema=self.pa_schema))
+        source = pa.table(
+            {"_ROW_ID": [0], "age": [9]},
+            schema=pa.schema([("_ROW_ID", pa.int64()), ("age", pa.int32())]),
+        )
+
+        for value in [0, -1, True, 1.5, "2"]:
+            with self.subTest(value=value):
+                with self.assertRaisesRegex(
+                        ValueError, "must be a positive integer"):
+                    update_by_row_id(
+                        target,
+                        source,
+                        self.catalog_options,
+                        update_cols=["age"],
+                        max_groups_per_commit=value,
+                    )
+
     def _run_with_fake_commit(self, *, recorder=None, new_commit_errors=None,
-                              commit_error=None, close_error=None):
+                              commit_error=None, close_error=None,
+                              incremental=False):
         import importlib
 
         m = importlib.import_module("pypaimon.ray.update_by_row_id")
@@ -354,7 +606,7 @@ class RayUpdateByRowIdTest(unittest.TestCase):
                 return False
 
         class FakeCommit:
-            def commit(self, msgs):
+            def commit(self, msgs, *args):
                 recorder["commit_calls"] += 1
                 recorder["commit_msgs"] = list(msgs)
                 if recorder["commit_error"] is not None:
@@ -396,6 +648,9 @@ class RayUpdateByRowIdTest(unittest.TestCase):
             def new_batch_write_builder(self):
                 return FakeWriteBuilder()
 
+            def new_stream_write_builder(self):
+                return FakeWriteBuilder()
+
         class FakeCatalog:
             def get_table(self, target):
                 return FakeTable()
@@ -410,6 +665,13 @@ class RayUpdateByRowIdTest(unittest.TestCase):
         parser_path = (
             "pypaimon.schema.data_types.PyarrowFieldParser.from_paimon_schema"
         )
+
+        def fake_apply(*args, **kwargs):
+            if incremental:
+                kwargs["on_group_result"](recorder["msgs"], 3, [])
+                return [], 3, []
+            return recorder["msgs"], 3, []
+
         with mock.patch(
                 "pypaimon.catalog.catalog_factory.CatalogFactory.create",
                 return_value=FakeCatalog()), \
@@ -425,12 +687,13 @@ class RayUpdateByRowIdTest(unittest.TestCase):
                                ("age", pa.int32()),
                            ])), \
                 mock.patch.object(m, "distributed_update_apply",
-                                  return_value=(recorder["msgs"], 3, [])):
+                                  side_effect=fake_apply):
             recorder["result"] = m.update_by_row_id(
                 "default.fake",
                 FakeSource(),
                 self.catalog_options,
                 update_cols=["age"],
+                max_groups_per_commit=1 if incremental else None,
             )
         return recorder
 

--- a/paimon-python/pypaimon/tests/ray_update_by_row_id_test.py
+++ b/paimon-python/pypaimon/tests/ray_update_by_row_id_test.py
@@ -177,6 +177,7 @@ class RayUpdateByRowIdTest(unittest.TestCase):
                 self.catalog_options,
                 update_cols=["age"],
                 num_partitions=4,
+                commit_mode="incremental",
                 max_groups_per_commit=2,
             )
 
@@ -228,6 +229,7 @@ class RayUpdateByRowIdTest(unittest.TestCase):
                         self.catalog_options,
                         update_cols=["age"],
                         num_partitions=1,
+                        commit_mode="incremental",
                         max_groups_per_commit=max_groups,
                     )
 
@@ -398,6 +400,7 @@ class RayUpdateByRowIdTest(unittest.TestCase):
                     self.catalog_options,
                     update_cols=["age"],
                     num_partitions=1,
+                    commit_mode="incremental",
                     max_groups_per_commit=1,
                 )
 
@@ -637,8 +640,46 @@ class RayUpdateByRowIdTest(unittest.TestCase):
                         source,
                         self.catalog_options,
                         update_cols=["age"],
+                        commit_mode="incremental",
                         max_groups_per_commit=value,
                     )
+
+    def test_requires_explicit_incremental_commit_mode(self):
+        target = self._create()
+        self._write(target, pa.Table.from_pydict(
+            {"id": [1], "name": ["a"], "age": [1]}, schema=self.pa_schema))
+        source = pa.table(
+            {"_ROW_ID": [0], "age": [9]},
+            schema=pa.schema([("_ROW_ID", pa.int64()), ("age", pa.int32())]),
+        )
+
+        with self.assertRaisesRegex(
+                ValueError, "requires commit_mode='incremental'"):
+            update_by_row_id(
+                target,
+                source,
+                self.catalog_options,
+                update_cols=["age"],
+                max_groups_per_commit=1,
+            )
+        with self.assertRaisesRegex(
+                ValueError, "requires max_groups_per_commit"):
+            update_by_row_id(
+                target,
+                source,
+                self.catalog_options,
+                update_cols=["age"],
+                commit_mode="incremental",
+            )
+        with self.assertRaisesRegex(
+                ValueError, "must be 'atomic' or 'incremental'"):
+            update_by_row_id(
+                target,
+                source,
+                self.catalog_options,
+                update_cols=["age"],
+                commit_mode="unknown",
+            )
 
     def _run_with_fake_commit(self, *, recorder=None, new_commit_errors=None,
                               commit_error=None, close_error=None,
@@ -758,6 +799,7 @@ class RayUpdateByRowIdTest(unittest.TestCase):
                 FakeSource(),
                 self.catalog_options,
                 update_cols=["age"],
+                commit_mode="incremental" if incremental else "atomic",
                 max_groups_per_commit=1 if incremental else None,
             )
         return recorder

--- a/paimon-python/pypaimon/tests/ray_update_by_row_id_test.py
+++ b/paimon-python/pypaimon/tests/ray_update_by_row_id_test.py
@@ -88,6 +88,16 @@ class RayUpdateByRowIdTest(unittest.TestCase):
         tab = self._read(target, ["_ROW_ID", "id"])
         return dict(zip(tab.column("id").to_pylist(), tab.column("_ROW_ID").to_pylist()))
 
+    @staticmethod
+    def _data_files_under(table):
+        table_path = table.file_io.to_filesystem_path(table.table_path)
+        return {
+            os.path.join(root, file_name)
+            for root, _, files in os.walk(table_path)
+            for file_name in files
+            if file_name.endswith(".parquet")
+        }
+
     def test_update_by_row_id_basic(self):
         target = self._create()
         self._write(target, pa.Table.from_pydict(
@@ -313,14 +323,16 @@ class RayUpdateByRowIdTest(unittest.TestCase):
         self.assertEqual([["group-3"]], aborted)
         self.assertEqual([True], close_calls)
 
-    def test_incremental_commit_failure_does_not_abort_unknown_outcome(self):
+    def test_incremental_commit_failure_aborts_later_groups(self):
         import importlib
 
         module = importlib.import_module("pypaimon.ray.update_by_row_id")
         aborted = []
+        commit_calls = []
 
         class FakeCommit:
             def commit(self, messages, commit_identifier):
+                commit_calls.append((list(messages), commit_identifier))
                 raise RuntimeError("commit failed")
 
             def close(self):
@@ -339,12 +351,65 @@ class RayUpdateByRowIdTest(unittest.TestCase):
                 module,
                 "_abort_pending_update_messages",
                 side_effect=lambda table, messages: aborted.append(list(messages))):
+            committer.add_group(["group-1"], 1, [])
+            committer.add_group(["group-2"], 1, [])
             with self.assertRaisesRegex(RuntimeError, "commit failed"):
-                committer.add_group(["group-1"], 1, [])
+                committer.finish()
             committer.abort_pending()
             committer.close()
 
-        self.assertEqual([], aborted)
+        self.assertEqual([(["group-1"], 1)], commit_calls)
+        self.assertEqual([["group-2"]], aborted)
+
+    def test_incremental_commit_conflict_aborts_buffered_group_files(self):
+        from pypaimon.write.commit.conflict_detection import CommitConflictError
+        from pypaimon.write.file_store_commit import FileStoreCommit
+
+        target = self._create()
+        for row_id in range(1, 4):
+            self._write(target, pa.Table.from_pydict(
+                {"id": [row_id], "name": ["a"], "age": [0]},
+                schema=self.pa_schema,
+            ))
+
+        table = self.catalog.get_table(target)
+        base_snapshot_id = table.snapshot_manager().get_latest_snapshot().id
+        files_before = self._data_files_under(table)
+        row_ids = self._rowid_by_id(target)
+        source = pa.table(
+            {
+                "_ROW_ID": [row_ids[1], row_ids[2], row_ids[3]],
+                "age": [100, 200, 300],
+            },
+            schema=pa.schema([
+                ("_ROW_ID", pa.int64()),
+                ("age", pa.int32()),
+            ]),
+        )
+
+        with mock.patch.object(
+                FileStoreCommit,
+                "commit",
+                side_effect=CommitConflictError("forced conflict")):
+            with self.assertRaisesRegex(CommitConflictError, "forced conflict"):
+                update_by_row_id(
+                    target,
+                    ray.data.from_arrow(source),
+                    self.catalog_options,
+                    update_cols=["age"],
+                    num_partitions=1,
+                    max_groups_per_commit=1,
+                )
+
+        self.assertEqual(files_before, self._data_files_under(table))
+        self.assertEqual(
+            base_snapshot_id,
+            table.snapshot_manager().get_latest_snapshot().id,
+        )
+        self.assertEqual(
+            [0, 0, 0],
+            self._read(target).sort_by("id")["age"].to_pylist(),
+        )
 
     def test_pins_base_snapshot_for_conflict_detection(self):
         # The update pins its base snapshot and threads it to distributed_update_apply,

--- a/paimon-python/pypaimon/tests/table_commit_test.py
+++ b/paimon-python/pypaimon/tests/table_commit_test.py
@@ -87,6 +87,7 @@ class TestTableCommitEmptyOverwrite(unittest.TestCase):
         else:
             mock_fsc.commit.assert_not_called()
             mock_fsc.overwrite.assert_not_called()
+            mock_fsc.clear_commit_context.assert_called_once_with()
 
     # -- StreamTableCommit overwrite should also reach overwrite() with empty messages --
 

--- a/paimon-python/pypaimon/tests/table_commit_test.py
+++ b/paimon-python/pypaimon/tests/table_commit_test.py
@@ -100,3 +100,10 @@ class TestTableCommitEmptyOverwrite(unittest.TestCase):
             commit_messages=[],
             commit_identifier=42,
         )
+
+    def test_stream_commit_metadata(self):
+        commit, mock_fsc = self._create_commit(StreamTableCommit)
+
+        commit.commit_metadata(42)
+
+        mock_fsc.commit_metadata.assert_called_once_with(42)

--- a/paimon-python/pypaimon/tests/write/conflict_detection_test.py
+++ b/paimon-python/pypaimon/tests/write/conflict_detection_test.py
@@ -26,9 +26,11 @@ from pypaimon.manifest.schema.data_file_meta import DataFileMeta
 from pypaimon.manifest.schema.manifest_entry import ManifestEntry
 from pypaimon.schema.data_types import AtomicType, DataField
 from pypaimon.table.row.generic_row import GenericRow
+from pypaimon.utils.range import Range
 from pypaimon.write.commit.conflict_detection import (
     ConflictDetection,
     RowIdColumnConflictChecker,
+    row_id_file_signature,
 )
 
 
@@ -314,10 +316,14 @@ class TestOverwriteConflictDetection(unittest.TestCase):
 
 class _FakeSnapshot:
 
-    def __init__(self, snapshot_id, commit_kind, next_row_id=None):
+    def __init__(self, snapshot_id, commit_kind, next_row_id=None,
+                 commit_user="external", schema_id=0, uuid=None):
         self.id = snapshot_id
         self.commit_kind = commit_kind
         self.next_row_id = next_row_id
+        self.commit_user = commit_user
+        self.schema_id = schema_id
+        self.uuid = uuid
 
 
 class _FakeSnapshotManager:
@@ -331,9 +337,12 @@ class _FakeSnapshotManager:
 
 class _FakeCommitScanner:
 
-    def __init__(self, entries_by_snapshot_id, raw_entries_by_snapshot_id=None):
+    def __init__(self, entries_by_snapshot_id, raw_entries_by_snapshot_id=None,
+                 range_entries=None, deleting_snapshot_ids=None):
         self._by_id = entries_by_snapshot_id
         self._raw_by_id = raw_entries_by_snapshot_id or {}
+        self._range_entries = range_entries or []
+        self._deleting_snapshot_ids = set(deleting_snapshot_ids or [])
 
     def read_incremental_entries_from_changed_partitions(self, snapshot, _):
         return self._by_id.get(snapshot.id, [])
@@ -341,11 +350,21 @@ class _FakeCommitScanner:
     def read_incremental_raw_entries_from_changed_partitions(self, snapshot, _):
         return self._raw_by_id.get(snapshot.id, self._by_id.get(snapshot.id, []))
 
+    def read_entries_for_row_id_ranges(self, snapshot, _):
+        return self._range_entries
+
+    def snapshot_deletes_files(self, snapshot):
+        return snapshot.id in self._deleting_snapshot_ids
+
 
 class _FakeTable:
 
-    def __init__(self, schema_manager):
+    def __init__(self, schema_manager, snapshot_manager=None):
         self.schema_manager = schema_manager
+        self._snapshot_manager = snapshot_manager
+
+    def snapshot_manager(self):
+        return self._snapshot_manager
 
 
 class TestCheckRowIdFromSnapshot(unittest.TestCase):
@@ -416,6 +435,67 @@ class TestCheckRowIdFromSnapshot(unittest.TestCase):
                     [check_snap, compact_snap], {2: compact_entries})
                 self.assertIsNone(
                     detection.check_row_id_from_snapshot(compact_snap, delta))
+
+
+class TestResumableRowIdCommitGuards(unittest.TestCase):
+
+    @staticmethod
+    def _detection(snapshots, scanner):
+        snapshot_manager = _FakeSnapshotManager(snapshots)
+        return ConflictDetection(
+            data_evolution_enabled=True,
+            snapshot_manager=snapshot_manager,
+            manifest_list_manager=None,
+            table=_FakeTable(
+                _FakeSchemaManager([_DEFAULT_SCHEMA]), snapshot_manager),
+            commit_scanner=scanner,
+        )
+
+    def test_rejects_external_rewrite_after_checkpoint(self):
+        checkpoint = _FakeSnapshot(
+            1, "APPEND", commit_user="operation")
+        overwrite = _FakeSnapshot(2, "OVERWRITE")
+        detection = self._detection(
+            [checkpoint, overwrite], _FakeCommitScanner({}))
+        detection.protect_from_external_rewrites(
+            checkpoint, "operation")
+
+        result = detection.check_external_rewrites(overwrite)
+
+        self.assertIsNotNone(result)
+        self.assertIn("Concurrent rewrite", str(result))
+
+    def test_allows_own_snapshots_and_external_appends(self):
+        checkpoint = _FakeSnapshot(
+            1, "APPEND", commit_user="operation")
+        own = _FakeSnapshot(
+            2, "APPEND", commit_user="operation")
+        append = _FakeSnapshot(3, "APPEND")
+        detection = self._detection(
+            [checkpoint, own, append], _FakeCommitScanner({}))
+        detection.protect_from_external_rewrites(
+            checkpoint, "operation")
+
+        self.assertIsNone(detection.check_external_rewrites(append))
+
+    def test_rejects_changed_planned_files(self):
+        expected = _make_entry(
+            "expected", first_row_id=0, row_count=10)
+        scanner = _FakeCommitScanner(
+            {}, range_entries=[_make_entry(
+                "replacement", first_row_id=0, row_count=10)])
+        detection = self._detection([], scanner)
+        detection.protect_planned_row_id_files(
+            [Range(0, 9)],
+            {row_id_file_signature(
+                expected.partition, expected.bucket, expected.file)},
+        )
+
+        result = detection.check_planned_row_id_files(
+            _FakeSnapshot(1, "APPEND"))
+
+        self.assertIsNotNone(result)
+        self.assertIn("Target files changed", str(result))
 
 
 class TestRowIdColumnConflictChecker(unittest.TestCase):

--- a/paimon-python/pypaimon/tests/write/conflict_detection_test.py
+++ b/paimon-python/pypaimon/tests/write/conflict_detection_test.py
@@ -497,6 +497,12 @@ class TestResumableRowIdCommitGuards(unittest.TestCase):
         self.assertIsNotNone(result)
         self.assertIn("Target files changed", str(result))
 
+        detection.refresh_planned_row_id_files(
+            _FakeSnapshot(1, "APPEND"))
+
+        self.assertIsNone(detection.check_planned_row_id_files(
+            _FakeSnapshot(1, "APPEND")))
+
 
 class TestRowIdColumnConflictChecker(unittest.TestCase):
 

--- a/paimon-python/pypaimon/write/commit/commit_scanner.py
+++ b/paimon-python/pypaimon/write/commit/commit_scanner.py
@@ -18,6 +18,8 @@
 """
 Manifest entries scanner for commit operations.
 """
+import bisect
+import os
 from typing import Optional, List
 
 from pypaimon.common.predicate_builder import PredicateBuilder
@@ -25,8 +27,51 @@ from pypaimon.manifest.index_manifest_file import IndexManifestFile
 from pypaimon.manifest.manifest_file_manager import ManifestFileManager
 from pypaimon.manifest.manifest_list_manager import ManifestListManager
 from pypaimon.manifest.schema.manifest_entry import ManifestEntry
-from pypaimon.read.scanner.file_scanner import FileScanner
+from pypaimon.read.scanner.file_scanner import (
+    FileScanner,
+    _filter_manifest_files_by_row_ranges,
+)
 from pypaimon.snapshot.snapshot import Snapshot
+from pypaimon.utils.range import Range
+
+
+class _RowIdRangeScope:
+    """Table-global row-id ranges for planned update files."""
+
+    def __init__(self, row_id_ranges):
+        self.ranges = Range.sort_and_merge_overlap(
+            list(row_id_ranges or []), True, True)
+        self._range_ends = [row_range.to for row_range in self.ranges]
+
+    def is_empty(self):
+        return not self.ranges
+
+    def matches_record(self, record):
+        file_dict = record.get("_FILE")
+        if file_dict is None:
+            return False
+        first_row_id = file_dict.get("_FIRST_ROW_ID")
+        row_count = file_dict.get("_ROW_COUNT")
+        if first_row_id is None or row_count is None:
+            return False
+        return self.matches_values(
+            int(first_row_id),
+            int(first_row_id) + int(row_count) - 1,
+        )
+
+    def matches_entry(self, entry):
+        row_range = entry.file.row_id_range()
+        return (
+            row_range is not None
+            and self.matches_values(row_range.from_, row_range.to)
+        )
+
+    def matches_values(self, from_, to):
+        index = bisect.bisect_left(self._range_ends, from_)
+        return (
+            index < len(self.ranges)
+            and self.ranges[index].from_ <= to
+        )
 
 
 class CommitScanner:
@@ -73,6 +118,36 @@ class CommitScanner:
         return FileScanner(
             self.table, lambda: ([], None), partition_predicate=partition_filter
         ).read_manifest_entries(all_manifests)
+
+    def read_entries_for_row_id_ranges(
+            self,
+            snapshot: Optional[Snapshot],
+            row_id_ranges):
+        """Read live entries intersecting table-global row-id ranges."""
+        if snapshot is None:
+            return []
+
+        scope = _RowIdRangeScope(row_id_ranges)
+        if scope.is_empty():
+            return []
+
+        manifest_files = self.manifest_list_manager.read_all(snapshot)
+        manifest_files = _filter_manifest_files_by_row_ranges(
+            manifest_files, scope.ranges)
+        max_workers = self.table.options.scan_manifest_parallelism(
+            os.cpu_count() or 8)
+        return ManifestFileManager(self.table).read_entries_parallel(
+            manifest_files,
+            manifest_entry_filter=scope.matches_entry,
+            max_workers=max_workers,
+            early_record_filter=scope.matches_record,
+        )
+
+    def snapshot_deletes_files(self, snapshot: Snapshot) -> bool:
+        return any(
+            manifest.num_deleted_files > 0
+            for manifest in self.manifest_list_manager.read_delta(snapshot)
+        )
 
     def read_incremental_entries_from_changed_partitions(self,
                                                          snapshot: Snapshot,

--- a/paimon-python/pypaimon/write/commit/conflict_detection.py
+++ b/paimon-python/pypaimon/write/commit/conflict_detection.py
@@ -170,6 +170,27 @@ class RowIdExistenceConflict(RuntimeError):
                 entry.bucket))
 
 
+def row_id_file_signature(partition, bucket, data_file):
+    values = (
+        tuple(partition.values)
+        if hasattr(partition, "values") else tuple(partition)
+    )
+    return (
+        values,
+        bucket,
+        data_file.level,
+        data_file.file_name,
+        tuple(data_file.extra_files) if data_file.extra_files else (),
+        data_file.embedded_index,
+        data_file.external_path,
+        data_file.first_row_id,
+        data_file.row_count,
+        data_file.schema_id,
+        tuple(data_file.write_cols)
+        if data_file.write_cols is not None else None,
+    )
+
+
 class ConflictDetection:
     """Detects conflicts between base and delta files during commit."""
 
@@ -180,7 +201,87 @@ class ConflictDetection:
         self.manifest_list_manager = manifest_list_manager
         self.table = table
         self._row_id_check_from_snapshot = None
+        self._planned_row_id_ranges = []
+        self._planned_row_id_signatures = set()
+        self._rewrite_checkpoint = None
+        self._rewrite_commit_user = None
         self.commit_scanner = commit_scanner
+
+    def protect_from_external_rewrites(
+            self, checkpoint_snapshot, commit_user):
+        self._rewrite_checkpoint = checkpoint_snapshot
+        self._rewrite_commit_user = commit_user
+
+    def check_external_rewrites(self, latest_snapshot):
+        checkpoint = self._rewrite_checkpoint
+        if checkpoint is None:
+            return None
+        if latest_snapshot is None or latest_snapshot.id < checkpoint.id:
+            return RuntimeError(
+                "Offset checkpoint is no longer in the snapshot lineage.")
+        if latest_snapshot.id == checkpoint.id:
+            if self._same_snapshot(checkpoint, latest_snapshot):
+                return None
+            return RuntimeError("Offset checkpoint snapshot was replaced.")
+
+        snapshot_manager = self.table.snapshot_manager()
+        for snapshot_id in range(checkpoint.id + 1, latest_snapshot.id + 1):
+            snapshot = snapshot_manager.get_snapshot_by_id(snapshot_id)
+            if snapshot is None:
+                return RuntimeError(
+                    "Cannot validate external rewrites because snapshot "
+                    "{} expired.".format(snapshot_id))
+            if snapshot.commit_user == self._rewrite_commit_user:
+                continue
+            if snapshot.schema_id != checkpoint.schema_id:
+                return RuntimeError(
+                    "Target schema changed during the offset update.")
+            if snapshot.commit_kind == "COMPACT":
+                continue
+            if (snapshot.commit_kind == "OVERWRITE"
+                    or self.commit_scanner.snapshot_deletes_files(snapshot)):
+                return RuntimeError(
+                    "Concurrent rewrite landed during the offset update.")
+        return None
+
+    def protect_planned_row_id_files(
+            self, row_id_ranges, file_signatures):
+        self._planned_row_id_ranges = Range.sort_and_merge_overlap(
+            list(row_id_ranges or []), True, True)
+        self._planned_row_id_signatures = set(file_signatures or [])
+
+    def clear_planned_row_id_files(self):
+        self._planned_row_id_ranges = []
+        self._planned_row_id_signatures = set()
+
+    def check_planned_row_id_files(self, latest_snapshot):
+        if not self._planned_row_id_ranges:
+            return None
+        latest_entries = self.commit_scanner.read_entries_for_row_id_ranges(
+            latest_snapshot, self._planned_row_id_ranges)
+        if (self._row_id_entry_signatures(latest_entries)
+                != self._planned_row_id_signatures):
+            return RuntimeError(
+                "Target files changed after the resumable update group "
+                "was planned.")
+        return None
+
+    @staticmethod
+    def _same_snapshot(left, right):
+        if left is None or right is None:
+            return left is right
+        if left.uuid is not None or right.uuid is not None:
+            return left.id == right.id and left.uuid == right.uuid
+        return left == right
+
+    @staticmethod
+    def _row_id_entry_signatures(entries):
+        return {
+            row_id_file_signature(
+                entry.partition, entry.bucket, entry.file)
+            for entry in entries
+            if entry.kind == 0
+        }
 
     def should_be_overwrite_commit(self, append_file_entries=None, append_index_files=None):
         for entry in append_file_entries or []:

--- a/paimon-python/pypaimon/write/commit/conflict_detection.py
+++ b/paimon-python/pypaimon/write/commit/conflict_detection.py
@@ -254,6 +254,11 @@ class ConflictDetection:
         self._planned_row_id_ranges = []
         self._planned_row_id_signatures = set()
 
+    def clear_resumable_commit_guards(self):
+        self.clear_planned_row_id_files()
+        self._rewrite_checkpoint = None
+        self._rewrite_commit_user = None
+
     def check_planned_row_id_files(self, latest_snapshot):
         if not self._planned_row_id_ranges:
             return None

--- a/paimon-python/pypaimon/write/commit/conflict_detection.py
+++ b/paimon-python/pypaimon/write/commit/conflict_detection.py
@@ -259,17 +259,25 @@ class ConflictDetection:
         self._rewrite_checkpoint = None
         self._rewrite_commit_user = None
 
+    def refresh_planned_row_id_files(self, latest_snapshot):
+        if self._planned_row_id_ranges:
+            self._planned_row_id_signatures = (
+                self._current_planned_row_id_signatures(latest_snapshot))
+
     def check_planned_row_id_files(self, latest_snapshot):
         if not self._planned_row_id_ranges:
             return None
-        latest_entries = self.commit_scanner.read_entries_for_row_id_ranges(
-            latest_snapshot, self._planned_row_id_ranges)
-        if (self._row_id_entry_signatures(latest_entries)
+        if (self._current_planned_row_id_signatures(latest_snapshot)
                 != self._planned_row_id_signatures):
             return RuntimeError(
                 "Target files changed after the resumable update group "
                 "was planned.")
         return None
+
+    def _current_planned_row_id_signatures(self, snapshot):
+        entries = self.commit_scanner.read_entries_for_row_id_ranges(
+            snapshot, self._planned_row_id_ranges)
+        return self._row_id_entry_signatures(entries)
 
     @staticmethod
     def _same_snapshot(left, right):

--- a/paimon-python/pypaimon/write/file_store_commit.py
+++ b/paimon-python/pypaimon/write/file_store_commit.py
@@ -157,6 +157,10 @@ class FileStoreCommit:
         self.conflict_detection.protect_from_external_rewrites(
             checkpoint_snapshot, commit_user)
 
+    def _clear_commit_context(self):
+        self.snapshot_properties = {}
+        self.conflict_detection.clear_resumable_commit_guards()
+
     def commit_metadata(self, commit_identifier: int):
         self._try_commit(
             commit_kind="APPEND",
@@ -415,6 +419,7 @@ class FileStoreCommit:
                     and not commit_entries
                     and not index_deletes
                     and not index_adds):
+                self._clear_commit_context()
                 break
 
             result = self._try_commit_once(
@@ -461,6 +466,7 @@ class FileStoreCommit:
                         self.table.identifier,
                         commit_duration_ms,
                     )
+                self._clear_commit_context()
                 break
             else:
                 retry_result = result

--- a/paimon-python/pypaimon/write/file_store_commit.py
+++ b/paimon-python/pypaimon/write/file_store_commit.py
@@ -157,7 +157,7 @@ class FileStoreCommit:
         self.conflict_detection.protect_from_external_rewrites(
             checkpoint_snapshot, commit_user)
 
-    def _clear_commit_context(self):
+    def clear_commit_context(self):
         self.snapshot_properties = {}
         self.conflict_detection.clear_resumable_commit_guards()
 
@@ -172,6 +172,7 @@ class FileStoreCommit:
     def commit(self, commit_messages: List[CommitMessage], commit_identifier: int):
         """Commit the given commit messages in normal append mode."""
         if not commit_messages:
+            self.clear_commit_context()
             return
 
         # Extract the minimum check_from_snapshot from commit messages
@@ -295,6 +296,8 @@ class FileStoreCommit:
                 index_adds=index_adds,
                 hash_index_base_snapshot=hash_index_base_snapshot,
             )
+        else:
+            self.clear_commit_context()
 
     @staticmethod
     def _hash_index_base_snapshot(
@@ -419,7 +422,7 @@ class FileStoreCommit:
                     and not commit_entries
                     and not index_deletes
                     and not index_adds):
-                self._clear_commit_context()
+                self.clear_commit_context()
                 break
 
             result = self._try_commit_once(
@@ -441,7 +444,8 @@ class FileStoreCommit:
                 self.conflict_detection._row_id_check_from_snapshot = (
                     latest_snapshot.id
                 )
-                self.conflict_detection.clear_planned_row_id_files()
+                self.conflict_detection.refresh_planned_row_id_files(
+                    latest_snapshot)
                 # No snapshot commit was attempted for the conflicting files,
                 # so the rewritten attempt is still deterministic.
                 retry_result = None
@@ -466,7 +470,7 @@ class FileStoreCommit:
                         self.table.identifier,
                         commit_duration_ms,
                     )
-                self._clear_commit_context()
+                self.clear_commit_context()
                 break
             else:
                 retry_result = result

--- a/paimon-python/pypaimon/write/file_store_commit.py
+++ b/paimon-python/pypaimon/write/file_store_commit.py
@@ -109,6 +109,7 @@ class FileStoreCommit:
         self.table: FileStoreTable = table
         self.commit_user = commit_user
         self.commit_callbacks: List[CommitCallback] = commit_callbacks if commit_callbacks is not None else []
+        self.snapshot_properties = {}
 
         self.snapshot_manager = table.snapshot_manager()
         self.manifest_file_manager = ManifestFileManager(table)
@@ -142,6 +143,27 @@ class FileStoreCommit:
 
         table_rollback = table.catalog_environment.catalog_table_rollback()
         self.rollback = CommitRollback(table_rollback) if table_rollback is not None else None
+
+    def with_snapshot_properties(self, properties):
+        self.snapshot_properties = dict(properties or {})
+
+    def protect_planned_row_id_files(
+            self, row_id_ranges, file_signatures):
+        self.conflict_detection.protect_planned_row_id_files(
+            row_id_ranges, file_signatures)
+
+    def protect_from_external_rewrites(
+            self, checkpoint_snapshot, commit_user):
+        self.conflict_detection.protect_from_external_rewrites(
+            checkpoint_snapshot, commit_user)
+
+    def commit_metadata(self, commit_identifier: int):
+        self._try_commit(
+            commit_kind="APPEND",
+            commit_identifier=commit_identifier,
+            commit_entries_plan=lambda _snapshot: [],
+            allow_empty=True,
+        )
 
     def commit(self, commit_messages: List[CommitMessage], commit_identifier: int):
         """Commit the given commit messages in normal append mode."""
@@ -373,7 +395,7 @@ class FileStoreCommit:
     def _try_commit(self, commit_kind, commit_identifier, commit_entries_plan,
                     detect_conflicts=False, allow_rollback=False, index_deletes=None,
                     index_adds=None, changelog_entries=None,
-                    hash_index_base_snapshot=None):
+                    hash_index_base_snapshot=None, allow_empty=False):
 
         retry_count = 0
         retry_result = None
@@ -389,7 +411,10 @@ class FileStoreCommit:
 
             # No entries to commit (e.g. drop_partitions with no matching data): skip commit
             # to avoid creating manifest/snapshot with empty partition_stats (causes read errors).
-            if not commit_entries and not index_deletes and not index_adds:
+            if (not allow_empty
+                    and not commit_entries
+                    and not index_deletes
+                    and not index_adds):
                 break
 
             result = self._try_commit_once(
@@ -411,6 +436,7 @@ class FileStoreCommit:
                 self.conflict_detection._row_id_check_from_snapshot = (
                     latest_snapshot.id
                 )
+                self.conflict_detection.clear_planned_row_id_files()
                 # No snapshot commit was attempted for the conflicting files,
                 # so the rewritten attempt is still deterministic.
                 retry_result = None
@@ -479,6 +505,14 @@ class FileStoreCommit:
         start_millis = int(time.time() * 1000)
         if self._is_duplicate_commit(retry_result, latest_snapshot, commit_identifier, commit_kind):
             return SuccessResult()
+
+        rewrite_conflict = (
+            self.conflict_detection.check_external_rewrites(latest_snapshot))
+        if rewrite_conflict is not None:
+            if retry_result is None or retry_result.exception is None:
+                raise CommitConflictError(
+                    str(rewrite_conflict)) from rewrite_conflict
+            raise rewrite_conflict
 
         latest_snapshot_id = latest_snapshot.id if latest_snapshot else 0
         if (
@@ -568,6 +602,15 @@ class FileStoreCommit:
                 # callers do not delete files which a snapshot may reference.
                 raise conflict_exception
 
+        planned_conflict = (
+            self.conflict_detection.check_planned_row_id_files(
+                latest_snapshot))
+        if planned_conflict is not None:
+            if retry_result is None or retry_result.exception is None:
+                raise CommitConflictError(
+                    str(planned_conflict)) from planned_conflict
+            raise planned_conflict
+
         # Apply row tracking logic after conflict detection (matches Java ordering)
         row_tracking_enabled = self.table.options.row_tracking_enabled()
         next_row_id = None
@@ -646,6 +689,7 @@ class FileStoreCommit:
                 time_millis=int(time.time() * 1000),
                 next_row_id=next_row_id,
                 index_manifest=index_manifest,
+                properties=self.snapshot_properties,
             )
             # Generate partition statistics for the commit
             statistics = self._generate_partition_statistics(commit_entries)

--- a/paimon-python/pypaimon/write/table_commit.py
+++ b/paimon-python/pypaimon/write/table_commit.py
@@ -96,6 +96,7 @@ class TableCommit:
                 )
             else:
                 if not non_empty_messages:
+                    self.file_store_commit.clear_commit_context()
                     return
                 logger.info(
                     "Committing table %s, %d non-empty messages",

--- a/paimon-python/pypaimon/write/table_commit.py
+++ b/paimon-python/pypaimon/write/table_commit.py
@@ -61,6 +61,22 @@ class TableCommit:
         """Register a callback to be invoked after each successful commit."""
         self._commit_callbacks.append(callback)
 
+    def with_snapshot_properties(self, properties):
+        self.file_store_commit.with_snapshot_properties(properties)
+        return self
+
+    def protect_planned_row_id_files(
+            self, row_id_ranges, file_signatures):
+        self.file_store_commit.protect_planned_row_id_files(
+            row_id_ranges, file_signatures)
+        return self
+
+    def protect_from_external_rewrites(
+            self, checkpoint_snapshot, commit_user):
+        self.file_store_commit.protect_from_external_rewrites(
+            checkpoint_snapshot, commit_user)
+        return self
+
     def _commit(self, commit_messages: List[CommitMessage], commit_identifier: int = BATCH_COMMIT_IDENTIFIER):
         non_empty_messages = [msg for msg in commit_messages if not msg.is_empty()]
 
@@ -146,3 +162,6 @@ class StreamTableCommit(TableCommit):
 
     def commit(self, commit_messages: List[CommitMessage], commit_identifier: int):
         self._commit(commit_messages, commit_identifier)
+
+    def commit_metadata(self, commit_identifier: int):
+        self.file_store_commit.commit_metadata(commit_identifier)


### PR DESCRIPTION
Depends on #8826.

This adds the remaining commit primitives needed by resumable row-id writers:

- read live entries intersecting planned row-id ranges;
- verify planned target files are still live before commit;
- attach checkpoint properties and create metadata-only stream commits.

Tests: commit scanner/conflict and table commit suites; project flake8 clean.