### PR TITLE
[core][python] Pin full-text reads to planned snapshot

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/table/source/DataEvolutionFullTextRead.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/source/DataEvolutionFullTextRead.java
@@ -18,6 +18,8 @@
 
 package org.apache.paimon.table.source;
 
+import org.apache.paimon.CoreOptions;
+import org.apache.paimon.Snapshot;
 import org.apache.paimon.globalindex.GlobalIndexIOMeta;
 import org.apache.paimon.globalindex.GlobalIndexReadThreadPool;
 import org.apache.paimon.globalindex.GlobalIndexReader;
@@ -78,7 +80,16 @@ public class DataEvolutionFullTextRead implements FullTextRead {
     }
 
     @Override
+    public GlobalIndexResult read(FullTextScan.Plan plan) {
+        return read(plan.splits(), plan.snapshot());
+    }
+
+    @Override
     public GlobalIndexResult read(List<FullTextSearchSplit> splits) {
+        return read(splits, null);
+    }
+
+    private GlobalIndexResult read(List<FullTextSearchSplit> splits, @Nullable Snapshot snapshot) {
         if (splits.isEmpty()) {
             return GlobalIndexResult.createEmpty();
         }
@@ -102,16 +113,38 @@ public class DataEvolutionFullTextRead implements FullTextRead {
         }
 
         GlobalIndexFileReader indexFileReader = m -> table.fileIO().newInputStream(m.filePath());
-        RoaringNavigableMap64 liveRows = GlobalIndexLiveRowFilter.liveRows(table, partitionFilter);
+        RoaringNavigableMap64 liveRows =
+                GlobalIndexLiveRowFilter.liveRows(table, snapshot, partitionFilter, null);
         ScoredGlobalIndexResult result =
                 evalQuery(splitsByColumn, indexPathFactory, indexFileReader, executor, liveRows);
         if (!rawRowRanges.isEmpty()) {
             result =
                     new RawFullTextReadImpl(
-                                    table, partitionFilter, limit, textColumn, this::evalQuery)
+                                    rawReadTable(snapshot),
+                                    partitionFilter,
+                                    limit,
+                                    textColumn,
+                                    this::evalQuery)
                             .withRawSearch(result, rawRowRanges, splitsByColumn, executor);
         }
         return result.topK(limit);
+    }
+
+    private FileStoreTable rawReadTable(@Nullable Snapshot planSnapshot) {
+        if (planSnapshot == null) {
+            return table;
+        }
+
+        Map<String, String> pinOptions = new HashMap<>();
+        pinOptions.put(
+                CoreOptions.SCAN_MODE.key(), CoreOptions.StartupMode.FROM_SNAPSHOT.toString());
+        pinOptions.put(CoreOptions.SCAN_SNAPSHOT_ID.key(), String.valueOf(planSnapshot.id()));
+        pinOptions.put(CoreOptions.SCAN_VERSION.key(), null);
+        pinOptions.put(CoreOptions.SCAN_TAG_NAME.key(), null);
+        pinOptions.put(CoreOptions.SCAN_WATERMARK.key(), null);
+        pinOptions.put(CoreOptions.SCAN_TIMESTAMP.key(), null);
+        pinOptions.put(CoreOptions.SCAN_TIMESTAMP_MILLIS.key(), null);
+        return table.copyWithoutTimeTravel(pinOptions);
     }
 
     ScoredGlobalIndexResult evalQuery(

--- a/paimon-core/src/main/java/org/apache/paimon/table/source/DataEvolutionFullTextScan.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/source/DataEvolutionFullTextScan.java
@@ -34,6 +34,8 @@ import org.apache.paimon.types.DataField;
 import org.apache.paimon.utils.Filter;
 import org.apache.paimon.utils.Range;
 
+import javax.annotation.Nullable;
+
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -128,7 +130,18 @@ public class DataEvolutionFullTextScan implements FullTextScan {
             }
         }
 
