### PR TITLE
[core] Abort single file writers on unchecked close failures

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/io/FormatTableSingleFileWriter.java
+++ b/paimon-core/src/main/java/org/apache/paimon/io/FormatTableSingleFileWriter.java
@@ -168,9 +168,14 @@ public class FormatTableSingleFileWriter {
                 committer = ((TwoPhaseOutputStream) out).closeForCommit();
                 out = null;
             }
-        } catch (IOException e) {
+        } catch (Throwable e) {
             LOG.warn("Exception occurs when closing file {}. Cleaning up.", path, e);
-            abort();
+            try {
+                abort();
+            } catch (Throwable t) {
+                // never let the cleanup replace the failure that caused it
+                e.addSuppressed(t);
+            }
             throw e;
         } finally {
             closed = true;

--- a/paimon-core/src/main/java/org/apache/paimon/io/FormatTableSingleFileWriter.java
+++ b/paimon-core/src/main/java/org/apache/paimon/io/FormatTableSingleFileWriter.java
@@ -173,7 +173,6 @@ public class FormatTableSingleFileWriter {
             try {
                 abort();
             } catch (Throwable t) {
-                // never let the cleanup replace the failure that caused it
                 e.addSuppressed(t);
             }
             throw e;

--- a/paimon-core/src/main/java/org/apache/paimon/io/SingleFileWriter.java
+++ b/paimon-core/src/main/java/org/apache/paimon/io/SingleFileWriter.java
@@ -247,9 +247,14 @@ public abstract class SingleFileWriter<T, R> implements FileWriter<T, R> {
                 out.close();
                 out = null;
             }
-        } catch (IOException e) {
+        } catch (Throwable e) {
             LOG.warn("Exception occurs when closing file {}. Cleaning up.", path, e);
-            abort();
+            try {
+                abort();
+            } catch (Throwable t) {
+                // never let the cleanup replace the failure that caused it
+                e.addSuppressed(t);
+            }
             throw e;
         } finally {
             closed = true;

--- a/paimon-core/src/main/java/org/apache/paimon/io/SingleFileWriter.java
+++ b/paimon-core/src/main/java/org/apache/paimon/io/SingleFileWriter.java
@@ -252,7 +252,6 @@ public abstract class SingleFileWriter<T, R> implements FileWriter<T, R> {
             try {
                 abort();
             } catch (Throwable t) {
-                // never let the cleanup replace the failure that caused it
                 e.addSuppressed(t);
             }
             throw e;

--- a/paimon-core/src/test/java/org/apache/paimon/io/FormatTableSingleFileWriterTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/io/FormatTableSingleFileWriterTest.java
@@ -88,6 +88,49 @@ public class FormatTableSingleFileWriterTest {
         assertThat(fileIO.readFileUtf8(path)).isEqualTo("keep me");
     }
 
+    @Test
+    public void testRuntimeExceptionWhileClosingLeavesNoFileBehind() throws IOException {
+        // several format writers wrap IO failures in unchecked exceptions on the close path
+        FormatTableSingleFileWriter writer =
+                newWriter(
+                        (out, compression) ->
+                                new ThrowingCloseWriter(new IllegalStateException("cannot close")));
+
+        assertThatThrownBy(writer::close)
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessage("cannot close");
+
+        // the staged two phase data must be discarded as well
+        assertThat(fileIO.listFiles(new Path(tempDir.toString()), true)).isEmpty();
+    }
+
+    @Test
+    public void testIOExceptionWhileClosingLeavesNoFileBehind() throws IOException {
+        FormatTableSingleFileWriter writer =
+                newWriter((out, compression) -> new ThrowingCloseWriter(new IOException("boom")));
+
+        // the checked failure must still reach the caller unwrapped
+        assertThatThrownBy(writer::close).isInstanceOf(IOException.class).hasMessage("boom");
+
+        assertThat(fileIO.listFiles(new Path(tempDir.toString()), true)).isEmpty();
+    }
+
+    @Test
+    public void testCleanupFailureDoesNotReplaceOriginalException() {
+        FormatTableSingleFileWriter writer =
+                new FormatTableSingleFileWriter(
+                        new DeleteFailingFileIO(),
+                        (out, compression) ->
+                                new ThrowingCloseWriter(new IllegalStateException("cannot close")),
+                        path,
+                        "zstd");
+
+        assertThatThrownBy(writer::close)
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessage("cannot close")
+                .hasSuppressedException(new RuntimeException("cannot delete"));
+    }
+
     private FormatTableSingleFileWriter newWriter(FormatWriterFactory factory) {
         return new FormatTableSingleFileWriter(fileIO, factory, path, "zstd");
     }
@@ -104,5 +147,38 @@ public class FormatTableSingleFileWriterTest {
 
         @Override
         public void close() {}
+    }
+
+    private static class DeleteFailingFileIO extends LocalFileIO {
+
+        @Override
+        public boolean delete(Path f, boolean recursive) {
+            throw new RuntimeException("cannot delete");
+        }
+    }
+
+    private static class ThrowingCloseWriter implements FormatWriter {
+
+        private final Throwable failure;
+
+        private ThrowingCloseWriter(Throwable failure) {
+            this.failure = failure;
+        }
+
+        @Override
+        public void addElement(InternalRow element) {}
+
+        @Override
+        public boolean reachTargetSize(boolean suggestedCheck, long targetSize) {
+            return false;
+        }
+
+        @Override
+        public void close() throws IOException {
+            if (failure instanceof IOException) {
+                throw (IOException) failure;
+            }
+            throw (RuntimeException) failure;
+        }
     }
 }

--- a/paimon-core/src/test/java/org/apache/paimon/io/FormatTableSingleFileWriterTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/io/FormatTableSingleFileWriterTest.java
@@ -100,7 +100,6 @@ public class FormatTableSingleFileWriterTest {
                 .isInstanceOf(IllegalStateException.class)
                 .hasMessage("cannot close");
 
-        // the staged two phase data must be discarded as well
         assertThat(fileIO.listFiles(new Path(tempDir.toString()), true)).isEmpty();
     }
 

--- a/paimon-core/src/test/java/org/apache/paimon/io/SingleFileWriterTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/io/SingleFileWriterTest.java
@@ -26,7 +26,9 @@ import org.apache.paimon.format.SupportsDirectWrite;
 import org.apache.paimon.fs.FileIO;
 import org.apache.paimon.fs.Path;
 import org.apache.paimon.fs.PositionOutputStream;
+import org.apache.paimon.fs.PositionOutputStreamWrapper;
 import org.apache.paimon.fs.local.LocalFileIO;
+import org.apache.paimon.utils.TraceableFileIO;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -146,6 +148,65 @@ public class SingleFileWriterTest {
     }
 
     @Test
+    public void testRuntimeExceptionWhileClosingDeletesFile() throws IOException {
+        // several format writers wrap IO failures in unchecked exceptions on the close path
+        TestSingleFileWriter writer =
+                newWriter(
+                        (out, compression) ->
+                                new ThrowingCloseWriter(new IllegalStateException("cannot close")));
+
+        assertThatThrownBy(writer::close)
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessage("cannot close");
+
+        assertThat(fileIO.exists(path)).isFalse();
+    }
+
+    @Test
+    public void testIOExceptionWhileClosingDeletesFile() throws IOException {
+        TestSingleFileWriter writer =
+                newWriter((out, compression) -> new ThrowingCloseWriter(new IOException("boom")));
+
+        // the checked failure must still reach the caller unwrapped
+        assertThatThrownBy(writer::close).isInstanceOf(IOException.class).hasMessage("boom");
+
+        assertThat(fileIO.exists(path)).isFalse();
+    }
+
+    @Test
+    public void testRuntimeExceptionWhileFlushingClosesStream() throws IOException {
+        // the output stream can fail with an unchecked exception too, for example
+        // AsyncPositionOutputStream when the writing thread is interrupted
+        FileIO trackedFileIO = new FlushFailingFileIO();
+        TestSingleFileWriter writer =
+                new TestSingleFileWriter(
+                        trackedFileIO, (out, compression) -> new NoOpFormatWriter(), path, false);
+
+        assertThatThrownBy(writer::close)
+                .isExactlyInstanceOf(RuntimeException.class)
+                .hasMessage("cannot flush");
+
+        assertThat(TraceableFileIO.openOutputStreams(path::equals)).isEmpty();
+        assertThat(trackedFileIO.exists(path)).isFalse();
+    }
+
+    @Test
+    public void testCleanupFailureDoesNotReplaceOriginalException() {
+        TestSingleFileWriter writer =
+                new TestSingleFileWriter(
+                        new DeleteFailingFileIO(),
+                        (out, compression) ->
+                                new ThrowingCloseWriter(new IllegalStateException("cannot close")),
+                        path,
+                        false);
+
+        assertThatThrownBy(writer::close)
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessage("cannot close")
+                .hasSuppressedException(new RuntimeException("cannot delete"));
+    }
+
+    @Test
     public void testSuccessfulOpenKeepsFile() throws IOException {
         NoOpFormatWriter formatWriter = new NoOpFormatWriter();
         TestSingleFileWriter writer = newWriter((out, compression) -> formatWriter);
@@ -223,6 +284,52 @@ public class SingleFileWriterTest {
         @Override
         public void close() {
             closed = true;
+        }
+    }
+
+    private static class ThrowingCloseWriter implements FormatWriter {
+
+        private final Throwable failure;
+
+        private ThrowingCloseWriter(Throwable failure) {
+            this.failure = failure;
+        }
+
+        @Override
+        public void addElement(InternalRow element) {}
+
+        @Override
+        public boolean reachTargetSize(boolean suggestedCheck, long targetSize) {
+            return false;
+        }
+
+        @Override
+        public void close() throws IOException {
+            if (failure instanceof IOException) {
+                throw (IOException) failure;
+            }
+            throw (RuntimeException) failure;
+        }
+    }
+
+    private static class DeleteFailingFileIO extends LocalFileIO {
+
+        @Override
+        public boolean delete(Path f, boolean recursive) {
+            throw new RuntimeException("cannot delete");
+        }
+    }
+
+    private static class FlushFailingFileIO extends TraceableFileIO {
+
+        @Override
+        public PositionOutputStream newOutputStream(Path f, boolean overwrite) throws IOException {
+            return new PositionOutputStreamWrapper(super.newOutputStream(f, overwrite)) {
+                @Override
+                public void flush() {
+                    throw new RuntimeException("cannot flush");
+                }
+            };
         }
     }
 


### PR DESCRIPTION
### Purpose

Closes #9007.

`close()` in `SingleFileWriter` and `FormatTableSingleFileWriter` routed only `IOException` to `abort()`, so an unchecked failure skipped cleanup entirely. The `finally` still sets `closed = true`, so nothing cleans up later either: the output stream stays open and the partially written file is orphaned. `writeImpl()`, `writeRow()` and `writeBundle()` have caught `Throwable` and called `abort()` since 2024, only `close()` was left narrower.

This is on the default path. `async-file-write` defaults to `true`, and `AsyncPositionOutputStream` throws a bare `RuntimeException` from `flush()` and `close()` when the writing thread is interrupted, so cancelling a Flink job can orphan a data file.

`abort()` is wrapped because `FileIO.deleteQuietly` only swallows `IOException`, so an unchecked cleanup failure would otherwise replace the real error. The rolling writers above still catch only `IOException` and are left for a separate change.

### Tests

Six tests in `SingleFileWriterTest` and `FormatTableSingleFileWriterTest`: unchecked failure from the format writer's `close()`, unchecked failure from the stream's `flush()` (asserting via `TraceableFileIO` that the stream is released), `IOException` still reaching the caller unwrapped, and a failing `abort()` not replacing the original exception. All fail against the unpatched code.
