### PR TITLE
[format] Avoid lossy Parquet predicate pushdown

### DIFF
--- a/paimon-format/src/main/java/org/apache/parquet/filter2/predicate/ParquetFilters.java
+++ b/paimon-format/src/main/java/org/apache/parquet/filter2/predicate/ParquetFilters.java
@@ -571,8 +571,9 @@ public class ParquetFilters {
 
     /**
      * The physical types a predicate on this Paimon type can be expressed in, most preferred first.
-     * The head is what Paimon itself writes; the tail is the type widening the vectorized reader
-     * accepts, so pushdown stays available for exactly the files that can be read.
+     * The head is what Paimon itself writes; the tail is a different type the vectorized reader
+     * accepts without changing predicate semantics. Lossy narrowing is excluded even when the file
+     * can be read, because filtering happens before the reader converts the value.
      */
     private static PrimitiveType.PrimitiveTypeName[] acceptableTypes(
             org.apache.paimon.types.DataType type) {
@@ -583,6 +584,11 @@ public class ParquetFilters {
                 };
             case TINYINT:
             case SMALLINT:
+                // Their INT64 readers cast values outside the target range, so a predicate on the
+                // converted value cannot safely prune the original long value.
+                return new PrimitiveType.PrimitiveTypeName[] {
+                    PrimitiveType.PrimitiveTypeName.INT32
+                };
             case INTEGER:
                 return new PrimitiveType.PrimitiveTypeName[] {
                     PrimitiveType.PrimitiveTypeName.INT32, PrimitiveType.PrimitiveTypeName.INT64
@@ -592,8 +598,9 @@ public class ParquetFilters {
                     PrimitiveType.PrimitiveTypeName.INT64, PrimitiveType.PrimitiveTypeName.INT32
                 };
             case FLOAT:
+                // A DOUBLE file value may round to the predicate's FLOAT value only after reading.
                 return new PrimitiveType.PrimitiveTypeName[] {
-                    PrimitiveType.PrimitiveTypeName.FLOAT, PrimitiveType.PrimitiveTypeName.DOUBLE
+                    PrimitiveType.PrimitiveTypeName.FLOAT
                 };
             case DOUBLE:
                 // A double bound cannot be narrowed to float without rounding it, so a FLOAT file

--- a/paimon-format/src/main/java/org/apache/parquet/filter2/predicate/ParquetFilters.java
+++ b/paimon-format/src/main/java/org/apache/parquet/filter2/predicate/ParquetFilters.java
@@ -543,12 +543,40 @@ public class ParquetFilters {
             throw new UnsupportedOperationException();
         }
 
+        validateNarrowIntegerPushdown(fieldRef, fileType);
+
         for (PrimitiveType.PrimitiveTypeName candidate : acceptable) {
             if (fileType.getPrimitiveTypeName() == candidate) {
                 return new PushdownTarget(fileType.getName(), candidate);
             }
         }
         throw new UnsupportedOperationException();
+    }
+
+    /** Reject physical integer ranges that the declared narrow type cannot preserve on read. */
+    private static void validateNarrowIntegerPushdown(FieldRef fieldRef, PrimitiveType fileType) {
+        int maxBitWidth;
+        switch (fieldRef.type().getTypeRoot()) {
+            case TINYINT:
+                maxBitWidth = 8;
+                break;
+            case SMALLINT:
+                maxBitWidth = 16;
+                break;
+            default:
+                return;
+        }
+
+        LogicalTypeAnnotation logicalType = fileType.getLogicalTypeAnnotation();
+        if (!(logicalType instanceof LogicalTypeAnnotation.IntLogicalTypeAnnotation)) {
+            throw new UnsupportedOperationException();
+        }
+
+        LogicalTypeAnnotation.IntLogicalTypeAnnotation intType =
+                (LogicalTypeAnnotation.IntLogicalTypeAnnotation) logicalType;
+        if (!intType.isSigned() || intType.getBitWidth() > maxBitWidth) {
+            throw new UnsupportedOperationException();
+        }
     }
 
     /**
@@ -584,8 +612,7 @@ public class ParquetFilters {
                 };
             case TINYINT:
             case SMALLINT:
-                // Their INT64 readers cast values outside the target range, so a predicate on the
-                // converted value cannot safely prune the original long value.
+                // INT64 is lossy; INT32 annotations are validated by pushdownTarget.
                 return new PrimitiveType.PrimitiveTypeName[] {
                     PrimitiveType.PrimitiveTypeName.INT32
                 };

--- a/paimon-format/src/test/java/org/apache/paimon/format/parquet/ParquetTypeWideningTest.java
+++ b/paimon-format/src/test/java/org/apache/paimon/format/parquet/ParquetTypeWideningTest.java
@@ -305,6 +305,86 @@ class ParquetTypeWideningTest {
                 .containsExactly((short) -1, (short) -1, (short) -1);
     }
 
+    /** A bare INT32 may also wrap when read as TINYINT, so its predicate cannot be pushed. */
+    @Test
+    void testInt32ReadAsTinyIntDoesNotPushLossyPredicate() throws Exception {
+        RowType readType =
+                RowType.builder()
+                        .field("pageviewId", DataTypes.STRING())
+                        .field("ecpm", DataTypes.TINYINT())
+                        .build();
+        Path path = write(ecpmSchema("int32 ecpm"), (group, i) -> group.append("ecpm", 128));
+        PredicateBuilder builder = new PredicateBuilder(readType);
+
+        List<Object[]> rows =
+                read(readType, path, Collections.singletonList(builder.equal(1, (byte) -128)));
+
+        assertThat(rows)
+                .extracting(row -> row[1])
+                .containsExactly((byte) -128, (byte) -128, (byte) -128);
+    }
+
+    /** A bare INT32 may also wrap when read as SMALLINT, so its predicate cannot be pushed. */
+    @Test
+    void testInt32ReadAsSmallIntDoesNotPushLossyPredicate() throws Exception {
+        RowType readType =
+                RowType.builder()
+                        .field("pageviewId", DataTypes.STRING())
+                        .field("ecpm", DataTypes.SMALLINT())
+                        .build();
+        Path path = write(ecpmSchema("int32 ecpm"), (group, i) -> group.append("ecpm", 65_535));
+        PredicateBuilder builder = new PredicateBuilder(readType);
+
+        List<Object[]> rows =
+                read(readType, path, Collections.singletonList(builder.equal(1, (short) -1)));
+
+        assertThat(rows)
+                .extracting(row -> row[1])
+                .containsExactly((short) -1, (short) -1, (short) -1);
+    }
+
+    /** A wider signed annotation still permits values outside the declared TINYINT range. */
+    @Test
+    void testInt16ReadAsTinyIntDoesNotPushLossyPredicate() throws Exception {
+        RowType readType =
+                RowType.builder()
+                        .field("pageviewId", DataTypes.STRING())
+                        .field("ecpm", DataTypes.TINYINT())
+                        .build();
+        Path path =
+                write(
+                        ecpmSchema("int32 ecpm (INTEGER(16,true))"),
+                        (group, i) -> group.append("ecpm", 128));
+        PredicateBuilder builder = new PredicateBuilder(readType);
+
+        List<Object[]> rows =
+                read(readType, path, Collections.singletonList(builder.equal(1, (byte) -128)));
+
+        assertThat(rows)
+                .extracting(row -> row[1])
+                .containsExactly((byte) -128, (byte) -128, (byte) -128);
+    }
+
+    /** Matching signed integer annotations retain predicate pushdown for valid physical values. */
+    @Test
+    void testAnnotatedInt8PushdownStillPrunes() throws Exception {
+        RowType readType =
+                RowType.builder()
+                        .field("pageviewId", DataTypes.STRING())
+                        .field("ecpm", DataTypes.TINYINT())
+                        .build();
+        Path path =
+                write(
+                        ecpmSchema("int32 ecpm (INTEGER(8,true))"),
+                        (group, i) -> group.append("ecpm", i + 1));
+        PredicateBuilder builder = new PredicateBuilder(readType);
+
+        List<Object[]> rows =
+                read(readType, path, Collections.singletonList(builder.greaterThan(1, (byte) 99)));
+
+        assertThat(rows).isEmpty();
+    }
+
     // ------------------------------------------------------------------
     // Control and mixed-file cases.
     // ------------------------------------------------------------------

--- a/paimon-format/src/test/java/org/apache/paimon/format/parquet/ParquetTypeWideningTest.java
+++ b/paimon-format/src/test/java/org/apache/paimon/format/parquet/ParquetTypeWideningTest.java
@@ -221,6 +221,30 @@ class ParquetTypeWideningTest {
         assertThat(rows).hasSize(3);
     }
 
+    /** DOUBLE values are rounded while reading, so predicates cannot be pushed before the cast. */
+    @Test
+    void testDoubleReadAsFloatDoesNotPushLossyPredicate() throws Exception {
+        RowType readType =
+                RowType.builder()
+                        .field("pageviewId", DataTypes.STRING())
+                        .field("rate", DataTypes.FLOAT())
+                        .build();
+        Path path =
+                writeSchema(
+                        "message root {\n"
+                                + "  optional binary pageviewId (UTF8);\n"
+                                + "  optional double rate;\n"
+                                + "}",
+                        (group, i) ->
+                                group.append("pageviewId", PAGEVIEW_IDS[i]).append("rate", 0.1d));
+        PredicateBuilder builder = new PredicateBuilder(readType);
+
+        List<Object[]> rows =
+                read(readType, path, Collections.singletonList(builder.equal(1, 0.1f)));
+
+        assertThat(rows).extracting(row -> row[1]).containsExactly(0.1f, 0.1f, 0.1f);
+    }
+
     // ------------------------------------------------------------------
     // Narrowing INT64 -> INT. The reader already handles it via
     // IntegerFromLongUpdater; only the pushdown was left behind.
@@ -241,6 +265,44 @@ class ParquetTypeWideningTest {
 
         assertThat(rows).hasSize(3);
         assertThat((Integer) rows.get(2)[1]).isEqualTo(3000);
+    }
+
+    /** The INT64 reader wraps values outside the TINYINT range, so pushdown would lose rows. */
+    @Test
+    void testInt64ReadAsTinyIntDoesNotPushLossyPredicate() throws Exception {
+        RowType readType =
+                RowType.builder()
+                        .field("pageviewId", DataTypes.STRING())
+                        .field("ecpm", DataTypes.TINYINT())
+                        .build();
+        Path path = write(ecpmSchema("int64 ecpm"), (group, i) -> group.append("ecpm", 128L));
+        PredicateBuilder builder = new PredicateBuilder(readType);
+
+        List<Object[]> rows =
+                read(readType, path, Collections.singletonList(builder.equal(1, (byte) -128)));
+
+        assertThat(rows)
+                .extracting(row -> row[1])
+                .containsExactly((byte) -128, (byte) -128, (byte) -128);
+    }
+
+    /** The INT64 reader wraps values outside the SMALLINT range, so pushdown would lose rows. */
+    @Test
+    void testInt64ReadAsSmallIntDoesNotPushLossyPredicate() throws Exception {
+        RowType readType =
+                RowType.builder()
+                        .field("pageviewId", DataTypes.STRING())
+                        .field("ecpm", DataTypes.SMALLINT())
+                        .build();
+        Path path = write(ecpmSchema("int64 ecpm"), (group, i) -> group.append("ecpm", 65_535L));
+        PredicateBuilder builder = new PredicateBuilder(readType);
+
+        List<Object[]> rows =
+                read(readType, path, Collections.singletonList(builder.equal(1, (short) -1)));
+
+        assertThat(rows)
+                .extracting(row -> row[1])
+                .containsExactly((short) -1, (short) -1, (short) -1);
     }
 
     // ------------------------------------------------------------------
@@ -406,11 +468,20 @@ class ParquetTypeWideningTest {
                 case VARCHAR:
                     values[i] = row.getString(i).toString();
                     break;
+                case TINYINT:
+                    values[i] = row.getByte(i);
+                    break;
+                case SMALLINT:
+                    values[i] = row.getShort(i);
+                    break;
                 case INTEGER:
                     values[i] = row.getInt(i);
                     break;
                 case BIGINT:
                     values[i] = row.getLong(i);
+                    break;
+                case FLOAT:
+                    values[i] = row.getFloat(i);
                     break;
                 case DOUBLE:
                     values[i] = row.getDouble(i);


### PR DESCRIPTION
## Purpose

Follow up on #8995 to prevent Parquet predicate pushdown from silently dropping rows when the file value is converted lossily before it is exposed as the declared table type.

A physical `DOUBLE` may round to a matching declared `FLOAT`, and an out-of-range physical integer wraps when read as `TINYINT` or `SMALLINT`. Comparing the predicate against the original physical value can therefore prune a row group that contains rows matching after conversion.

## Changes

- Do not push declared `FLOAT` predicates to physical `DOUBLE` columns.
- Do not push declared `TINYINT` or `SMALLINT` predicates to physical `INT64` columns.
- Allow physical `INT32` pushdown for `TINYINT` and `SMALLINT` only when its signed integer logical annotation proves the physical range fits the declared type.
- Keep the lossless `INT64` to `INTEGER`, `INT32` to `BIGINT`, and `FLOAT` to `DOUBLE` paths unchanged.
- Add end-to-end regression coverage for lossy narrowing and compatible annotated integer pushdown.

## Tests

```shell
mvn -pl paimon-format \
  -DwildcardSuites=none \
  -Dtest=ParquetTypeWideningTest,ParquetFiltersTest,FileTypeNotMatchReadTypeTest \
  test
```

57 tests passed; checkstyle, Spotless, and Maven enforcer checks also passed.