-        return () -> splits;
+        @Nullable Snapshot planSnapshot = snapshot;
+        return new Plan() {
+            @Override
+            public List<FullTextSearchSplit> splits() {
+                return splits;
+            }
+
+            @Override
+            public Snapshot snapshot() {
+                return planSnapshot;
+            }
+        };
     }
 
     /**

--- a/paimon-core/src/main/java/org/apache/paimon/table/source/FullTextScan.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/source/FullTextScan.java
@@ -18,6 +18,10 @@
 
 package org.apache.paimon.table.source;
 
+import org.apache.paimon.Snapshot;
+
+import javax.annotation.Nullable;
+
 import java.util.List;
 
 /** Full-text scan to scan index files. */
@@ -28,5 +32,11 @@ public interface FullTextScan {
     /** Plan of full-text scan. */
     interface Plan {
         List<FullTextSearchSplit> splits();
+
+        /** Snapshot the plan was built against; the read pins live-row filtering to it. */
+        @Nullable
+        default Snapshot snapshot() {
+            return null;
+        }
     }
 }

--- a/paimon-core/src/test/java/org/apache/paimon/table/source/FullTextSearchBuilderTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/table/source/FullTextSearchBuilderTest.java
@@ -163,6 +163,75 @@ public class FullTextSearchBuilderTest extends TableTestBase {
     }
 
     @Test
