### PR TITLE
[orc] Support time type predicate push down for orc

### DIFF
--- a/paimon-format/src/main/java/org/apache/paimon/format/orc/filter/OrcPredicateFunctionVisitor.java
+++ b/paimon-format/src/main/java/org/apache/paimon/format/orc/filter/OrcPredicateFunctionVisitor.java
@@ -230,6 +230,7 @@ public class OrcPredicateFunctionVisitor
             case SMALLINT:
             case INTEGER:
             case BIGINT:
+            case TIME_WITHOUT_TIME_ZONE:
                 return PredicateLeaf.Type.LONG;
             case FLOAT:
             case DOUBLE:

--- a/paimon-format/src/test/java/org/apache/paimon/format/orc/filter/OrcFilterConverterTest.java
+++ b/paimon-format/src/test/java/org/apache/paimon/format/orc/filter/OrcFilterConverterTest.java
@@ -287,7 +287,7 @@ public class OrcFilterConverterTest {
                 Tuple4.of(new MultisetType(new TimeType()), null, null, false),
                 Tuple4.of(new ArrayType(new TimeType()), null, null, false),
                 Tuple4.of(new MapType(new BooleanType(), new BooleanType()), null, null, false),
-                Tuple4.of(new TimeType(), null, null, false),
+                Tuple4.of(new TimeType(), PredicateLeaf.Type.LONG, 10, true),
                 Tuple4.of(new BinaryType(), PredicateLeaf.Type.STRING, LocalDateTime.now(), false),
                 Tuple4.of(
                         new VarBinaryType(), PredicateLeaf.Type.STRING, LocalDateTime.now(), false),


### PR DESCRIPTION
### Purpose
 - OrcPredicateFunctionVisitor has no case for the Time type, `toOrcType` returns null and predicates on `time` column are dropped.
 - Map the time column to predicate long so can push down filter to orc.

### Tests
 - UT