### PR TITLE
[python] Fix benchmark package lint

### DIFF
--- a/paimon-python/pypaimon/benchmark/__init__.py
+++ b/paimon-python/pypaimon/benchmark/__init__.py
@@ -14,4 +14,3 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-


### PR DESCRIPTION
### Purpose

The regular Python CI fails flake8 with `W391 blank line at end of file` for `pypaimon/benchmark/__init__.py`.

### Changes

Remove the trailing blank line from the benchmark package initializer.

### Tests

- `flake8 --config=dev/cfg.ini pypaimon/benchmark/__init__.py`
- `python dev/check_license_header.py`
- `git diff --check`