+    public void testFullTextSearchPinsLiveRowsToPlanSnapshot() throws Exception {
+        Identifier identifier = identifier("full_text_pinned_live_rows");
+        Schema schema =
+                Schema.newBuilder()
+                        .column("id", DataTypes.INT())
+                        .column(TEXT_FIELD_NAME, DataTypes.STRING())
+                        .option(CoreOptions.BUCKET.key(), "-1")
+                        .option(CoreOptions.ROW_TRACKING_ENABLED.key(), "true")
+                        .option(CoreOptions.DATA_EVOLUTION_ENABLED.key(), "true")
+                        .option(CoreOptions.DELETION_VECTORS_ENABLED.key(), "true")
+                        .build();
+        catalog.createTable(identifier, schema, false);
+        FileStoreTable table = getTable(identifier);
+
+        String[] documents = {
+            "paimon keyword", "paimon keyword", "paimon keyword", "paimon keyword"
+        };
+        writeDocuments(table, documents);
+        buildAndCommitIndex(table, documents);
+
+        FullTextSearchBuilder builder =
+                table.newFullTextSearchBuilder()
+                        .withQuery(TEXT_FIELD_NAME, matchQuery("keyword"))
+                        .withLimit(4);
+        FullTextScan.Plan plan = builder.newFullTextScan().scan();
+
+        // Row 0 was live when the plan was created. A later DV commit must not change
+        // the plan's live-row view.
+        commitDeletionVectors(table, 0L);
+
+        GlobalIndexResult result = builder.newFullTextRead().read(plan);
+        assertThat(result.results()).contains(0L);
+    }
+
+    @Test
+    public void testFullTextRawFallbackPinsDataReadToPlanSnapshot() throws Exception {
+        Identifier identifier = identifier("full_text_pinned_raw_fallback");
+        Schema schema =
+                Schema.newBuilder()
+                        .column("id", DataTypes.INT())
+                        .column(TEXT_FIELD_NAME, DataTypes.STRING())
+                        .option(CoreOptions.BUCKET.key(), "-1")
+                        .option(CoreOptions.ROW_TRACKING_ENABLED.key(), "true")
+                        .option(CoreOptions.DATA_EVOLUTION_ENABLED.key(), "true")
+                        .option(CoreOptions.DELETION_VECTORS_ENABLED.key(), "true")
+                        .option(CoreOptions.FULL_TEXT_INDEX_SEARCH_MODE.key(), "full")
+                        .build();
+        catalog.createTable(identifier, schema, false);
+        FileStoreTable table = getTable(identifier);
+
+        String[] indexedDocuments = {"indexed document", "another indexed document"};
+        writeDocuments(table, indexedDocuments);
+        buildAndCommitIndex(table, indexedDocuments);
+        writeDocuments(table, new String[] {"fresh planned document", "other raw document"});
+
+        FullTextSearchBuilder builder =
+                table.newFullTextSearchBuilder()
+                        .withQuery(TEXT_FIELD_NAME, matchQuery("fresh"))
+                        .withLimit(4);
+        FullTextScan.Plan plan = builder.newFullTextScan().scan();
+
+        // Row id 2 belongs to the raw fallback and was live at planning time.
+        commitDeletionVectors(table, 2L);
+
+        GlobalIndexResult result = builder.newFullTextRead().read(plan);
+        assertThat(result.results()).contains(2L);
+    }
+
+    @Test
     public void testFullTextSearchNonFastModesScanUnindexedData() throws Exception {
         createTableDefault();
         FileStoreTable table = getTableDefault();

--- a/paimon-python/pypaimon/table/source/full_text_read.py
+++ b/paimon-python/pypaimon/table/source/full_text_read.py
@@ -72,7 +72,13 @@ class DataEvolutionFullTextRead(FullTextRead):
         self._query = query
         self._partition_filter = partition_filter
 
+    def read_plan(self, plan: FullTextScanPlan) -> GlobalIndexResult:
+        return self._read(plan.splits(), plan.snapshot())
+
     def read(self, splits: List[FullTextSearchSplit]) -> GlobalIndexResult:
+        return self._read(splits, None)
+
+    def _read(self, splits: List[FullTextSearchSplit], snapshot) -> GlobalIndexResult:
         index_splits, raw_splits = _split_search_splits(splits)
         if not index_splits and not raw_splits:
             return GlobalIndexResult.create_empty()
@@ -81,10 +87,10 @@ class DataEvolutionFullTextRead(FullTextRead):
         for split in index_splits:
             splits_by_column.setdefault(split.column_name, []).append(split)
         live_rows = global_index_live_row_filter.live_rows(
-            self._table, self._partition_filter)
+            self._table, self._partition_filter, snapshot)
         indexed_result = self._eval_column_query(splits_by_column, live_rows)
         raw_result = self._read_raw_search(
-            _raw_row_ranges(raw_splits), _index_type(index_splits))
+            _raw_row_ranges(raw_splits), _index_type(index_splits), snapshot)
         return indexed_result.or_(raw_result).top_k(self._limit)
 
     def _eval_column_query(
@@ -160,7 +166,7 @@ class DataEvolutionFullTextRead(FullTextRead):
         future.add_done_callback(lambda _: reader.close())
         return future
 
-    def _read_raw_search(self, raw_row_ranges, index_type):
+    def _read_raw_search(self, raw_row_ranges, index_type, snapshot=None):
         raw_row_ranges = Range.sort_and_merge_overlap(raw_row_ranges, True)
         if not raw_row_ranges:
             return DictBasedScoredIndexResult({})
@@ -169,7 +175,7 @@ class DataEvolutionFullTextRead(FullTextRead):
 
         row_range_start = raw_row_ranges[0].from_
         row_range_end = raw_row_ranges[-1].to
-        table = self._read_raw_rows(raw_row_ranges)
+        table = self._read_raw_rows(raw_row_ranges, snapshot)
         if table is None or table.num_rows == 0:
             return DictBasedScoredIndexResult({})
 
@@ -188,8 +194,10 @@ class DataEvolutionFullTextRead(FullTextRead):
             _candidate_limit(row_range_start, row_range_end),
         ).top_k(self._limit)
 
-    def _read_raw_rows(self, raw_row_ranges):
-        read_builder = self._table.new_read_builder()
+    def _read_raw_rows(self, raw_row_ranges, snapshot=None):
+        read_table = global_index_live_row_filter.table_at_snapshot(
+            self._table, snapshot)
+        read_builder = read_table.new_read_builder()
         if self._partition_filter is not None:
             read_builder = read_builder.with_partition_filter(self._partition_filter)
 

--- a/paimon-python/pypaimon/table/source/full_text_scan.py
+++ b/paimon-python/pypaimon/table/source/full_text_scan.py
@@ -36,11 +36,15 @@ from pypaimon.utils.range import Range
 class FullTextScanPlan:
     """Plan of full-text scan."""
 
