### PR TITLE
[flink] Fix data evolution DELETE without forwarded context

### DIFF
--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/dataevolution/DataEvolutionRowLevelModificationScanContext.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/dataevolution/DataEvolutionRowLevelModificationScanContext.java
@@ -34,6 +34,9 @@ public class DataEvolutionRowLevelModificationScanContext
 
     public static final long EMPTY_TABLE_SNAPSHOT = -1L;
 
+    private static final ThreadLocal<Map<Pair<String, String>, Long>> FALLBACK_SNAPSHOT_IDS =
+            ThreadLocal.withInitial(HashMap::new);
+
     private final Map<Pair<String, String>, Long> snapshotIds;
 
     private DataEvolutionRowLevelModificationScanContext(
@@ -65,5 +68,37 @@ public class DataEvolutionRowLevelModificationScanContext
         }
         return ((DataEvolutionRowLevelModificationScanContext) context)
                 .snapshotIds.get(Pair.of(tableLocation, branch));
+    }
+
+    /**
+     * Registers a planned snapshot for planners which do not forward the row-level modification
+     * context from source to sink.
+     *
+     * <p>The fallback is thread-confined and consumed once. It never derives a snapshot from the
+     * sink-side table, so a concurrent commit cannot move the DELETE to a newer snapshot.
+     */
+    public static void registerFallbackSnapshot(
+            String tableLocation, String branch, long snapshotId) {
+        FALLBACK_SNAPSHOT_IDS.get().put(Pair.of(tableLocation, branch), snapshotId);
+    }
+
+    @Nullable
+    public static Long takeFallbackSnapshot(String tableLocation, String branch) {
+        Map<Pair<String, String>, Long> snapshotIds = FALLBACK_SNAPSHOT_IDS.get();
+        Long snapshotId = snapshotIds.remove(Pair.of(tableLocation, branch));
+        removeFallbackIfEmpty(snapshotIds);
+        return snapshotId;
+    }
+
+    public static void clearFallbackSnapshot(String tableLocation, String branch) {
+        Map<Pair<String, String>, Long> snapshotIds = FALLBACK_SNAPSHOT_IDS.get();
+        snapshotIds.remove(Pair.of(tableLocation, branch));
+        removeFallbackIfEmpty(snapshotIds);
+    }
+
+    private static void removeFallbackIfEmpty(Map<Pair<String, String>, Long> snapshotIds) {
+        if (snapshotIds.isEmpty()) {
+            FALLBACK_SNAPSHOT_IDS.remove();
+        }
     }
 }

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/SupportsRowLevelOperationFlinkTableSink.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/SupportsRowLevelOperationFlinkTableSink.java
@@ -142,12 +142,21 @@ public abstract class SupportsRowLevelOperationFlinkTableSink extends FlinkTable
             @Nullable RowLevelModificationScanContext rowLevelModificationScanContext) {
         if (isDataEvolutionTable()) {
             FileStoreTable fileStoreTable = (FileStoreTable) table;
+            String tableLocation = fileStoreTable.location().toString();
+            String branch = fileStoreTable.snapshotManager().branch();
+            Long snapshotId;
+            if (rowLevelModificationScanContext == null) {
+                snapshotId =
+                        DataEvolutionRowLevelModificationScanContext.takeFallbackSnapshot(
+                                tableLocation, branch);
+            } else {
+                DataEvolutionRowLevelModificationScanContext.clearFallbackSnapshot(
+                        tableLocation, branch);
+                snapshotId =
+                        DataEvolutionRowLevelModificationScanContext.snapshotId(
+                                rowLevelModificationScanContext, tableLocation, branch);
+            }
             DataEvolutionDeleteSink.validateTable(fileStoreTable);
-            Long snapshotId =
-                    DataEvolutionRowLevelModificationScanContext.snapshotId(
-                            rowLevelModificationScanContext,
-                            fileStoreTable.location().toString(),
-                            fileStoreTable.snapshotManager().branch());
             if (snapshotId == null) {
                 throw new IllegalStateException(
                         "Data Evolution DELETE requires a snapshot from the Paimon table source.");

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/source/DataTableSource.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/source/DataTableSource.java
@@ -153,6 +153,12 @@ public class DataTableSource extends BaseDataTableSource
     public RowLevelModificationScanContext applyRowLevelModificationScan(
             RowLevelModificationType rowLevelModificationType,
             @Nullable RowLevelModificationScanContext previousContext) {
+        if (isDataEvolutionTable()) {
+            FileStoreTable fileStoreTable = (FileStoreTable) table;
+            DataEvolutionRowLevelModificationScanContext.clearFallbackSnapshot(
+                    fileStoreTable.location().toString(),
+                    fileStoreTable.snapshotManager().branch());
+        }
         if (rowLevelModificationType != RowLevelModificationType.DELETE
                 || !isDataEvolutionTable()
                 || TimeTravelUtil.hasTimeTravelOptions(Options.fromMap(table.options()))) {
@@ -165,6 +171,10 @@ public class DataTableSource extends BaseDataTableSource
                 snapshotId == null
                         ? DataEvolutionRowLevelModificationScanContext.EMPTY_TABLE_SNAPSHOT
                         : snapshotId;
+        DataEvolutionRowLevelModificationScanContext.registerFallbackSnapshot(
+                fileStoreTable.location().toString(),
+                fileStoreTable.snapshotManager().branch(),
+                rowLevelModificationSnapshotId);
         return DataEvolutionRowLevelModificationScanContext.addSnapshot(
                 previousContext,
                 fileStoreTable.location().toString(),

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/source/DataTableSourceTest.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/source/DataTableSourceTest.java
@@ -21,6 +21,9 @@ package org.apache.paimon.flink.source;
 import org.apache.paimon.data.GenericRow;
 import org.apache.paimon.flink.FlinkConnectorOptions;
 import org.apache.paimon.flink.PaimonDataStreamScanProvider;
+import org.apache.paimon.flink.dataevolution.DataEvolutionRowLevelModificationScanContext;
+import org.apache.paimon.flink.sink.FlinkTableSink;
+import org.apache.paimon.flink.sink.SupportsRowLevelOperationFlinkTableSink;
 import org.apache.paimon.fs.FileIO;
 import org.apache.paimon.fs.Path;
 import org.apache.paimon.fs.local.LocalFileIO;
@@ -44,15 +47,18 @@ import org.apache.flink.configuration.ExecutionOptions;
 import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.table.catalog.ObjectIdentifier;
+import org.apache.flink.table.connector.RowLevelModificationScanContext;
 import org.apache.flink.table.connector.source.DynamicTableSource;
 import org.apache.flink.table.connector.source.LookupTableSource;
 import org.apache.flink.table.connector.source.ScanTableSource;
+import org.apache.flink.table.connector.source.abilities.SupportsRowLevelModificationScan.RowLevelModificationType;
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.types.DataType;
 import org.apache.flink.table.types.logical.LogicalType;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
+import java.lang.reflect.Field;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
@@ -225,6 +231,57 @@ class DataTableSourceTest {
                 ContinuousFileStoreSource.class.getDeclaredField("unordered");
         unorderedField.setAccessible(true);
         assertThat((boolean) unorderedField.get(source)).isFalse();
+    }
+
+    @Test
+    void testDataEvolutionDeleteWithoutForwardedContextUsesPlannedSnapshot() throws Exception {
+        FileStoreTable table =
+                createTable(
+                        ImmutableMap.of(
+                                "bucket",
+                                "-1",
+                                "row-tracking.enabled",
+                                "true",
+                                "data-evolution.enabled",
+                                "true",
+                                "deletion-vectors.enabled",
+                                "true"));
+        writeData(table);
+
+        ObjectIdentifier identifier = ObjectIdentifier.of("cat", "db", "table");
+        DataEvolutionDataTableSource source =
+                new DataEvolutionDataTableSource(identifier, table, false, null);
+        RowLevelModificationScanContext scanContext =
+                source.applyRowLevelModificationScan(RowLevelModificationType.DELETE, null);
+        Long plannedSnapshot =
+                DataEvolutionRowLevelModificationScanContext.snapshotId(
+                        scanContext, table.location().toString(), table.snapshotManager().branch());
+
+        DataEvolutionDataTableSource copiedSource = (DataEvolutionDataTableSource) source.copy();
+        assertThat(copiedSource.listReadableMetadata().containsKey("_ROW_ID")).isTrue();
+
+        // The sink must use the source snapshot even if another commit arrives after planning.
+        writeData(table);
+        assertThat(table.snapshotManager().latestSnapshotId()).isGreaterThan(plannedSnapshot);
+
+        FlinkTableSink sink = new FlinkTableSink(identifier, table, null);
+        sink.applyRowLevelDelete(null);
+        FlinkTableSink copiedSink = (FlinkTableSink) sink.copy();
+        assertThat(dataEvolutionDeleteSnapshotId(copiedSink)).isEqualTo(plannedSnapshot);
+
+        // The fallback is one-shot, so another sink cannot reuse a stale planned snapshot.
+        assertThatThrownBy(
+                        () -> new FlinkTableSink(identifier, table, null).applyRowLevelDelete(null))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("requires a snapshot");
+    }
+
+    private static Long dataEvolutionDeleteSnapshotId(FlinkTableSink sink) throws Exception {
+        Field field =
+                SupportsRowLevelOperationFlinkTableSink.class.getDeclaredField(
+                        "dataEvolutionDeleteSnapshotId");
+        field.setAccessible(true);
+        return (Long) field.get(sink);
     }
 
     private PaimonDataStreamScanProvider runtimeProvider(FlinkTableSource tableSource) {


### PR DESCRIPTION
### Purpose

Follow up on #8988 by making Data Evolution SQL DELETE compatible with Flink-derived planners which do not forward `RowLevelModificationScanContext` from the target source to the sink.

The standard Flink context remains the primary path. During source planning, Paimon also records the exact planned snapshot in a thread-confined fallback keyed by table location and branch. The sink consumes it once only when the received context is `null`.

This fallback never reads `latestSnapshot()` on the sink side. If planning moves to another thread or no Paimon source pinned a snapshot, DELETE still fails instead of risking an inconsistent deletion vector.

The regression test commits a newer snapshot between source planning and sink setup, verifies that the sink retains the original planned snapshot through copies, and verifies that the fallback cannot be reused.

The separate Flink Planner issue for DELETE projections containing only virtual metadata is outside this PR.

### Tests

- `DataTableSourceTest` and `DataEvolutionDeleteSqlITCase`: 17 passed with Flink 1 profile
- `paimon-flink-common` compiled successfully with Flink 2 profile
- Spotless check and `git diff --check`: passed