### PR TITLE
[flink] Expose sorted index build stream

### DIFF
--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/globalindex/SortedIndexTopoBuilder.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/globalindex/SortedIndexTopoBuilder.java
@@ -101,6 +101,36 @@ public class SortedIndexTopoBuilder {
             PartitionPredicate partitionPredicate,
             Options userOptions)
             throws Exception {
+        Optional<DataStream<Committable>> written =
+                buildIndexStream(
+                        env,
+                        indexBuilderSupplier,
+                        table,
+                        indexColumns,
+                        partitionPredicate,
+                        userOptions);
+        if (!written.isPresent()) {
+            return false;
+        }
+
+        commit(table, written.get(), CoreOptions.createCommitUser(userOptions));
+        return true;
+    }
+
+    /**
+     * Builds sorted indexes and returns their committables without attaching a committer.
+     *
+     * <p>This allows callers which combine multiple maintenance topologies to send all committables
+     * to one shared committer.
+     */
+    public static Optional<DataStream<Committable>> buildIndexStream(
+            StreamExecutionEnvironment env,
+            Supplier<SortedGlobalIndexBuilder> indexBuilderSupplier,
+            FileStoreTable table,
+            List<String> indexColumns,
+            PartitionPredicate partitionPredicate,
+            Options userOptions)
+            throws Exception {
         List<DataStream<Committable>> allStreams = new ArrayList<>();
         for (String indexColumn : indexColumns) {
             SortedGlobalIndexBuilder indexBuilder =
@@ -175,7 +205,7 @@ public class SortedIndexTopoBuilder {
             }
 
             if (buildTasks.isEmpty()) {
-                return false;
+                return Optional.empty();
             }
 
             DataStream<Committable> commitMessages =
@@ -198,15 +228,13 @@ public class SortedIndexTopoBuilder {
 
             allStreams.add(commitMessages);
         }
-        if (!allStreams.isEmpty()) {
-            @SuppressWarnings("unchecked")
-            DataStream<Committable>[] rest =
-                    allStreams.subList(1, allStreams.size()).toArray(new DataStream[0]);
-            commit(table, allStreams.get(0).union(rest), CoreOptions.createCommitUser(userOptions));
-            return true;
+        if (allStreams.isEmpty()) {
+            return Optional.empty();
         }
-
-        return false;
+        @SuppressWarnings("unchecked")
+        DataStream<Committable>[] rest =
+                allStreams.subList(1, allStreams.size()).toArray(new DataStream[0]);
+        return Optional.of(allStreams.get(0).union(rest));
     }
 
     public static void buildIndexAndExecute(

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/globalindex/SortedIndexTopoBuilderTest.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/globalindex/SortedIndexTopoBuilderTest.java
@@ -118,6 +118,26 @@ public class SortedIndexTopoBuilderTest {
     }
 
     @Test
+    public void testBuildIndexStreamReturnsEmptyWhenNoBuildTask() throws Exception {
+        SortedGlobalIndexBuilder indexBuilder = mock(SortedGlobalIndexBuilder.class);
+        when(indexBuilder.withIndexField("id")).thenReturn(indexBuilder);
+        when(indexBuilder.incrementalScan()).thenReturn(Optional.empty());
+        StreamExecutionEnvironment env = mock(StreamExecutionEnvironment.class);
+
+        assertThat(
+                        SortedIndexTopoBuilder.buildIndexStream(
+                                env,
+                                () -> indexBuilder,
+                                mock(FileStoreTable.class),
+                                Collections.singletonList("id"),
+                                null,
+                                new Options()))
+                .isEmpty();
+        verify(indexBuilder).incrementalScan();
+        verifyNoInteractions(env);
+    }
+
+    @Test
     public void testCalculateParallelismByTotalRowsInsteadOfRangeCount() {
         List<SortedBuildTask> tasks = new ArrayList<>();
         for (int i = 0; i < 100; i++) {


### PR DESCRIPTION
## What changed

- Expose `SortedIndexTopoBuilder.buildIndexStream(...)` to build sorted-index committables without attaching a committer.
- Keep `buildIndex(...)` behavior unchanged by delegating to the stream builder and attaching the default committer.
- Add coverage for the empty-build-plan result.

## Why

Callers that combine multiple maintenance topologies need to union their committable streams and attach one shared committer. Previously `SortedIndexTopoBuilder` always attached its own committer, forcing downstream projects to copy the topology builder.

## Validation

- `mvn -pl paimon-flink/paimon-flink-common -am -Pfast-build -Pflink1 -DwildcardSuites=none -DfailIfNoTests=false -Dsurefire.failIfNoSpecifiedTests=false -Dtest=SortedIndexTopoBuilderTest test`
- `mvn -pl paimon-flink/paimon-flink-common -am -Pflink1 -DwildcardSuites=none -DfailIfNoTests=false -Dsurefire.failIfNoSpecifiedTests=false -Dtest=SortedIndexTopoBuilderTest test`