### PR TITLE
[python] Add CI coverage for native split planning

### DIFF
--- a/.github/workflows/paimon-python-checks.yml
+++ b/.github/workflows/paimon-python-checks.yml
@@ -137,15 +137,18 @@ jobs:
               python -m pip install "git+https://github.com/apache/paimon-rust.git@${PYPAIMON_RUST_REV}#subdirectory=bindings/python"
               python -m pip install "./paimon-python[sql]"
               python -c "import importlib.metadata as m; from pypaimon_rust.datafusion import PaimonCatalog, Split; assert m.version('pypaimon-rust') == '0.4.0'; assert hasattr(PaimonCatalog, 'get_table'); assert hasattr(Split, 'serialize')"
-              python -m pip check
             else
               python -m pip install pypaimon-rust==0.3.0
             fi
             python -m pip install 'lumina-data>=${{ env.LUMINA_DATA_VERSION }}' -i https://pypi.org/simple/
             if python -c "import sys; sys.exit(0 if sys.version_info >= (3, 11) else 1)"; then
-              python -m pip install vortex-data==0.70.0
+              # Vortex requires pyarrow >= 17, while Pypaimon requires pyarrow < 20 and != 19.
+              python -m pip install vortex-data==0.70.0 pyarrow==18.1.0
             fi
             python -m pip install 'paimon-mosaic>=0.1.0'
+            if [[ "${{ matrix.python-version }}" == "3.11" ]]; then
+              python -m pip check
+            fi
           fi
           df -h
 

--- a/.github/workflows/paimon-python-checks.yml
+++ b/.github/workflows/paimon-python-checks.yml
@@ -34,7 +34,7 @@ env:
   JDK_VERSION: 8
   MAVEN_OPTS: -Dmaven.wagon.httpconnectionManager.ttlSeconds=30 -Dmaven.wagon.http.retryHandler.requestSentEnabled=true
   LUMINA_DATA_VERSION: 0.1.0
-  PYPAIMON_RUST_REV: 6b6782923a59eeba766cbd45dde6989705b282bc
+  PYPAIMON_RUST_REV: 4df2bcc2e8d245aafba98c8014e710098ef7ac6b
 
 
 concurrency:
@@ -136,7 +136,8 @@ jobs:
               # Exercise the 0.4 API in one lane until its wheel is published.
               python -m pip install "git+https://github.com/apache/paimon-rust.git@${PYPAIMON_RUST_REV}#subdirectory=bindings/python"
               python -m pip install "./paimon-python[sql]"
-              python -c "import tempfile; from datafusion import SessionContext; from pypaimon_rust.datafusion import PaimonCatalog; warehouse = tempfile.TemporaryDirectory(); ctx = SessionContext(); ctx.register_catalog_provider('paimon', PaimonCatalog({'warehouse': warehouse.name}))"
+              python -c "import importlib.metadata as m; from pypaimon_rust.datafusion import PaimonCatalog, Split; assert m.version('pypaimon-rust') == '0.4.0'; assert hasattr(PaimonCatalog, 'get_table'); assert hasattr(Split, 'serialize')"
+              python -m pip check
             else
               python -m pip install pypaimon-rust==0.3.0
             fi
@@ -152,6 +153,9 @@ jobs:
         shell: bash
         run: |
           chmod +x paimon-python/dev/lint-python.sh
+          if [[ "${{ matrix.python-version }}" == "3.11" ]]; then
+            export PYPAIMON_TEST_NATIVE_PLAN=1
+          fi
           ./paimon-python/dev/lint-python.sh -e pytest_torch
 
   torch_test:

--- a/paimon-python/conftest.py
+++ b/paimon-python/conftest.py
@@ -1,0 +1,84 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+
+import pytest
+
+
+_NATIVE_PLAN_ENV = "PYPAIMON_TEST_NATIVE_PLAN"
+_native_plan_count = 0
+_force_native_for_test = False
+
+
+def _native_plan_enabled():
+    return os.environ.get(_NATIVE_PLAN_ENV) == "1"
+
+
+def pytest_configure(config):
+    config.addinivalue_line(
+        "markers", "python_plan: keep Python planner assertions on the Python lane")
+    if not _native_plan_enabled():
+        return
+
+    from pypaimon.read.table_scan import TableScan
+
+    original = TableScan._try_native_plan
+
+    def tracked(self):
+        global _native_plan_count
+        plan = original(self)
+        if plan is not None and _force_native_for_test:
+            _native_plan_count += 1
+        return plan
+
+    TableScan._try_native_plan = tracked
+
+
+@pytest.fixture(autouse=True)
+def enable_native_plan(request, monkeypatch):
+    global _force_native_for_test
+    if (not _native_plan_enabled()
+            or request.node.get_closest_marker("python_plan") is not None
+            or request.path.name in (
+                "native_plan_test.py", "native_plan_integration_test.py")):
+        yield
+        return
+
+    from pypaimon.common.options.core_options import CoreOptions
+
+    original = CoreOptions.native_plan_enabled
+
+    def enabled(self, default=None):
+        return original(self, True if default is None else default)
+
+    monkeypatch.setattr(CoreOptions, "native_plan_enabled", enabled)
+    _force_native_for_test = True
+    try:
+        yield
+    finally:
+        _force_native_for_test = False
+
+
+def pytest_sessionfinish(session, exitstatus):
+    if _native_plan_enabled() and exitstatus == 0 and _native_plan_count == 0:
+        session.exitstatus = pytest.ExitCode.TESTS_FAILED
+
+
+def pytest_terminal_summary(terminalreporter):
+    if _native_plan_enabled():
+        terminalreporter.write_line(
+            "native plans exercised: %d" % _native_plan_count)

