### PR TITLE
[jindo] Disable directory timestamps for faster listings

### DIFF
--- a/paimon-filesystems/paimon-jindo/src/main/java/org/apache/paimon/jindo/JindoFileIO.java
+++ b/paimon-filesystems/paimon-jindo/src/main/java/org/apache/paimon/jindo/JindoFileIO.java
@@ -75,6 +75,7 @@ public class JindoFileIO extends HadoopCompliantFileIO implements HadoopOptionsP
     private static final String OSS_SECURITY_TOKEN = "fs.oss.securityToken";
     private static final String OSS_REGION = "fs.oss.region";
     private static final String OSS_USER_AGENT_EXTENDED = "fs.oss.user.agent.extended";
+    private static final String OSS_SHOW_DIR_TIMESTAMP = "fs.oss.show-dir-timestamp";
     private static final String DLF_ACCESS_TRACKING_EXTENDED_INFO =
             "dlf.access-tracking.extended-info";
 
@@ -148,6 +149,11 @@ public class JindoFileIO extends HadoopCompliantFileIO implements HadoopOptionsP
             context.hadoopConf()
                     .iterator()
                     .forEachRemaining(entry -> hadoopOptions.set(entry.getKey(), entry.getValue()));
+        }
+
+        // Resolving a timestamp for every listed directory is expensive in Jindo.
+        if (!hadoopOptions.containsKey(OSS_SHOW_DIR_TIMESTAMP)) {
+            hadoopOptions.set(OSS_SHOW_DIR_TIMESTAMP, "false");
         }
 
         String dlfAccessTrackingExtendedInfo =

--- a/paimon-filesystems/paimon-jindo/src/test/java/org/apache/paimon/jindo/JindoFileIOTest.java
+++ b/paimon-filesystems/paimon-jindo/src/test/java/org/apache/paimon/jindo/JindoFileIOTest.java
@@ -18,6 +18,7 @@
 
 package org.apache.paimon.jindo;
 
+import org.apache.paimon.catalog.CatalogContext;
 import org.apache.paimon.data.BlobDescriptor;
 import org.apache.paimon.fs.Path;
 import org.apache.paimon.options.Options;
@@ -43,6 +44,32 @@ import static org.mockito.Mockito.when;
 
 /** Tests for {@link JindoFileIO}. */
 public class JindoFileIOTest {
+
+    private static final String SHOW_DIR_TIMESTAMP = "fs.oss.show-dir-timestamp";
+
+    @Test
+    public void testDisableDirectoryTimestampByDefault() {
+        JindoFileIO fileIO = new JindoFileIO();
+        fileIO.configure(CatalogContext.create(new Options()));
+
+        assertThat(
+                        fileIO.hadoopOptions(new Path("oss://bucket/table"), "meta")
+                                .get(SHOW_DIR_TIMESTAMP))
+                .isEqualTo("false");
+    }
+
+    @Test
+    public void testKeepExplicitDirectoryTimestampSetting() {
+        Options options = new Options();
+        options.set(SHOW_DIR_TIMESTAMP, "true");
+        JindoFileIO fileIO = new JindoFileIO();
+        fileIO.configure(CatalogContext.create(options));
+
+        assertThat(
+                        fileIO.hadoopOptions(new Path("oss://bucket/table"), "meta")
+                                .get(SHOW_DIR_TIMESTAMP))
+                .isEqualTo("true");
+    }
 
     @Test
     public void testCreateBlobClientUsesConfiguredSts() {


### PR DESCRIPTION
### Purpose

Jindo resolves a timestamp for every directory entry during `listStatus` when `fs.oss.show-dir-timestamp` is enabled, which is its default. Listing a directory with about 1,000 subdirectories takes 11s with the option on and 0.2s with it off, while Paimon does not read directory timestamps from listings. This PR defaults the option to `false` in `JindoFileIO` and keeps an explicit user setting unchanged.

### Tests

New tests in `JindoFileIOTest` cover the default and an explicit `true` setting.
