### PR TITLE
[core] Fix wrong privilege type in NoPrivilegeException for assertCanCreateDatabase

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/privilege/PrivilegeCheckerImpl.java
+++ b/paimon-core/src/main/java/org/apache/paimon/privilege/PrivilegeCheckerImpl.java
@@ -102,7 +102,7 @@ public class PrivilegeCheckerImpl implements PrivilegeChecker {
                     user,
                     "catalog",
                     FileBasedPrivilegeManager.IDENTIFIER_WHOLE_CATALOG,
-                    PrivilegeType.DROP_DATABASE);
+                    PrivilegeType.CREATE_DATABASE);
         }
     }
 


### PR DESCRIPTION
### Purpose

`PrivilegeCheckerImpl#assertCanCreateDatabase` checks for `PrivilegeType.CREATE_DATABASE`, but when the check fails it throws `NoPrivilegeException` reporting the missing privilege as `PrivilegeType.DROP_DATABASE`

### Tests
