### PR TITLE
[cdc] Support PostgreSQL jsonb type in postgres sync

### DIFF
--- a/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/action/cdc/postgres/PostgresTypeUtils.java
+++ b/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/action/cdc/postgres/PostgresTypeUtils.java
@@ -69,6 +69,7 @@ public class PostgresTypeUtils {
     private static final String PG_CHARACTER_VARYING = "varchar";
     private static final String PG_CHARACTER_VARYING_ARRAY = "_varchar";
     private static final String PG_JSON = "json";
+    private static final String PG_JSONB = "jsonb";
     private static final String PG_ENUM = "enum";
     private static final String PG_UUID = "uuid";
 
@@ -159,6 +160,7 @@ public class PostgresTypeUtils {
                 return DataTypes.ARRAY(DataTypes.VARCHAR(precision));
             case PG_TEXT:
             case PG_JSON:
+            case PG_JSONB:
             case PG_ENUM:
             case PG_UUID:
                 return DataTypes.STRING();

--- a/paimon-flink/paimon-flink-cdc/src/test/java/org/apache/paimon/flink/action/cdc/postgres/PostgresSyncTableActionITCase.java
+++ b/paimon-flink/paimon-flink-cdc/src/test/java/org/apache/paimon/flink/action/cdc/postgres/PostgresSyncTableActionITCase.java
@@ -365,6 +365,7 @@ public class PostgresSyncTableActionITCase extends PostgresActionITCaseBase {
                             DataTypes.STRING(), // _text
                             DataTypes.BYTES(), // _bin
                             DataTypes.STRING(), // _json
+                            DataTypes.STRING(), // _jsonb
                             DataTypes.STRING(), // _uuid
                             DataTypes.ARRAY(DataTypes.STRING()) // _array
                         },
@@ -399,6 +400,7 @@ public class PostgresSyncTableActionITCase extends PostgresActionITCaseBase {
                             "_text",
                             "_bin",
                             "_json",
+                            "_jsonb",
                             "_uuid",
                             "_array",
                         });
@@ -425,6 +427,7 @@ public class PostgresSyncTableActionITCase extends PostgresActionITCaseBase {
                                 + "Paimon    , Apache Paimon, Apache Paimon PostgreSQL Test Data, "
                                 + "[98, 121, 116, 101, 115], "
                                 + "{\"a\": \"b\"}, "
+                                + "{\"c\": \"d\"}, "
                                 + "123e4567-e89b-12d3-a456-426655440000, "
                                 + "[item1, item2]"
                                 + "]",
@@ -445,6 +448,7 @@ public class PostgresSyncTableActionITCase extends PostgresActionITCaseBase {
                                 + "NULL, NULL, "
                                 + "NULL, NULL, "
                                 + "NULL, NULL, "
+                                + "NULL, "
                                 + "NULL, "
                                 + "NULL, "
                                 + "NULL, "

--- a/paimon-flink/paimon-flink-cdc/src/test/java/org/apache/paimon/flink/action/cdc/postgres/PostgresTypeUtilsTest.java
+++ b/paimon-flink/paimon-flink-cdc/src/test/java/org/apache/paimon/flink/action/cdc/postgres/PostgresTypeUtilsTest.java
@@ -93,4 +93,10 @@ public class PostgresTypeUtilsTest {
         assertThat(PostgresTypeUtils.toDataType("uuid", null, null, EMPTY))
                 .isEqualTo(DataTypes.STRING());
     }
+
+    @Test
+    public void testJsonbMapsToString() {
+        assertThat(PostgresTypeUtils.toDataType("jsonb", null, null, EMPTY))
+                .isEqualTo(DataTypes.STRING());
+    }
 }

--- a/paimon-flink/paimon-flink-cdc/src/test/resources/postgres/sync_table_setup.sql
+++ b/paimon-flink/paimon-flink-cdc/src/test/resources/postgres/sync_table_setup.sql
@@ -105,6 +105,7 @@ CREATE TABLE all_types_table (
     _bin BYTEA,
     -- json
     _json JSON,
+    _jsonb JSONB,
     -- UUID
     _uuid UUID,
     _array VARCHAR[],
@@ -131,7 +132,7 @@ INSERT INTO all_types_table (
     _time, _time0,
     _char, _varchar, _text,
     _bin,
-    _json, _uuid,
+    _json, _jsonb, _uuid,
     _array
 ) VALUES (
     1, 1.1,
@@ -150,7 +151,7 @@ INSERT INTO all_types_table (
     '10:13:23'::TIME, '10:13:23'::TIME,
     'Paimon', 'Apache Paimon', 'Apache Paimon PostgreSQL Test Data',
     'bytes',
-    '{"a": "b"}'::JSON, '123e4567-e89b-12d3-a456-426655440000'::UUID,
+    '{"a": "b"}'::JSON, '{"c": "d"}'::JSONB, '123e4567-e89b-12d3-a456-426655440000'::UUID,
     ARRAY['item1', 'item2']::VARCHAR[]
     ), (
     2, 2.2,
@@ -169,7 +170,7 @@ INSERT INTO all_types_table (
     NULL, NULL,
     NULL, NULL, NULL,
     NULL,
-    NULL, NULL,
+    NULL, NULL, NULL,
     NULL
     );
 


### PR DESCRIPTION
### Purpose
- Postgres sync fails when the source table has a JSONB column: `UnsupportedOperationException: Doesn't support 'jsonb'`.
- Debezium already emits jsonb values as plain json strings (`io.debezium.data.Json`), same as the supported json type.
- Map the jsonb type to string to support the same.

### Tests
 - UT