-    def __init__(self, splits: List[FullTextSearchSplit]):
+    def __init__(self, splits: List[FullTextSearchSplit], snapshot=None):
         self._splits = splits
+        self._snapshot = snapshot
 
     def splits(self) -> List[FullTextSearchSplit]:
         return self._splits
+
+    def snapshot(self):
+        return self._snapshot
 
 
 class FullTextScan(ABC):
@@ -129,7 +133,7 @@ class DataEvolutionFullTextScan(FullTextScan):
             if raw_row_ranges:
                 splits.append(RawFullTextSearchSplit(raw_row_ranges))
 
-        return FullTextScanPlan(splits)
+        return FullTextScanPlan(splits, snapshot)
 
 
 def _supports_full_text_search(index_type):

--- a/paimon-python/pypaimon/tests/vector_search_filter_test.py
+++ b/paimon-python/pypaimon/tests/vector_search_filter_test.py
@@ -881,10 +881,13 @@ class FullTextSearchBuilderDslTest(unittest.TestCase):
             None, field_id=1, index_type="btree",
             file_name="btree.index", row_range_start=0, row_range_end=9)
         table = _StubTable(fields=[text_field], entries=[ft_entry, btree_entry])
-        _patch_snapshot(self, [ft_entry, btree_entry])
+        snapshot = types.SimpleNamespace(id=7)
+        _patch_snapshot(self, [ft_entry, btree_entry], snapshot)
 
-        splits = DataEvolutionFullTextScan(table, [text_field]).scan().splits()
+        plan = DataEvolutionFullTextScan(table, [text_field]).scan()
+        splits = plan.splits()
 
