### PR TITLE
[format] Fix DELETE and UPDATE targeting wrong rows after Parquet predicate filtering

### DIFF
--- a/paimon-format/src/main/java/org/apache/paimon/format/parquet/reader/ColumnarBatch.java
+++ b/paimon-format/src/main/java/org/apache/paimon/format/parquet/reader/ColumnarBatch.java
@@ -67,6 +67,10 @@ public class ColumnarBatch {
         this.vectorizedColumnBatch.setNumRows(numRows);
     }
 
+    int numRows() {
+        return vectorizedColumnBatch.getNumRows();
+    }
+
     /** Returns the column at `ordinal`. */
     public ColumnVector column(int ordinal) {
         return columns[ordinal];

--- a/paimon-format/src/main/java/org/apache/paimon/format/parquet/reader/RowIndexGenerator.java
+++ b/paimon-format/src/main/java/org/apache/paimon/format/parquet/reader/RowIndexGenerator.java
@@ -29,9 +29,11 @@ import java.util.PrimitiveIterator;
 public class RowIndexGenerator implements LongIterator {
 
     private LongIterator rowIndexIterator;
+    private long pendingSkips;
     private int remainingIndexes;
 
     public void initFromPageReadStore(PageReadStore pageReadStore) {
+        pendingSkips = 0;
         remainingIndexes = 0;
         long startingRowIdx = pageReadStore.getRowIndexOffset().orElse(0L);
         PrimitiveIterator.OfLong rowIndexes = pageReadStore.getRowIndexes().orElse(null);
@@ -56,10 +58,7 @@ public class RowIndexGenerator implements LongIterator {
     }
 
     public void populateRowIndex(ColumnarBatch columnarBatch) {
-        // Positions are consumed lazily, so finish the previous batch first.
-        while (remainingIndexes > 0) {
-            next();
-        }
+        pendingSkips += remainingIndexes;
         remainingIndexes = columnarBatch.numRows();
         columnarBatch.resetPositions(this);
     }
@@ -73,6 +72,10 @@ public class RowIndexGenerator implements LongIterator {
     public long next() {
         if (remainingIndexes == 0) {
             throw new NoSuchElementException();
+        }
+        while (pendingSkips > 0) {
+            rowIndexIterator.next();
+            pendingSkips--;
         }
         long index = rowIndexIterator.next();
         remainingIndexes--;

--- a/paimon-format/src/main/java/org/apache/paimon/format/parquet/reader/RowIndexGenerator.java
+++ b/paimon-format/src/main/java/org/apache/paimon/format/parquet/reader/RowIndexGenerator.java
@@ -22,14 +22,17 @@ import org.apache.paimon.utils.LongIterator;
 
 import org.apache.parquet.column.page.PageReadStore;
 
+import java.util.NoSuchElementException;
 import java.util.PrimitiveIterator;
 
 /** Generate row index for columnar batch. */
-public class RowIndexGenerator {
+public class RowIndexGenerator implements LongIterator {
 
     private LongIterator rowIndexIterator;
+    private int remainingIndexes;
 
     public void initFromPageReadStore(PageReadStore pageReadStore) {
+        remainingIndexes = 0;
         long startingRowIdx = pageReadStore.getRowIndexOffset().orElse(0L);
         PrimitiveIterator.OfLong rowIndexes = pageReadStore.getRowIndexes().orElse(null);
         if (rowIndexes != null) {
@@ -53,6 +56,26 @@ public class RowIndexGenerator {
     }
 
     public void populateRowIndex(ColumnarBatch columnarBatch) {
-        columnarBatch.resetPositions(rowIndexIterator);
+        // Positions are consumed lazily, so finish the previous batch first.
+        while (remainingIndexes > 0) {
+            next();
+        }
+        remainingIndexes = columnarBatch.numRows();
+        columnarBatch.resetPositions(this);
+    }
+
+    @Override
+    public boolean hasNext() {
+        return remainingIndexes > 0 && rowIndexIterator.hasNext();
+    }
+
+    @Override
+    public long next() {
+        if (remainingIndexes == 0) {
+            throw new NoSuchElementException();
+        }
+        long index = rowIndexIterator.next();
+        remainingIndexes--;
+        return index;
     }
 }

--- a/paimon-format/src/test/java/org/apache/paimon/format/parquet/reader/RowIndexGeneratorTest.java
+++ b/paimon-format/src/test/java/org/apache/paimon/format/parquet/reader/RowIndexGeneratorTest.java
@@ -32,6 +32,9 @@ import org.apache.parquet.column.page.PageReader;
 import org.junit.jupiter.api.Test;
 
 import java.util.Collections;
+import java.util.Optional;
+import java.util.PrimitiveIterator;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -40,6 +43,22 @@ public class RowIndexGeneratorTest {
 
     @Test
     public void testLazyRowIdAcrossBatches() {
+        AtomicInteger consumed = new AtomicInteger();
+        PrimitiveIterator.OfLong indexes =
+                new PrimitiveIterator.OfLong() {
+                    private long next;
+
+                    @Override
+                    public long nextLong() {
+                        consumed.incrementAndGet();
+                        return next++;
+                    }
+
+                    @Override
+                    public boolean hasNext() {
+                        return next < 6;
+                    }
+                };
         HeapLongVector rowIds = new HeapLongVector(3);
         rowIds.fillWithNulls();
         ColumnarBatch batch =
@@ -60,6 +79,11 @@ public class RowIndexGeneratorTest {
                     public long getRowCount() {
                         return 6;
                     }
+
+                    @Override
+                    public Optional<PrimitiveIterator.OfLong> getRowIndexes() {
+                        return Optional.of(indexes);
+                    }
                 };
         RowIndexGenerator generator = new RowIndexGenerator();
         generator.initFromPageReadStore(page);
@@ -73,7 +97,9 @@ public class RowIndexGeneratorTest {
 
         batch.setNumRows(3);
         generator.populateRowIndex(batch);
+        assertThat(consumed).hasValue(0);
         row = iterator.next();
         assertThat(row.getLong(1)).isEqualTo(500_003L);
+        assertThat(consumed).hasValue(4);
     }
 }

--- a/paimon-format/src/test/java/org/apache/paimon/format/parquet/reader/RowIndexGeneratorTest.java
+++ b/paimon-format/src/test/java/org/apache/paimon/format/parquet/reader/RowIndexGeneratorTest.java
@@ -34,6 +34,7 @@ import org.junit.jupiter.api.Test;
 import java.util.Collections;
 import java.util.Optional;
 import java.util.PrimitiveIterator;
+import java.util.stream.LongStream;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -96,6 +97,33 @@ public class RowIndexGeneratorTest {
         assertThat(indexes.nextIndex).isEqualTo(7);
     }
 
+    @Test
+    public void testRowGroupResetDropsPendingPositions() {
+        CountingRowIndexes firstGroup = new CountingRowIndexes(3);
+        RowIndexGenerator generator = newGenerator(firstGroup);
+        ColumnarBatch batch = newBatch();
+        generator.populateRowIndex(batch);
+
+        CountingRowIndexes secondGroup = new CountingRowIndexes(3);
+        initGenerator(generator, secondGroup, 100);
+        generator.populateRowIndex(batch);
+
+        assertThat(firstGroup.nextIndex).isZero();
+        assertThat(generator.next()).isEqualTo(100);
+    }
+
+    @Test
+    public void testNonContinuousRowIndexes() {
+        PrimitiveIterator.OfLong indexes = LongStream.of(1, 4, 9, 12, 20, 30).iterator();
+        RowIndexGenerator generator = newGenerator(indexes, 6);
+        ColumnarBatch batch = newBatch();
+
+        generator.populateRowIndex(batch);
+        generator.populateRowIndex(batch);
+
+        assertThat(generator.next()).isEqualTo(12);
+    }
+
     private static ColumnarBatch newBatch() {
         ColumnarBatch batch =
                 new ColumnarBatch(
@@ -105,6 +133,25 @@ public class RowIndexGeneratorTest {
     }
 
     private static RowIndexGenerator newGenerator(CountingRowIndexes indexes) {
+        return newGenerator(indexes, indexes.end);
+    }
+
+    private static RowIndexGenerator newGenerator(PrimitiveIterator.OfLong indexes, long rowCount) {
+        RowIndexGenerator generator = new RowIndexGenerator();
+        initGenerator(generator, indexes, rowCount, 0);
+        return generator;
+    }
+
+    private static void initGenerator(
+            RowIndexGenerator generator, CountingRowIndexes indexes, long rowIndexOffset) {
+        initGenerator(generator, indexes, indexes.end, rowIndexOffset);
+    }
+
+    private static void initGenerator(
+            RowIndexGenerator generator,
+            PrimitiveIterator.OfLong indexes,
+            long rowCount,
+            long rowIndexOffset) {
         PageReadStore page =
                 new PageReadStore() {
                     @Override
@@ -114,7 +161,12 @@ public class RowIndexGeneratorTest {
 
                     @Override
                     public long getRowCount() {
-                        return indexes.end;
+                        return rowCount;
+                    }
+
+                    @Override
+                    public Optional<Long> getRowIndexOffset() {
+                        return Optional.of(rowIndexOffset);
                     }
 
                     @Override
@@ -122,9 +174,7 @@ public class RowIndexGeneratorTest {
                         return Optional.of(indexes);
                     }
                 };
-        RowIndexGenerator generator = new RowIndexGenerator();
         generator.initFromPageReadStore(page);
-        return generator;
     }
 
     private static class CountingRowIndexes implements PrimitiveIterator.OfLong {

--- a/paimon-format/src/test/java/org/apache/paimon/format/parquet/reader/RowIndexGeneratorTest.java
+++ b/paimon-format/src/test/java/org/apache/paimon/format/parquet/reader/RowIndexGeneratorTest.java
@@ -34,7 +34,6 @@ import org.junit.jupiter.api.Test;
 import java.util.Collections;
 import java.util.Optional;
 import java.util.PrimitiveIterator;
-import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -43,22 +42,7 @@ public class RowIndexGeneratorTest {
 
     @Test
     public void testLazyRowIdAcrossBatches() {
-        AtomicInteger consumed = new AtomicInteger();
-        PrimitiveIterator.OfLong indexes =
-                new PrimitiveIterator.OfLong() {
-                    private long next;
-
-                    @Override
-                    public long nextLong() {
-                        consumed.incrementAndGet();
-                        return next++;
-                    }
-
-                    @Override
-                    public boolean hasNext() {
-                        return next < 6;
-                    }
-                };
+        CountingRowIndexes indexes = new CountingRowIndexes(6);
         HeapLongVector rowIds = new HeapLongVector(3);
         rowIds.fillWithNulls();
         ColumnarBatch batch =
@@ -68,25 +52,7 @@ public class RowIndexGeneratorTest {
         iterator.assignRowTracking(
                 500_000L, 1L, Collections.singletonMap(SpecialFields.ROW_ID.name(), 1));
 
-        PageReadStore page =
-                new PageReadStore() {
-                    @Override
-                    public PageReader getPageReader(ColumnDescriptor descriptor) {
-                        return null;
-                    }
-
-                    @Override
-                    public long getRowCount() {
-                        return 6;
-                    }
-
-                    @Override
-                    public Optional<PrimitiveIterator.OfLong> getRowIndexes() {
-                        return Optional.of(indexes);
-                    }
-                };
-        RowIndexGenerator generator = new RowIndexGenerator();
-        generator.initFromPageReadStore(page);
+        RowIndexGenerator generator = newGenerator(indexes);
 
         batch.setNumRows(3);
         generator.populateRowIndex(batch);
@@ -97,9 +63,87 @@ public class RowIndexGeneratorTest {
 
         batch.setNumRows(3);
         generator.populateRowIndex(batch);
-        assertThat(consumed).hasValue(0);
+        assertThat(indexes.nextIndex).isZero();
         row = iterator.next();
         assertThat(row.getLong(1)).isEqualTo(500_003L);
-        assertThat(consumed).hasValue(4);
+        assertThat(indexes.nextIndex).isEqualTo(4);
+    }
+
+    @Test
+    public void testPartiallyConsumedBatch() {
+        CountingRowIndexes indexes = new CountingRowIndexes(6);
+        RowIndexGenerator generator = newGenerator(indexes);
+        ColumnarBatch batch = newBatch();
+
+        generator.populateRowIndex(batch);
+        assertThat(generator.next()).isZero();
+
+        generator.populateRowIndex(batch);
+        assertThat(generator.next()).isEqualTo(3);
+    }
+
+    @Test
+    public void testMultipleUnconsumedBatchesStayLazy() {
+        CountingRowIndexes indexes = new CountingRowIndexes(9);
+        RowIndexGenerator generator = newGenerator(indexes);
+        ColumnarBatch batch = newBatch();
+
+        generator.populateRowIndex(batch);
+        generator.populateRowIndex(batch);
+        generator.populateRowIndex(batch);
+        assertThat(indexes.nextIndex).isZero();
+        assertThat(generator.next()).isEqualTo(6);
+        assertThat(indexes.nextIndex).isEqualTo(7);
+    }
+
+    private static ColumnarBatch newBatch() {
+        ColumnarBatch batch =
+                new ColumnarBatch(
+                        new Path("test"), new ColumnVector[] {new HeapIntVector(3)}, null);
+        batch.setNumRows(3);
+        return batch;
+    }
+
+    private static RowIndexGenerator newGenerator(CountingRowIndexes indexes) {
+        PageReadStore page =
+                new PageReadStore() {
+                    @Override
+                    public PageReader getPageReader(ColumnDescriptor descriptor) {
+                        return null;
+                    }
+
+                    @Override
+                    public long getRowCount() {
+                        return indexes.end;
+                    }
+
+                    @Override
+                    public Optional<PrimitiveIterator.OfLong> getRowIndexes() {
+                        return Optional.of(indexes);
+                    }
+                };
+        RowIndexGenerator generator = new RowIndexGenerator();
+        generator.initFromPageReadStore(page);
+        return generator;
+    }
+
+    private static class CountingRowIndexes implements PrimitiveIterator.OfLong {
+
+        private final long end;
+        private long nextIndex;
+
+        private CountingRowIndexes(long end) {
+            this.end = end;
+        }
+
+        @Override
+        public long nextLong() {
+            return nextIndex++;
+        }
+
+        @Override
+        public boolean hasNext() {
+            return nextIndex < end;
+        }
     }
 }

--- a/paimon-format/src/test/java/org/apache/paimon/format/parquet/reader/RowIndexGeneratorTest.java
+++ b/paimon-format/src/test/java/org/apache/paimon/format/parquet/reader/RowIndexGeneratorTest.java
@@ -1,0 +1,79 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.format.parquet.reader;
+
+import org.apache.paimon.data.InternalRow;
+import org.apache.paimon.data.columnar.ColumnVector;
+import org.apache.paimon.data.columnar.ColumnarRowIterator;
+import org.apache.paimon.data.columnar.heap.HeapIntVector;
+import org.apache.paimon.data.columnar.heap.HeapLongVector;
+import org.apache.paimon.fs.Path;
+import org.apache.paimon.table.SpecialFields;
+
+import org.apache.parquet.column.ColumnDescriptor;
+import org.apache.parquet.column.page.PageReadStore;
+import org.apache.parquet.column.page.PageReader;
+import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Tests for {@link RowIndexGenerator}. */
+public class RowIndexGeneratorTest {
+
+    @Test
+    public void testLazyRowIdAcrossBatches() {
+        HeapLongVector rowIds = new HeapLongVector(3);
+        rowIds.fillWithNulls();
+        ColumnarBatch batch =
+                new ColumnarBatch(
+                        new Path("test"), new ColumnVector[] {new HeapIntVector(3), rowIds}, null);
+        ColumnarRowIterator iterator = batch.vectorizedRowIterator;
+        iterator.assignRowTracking(
+                500_000L, 1L, Collections.singletonMap(SpecialFields.ROW_ID.name(), 1));
+
+        PageReadStore page =
+                new PageReadStore() {
+                    @Override
+                    public PageReader getPageReader(ColumnDescriptor descriptor) {
+                        return null;
+                    }
+
+                    @Override
+                    public long getRowCount() {
+                        return 6;
+                    }
+                };
+        RowIndexGenerator generator = new RowIndexGenerator();
+        generator.initFromPageReadStore(page);
+
+        batch.setNumRows(3);
+        generator.populateRowIndex(batch);
+        InternalRow row;
+        while ((row = iterator.next()) != null) {
+            row.getInt(0);
+        }
+
+        batch.setNumRows(3);
+        generator.populateRowIndex(batch);
+        row = iterator.next();
+        assertThat(row.getLong(1)).isEqualTo(500_003L);
+    }
+}


### PR DESCRIPTION
### Purpose

Parquet row positions used to derive `_ROW_ID` are consumed lazily. Query engines may evaluate a predicate first and read `_ROW_ID` only for matching rows. If an entire vectorized batch is filtered out, its positions remain unconsumed, so rows in the next batch receive stale `_ROW_ID` values.

For example, with a batch size of 2048, a matching row at physical position 2760 may receive the row ID for position 712. A DELETE or UPDATE based on that `_ROW_ID` can therefore modify the wrong row.

Carry unconsumed positions across batches and skip them only when a later row position is requested.

### Tests

- Covered fully skipped, partially consumed, and multiple unconsumed batches.
- Covered row-group resets and non-continuous selected row indexes.
- Verified that positions remain unconsumed until `_ROW_ID` is read.
- Related Parquet tests: 51 passed.