### PR TITLE
[spark] Support skipping expired partitions during compaction

### DIFF
--- a/docs/docs/maintenance/dedicated-compaction.mdx
+++ b/docs/docs/maintenance/dedicated-compaction.mdx
@@ -489,6 +489,17 @@ CALL sys.compact(`table` => 'default.T', options => 'compaction.skip-expired-par
 
 </TabItem>
 
+<TabItem value="spark-sql" label="Spark SQL">
+
+Run the following sql:
+
+```sql
+-- skip expired partitions compact table
+CALL sys.compact(table => 'default.T', options => 'compaction.skip-expired-partitions=true')
+```
+
+</TabItem>
+
 <TabItem value="flink-action-jar" label="Flink Action Jar">
 
 ```bash
@@ -520,6 +531,20 @@ CALL sys.compact_database(
   including_databases => 'includingDatabases',
   mode => 'divided',
   table_options => 'compaction.skip-expired-partitions=true'
+)
+```
+
+</TabItem>
+
+<TabItem value="spark-sql" label="Spark SQL">
+
+Run the following sql:
+
+```sql
+-- skip expired partitions compact database
+CALL sys.compact_database(
+  including_databases => 'default',
+  options => 'compaction.skip-expired-partitions=true'
 )
 ```
 

--- a/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/procedure/CompactProcedure.java
+++ b/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/procedure/CompactProcedure.java
@@ -38,6 +38,7 @@ import org.apache.paimon.io.DataIncrement;
 import org.apache.paimon.manifest.PartitionEntry;
 import org.apache.paimon.operation.BaseAppendFileStoreWrite;
 import org.apache.paimon.partition.PartitionPredicate;
+import org.apache.paimon.partition.PartitionValuesTimeExpireStrategy;
 import org.apache.paimon.spark.SparkUtils;
 import org.apache.paimon.spark.commands.PaimonSparkWriter;
 import org.apache.paimon.spark.sort.TableSorter;
@@ -94,6 +95,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
 import scala.collection.JavaConverters;
@@ -325,6 +327,7 @@ public class CompactProcedure extends BaseProcedure {
         boolean filterByPartitionIdleTime = partitionIdleTime != null;
         Set<BinaryRow> partitionToBeCompacted =
                 getPartitionsToCompact(snapshotReader, partitionIdleTime);
+        Predicate<BinaryRow> shouldCompactPartition = nonExpiredPartitionPredicate(table);
         List<Pair<byte[], Integer>> partitionBuckets =
                 snapshotReader.bucketEntries().stream()
                         .map(entry -> Pair.of(entry.partition(), entry.bucket()))
@@ -333,6 +336,7 @@ public class CompactProcedure extends BaseProcedure {
                                 pair ->
                                         !filterByPartitionIdleTime
                                                 || partitionToBeCompacted.contains(pair.getKey()))
+                        .filter(pair -> shouldCompactPartition.test(pair.getKey()))
                         .map(
                                 p ->
                                         Pair.of(
@@ -393,6 +397,23 @@ public class CompactProcedure extends BaseProcedure {
         } catch (Exception e) {
             throw new RuntimeException(e);
         }
+    }
+
+    private static Predicate<BinaryRow> nonExpiredPartitionPredicate(FileStoreTable table) {
+        CoreOptions options = table.coreOptions();
+        if (!options.compactionSkipExpiredPartitions()
+                || options.partitionExpireTime() == null
+                || !CoreOptions.PartitionExpireStrategy.VALUES_TIME
+                        .toString()
+                        .equals(options.partitionExpireStrategy())) {
+            return partition -> true;
+        }
+
+        LocalDateTime expireDateTime = LocalDateTime.now().minus(options.partitionExpireTime());
+        PartitionValuesTimeExpireStrategy expireStrategy =
+                new PartitionValuesTimeExpireStrategy(
+                        options, table.schema().logicalPartitionType());
+        return partition -> !expireStrategy.isExpired(expireDateTime, partition);
     }
 
     private void compactUnAwareBucketTable(

--- a/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/procedure/CompactProcedureTestBase.scala
+++ b/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/procedure/CompactProcedureTestBase.scala
@@ -718,8 +718,9 @@ abstract class CompactProcedureTestBase extends PaimonSparkTestBase with StreamT
       val table = loadTable("T")
       val (_, activeDt) = writeExpiredAndActivePartitions()
 
-      spark.sql("ALTER TABLE T SET TBLPROPERTIES (" +
-        "'end-input.check-partition-expire'='true')")
+      spark.sql(
+        "ALTER TABLE T SET TBLPROPERTIES (" +
+          "'end-input.check-partition-expire'='true')")
 
       spark.sql(
         "CALL sys.compact(table => 'T', " +
@@ -737,21 +738,20 @@ abstract class CompactProcedureTestBase extends PaimonSparkTestBase with StreamT
       endInputCheck: Boolean): Unit = {
     val dynamicBucketOption =
       if (bucket == -1) ", 'dynamic-bucket.initial-buckets'='1'" else ""
-    spark.sql(
-      s"""
-         |CREATE TABLE T (id INT, value STRING, dt STRING)
-         |TBLPROPERTIES (
-         |  'primary-key'='id, dt',
-         |  'bucket'='$bucket',
-         |  'write-only'='true',
-         |  'partition.expiration-time'='7 d',
-         |  'partition.expiration-strategy'='$expirationStrategy',
-         |  'partition.timestamp-formatter'='yyyyMMdd',
-         |  'partition.expiration-check-interval'='999 d',
-         |  'end-input.check-partition-expire'='$endInputCheck'
-         |  $dynamicBucketOption)
-         |PARTITIONED BY (dt)
-         |""".stripMargin)
+    spark.sql(s"""
+                 |CREATE TABLE T (id INT, value STRING, dt STRING)
+                 |TBLPROPERTIES (
+                 |  'primary-key'='id, dt',
+                 |  'bucket'='$bucket',
+                 |  'write-only'='true',
+                 |  'partition.expiration-time'='7 d',
+                 |  'partition.expiration-strategy'='$expirationStrategy',
+                 |  'partition.timestamp-formatter'='yyyyMMdd',
+                 |  'partition.expiration-check-interval'='999 d',
+                 |  'end-input.check-partition-expire'='$endInputCheck'
+                 |  $dynamicBucketOption)
+                 |PARTITIONED BY (dt)
+                 |""".stripMargin)
   }
 
   private def writeExpiredAndActivePartitions(): (String, String) = {

--- a/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/procedure/CompactProcedureTestBase.scala
+++ b/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/procedure/CompactProcedureTestBase.scala
@@ -35,6 +35,8 @@ import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.scalatest.time.Span
 
 import java.lang.reflect.{InvocationHandler, Method, Proxy}
+import java.time.LocalDate
+import java.time.format.DateTimeFormatter
 import java.util
 import java.util.concurrent.atomic.AtomicBoolean
 
@@ -656,6 +658,118 @@ abstract class CompactProcedureTestBase extends PaimonSparkTestBase with StreamT
       spark.sql(s"SELECT * FROM T ORDER BY id"),
       Row(1, "a", "p1") :: Row(2, "b", "p2") :: Row(3, "c", "p1") :: Row(4, "d", "p2") ::
         Row(5, "e", "p1") :: Row(6, "f", "p2") :: Nil)
+  }
+
+  test("Paimon Procedure: compact skips expired partitions for aware bucket table") {
+    Seq(1, -1).foreach {
+      bucket =>
+        withClue(s"bucket=$bucket") {
+          withTable("T") {
+            createPartitionExpireTable(bucket, "values-time", endInputCheck = false)
+            val table = loadTable("T")
+            val (expiredDt, activeDt) = writeExpiredAndActivePartitions()
+
+            spark.sql(
+              "CALL sys.compact(table => 'T', " +
+                "options => 'compaction.skip-expired-partitions=true')")
+
+            Assertions.assertThat(lastSnapshotCommand(table)).isEqualTo(CommitKind.COMPACT)
+            val fileCounts = partitionFileCounts(table)
+            Assertions.assertThat(fileCounts(expiredDt)).isEqualTo(2)
+            Assertions.assertThat(fileCounts(activeDt)).isEqualTo(1)
+          }
+        }
+    }
+  }
+
+  test("Paimon Procedure: compact does not skip expired partitions by default") {
+    withTable("T") {
+      createPartitionExpireTable(1, "values-time", endInputCheck = false)
+      val table = loadTable("T")
+      val (expiredDt, activeDt) = writeExpiredAndActivePartitions()
+
+      spark.sql("CALL sys.compact(table => 'T')")
+
+      val fileCounts = partitionFileCounts(table)
+      Assertions.assertThat(fileCounts(expiredDt)).isEqualTo(1)
+      Assertions.assertThat(fileCounts(activeDt)).isEqualTo(1)
+    }
+  }
+
+  test("Paimon Procedure: compact skip expired partitions ignores update-time strategy") {
+    withTable("T") {
+      createPartitionExpireTable(1, "update-time", endInputCheck = false)
+      val table = loadTable("T")
+      val (expiredDt, activeDt) = writeExpiredAndActivePartitions()
+
+      spark.sql(
+        "CALL sys.compact(table => 'T', " +
+          "options => 'compaction.skip-expired-partitions=true')")
+
+      val fileCounts = partitionFileCounts(table)
+      Assertions.assertThat(fileCounts(expiredDt)).isEqualTo(1)
+      Assertions.assertThat(fileCounts(activeDt)).isEqualTo(1)
+    }
+  }
+
+  test("Paimon Procedure: compact end input still expires skipped partitions") {
+    withTable("T") {
+      createPartitionExpireTable(1, "values-time", endInputCheck = false)
+      val table = loadTable("T")
+      val (_, activeDt) = writeExpiredAndActivePartitions()
+
+      spark.sql("ALTER TABLE T SET TBLPROPERTIES (" +
+        "'end-input.check-partition-expire'='true')")
+
+      spark.sql(
+        "CALL sys.compact(table => 'T', " +
+          "options => 'compaction.skip-expired-partitions=true')")
+
+      val fileCounts = partitionFileCounts(table)
+      Assertions.assertThat(fileCounts.asJava).containsOnlyKeys(activeDt)
+      Assertions.assertThat(fileCounts(activeDt)).isEqualTo(1)
+    }
+  }
+
+  private def createPartitionExpireTable(
+      bucket: Int,
+      expirationStrategy: String,
+      endInputCheck: Boolean): Unit = {
+    val dynamicBucketOption =
+      if (bucket == -1) ", 'dynamic-bucket.initial-buckets'='1'" else ""
+    spark.sql(
+      s"""
+         |CREATE TABLE T (id INT, value STRING, dt STRING)
+         |TBLPROPERTIES (
+         |  'primary-key'='id, dt',
+         |  'bucket'='$bucket',
+         |  'write-only'='true',
+         |  'partition.expiration-time'='7 d',
+         |  'partition.expiration-strategy'='$expirationStrategy',
+         |  'partition.timestamp-formatter'='yyyyMMdd',
+         |  'partition.expiration-check-interval'='999 d',
+         |  'end-input.check-partition-expire'='$endInputCheck'
+         |  $dynamicBucketOption)
+         |PARTITIONED BY (dt)
+         |""".stripMargin)
+  }
+
+  private def writeExpiredAndActivePartitions(): (String, String) = {
+    val formatter = DateTimeFormatter.ofPattern("yyyyMMdd")
+    val expiredDt = LocalDate.now.minusDays(30).format(formatter)
+    val activeDt = LocalDate.now.format(formatter)
+    spark.sql(s"INSERT INTO T VALUES (1, 'old', '$expiredDt'), (1, 'new', '$activeDt')")
+    spark.sql(s"INSERT INTO T VALUES (2, 'old', '$expiredDt'), (2, 'new', '$activeDt')")
+    (expiredDt, activeDt)
+  }
+
+  private def partitionFileCounts(table: FileStoreTable): Map[String, Int] = {
+    table.newSnapshotReader.read.dataSplits.asScala
+      .groupBy(_.partition().getString(0).toString)
+      .map {
+        case (partition, splits) =>
+          partition -> splits.map(_.dataFiles().size()).sum
+      }
   }
 
   test("Paimon Procedure: compact with partition_idle_time for pk table") {


### PR DESCRIPTION
### Purpose
  Support compaction.skip-expired-partitions in Spark compaction. 
  For partitioned primary-key tables using the values-time expiration strategy, 
  avoid unnecessary compaction IO on partitions that are already expired and will subsequently be deleted.
  
### Changes
  - Filter expired partitions while Spark plans fixed/dynamic bucket compaction tasks.
  - Reuse PartitionValuesTimeExpireStrategy to keep expiration semantics aligned with Flink.
  - Apply filtering before Spark parallelizes compact tasks and reads data files.
  - Preserve existing behavior when:
      - the option is disabled;
      - partition.expiration-time is not configured;
      - the expiration strategy is not values-time;
      - the table uses an unsupported bucket mode.

  - Preserve partition expiration during commit, including when end-input.check-partition-expire=true.
  - Add Spark SQL documentation for compact and compact_database.

  Related PR:
  https://github.com/apache/paimon/pull/7537
  https://github.com/apache/paimon/pull/8973

  
### Tests
  - Skipping expired partitions for fixed bucket primary-key tables.
  - Skipping expired partitions for dynamic bucket primary-key tables.
  - Default behavior when the option is disabled.
  - Ignoring the option for the update-time strategy.
  - Deleting skipped partitions during commit when end-input.check-partition-expire=true.