### PR TITLE
[core] Fix dropping stats in data evolution scan

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/operation/DataEvolutionFileStoreScan.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/DataEvolutionFileStoreScan.java
@@ -181,24 +181,27 @@ public class DataEvolutionFileStoreScan extends AppendOnlyFileStoreScan {
 
     @Override
     protected boolean postFilterManifestEntriesEnabled() {
-        // Always enable post-filtering. The list filterByStats handles predicate-based pruning
-        // and pruneByReadType strips per-file columns that are not requested — both
-        // need row-id-range grouping that single filterByStats(ManifestEntry) cannot see.
-        return inputFilter != null || readType != null;
+        return true;
     }
 
     @Override
     protected List<ManifestEntry> postFilterManifestEntries(List<ManifestEntry> entries) {
-        // group by row id range
-        RangeHelper<ManifestEntry> rangeHelper =
-                new RangeHelper<>(e -> e.file().nonNullRowIdRange());
-        List<List<ManifestEntry>> splitByRowId = rangeHelper.mergeOverlappingRanges(entries);
+        if (inputFilter != null || readType != null) {
+            // group by row id range
+            RangeHelper<ManifestEntry> rangeHelper =
+                    new RangeHelper<>(e -> e.file().nonNullRowIdRange());
+            List<List<ManifestEntry>> splitByRowId = rangeHelper.mergeOverlappingRanges(entries);
 
-        return splitByRowId.stream()
-                .filter(group -> inputFilter == null || filterByStats(group))
-                .flatMap(group -> pruneByReadType(group).stream())
-                .map(entry -> dropStats ? dropStats(entry) : entry)
-                .collect(Collectors.toList());
+            return splitByRowId.stream()
+                    .filter(group -> inputFilter == null || filterByStats(group))
+                    .flatMap(group -> pruneByReadType(group).stream())
+                    .map(entry -> dropStats ? dropStats(entry) : entry)
+                    .collect(Collectors.toList());
+        } else if (dropStats) {
+            return entries.stream().map(this::dropStats).collect(Collectors.toList());
+        } else {
+            return entries;
+        }
     }
 
     private boolean filterByStats(List<ManifestEntry> entries) {

--- a/paimon-core/src/test/java/org/apache/paimon/table/DataEvolutionTableTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/table/DataEvolutionTableTest.java
@@ -70,6 +70,7 @@ import java.util.OptionalLong;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
 
+import static org.apache.paimon.stats.SimpleStats.EMPTY_STATS;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 
 /** Test for table with data evolution. */
@@ -2096,18 +2097,26 @@ public class DataEvolutionTableTest extends DataEvolutionTestBase {
         assertThat(plannedFileCount(table, readF2, null)).isEqualTo(2);
     }
 
-    /**
-     * System-field-only projection is filtered out of readType in
-     * DataEvolutionFileStoreScan.withReadType — readType stays null and
-     * postFilterManifestEntriesEnabled returns false. The column-pruning path is not entered, so
-     * every file in every group flows through unchanged.
-     */
+    /** System-field-only projection is not used for per-file column pruning. */
     @Test
     public void testSystemFieldOnlyProjectionIsNotPruned() throws Exception {
         write(5);
         FileStoreTable table = getTableDefault();
         assertThat(plannedFileCount(table, null, null)).isEqualTo(2);
         assertThat(plannedFileCount(table, RowType.of(SpecialFields.ROW_ID), null)).isEqualTo(2);
+    }
+
+    @Test
+    public void testDropStatsWithoutFilterOrReadType() throws Exception {
+        write(5);
+
+        List<ManifestEntry> entries =
+                getTableDefault().store().newScan().dropStats().plan().files();
+
+        assertThat(entries.isEmpty()).isFalse();
+        for (ManifestEntry entry : entries) {
+            assertThat(entry.file().valueStats()).isEqualTo(EMPTY_STATS);
+        }
     }
 
     private List<DataFileMeta> writeOneFullRowAndCollectNewFiles(FileStoreTable table)


### PR DESCRIPTION
### Purpose

`DataEvolutionFileStoreScan` keeps file statistics during manifest reading because predicate evaluation and per-file column pruning are performed in `postFilterManifestEntries`.

When neither an input filter nor a read type is configured, `postFilterManifestEntriesEnabled()` previously returned `false`. As a result, calling `dropStats()` had no effect because the post-filtering hook that removes statistics was skipped.

This change:

- always enables post-filtering for data-evolution scans;
- preserves row-id grouping, statistics filtering, and read-type pruning when an input filter or read type is present;
- directly drops statistics when neither an input filter nor a read type is present;
- adds a regression test for `dropStats()` without a filter or read type.

### Tests

- `mvn -pl paimon-core -DwildcardSuites=none -Dtest=DataEvolutionTableTest#testDropStatsWithoutFilterOrReadType+testSystemFieldOnlyProjectionIsNotPruned test`
- `mvn -pl paimon-core -Pfast-build -DwildcardSuites=none -Dtest=DataEvolutionTableTest test` (42 tests)