+        self.assertIs(snapshot, plan.snapshot())
         self.assertEqual(1, len(splits))
         self.assertEqual(
             ["ft.index"],
@@ -2905,6 +2908,98 @@ class VectorSearchManySplitsTest(unittest.TestCase):
 
 class FullTextSearchManySplitsTest(unittest.TestCase):
 
+    def test_full_text_read_plan_pins_live_rows_to_snapshot(self):
+        from pypaimon.globalindex.vector_search_result import (
+            DictBasedScoredIndexResult,
+        )
+        from pypaimon.table.source.full_text_read import DataEvolutionFullTextRead
+        from pypaimon.table.source.full_text_scan import FullTextScanPlan
+        from pypaimon.table.source.full_text_search_split import (
+            IndexFullTextSearchSplit,
+        )
+
+        snapshot = types.SimpleNamespace(id=7)
+        text_field = _field(1, "content", "STRING")
+        entry = _entry(None, field_id=1, index_type="full-text",
+                       file_name="ft.index", row_range_start=10,
+                       row_range_end=14)
+        table = _StubTable(fields=[text_field], entries=[entry])
+        split = IndexFullTextSearchSplit(
+            column_name="content",
+            row_range_start=10,
+            row_range_end=14,
+            full_text_index_files=[entry.index_file],
+        )
+        live_rows = _bitmap(10, 12, 13, 14)
+
+        def _fake_create(index_type, file_io, index_path, index_io_meta_list):
+            class _FakeReader:
+                def visit_full_text_search(self_inner, fts):
+                    return _completed_future(
+                        DictBasedScoredIndexResult({
+                            row_id: float(row_id)
+                            for row_id in fts.include_row_ids
+                        }))
+
+                def close(self_inner):
+                    pass
+
+            return _FakeReader()
+
+        with mock.patch(
+                "pypaimon.table.source.full_text_read."
+                "global_index_live_row_filter.live_rows",
+                return_value=live_rows) as live_rows_fn, \
+             mock.patch(
+                "pypaimon.table.source.full_text_read._create_full_text_reader",
+                side_effect=_fake_create):
+            result = DataEvolutionFullTextRead(
+                table,
+                limit=10,
+                text_column=text_field,
+                query=match_query("test"),
+            ).read_plan(FullTextScanPlan([split], snapshot))
+
+        live_rows_fn.assert_called_once_with(table, None, snapshot)
+        self.assertEqual([10, 12, 13, 14], sorted(list(result.results())))
+
+    def test_full_text_raw_fallback_pins_data_read_to_snapshot(self):
+        from pypaimon.globalindex.vector_search_result import (
+            DictBasedScoredIndexResult,
+        )
+        from pypaimon.table.source.full_text_read import DataEvolutionFullTextRead
+        from pypaimon.table.source.full_text_scan import FullTextScanPlan
+        from pypaimon.table.source.full_text_search_split import RawFullTextSearchSplit
+
+        snapshot = types.SimpleNamespace(id=7)
+        text_field = _field(1, "content", "STRING")
+        table = _StubTable(fields=[text_field], entries=[])
+        planned_table = _StubTable(fields=[text_field], entries=[])
+        _install_raw_full_text_read_builder(
+            planned_table, "content", {5: "raw paimon"})
+        table.copy_without_time_travel = mock.Mock(return_value=planned_table)
+
+        with mock.patch(
+                "pypaimon.table.source.full_text_read."
+                "DataEvolutionFullTextRead._build_raw_index",
+                return_value=b"raw-index"), \
+             mock.patch(
+                "pypaimon.table.source.full_text_read._search_raw_full_text",
+                return_value=DictBasedScoredIndexResult({5: 9.0})):
+            result = DataEvolutionFullTextRead(
+                table,
+                limit=10,
+                text_column=text_field,
+                query=match_query("paimon"),
+            ).read_plan(FullTextScanPlan(
+                [RawFullTextSearchSplit([Range(5, 5)])], snapshot))
+
+        table.copy_without_time_travel.assert_called_once_with({
+            CoreOptions.SCAN_MODE.key(): "from-snapshot",
+            CoreOptions.SCAN_SNAPSHOT_ID.key(): "7",
+        })
+        self.assertEqual([5], sorted(list(result.results())))
+
     def test_full_text_read_threads_external_path_to_reader(self):
         from pypaimon.table.source.full_text_read import DataEvolutionFullTextRead
         from pypaimon.table.source.full_text_search_split import (
@@ -3002,7 +3097,7 @@ class FullTextSearchManySplitsTest(unittest.TestCase):
                 partition_filter=partition_filter,
             ).read([split])
 
-        live_rows_fn.assert_called_once_with(table, partition_filter)
+        live_rows_fn.assert_called_once_with(table, partition_filter, None)
         self.assertEqual([[0, 2, 3, 4]], [b.to_list() for b in captured])
         self.assertEqual([10, 12, 13, 14], sorted(list(result.results())))
 


### PR DESCRIPTION
## What changes

- carry the planning snapshot in Java and Python full-text scan plans
- pin deletion-vector live-row filtering and raw fallback reads to that snapshot
- keep direct `read(splits)` calls unpinned and preserve primary-key full-text behavior
- add regression coverage for commits that happen between planning and reading

## Why

Data-evolution full-text scans selected index and raw ranges from one snapshot, but the reader evaluated deletion vectors and uncovered rows against the latest table state. A commit between planning and reading could therefore remove rows that were valid in the plan or otherwise make indexed and raw results inconsistent.

The plan snapshot is exposed through a default Java method and an optional Python constructor argument, so existing plan implementations and callers remain compatible.

## Checks

- `mvn -pl paimon-core -Pfast-build -DwildcardSuites=none -Dtest=FullTextSearchBuilderTest,PrimaryKeyFullTextReadTest,PrimaryKeyFullTextScanTest,PrimaryKeyFullTextSearchTest test` (38 tests)
- `python3 -m pytest pypaimon/tests/vector_search_filter_test.py pypaimon/tests/primary_key_index_definitions_test.py -q` (88 tests, 7 subtests)
- `mvn -pl paimon-core -DskipTests compile`
- `python3 -m py_compile pypaimon/table/source/full_text_scan.py pypaimon/table/source/full_text_read.py pypaimon/tests/vector_search_filter_test.py`