--- a/paimon-python/dev/lint-python.sh
+++ b/paimon-python/dev/lint-python.sh
@@ -247,6 +247,9 @@ function pytest_torch_check() {
 }
 # Mixed tests check - runs Java-Python interoperability tests
 function mixed_check() {
+    # Native-plan coverage is asserted only by the main pytest session.
+    unset PYPAIMON_TEST_NATIVE_PLAN
+
     # Get Python version
     PYTHON_VERSION=$(python -c "import sys; print(f'{sys.version_info.major}.{sys.version_info.minor}')")
     echo "Detected Python version: $PYTHON_VERSION"

--- a/paimon-python/pypaimon/tests/binary_row_test.py
+++ b/paimon-python/pypaimon/tests/binary_row_test.py
@@ -23,6 +23,7 @@ import unittest
 from typing import List
 
 import pyarrow as pa
+import pytest
 
 from pypaimon import CatalogFactory, Schema
 from pypaimon.manifest.schema.manifest_entry import ManifestEntry
@@ -81,6 +82,7 @@ class BinaryRowTest(unittest.TestCase):
     def tearDownClass(cls):
         shutil.rmtree(cls.tempdir, ignore_errors=True)
 
+    @pytest.mark.python_plan
     def test_not_equal_append(self):
         table = self.catalog.get_table('default.test_append')
         self._overwrite_manifest_entry(table)
@@ -92,6 +94,7 @@ class BinaryRowTest(unittest.TestCase):
         self.assertEqual(expected, actual)
         self.assertEqual(len(expected), len(splits))
 
+    @pytest.mark.python_plan
     def test_less_than_append(self):
         table = self.catalog.get_table('default.test_append')
 
@@ -115,6 +118,7 @@ class BinaryRowTest(unittest.TestCase):
         self.assertEqual(expected, actual)
         self.assertEqual(len(expected), len(splits))
 
+    @pytest.mark.python_plan
     def test_is_not_null_append(self):
         table = self.catalog.get_table('default.test_append')
         file_scanner = FileScanner(table, lambda: ([], None))
@@ -140,6 +144,7 @@ class BinaryRowTest(unittest.TestCase):
         self.assertEqual(expected, actual)
         self.assertEqual(len(expected), len(splits))
 
+    @pytest.mark.python_plan
     def test_is_in_append(self):
         table = self.catalog.get_table('default.test_append')
         self._overwrite_manifest_entry(table)
@@ -161,6 +166,7 @@ class BinaryRowTest(unittest.TestCase):
         self.assertEqual(expected, actual)
         self.assertEqual(len(splits), len(expected))  # test partition filter when filtering ManifestEntry
 
+    @pytest.mark.python_plan
     def test_not_equal_pk(self):
         table = self.catalog.get_table('default.test_pk')
         read_builder = table.new_read_builder()
@@ -171,6 +177,7 @@ class BinaryRowTest(unittest.TestCase):
         self.assertEqual(actual, expected)
         self.assertEqual(len(splits), len(expected))  # test partition filter when filtering ManifestEntry
 
+    @pytest.mark.python_plan
     def test_less_than_pk(self):
         table = self.catalog.get_table('default.test_pk')
         read_builder = table.new_read_builder()
@@ -190,6 +197,7 @@ class BinaryRowTest(unittest.TestCase):
         expected = self.data.slice(4, 1)
         self.assertEqual(actual, expected)
 
+    @pytest.mark.python_plan
     def test_is_not_null_pk(self):
         table = self.catalog.get_table('default.test_pk')
         read_builder = table.new_read_builder()
@@ -199,6 +207,7 @@ class BinaryRowTest(unittest.TestCase):
         expected = self.data.slice(0, 4)
         self.assertEqual(actual, expected)
 
+    @pytest.mark.python_plan
     def test_is_in_pk(self):
         table = self.catalog.get_table('default.test_pk')
         read_builder = table.new_read_builder()
@@ -210,6 +219,7 @@ class BinaryRowTest(unittest.TestCase):
         self.assertEqual(actual, expected)
         self.assertEqual(len(splits), len(expected))  # test key stats filter when filtering ManifestEntry
 
+    @pytest.mark.python_plan
     def test_append_multi_cols(self):
         # Create a 10-column append table and write 10 rows
         pa_schema = pa.schema([

--- a/paimon-python/pypaimon/tests/blob_table_test.py
+++ b/paimon-python/pypaimon/tests/blob_table_test.py
@@ -23,6 +23,7 @@ import tempfile
 import unittest
 
 import pyarrow as pa
+import pytest
 
 from pypaimon import CatalogFactory, Schema
 from pypaimon.schema.schema_change import SchemaChange
@@ -2254,6 +2255,7 @@ class DedicatedFormatWriterTest(unittest.TestCase):
             5: b'blob-5',
         })
 
+    @pytest.mark.python_plan
     def test_blob_write_read_partition(self):
         """Test complete end-to-end blob functionality: write blob data and read it back to verify correctness."""
         from pypaimon import Schema

--- a/paimon-python/pypaimon/tests/cli_table_test.py
+++ b/paimon-python/pypaimon/tests/cli_table_test.py
@@ -23,6 +23,7 @@ from io import StringIO
 from unittest.mock import patch
 
 import pyarrow as pa
+import pytest
 
 from pypaimon import CatalogFactory, Schema
 from pypaimon.cli.cli import main
@@ -1499,6 +1500,7 @@ class CliTableTest(unittest.TestCase):
                 # The per-split bullet uses "[0] partition=" as a prefix
                 self.assertIn('[0] partition=', output)
 
+    @pytest.mark.python_plan
     def test_cli_table_explain_where_partition_pruning(self):
         """A partition predicate fires the partition-pruning funnel."""
         self._create_partitioned_table()

--- a/paimon-python/pypaimon/tests/daft/daft_integration_test.py
+++ b/paimon-python/pypaimon/tests/daft/daft_integration_test.py
@@ -613,9 +613,12 @@ def test_read_paimon_filter_pruning_matches_explain(catalog_options, monkeypatch
     assert result == {"id": [999], "name": ["file-b"]}
     assert len(planned_paths) == 1
     assert explain.total_file_count == len(planned_paths)
-    assert explain.paimon_scan.file_skipping is not None
-    assert explain.paimon_scan.file_skipping.before == 2
-    assert explain.paimon_scan.file_skipping.after == 1
+    if explain.paimon_scan.native_planned:
+        assert explain.paimon_scan.file_skipping is None
+    else:
+        assert explain.paimon_scan.file_skipping is not None
+        assert explain.paimon_scan.file_skipping.before == 2
+        assert explain.paimon_scan.file_skipping.after == 1
 
 
 def test_read_paimon_limit(catalog_options):

--- a/paimon-python/pypaimon/tests/data_evolution_formats_test.py
+++ b/paimon-python/pypaimon/tests/data_evolution_formats_test.py
@@ -740,7 +740,7 @@ class DataEvolutionFormatsTest(unittest.TestCase):
         self.assertEqual(actual.num_rows, 3)
         expect = pa.Table.from_pydict(
             {'x': [1, 2, 3], 'y': ['a', 'b', 'c']}, schema=pa_schema)
-        self.assertEqual(actual, expect)
+        self.assertEqual(actual.sort_by('x'), expect)
 
     @unittest.skipIf(sys.version_info < (3, 11), "vortex-data requires Python >= 3.11")
     @unittest.skipUnless(

--- a/paimon-python/pypaimon/tests/data_evolution_formats_test.py
+++ b/paimon-python/pypaimon/tests/data_evolution_formats_test.py
@@ -28,6 +28,7 @@ import tempfile
 import unittest
 
 import pyarrow as pa
+import pytest
 
 from pypaimon import CatalogFactory, Schema
 from pypaimon.manifest.schema.data_file_meta import DataFileMeta
@@ -330,6 +331,7 @@ class DataEvolutionFormatsTest(unittest.TestCase):
             {'k': [10, 20], 'v': ['new1', 'new2']}, schema=pa_schema)
         self.assertEqual(actual, expect)
 
+    @pytest.mark.python_plan
     def test_parquet_append_new_rows(self):
         """Append new rows (new first_row_id) with column subsets, merge-read all."""
         pa_schema = pa.schema([

--- a/paimon-python/pypaimon/tests/data_evolution_test.py
+++ b/paimon-python/pypaimon/tests/data_evolution_test.py
@@ -25,6 +25,7 @@ from types import SimpleNamespace
 import pandas as pd
 import pyarrow as pa
 import pyarrow.dataset as ds
+import pytest
 
 from pypaimon import CatalogFactory, Schema
 from pypaimon.common.predicate import Predicate
@@ -413,6 +414,7 @@ class DataEvolutionTest(unittest.TestCase):
             "Full set b mismatch",
         )
 
+    @pytest.mark.python_plan
     def test_multiple_appends(self):
         simple_pa_schema = pa.schema([
             ('f0', pa.int32()),

--- a/paimon-python/pypaimon/tests/global_index_test.py
+++ b/paimon-python/pypaimon/tests/global_index_test.py
@@ -19,6 +19,7 @@ import unittest
 from unittest.mock import patch
 
 import pyarrow as pa
+import pytest
 
 from pypaimon.common.options.core_options import CoreOptions, GlobalIndexSearchMode
 from pypaimon.common.options.options import Options
@@ -294,6 +295,7 @@ class PlanSnapshotFetchRegressionTest(
         'bucket': '-1',
     }
 
+    @pytest.mark.python_plan
     def test_plan_fetches_latest_snapshot_only_once(self):
         table = self._create_table()
         self._write_arrow(table, pa.table(
@@ -321,6 +323,7 @@ class PlanSnapshotFetchRegressionTest(
                 "duplicate from #7513: manifest_scanner + "
                 "DataEvolutionGlobalIndexScanner.create both fetch independently.")
 
+    @pytest.mark.python_plan
     def test_time_travel_plan(self):
         table = self._create_table()
         self._write_arrow(table, pa.table(

--- a/paimon-python/pypaimon/tests/predicates_test.py
+++ b/paimon-python/pypaimon/tests/predicates_test.py
@@ -23,6 +23,7 @@ import unittest
 
 import pandas as pd
 import pyarrow as pa
+import pytest
 import pyarrow.dataset as ds
 
 from pypaimon import CatalogFactory, Schema
@@ -557,6 +558,7 @@ class PredicateTest(unittest.TestCase):
 
         self.assertEqual(scanner.to_table().to_pydict(), {"val": [3]})
 
+    @pytest.mark.python_plan
     def test_pk_reader_with_filter(self):
         pa_schema = pa.schema([
             pa.field('key1', pa.int32(), nullable=False),

--- a/paimon-python/pypaimon/tests/pushdown_bucket_test.py
+++ b/paimon-python/pypaimon/tests/pushdown_bucket_test.py
@@ -47,6 +47,7 @@ import unittest
 from typing import Any, Dict, List
 
 import pyarrow as pa
+import pytest
 
 from pypaimon import CatalogFactory, Schema
 from pypaimon.common.predicate_builder import PredicateBuilder
@@ -816,6 +817,7 @@ class BucketPruningIntegrationTest(unittest.TestCase):
         self.assertEqual(self._split_buckets(splits),
                          self._expected_buckets(table, [17]))
 
+    @pytest.mark.python_plan
     def test_per_partition_pruning_with_mixed_or(self):
         """``(part='a' AND id=1) OR (part='b' AND id=2)``: each partition
         sees only the bucket for its own ``id`` literal. Without

--- a/paimon-python/pypaimon/tests/read_builder_explain_test.py
+++ b/paimon-python/pypaimon/tests/read_builder_explain_test.py
@@ -25,6 +25,7 @@ import unittest
 from typing import Any, Dict, List
 
 import pyarrow as pa
+import pytest
 
 from pypaimon import CatalogFactory, Schema
 from pypaimon.common.predicate import Predicate
@@ -131,6 +132,7 @@ class ReadBuilderExplainTest(unittest.TestCase):
 
     # ---- 2. PK + partition + bucket pruning ----------------------------
 
+    @pytest.mark.python_plan
     def test_explain_pk_table_with_partition_and_bucket_predicate(self):
         table, pa_schema = self._pk_partitioned_bucketed_table(
             'explain_pk_pruning', num_buckets=4)

--- a/paimon-python/pypaimon/tests/reader_append_only_test.py
+++ b/paimon-python/pypaimon/tests/reader_append_only_test.py
@@ -25,6 +25,7 @@ import unittest
 import numpy as np
 import pandas as pd
 import pyarrow as pa
+import pytest
 
 from pypaimon import CatalogFactory, Schema
 from pypaimon.common.options.core_options import CoreOptions
@@ -1022,6 +1023,7 @@ class AoReaderTest(unittest.TestCase):
 
             print(f"✓ Iteration {test_iteration + 1}/{iter_num} completed successfully")
 
+    @pytest.mark.python_plan
     def test_is_in_with_partitions(self):
         from pypaimon.manifest.manifest_file_manager import ManifestFileManager
         from io import BytesIO
@@ -1119,6 +1121,7 @@ class AoReaderTest(unittest.TestCase):
         self.assertFalse(pb.equal('pt', 'x').test(row_null))
         self.assertTrue(pb.equal('pt', 'x').test(row_x))
 
+    @pytest.mark.python_plan
     def test_early_partition_filter_isnull_scan(self):
         # Black-box: drive the early manifest partition filter through an actual
         # scan (not just Predicate.test), over a null + non-null partition mix.

--- a/paimon-python/pypaimon/tests/reader_base_test.py
+++ b/paimon-python/pypaimon/tests/reader_base_test.py
@@ -27,6 +27,7 @@ from unittest.mock import Mock
 
 import pandas as pd
 import pyarrow as pa
+import pytest
 from parameterized import parameterized
 
 from pypaimon import CatalogFactory, Schema
@@ -226,6 +227,7 @@ class ReaderBasicTest(unittest.TestCase):
         pd.testing.assert_frame_equal(
             actual_df.reset_index(drop=True), expected_df.reset_index(drop=True))
 
+    @pytest.mark.python_plan
     def test_full_data_types(self):
         simple_pa_schema = pa.schema([
             ('f0', pa.int8()),

--- a/paimon-python/pypaimon/tests/schema_evolution_read_test.py
+++ b/paimon-python/pypaimon/tests/schema_evolution_read_test.py
@@ -22,6 +22,7 @@ import unittest
 
 import pandas
 import pyarrow as pa
+import pytest
 
 from pypaimon import CatalogFactory, Schema
 
@@ -59,6 +60,7 @@ class SchemaEvolutionReadTest(unittest.TestCase):
     def tearDownClass(cls):
         shutil.rmtree(cls.tempdir, ignore_errors=True)
 
+    @pytest.mark.python_plan
     def test_schema_evolution(self):
         # schema 0
         pa_schema = pa.schema([
@@ -129,6 +131,7 @@ class SchemaEvolutionReadTest(unittest.TestCase):
         }, schema=pa_schema)
         self.assertEqual(expected, actual)
 
+    @pytest.mark.python_plan
     def test_schema_evolution_type(self):
         # schema 0
         pa_schema = pa.schema([
@@ -419,6 +422,7 @@ class SchemaEvolutionReadTest(unittest.TestCase):
         entries = new_scan.file_scanner.read_manifest_entries(manifest_files)
         self.assertEqual(1, len(entries))  # verify scan filter success for schema evolution
 
+    @pytest.mark.python_plan
     def test_schema_evolution_with_read_filter(self):
         # schema 0
         pa_schema = pa.schema([

--- a/paimon-python/pypaimon/tests/table_update_test.py
+++ b/paimon-python/pypaimon/tests/table_update_test.py
@@ -23,6 +23,7 @@ import unittest
 from unittest import mock
 
 import pyarrow as pa
+import pytest
 
 from pypaimon.tests.data_evolution_test_helpers import (
     BatchModeMixin,
@@ -197,6 +198,7 @@ class _TableUpdateTestBase(DataEvolutionTestBase):
             self._read_all(table)['age'].to_pylist(),
         )
 
+    @pytest.mark.python_plan
     def test_update_by_predicate(self):
         table = self._create_seeded_table()
         wb = self._make_write_builder(table)
@@ -758,6 +760,7 @@ class _TableUpdateTestBase(DataEvolutionTestBase):
                 '_ROW_ID': [0, 1],
             }), cid)
 
+    @pytest.mark.python_plan
     def test_partitioned_table_update(self):
         """Updates work on a partitioned table the same as a flat one."""
         table = self._create_table(partition_keys=['city'])


### PR DESCRIPTION
Follow up on #9000.

### What changed

- Enable native split planning by default in the Python 3.11 test lane.
- Keep Python 3.10 as the Python-planner lane.
- Fail the native lane unless ordinary tests actually exercise native plans.
- Keep tests that explicitly verify Python planner behavior on the Python planner.
- Verify the pypaimon-rust version/API and run pip check.

### Validation

- Native unit and integration tests: 38 passed.
- Forced-native regression: 467 passed, 16 deselected; 358 native plans exercised.
- flake8 and git diff --check passed.