### PR TITLE
[python][ray] Add time-based resumable commits to write_paimon

### DIFF
--- a/docs/docs/pypaimon/ray-data.md
+++ b/docs/docs/pypaimon/ray-data.md
@@ -279,7 +279,22 @@ overlapping buckets or sequence numbers for those modes.
 
 ### Incremental write
 
-Long-running updates can commit periodically and resume by `operation_id`:
+An existing Ray Dataset can commit target groups periodically:
+
+```python
+write_paimon(
+    updates,
+    "database_name.target",
+    {"warehouse": "/path/to/warehouse"},
+    commit_mode="incremental",
+    update_cols=["feature"],
+    commit_interval_seconds=600,
+)
+```
+
+Committed groups survive failure, but retrying recomputes the Dataset lineage.
+Pin the starting snapshot when the Dataset reads from the target table itself.
+Use `PaimonOffsetSource` with an `operation_id` to also resume source progress:
 
 ```python
 from pypaimon.ray import PaimonOffsetSource, write_paimon
@@ -298,10 +313,10 @@ write_paimon(
 
 Use a fixed-bucket, partial-update target. Source rows need unique primary keys
 and all `update_cols`; missing keys are inserted. Source splits run in bounded
-windows, so the actual interval may be longer. Concurrent target writes or
-schema changes fail. After success, `delete_write_paimon_checkpoint` releases
-retained snapshots. An `operation_id` must not be reused after changing the
-source transformation.
+windows, so the actual interval may be longer. Concurrent data changes or schema
+changes fail; compaction is allowed. After success,
+`delete_write_paimon_checkpoint` releases retained snapshots. An `operation_id`
+must not be reused after changing the source transformation.
 
 ### `TableWrite.write_ray()` (lower-level)
 

--- a/docs/docs/pypaimon/ray-data.md
+++ b/docs/docs/pypaimon/ray-data.md
@@ -293,13 +293,23 @@ write_paimon(
 ```
 
 Committed groups survive failure, but retrying recomputes the Dataset lineage.
-Pin the starting snapshot when the Dataset reads from the target table itself.
-Use `PaimonOffsetSource` with an `operation_id` to also resume source progress:
+A plain Dataset does not accept `operation_id`. Pin the starting snapshot when
+it reads from the target table itself.
+
+Use `PaimonOffsetSource` to resume source progress. Put the replayable
+transformation, including inference, in `transform`:
 
 ```python
 from pypaimon.ray import PaimonOffsetSource, write_paimon
 
-source = PaimonOffsetSource("database_name.updates", projection=["id", "feature"])
+def build_updates(window):
+    return window.map_batches(infer, batch_format="pyarrow")
+
+source = PaimonOffsetSource(
+    "database_name.source",
+    projection=["id", "payload"],
+    transform=build_updates,
+)
 write_paimon(
     source,
     "database_name.target",
@@ -310,6 +320,9 @@ write_paimon(
     commit_interval_seconds=600,
 )
 ```
+
+Retry with the same `operation_id` skips completed source windows; only an
+unfinished window may run again.
 
 Use a fixed-bucket, partial-update target. Source rows need unique primary keys
 and all `update_cols`; missing keys are inserted. Source splits run in bounded

--- a/docs/docs/pypaimon/ray-data.md
+++ b/docs/docs/pypaimon/ray-data.md
@@ -296,7 +296,8 @@ Use a fixed-bucket, partial-update target. Source rows need unique primary keys
 and all `update_cols`; missing keys are inserted. Source splits run in bounded
 windows, so the actual
 interval may be longer. Concurrent target writes or schema changes fail. After
-success, `delete_write_paimon_checkpoint` releases retained snapshots.
+success, `delete_write_paimon_checkpoint` releases retained snapshots. An
+`operation_id` must not be reused after changing the source transformation.
 
 ### `TableWrite.write_ray()` (lower-level)
 

--- a/docs/docs/pypaimon/ray-data.md
+++ b/docs/docs/pypaimon/ray-data.md
@@ -273,23 +273,17 @@ overlapping buckets or sequence numbers for those modes.
   HASH_FIXED primary-key group. Each `(partition_keys..., bucket)` group
   must fit in memory on one Ray node. This option does not enable Ray
   writes for HASH_DYNAMIC or CROSS_PARTITION primary-key tables.
-- `commit_mode`: `"atomic"` (default) or `"incremental"`.
-- `operation_id`, `commit_interval_seconds`, `update_cols`: required by
-  incremental writes as described below.
+- `commit_mode`: `"atomic"` (default) or `"incremental"`; see below.
 
 ### Incremental write
 
-Long-running primary-key updates can commit completed work periodically and
-resume with the same `operation_id`:
+Long-running updates can commit periodically and resume by `operation_id`:
 
 ```python
 from pypaimon.ray import PaimonOffsetSource, write_paimon
 
-source = PaimonOffsetSource(
-    "database_name.updates",
-    projection=["id", "feature"],
-)
-metrics = write_paimon(
+source = PaimonOffsetSource("database_name.updates", projection=["id", "feature"])
+write_paimon(
     source,
     "database_name.target",
     {"warehouse": "/path/to/warehouse"},
@@ -300,13 +294,11 @@ metrics = write_paimon(
 )
 ```
 
-The target must use fixed buckets and `merge-engine=partial-update`. Source
-rows must contain unique target primary keys and every `update_cols` column;
-other columns must be nullable. Missing keys are inserted. Sequence fields are
-not supported yet. Commits occur after completed internal windows, so the
-actual interval may be longer than `commit_interval_seconds`. Concurrent target
-writes or schema changes fail. After success, `delete_write_paimon_checkpoint`
-releases the retained source and checkpoint snapshots.
+The target must use fixed buckets and `merge-engine=partial-update`. Source rows
+must contain unique primary keys and every `update_cols` column. Missing keys
+are inserted. Commits occur after completed source splits, so the actual
+interval may be longer. Concurrent target writes or schema changes fail. After
+success, `delete_write_paimon_checkpoint` releases retained snapshots.
 
 ### `TableWrite.write_ray()` (lower-level)
 

--- a/docs/docs/pypaimon/ray-data.md
+++ b/docs/docs/pypaimon/ray-data.md
@@ -293,8 +293,8 @@ write_paimon(
 ```
 
 Use a fixed-bucket, partial-update target. Source rows need unique primary keys
-and all `update_cols`; missing keys are inserted. Commits occur after source
-splits, so the actual
+and all `update_cols`; missing keys are inserted. Source splits run in bounded
+windows, so the actual
 interval may be longer. Concurrent target writes or schema changes fail. After
 success, `delete_write_paimon_checkpoint` releases retained snapshots.
 

--- a/docs/docs/pypaimon/ray-data.md
+++ b/docs/docs/pypaimon/ray-data.md
@@ -273,6 +273,40 @@ overlapping buckets or sequence numbers for those modes.
   HASH_FIXED primary-key group. Each `(partition_keys..., bucket)` group
   must fit in memory on one Ray node. This option does not enable Ray
   writes for HASH_DYNAMIC or CROSS_PARTITION primary-key tables.
+- `commit_mode`: `"atomic"` (default) or `"incremental"`.
+- `operation_id`, `commit_interval_seconds`, `update_cols`: required by
+  incremental writes as described below.
+
+### Incremental write
+
+Long-running primary-key updates can commit completed work periodically and
+resume with the same `operation_id`:
+
+```python
+from pypaimon.ray import PaimonOffsetSource, write_paimon
+
+source = PaimonOffsetSource(
+    "database_name.updates",
+    projection=["id", "feature"],
+)
+metrics = write_paimon(
+    source,
+    "database_name.target",
+    {"warehouse": "/path/to/warehouse"},
+    commit_mode="incremental",
+    update_cols=["feature"],
+    operation_id="feature-backfill-2026-07",
+    commit_interval_seconds=600,
+)
+```
+
+The target must use fixed buckets and `merge-engine=partial-update`. Source
+rows must contain unique target primary keys and every `update_cols` column;
+other columns must be nullable. Missing keys are inserted. Sequence fields are
+not supported yet. Commits occur after completed internal windows, so the
+actual interval may be longer than `commit_interval_seconds`. Concurrent target
+writes or schema changes fail. After success, `delete_write_paimon_checkpoint`
+releases the retained source and checkpoint snapshots.
 
 ### `TableWrite.write_ray()` (lower-level)
 

--- a/docs/docs/pypaimon/ray-data.md
+++ b/docs/docs/pypaimon/ray-data.md
@@ -273,8 +273,6 @@ overlapping buckets or sequence numbers for those modes.
   HASH_FIXED primary-key group. Each `(partition_keys..., bucket)` group
   must fit in memory on one Ray node. This option does not enable Ray
   writes for HASH_DYNAMIC or CROSS_PARTITION primary-key tables.
-- `commit_mode`: `"atomic"` (default) or `"incremental"`; see below.
-
 ### Incremental write
 
 Long-running updates can commit periodically and resume by `operation_id`:
@@ -294,9 +292,9 @@ write_paimon(
 )
 ```
 
-The target must use fixed buckets and `merge-engine=partial-update`. Source rows
-must contain unique primary keys and every `update_cols` column. Missing keys
-are inserted. Commits occur after completed source splits, so the actual
+Use a fixed-bucket, partial-update target. Source rows need unique primary keys
+and all `update_cols`; missing keys are inserted. Commits occur after source
+splits, so the actual
 interval may be longer. Concurrent target writes or schema changes fail. After
 success, `delete_write_paimon_checkpoint` releases retained snapshots.
 

--- a/paimon-python/pypaimon/ray/__init__.py
+++ b/paimon-python/pypaimon/ray/__init__.py
@@ -30,6 +30,8 @@ from pypaimon.ray.data_evolution_merge_transform import (
 )
 from pypaimon.ray.update_by_row_id import update_by_row_id
 from pypaimon.ray.read_by_row_id import read_by_row_id
+from pypaimon.ray.offset_source import PaimonOffsetSource
+from pypaimon.ray.incremental_write import delete_write_paimon_checkpoint
 
 __all__ = [
     "read_paimon",
@@ -40,6 +42,8 @@ __all__ = [
     "merge_into",
     "update_by_row_id",
     "read_by_row_id",
+    "PaimonOffsetSource",
+    "delete_write_paimon_checkpoint",
     "WhenMatched",
     "WhenNotMatched",
     "source_col",

--- a/paimon-python/pypaimon/ray/incremental_write.py
+++ b/paimon-python/pypaimon/ray/incremental_write.py
@@ -247,8 +247,7 @@ def _write_offset_source(
                         planned_schema_id, commit_user, checkpoint_tags,
                         checkpoint_id, pending_messages, state)
                 except Exception:
-                    # Commit failures have a known or uncertain outcome; the
-                    # commit layer owns cleanup in the known case.
+                    # Avoid aborting files after an uncertain commit outcome.
                     pending_messages = []
                     raise
                 pending_messages = []
@@ -287,7 +286,7 @@ def _write_dataset_periodically(
                 )
                 committer.commit()
         except Exception:
-            # Preserve completed groups before surfacing a source or worker error.
+            # Commit completed groups before reporting the failure.
             committer.commit()
             raise
     except Exception:

--- a/paimon-python/pypaimon/ray/incremental_write.py
+++ b/paimon-python/pypaimon/ray/incremental_write.py
@@ -52,10 +52,6 @@ def incremental_write_paimon(
     from pypaimon.write.ray_datasink import _write_primary_key_groups
 
     resumable = isinstance(source, PaimonOffsetSource)
-    if not resumable and not hasattr(source, "map_batches"):
-        raise ValueError(
-            "incremental write_paimon requires a ray.data.Dataset or "
-            "PaimonOffsetSource.")
     if resumable:
         _validate_operation_id(operation_id)
     elif operation_id is not None:

--- a/paimon-python/pypaimon/ray/incremental_write.py
+++ b/paimon-python/pypaimon/ray/incremental_write.py
@@ -46,7 +46,6 @@ def incremental_write_paimon(
     """Write a Ray source with periodic commits and optional source checkpoints."""
     from pypaimon.catalog.catalog_factory import CatalogFactory
     from pypaimon.ray.offset_source import PaimonOffsetSource
-    from pypaimon.write.ray_datasink import _write_primary_key_groups
 
     resumable = isinstance(source, PaimonOffsetSource)
     if resumable:
@@ -73,6 +72,93 @@ def incremental_write_paimon(
             concurrency,
             ray_remote_args,
         )
+
+    return _write_offset_source(
+        source,
+        target,
+        catalog,
+        table,
+        operation_id,
+        commit_interval_seconds,
+        update_cols,
+        to_write_batch,
+        concurrency,
+        ray_remote_args,
+    )
+
+
+def _prepare_incremental_target(table, target, update_cols):
+    from pypaimon.common.options.core_options import MergeEngine
+    from pypaimon.schema.data_types import PyarrowFieldParser
+    from pypaimon.table.bucket_mode import BucketMode
+
+    if not update_cols:
+        raise ValueError("update_cols must be non-empty.")
+    update_cols = list(dict.fromkeys(update_cols))
+
+    if not table.is_primary_key_table:
+        raise ValueError(
+            "incremental write_paimon requires a primary-key target.")
+    if table.bucket_mode() != BucketMode.HASH_FIXED:
+        raise ValueError(
+            "incremental write_paimon requires a fixed-bucket target.")
+    if table.cross_partition_update:
+        raise ValueError(
+            "incremental write_paimon does not support cross-partition "
+            "updates.")
+    if table.options.merge_engine() != MergeEngine.PARTIAL_UPDATE:
+        raise ValueError(
+            "incremental write_paimon requires "
+            "'merge-engine'='partial-update'.")
+    if table.options.sequence_field():
+        raise ValueError(
+            "incremental write_paimon does not support sequence fields.")
+
+    primary_keys = list(table.primary_keys)
+    invalid = [name for name in update_cols if name not in table.field_names]
+    if invalid:
+        raise ValueError(
+            "update column {!r} is not in target {!r}.".format(
+                invalid[0], target))
+    key_updates = [name for name in update_cols if name in primary_keys]
+    if key_updates:
+        raise ValueError(
+            "primary-key column {!r} cannot be updated.".format(
+                key_updates[0]))
+    omitted_non_null = [
+        field.name for field in table.table_schema.fields
+        if (field.name not in primary_keys
+            and field.name not in update_cols
+            and not field.type.nullable)
+    ]
+    if omitted_non_null:
+        raise ValueError(
+            "unprovided partial-update column {!r} must be nullable.".format(
+                omitted_non_null[0]))
+
+    target_schema = PyarrowFieldParser.from_paimon_schema(
+        table.table_schema.fields)
+    required = primary_keys + update_cols
+
+    def to_write_batch(batch):
+        missing = [name for name in required if name not in batch.column_names]
+        if missing:
+            raise ValueError("source is missing columns {}.".format(missing))
+        arrays = [
+            batch.column(field.name).cast(field.type)
+            if field.name in required
+            else pa.nulls(batch.num_rows, type=field.type)
+            for field in target_schema
+        ]
+        return pa.Table.from_arrays(arrays, schema=target_schema)
+    return update_cols, to_write_batch
+
+
+def _write_offset_source(
+        source, target, catalog, table, operation_id,
+        commit_interval_seconds, update_cols, to_write_batch,
+        concurrency, ray_remote_args):
+    from pypaimon.write.ray_datasink import _write_primary_key_groups
 
     commit_user = _commit_user(operation_id)
     checkpoint_tags = _checkpoint_tags(operation_id)
@@ -175,73 +261,6 @@ def incremental_write_paimon(
         if pending_messages:
             _abort_messages(table, pending_messages)
         raise
-
-
-def _prepare_incremental_target(table, target, update_cols):
-    from pypaimon.common.options.core_options import MergeEngine
-    from pypaimon.schema.data_types import PyarrowFieldParser
-    from pypaimon.table.bucket_mode import BucketMode
-
-    if not update_cols:
-        raise ValueError("update_cols must be non-empty.")
-    update_cols = list(dict.fromkeys(update_cols))
-
-    if not table.is_primary_key_table:
-        raise ValueError(
-            "incremental write_paimon requires a primary-key target.")
-    if table.bucket_mode() != BucketMode.HASH_FIXED:
-        raise ValueError(
-            "incremental write_paimon requires a fixed-bucket target.")
-    if table.cross_partition_update:
-        raise ValueError(
-            "incremental write_paimon does not support cross-partition "
-            "updates.")
-    if table.options.merge_engine() != MergeEngine.PARTIAL_UPDATE:
-        raise ValueError(
-            "incremental write_paimon requires "
-            "'merge-engine'='partial-update'.")
-    if table.options.sequence_field():
-        raise ValueError(
-            "incremental write_paimon does not support sequence fields.")
-
-    primary_keys = list(table.primary_keys)
-    invalid = [name for name in update_cols if name not in table.field_names]
-    if invalid:
-        raise ValueError(
-            "update column {!r} is not in target {!r}.".format(
-                invalid[0], target))
-    key_updates = [name for name in update_cols if name in primary_keys]
-    if key_updates:
-        raise ValueError(
-            "primary-key column {!r} cannot be updated.".format(
-                key_updates[0]))
-    omitted_non_null = [
-        field.name for field in table.table_schema.fields
-        if (field.name not in primary_keys
-            and field.name not in update_cols
-            and not field.type.nullable)
-    ]
-    if omitted_non_null:
-        raise ValueError(
-            "unprovided partial-update column {!r} must be nullable.".format(
-                omitted_non_null[0]))
-
-    target_schema = PyarrowFieldParser.from_paimon_schema(
-        table.table_schema.fields)
-    required = primary_keys + update_cols
-
-    def to_write_batch(batch):
-        missing = [name for name in required if name not in batch.column_names]
-        if missing:
-            raise ValueError("source is missing columns {}.".format(missing))
-        arrays = [
-            batch.column(field.name).cast(field.type)
-            if field.name in required
-            else pa.nulls(batch.num_rows, type=field.type)
-            for field in target_schema
-        ]
-        return pa.Table.from_arrays(arrays, schema=target_schema)
-    return update_cols, to_write_batch
 
 
 def _write_dataset_periodically(

--- a/paimon-python/pypaimon/ray/incremental_write.py
+++ b/paimon-python/pypaimon/ray/incremental_write.py
@@ -43,7 +43,7 @@ def incremental_write_paimon(
         update_cols,
         concurrency=None,
         ray_remote_args=None):
-    """Write a replayable Paimon source with periodic checkpoints."""
+    """Write a Ray source with periodic commits and optional source checkpoints."""
     from pypaimon.catalog.catalog_factory import CatalogFactory
     from pypaimon.common.options.core_options import MergeEngine
     from pypaimon.ray.offset_source import PaimonOffsetSource
@@ -51,10 +51,17 @@ def incremental_write_paimon(
     from pypaimon.table.bucket_mode import BucketMode
     from pypaimon.write.ray_datasink import _write_primary_key_groups
 
-    if not isinstance(source, PaimonOffsetSource):
+    resumable = isinstance(source, PaimonOffsetSource)
+    if not resumable and not hasattr(source, "map_batches"):
         raise ValueError(
-            "incremental write_paimon requires a PaimonOffsetSource.")
-    _validate_operation_id(operation_id)
+            "incremental write_paimon requires a ray.data.Dataset or "
+            "PaimonOffsetSource.")
+    if resumable:
+        _validate_operation_id(operation_id)
+    elif operation_id is not None:
+        raise ValueError(
+            "operation_id requires a PaimonOffsetSource; a plain Ray Dataset "
+            "does not expose resumable source offsets.")
     if (isinstance(commit_interval_seconds, bool)
             or not isinstance(commit_interval_seconds, (int, float))
             or commit_interval_seconds <= 0):
@@ -104,6 +111,31 @@ def incremental_write_paimon(
         raise ValueError(
             "unprovided partial-update column {!r} must be nullable.".format(
                 omitted_non_null[0]))
+
+    target_schema = PyarrowFieldParser.from_paimon_schema(
+        table.table_schema.fields)
+    required = primary_keys + update_cols
+
+    def to_write_batch(batch):
+        missing = [name for name in required if name not in batch.column_names]
+        if missing:
+            raise ValueError("source is missing columns {}.".format(missing))
+        arrays = [
+            batch.column(field.name).cast(field.type)
+            if field.name in required
+            else pa.nulls(batch.num_rows, type=field.type)
+            for field in target_schema
+        ]
+        return pa.Table.from_arrays(arrays, schema=target_schema)
+
+    if not resumable:
+        return _write_dataset_periodically(
+            source.map_batches(to_write_batch, batch_format="pyarrow"),
+            table,
+            commit_interval_seconds,
+            concurrency,
+            ray_remote_args,
+        )
 
     commit_user = _commit_user(operation_id)
     checkpoint_tags = _checkpoint_tags(operation_id)
@@ -156,22 +188,6 @@ def incremental_write_paimon(
         if bound.num_units == 0:
             return
 
-    target_schema = PyarrowFieldParser.from_paimon_schema(
-        table.table_schema.fields)
-    required = primary_keys + update_cols
-
-    def to_write_batch(batch):
-        missing = [name for name in required if name not in batch.column_names]
-        if missing:
-            raise ValueError("source is missing columns {}.".format(missing))
-        arrays = [
-            batch.column(field.name).cast(field.type)
-            if field.name in required
-            else pa.nulls(batch.num_rows, type=field.type)
-            for field in target_schema
-        ]
-        return pa.Table.from_arrays(arrays, schema=target_schema)
-
     pending_messages = []
     pending_offset = next_offset
     last_commit_time = time.monotonic()
@@ -222,6 +238,125 @@ def incremental_write_paimon(
         if pending_messages:
             _abort_messages(table, pending_messages)
         raise
+
+
+def _write_dataset_periodically(
+        dataset, table, commit_interval_seconds, concurrency,
+        ray_remote_args):
+    from pypaimon.write.ray_datasink import _write_primary_key_groups
+
+    committer = _PeriodicDatasetCommitter(
+        table,
+        table.snapshot_manager().get_latest_snapshot(),
+        table.table_schema.id)
+    windows = _dataset_windows(dataset, commit_interval_seconds)
+    try:
+        try:
+            for window in windows:
+                _write_primary_key_groups(
+                    window,
+                    table,
+                    overwrite=False,
+                    static_partition=None,
+                    concurrency=concurrency,
+                    ray_remote_args=ray_remote_args,
+                    on_group_result=committer.add_group,
+                )
+                committer.commit()
+        except Exception:
+            # Preserve completed groups before surfacing a source or worker error.
+            committer.commit()
+            raise
+    except Exception:
+        committer.abort_pending()
+        raise
+    finally:
+        windows.close()
+        committer.close()
+
+
+def _dataset_windows(dataset, interval):
+    """Yield time windows without copying Ray blocks through the driver."""
+    import ray.data
+
+    bundles = []
+    source = dataset.iter_internal_ref_bundles()
+    last_window = time.monotonic()
+    try:
+        for bundle in source:
+            bundles.append(bundle)
+            if time.monotonic() - last_window < interval:
+                continue
+            current, bundles = bundles, []
+            try:
+                yield ray.data.from_arrow_refs([
+                    ref for item in current for ref in item.block_refs])
+            finally:
+                for item in current:
+                    item.destroy_if_owned()
+            last_window = time.monotonic()
+        if bundles:
+            current, bundles = bundles, []
+            try:
+                yield ray.data.from_arrow_refs([
+                    ref for item in current for ref in item.block_refs])
+            finally:
+                for item in current:
+                    item.destroy_if_owned()
+    finally:
+        for item in bundles:
+            item.destroy_if_owned()
+        close = getattr(source, "close", None)
+        if close is not None:
+            close()
+
+
+class _PeriodicDatasetCommitter:
+
+    def __init__(self, table, base_snapshot, schema_id):
+        self._table = table
+        self._base_snapshot = base_snapshot
+        self._schema_id = schema_id
+        builder = table.new_stream_write_builder()
+        self._commit_user = builder.commit_user
+        self._commit = builder.new_commit()
+        self._pending = []
+        self._next_commit_id = 1
+
+    def add_group(self, messages):
+        self._pending.extend(message for message in messages
+                             if not message.is_empty())
+
+    def commit(self):
+        if not self._pending:
+            return
+        messages = self._pending
+        self._pending = []
+        commit_id = self._next_commit_id
+        base_id = self._base_snapshot.id if self._base_snapshot is not None else 0
+        self._commit.protect_from_external_commits(
+            self._base_snapshot, self._schema_id, allow_maintenance=True)
+        self._commit.commit(messages, commit_id)
+        committed = _find_committed_snapshot(
+            self._table, self._commit_user, commit_id, base_id)
+        if committed is None:
+            raise RuntimeError("Committed periodic write snapshot is missing.")
+        self._base_snapshot = committed
+        _validate_schema(self._table, self._schema_id)
+        self._next_commit_id += 1
+
+    def abort_pending(self):
+        if not self._pending:
+            return
+        messages = self._pending
+        self._pending = []
+        _abort_messages(self._table, messages)
+
+    def close(self):
+        try:
+            self._commit.close()
+        except Exception:
+            logger.warning("Failed to close periodic write commit.", exc_info=True)
 
 
 def delete_write_paimon_checkpoint(
@@ -379,6 +514,14 @@ def _read_checkpoint(snapshot, strict=True):
 
 
 def _find_checkpoint_snapshot(table, commit_user, checkpoint_id, after_id):
+    snapshot = _find_committed_snapshot(
+        table, commit_user, checkpoint_id, after_id)
+    if snapshot is None or _read_checkpoint(snapshot, strict=False) is None:
+        return None
+    return snapshot
+
+
+def _find_committed_snapshot(table, commit_user, commit_id, after_id):
     manager = table.snapshot_manager()
     latest = manager.get_latest_snapshot()
     if latest is None:
@@ -387,8 +530,7 @@ def _find_checkpoint_snapshot(table, commit_user, checkpoint_id, after_id):
         snapshot = manager.get_snapshot_by_id(snapshot_id)
         if (snapshot is not None
                 and snapshot.commit_user == commit_user
-                and snapshot.commit_identifier == checkpoint_id
-                and _read_checkpoint(snapshot, strict=False) is not None):
+                and snapshot.commit_identifier == commit_id):
             return snapshot
     return None
 

--- a/paimon-python/pypaimon/ray/incremental_write.py
+++ b/paimon-python/pypaimon/ray/incremental_write.py
@@ -21,8 +21,6 @@ import json
 import logging
 import time
 
-import pyarrow as pa
-
 from pypaimon.write.commit.conflict_detection import CommitConflictError
 
 logger = logging.getLogger(__name__)
@@ -46,6 +44,7 @@ def incremental_write_paimon(
     """Write a Ray source with periodic commits and optional source checkpoints."""
     from pypaimon.catalog.catalog_factory import CatalogFactory
     from pypaimon.ray.offset_source import PaimonOffsetSource
+    from pypaimon.write.ray_datasink import _prepare_incremental_update
 
     resumable = isinstance(source, PaimonOffsetSource)
     if resumable:
@@ -61,7 +60,7 @@ def incremental_write_paimon(
 
     catalog = CatalogFactory.create(catalog_options)
     table = catalog.get_table(target)
-    update_cols, to_write_batch = _prepare_incremental_target(
+    update_cols, to_write_batch = _prepare_incremental_update(
         table, target, update_cols)
 
     if not resumable:
@@ -85,73 +84,6 @@ def incremental_write_paimon(
         concurrency,
         ray_remote_args,
     )
-
-
-def _prepare_incremental_target(table, target, update_cols):
-    from pypaimon.common.options.core_options import MergeEngine
-    from pypaimon.schema.data_types import PyarrowFieldParser
-    from pypaimon.table.bucket_mode import BucketMode
-
-    if not update_cols:
-        raise ValueError("update_cols must be non-empty.")
-    update_cols = list(dict.fromkeys(update_cols))
-
-    if not table.is_primary_key_table:
-        raise ValueError(
-            "incremental write_paimon requires a primary-key target.")
-    if table.bucket_mode() != BucketMode.HASH_FIXED:
-        raise ValueError(
-            "incremental write_paimon requires a fixed-bucket target.")
-    if table.cross_partition_update:
-        raise ValueError(
-            "incremental write_paimon does not support cross-partition "
-            "updates.")
-    if table.options.merge_engine() != MergeEngine.PARTIAL_UPDATE:
-        raise ValueError(
-            "incremental write_paimon requires "
-            "'merge-engine'='partial-update'.")
-    if table.options.sequence_field():
-        raise ValueError(
-            "incremental write_paimon does not support sequence fields.")
-
-    primary_keys = list(table.primary_keys)
-    invalid = [name for name in update_cols if name not in table.field_names]
-    if invalid:
-        raise ValueError(
-            "update column {!r} is not in target {!r}.".format(
-                invalid[0], target))
-    key_updates = [name for name in update_cols if name in primary_keys]
-    if key_updates:
-        raise ValueError(
-            "primary-key column {!r} cannot be updated.".format(
-                key_updates[0]))
-    omitted_non_null = [
-        field.name for field in table.table_schema.fields
-        if (field.name not in primary_keys
-            and field.name not in update_cols
-            and not field.type.nullable)
-    ]
-    if omitted_non_null:
-        raise ValueError(
-            "unprovided partial-update column {!r} must be nullable.".format(
-                omitted_non_null[0]))
-
-    target_schema = PyarrowFieldParser.from_paimon_schema(
-        table.table_schema.fields)
-    required = primary_keys + update_cols
-
-    def to_write_batch(batch):
-        missing = [name for name in required if name not in batch.column_names]
-        if missing:
-            raise ValueError("source is missing columns {}.".format(missing))
-        arrays = [
-            batch.column(field.name).cast(field.type)
-            if field.name in required
-            else pa.nulls(batch.num_rows, type=field.type)
-            for field in target_schema
-        ]
-        return pa.Table.from_arrays(arrays, schema=target_schema)
-    return update_cols, to_write_batch
 
 
 def _write_offset_source(

--- a/paimon-python/pypaimon/ray/incremental_write.py
+++ b/paimon-python/pypaimon/ray/incremental_write.py
@@ -45,10 +45,7 @@ def incremental_write_paimon(
         ray_remote_args=None):
     """Write a Ray source with periodic commits and optional source checkpoints."""
     from pypaimon.catalog.catalog_factory import CatalogFactory
-    from pypaimon.common.options.core_options import MergeEngine
     from pypaimon.ray.offset_source import PaimonOffsetSource
-    from pypaimon.schema.data_types import PyarrowFieldParser
-    from pypaimon.table.bucket_mode import BucketMode
     from pypaimon.write.ray_datasink import _write_primary_key_groups
 
     resumable = isinstance(source, PaimonOffsetSource)
@@ -62,67 +59,11 @@ def incremental_write_paimon(
             or not isinstance(commit_interval_seconds, (int, float))
             or commit_interval_seconds <= 0):
         raise ValueError("commit_interval_seconds must be positive.")
-    if not update_cols:
-        raise ValueError("update_cols must be non-empty.")
-    update_cols = list(dict.fromkeys(update_cols))
 
     catalog = CatalogFactory.create(catalog_options)
     table = catalog.get_table(target)
-    if not table.is_primary_key_table:
-        raise ValueError(
-            "incremental write_paimon requires a primary-key target.")
-    if table.bucket_mode() != BucketMode.HASH_FIXED:
-        raise ValueError(
-            "incremental write_paimon requires a fixed-bucket target.")
-    if table.cross_partition_update:
-        raise ValueError(
-            "incremental write_paimon does not support cross-partition "
-            "updates.")
-    if table.options.merge_engine() != MergeEngine.PARTIAL_UPDATE:
-        raise ValueError(
-            "incremental write_paimon requires "
-            "'merge-engine'='partial-update'.")
-    if table.options.sequence_field():
-        raise ValueError(
-            "incremental write_paimon does not support sequence fields.")
-
-    primary_keys = list(table.primary_keys)
-    invalid = [name for name in update_cols if name not in table.field_names]
-    if invalid:
-        raise ValueError(
-            "update column {!r} is not in target {!r}.".format(
-                invalid[0], target))
-    key_updates = [name for name in update_cols if name in primary_keys]
-    if key_updates:
-        raise ValueError(
-            "primary-key column {!r} cannot be updated.".format(
-                key_updates[0]))
-    omitted_non_null = [
-        field.name for field in table.table_schema.fields
-        if (field.name not in primary_keys
-            and field.name not in update_cols
-            and not field.type.nullable)
-    ]
-    if omitted_non_null:
-        raise ValueError(
-            "unprovided partial-update column {!r} must be nullable.".format(
-                omitted_non_null[0]))
-
-    target_schema = PyarrowFieldParser.from_paimon_schema(
-        table.table_schema.fields)
-    required = primary_keys + update_cols
-
-    def to_write_batch(batch):
-        missing = [name for name in required if name not in batch.column_names]
-        if missing:
-            raise ValueError("source is missing columns {}.".format(missing))
-        arrays = [
-            batch.column(field.name).cast(field.type)
-            if field.name in required
-            else pa.nulls(batch.num_rows, type=field.type)
-            for field in target_schema
-        ]
-        return pa.Table.from_arrays(arrays, schema=target_schema)
+    update_cols, to_write_batch = _prepare_incremental_target(
+        table, target, update_cols)
 
     if not resumable:
         return _write_dataset_periodically(
@@ -234,6 +175,73 @@ def incremental_write_paimon(
         if pending_messages:
             _abort_messages(table, pending_messages)
         raise
+
+
+def _prepare_incremental_target(table, target, update_cols):
+    from pypaimon.common.options.core_options import MergeEngine
+    from pypaimon.schema.data_types import PyarrowFieldParser
+    from pypaimon.table.bucket_mode import BucketMode
+
+    if not update_cols:
+        raise ValueError("update_cols must be non-empty.")
+    update_cols = list(dict.fromkeys(update_cols))
+
+    if not table.is_primary_key_table:
+        raise ValueError(
+            "incremental write_paimon requires a primary-key target.")
+    if table.bucket_mode() != BucketMode.HASH_FIXED:
+        raise ValueError(
+            "incremental write_paimon requires a fixed-bucket target.")
+    if table.cross_partition_update:
+        raise ValueError(
+            "incremental write_paimon does not support cross-partition "
+            "updates.")
+    if table.options.merge_engine() != MergeEngine.PARTIAL_UPDATE:
+        raise ValueError(
+            "incremental write_paimon requires "
+            "'merge-engine'='partial-update'.")
+    if table.options.sequence_field():
+        raise ValueError(
+            "incremental write_paimon does not support sequence fields.")
+
+    primary_keys = list(table.primary_keys)
+    invalid = [name for name in update_cols if name not in table.field_names]
+    if invalid:
+        raise ValueError(
+            "update column {!r} is not in target {!r}.".format(
+                invalid[0], target))
+    key_updates = [name for name in update_cols if name in primary_keys]
+    if key_updates:
+        raise ValueError(
+            "primary-key column {!r} cannot be updated.".format(
+                key_updates[0]))
+    omitted_non_null = [
+        field.name for field in table.table_schema.fields
+        if (field.name not in primary_keys
+            and field.name not in update_cols
+            and not field.type.nullable)
+    ]
+    if omitted_non_null:
+        raise ValueError(
+            "unprovided partial-update column {!r} must be nullable.".format(
+                omitted_non_null[0]))
+
+    target_schema = PyarrowFieldParser.from_paimon_schema(
+        table.table_schema.fields)
+    required = primary_keys + update_cols
+
+    def to_write_batch(batch):
+        missing = [name for name in required if name not in batch.column_names]
+        if missing:
+            raise ValueError("source is missing columns {}.".format(missing))
+        arrays = [
+            batch.column(field.name).cast(field.type)
+            if field.name in required
+            else pa.nulls(batch.num_rows, type=field.type)
+            for field in target_schema
+        ]
+        return pa.Table.from_arrays(arrays, schema=target_schema)
+    return update_cols, to_write_batch
 
 
 def _write_dataset_periodically(

--- a/paimon-python/pypaimon/ray/incremental_write.py
+++ b/paimon-python/pypaimon/ray/incremental_write.py
@@ -28,7 +28,6 @@ from pypaimon.write.commit.conflict_detection import CommitConflictError
 logger = logging.getLogger(__name__)
 
 _CHECKPOINT_PROPERTY = "ray.write-paimon.checkpoint"
-_CHECKPOINT_MODE = "primary-key-source-offset"
 _CHECKPOINT_VERSION = 1
 _TAG_PREFIX = "_pypaimon_write_"
 
@@ -49,7 +48,7 @@ def incremental_write_paimon(
     from pypaimon.ray.offset_source import PaimonOffsetSource
     from pypaimon.schema.data_types import PyarrowFieldParser
     from pypaimon.table.bucket_mode import BucketMode
-    from pypaimon.write.ray_datasink import _prepare_primary_key_groups
+    from pypaimon.write.ray_datasink import _write_primary_key_groups
 
     if not isinstance(source, PaimonOffsetSource):
         raise ValueError(
@@ -71,10 +70,6 @@ def incremental_write_paimon(
     if table.bucket_mode() != BucketMode.HASH_FIXED:
         raise ValueError(
             "incremental write_paimon requires a fixed-bucket target.")
-    if table.cross_partition_update:
-        raise ValueError(
-            "incremental write_paimon does not support cross-partition "
-            "updates.")
     if table.options.merge_engine() != MergeEngine.PARTIAL_UPDATE:
         raise ValueError(
             "incremental write_paimon requires "
@@ -116,7 +111,7 @@ def incremental_write_paimon(
     checkpoint_snapshot, state = loaded if loaded is not None else (None, None)
     latest_snapshot = table.snapshot_manager().get_latest_snapshot()
     if (state is not None
-            and not state["complete"]
+            and state["next_offset"] < state["source"]["num_units"]
             and latest_snapshot is not None
             and latest_snapshot.id != checkpoint_snapshot.id):
         raise RuntimeError("Concurrent target commit detected.")
@@ -138,23 +133,24 @@ def incremental_write_paimon(
         bound.plan["snapshot_id"])
 
     next_offset = state["next_offset"] if state is not None else 0
-    num_written = state["num_written"] if state is not None else 0
-    checkpoint_id = state["checkpoint_id"] if state is not None else 0
+    checkpoint_id = (
+        checkpoint_snapshot.commit_identifier
+        if checkpoint_snapshot is not None else 0)
     if next_offset > bound.num_units:
         raise RuntimeError("Checkpoint is beyond the source unit count.")
-    if state is not None and state["complete"]:
-        return {"num_written": num_written}
+    if state is not None and next_offset == bound.num_units:
+        return
     if state is None:
         checkpoint_id = 1
         state = _checkpoint_state(
             operation_id, planned_schema_id, update_cols,
-            bound.plan, 0, 0, checkpoint_id, bound.num_units == 0)
+            bound.plan, 0)
         base_snapshot = _commit_checkpoint(
             catalog, target, table, base_snapshot,
             planned_schema_id, commit_user, checkpoint_tags,
             checkpoint_id, [], state)
-        if state["complete"]:
-            return {"num_written": 0}
+        if bound.num_units == 0:
+            return
 
     target_schema = PyarrowFieldParser.from_paimon_schema(
         table.table_schema.fields)
@@ -173,22 +169,24 @@ def incremental_write_paimon(
         return pa.Table.from_arrays(arrays, schema=target_schema)
 
     pending_messages = []
-    pending_rows = 0
     pending_offset = next_offset
     last_commit_time = time.monotonic()
 
     try:
-        for _, end in bound.windows(next_offset):
+        for start in range(next_offset, bound.num_units):
+            end = start + 1
             dataset = bound.read_window(pending_offset, end).map_batches(
                 to_write_batch, batch_format="pyarrow")
-            messages, rows = _prepare_primary_key_groups(
+            messages = _write_primary_key_groups(
                 dataset,
                 table,
+                overwrite=False,
+                static_partition=None,
                 concurrency=concurrency,
                 ray_remote_args=ray_remote_args,
+                prepare_only=True,
             )
             pending_messages.extend(messages)
-            pending_rows += rows
             pending_offset = end
             complete = end == bound.num_units
             if (complete
@@ -197,8 +195,7 @@ def incremental_write_paimon(
                 checkpoint_id += 1
                 state = _checkpoint_state(
                     operation_id, planned_schema_id, update_cols,
-                    bound.plan, pending_offset,
-                    num_written + pending_rows, checkpoint_id, complete)
+                    bound.plan, pending_offset)
                 try:
                     base_snapshot = _commit_checkpoint(
                         catalog, target, table, base_snapshot,
@@ -209,16 +206,12 @@ def incremental_write_paimon(
                     # commit layer owns cleanup in the known case.
                     pending_messages = []
                     raise
-                num_written += pending_rows
                 pending_messages = []
-                pending_rows = 0
                 logger.info(
                     "Committed incremental write %s at offset %d/%d.",
                     operation_id, pending_offset, bound.num_units)
                 if not complete:
                     last_commit_time = time.monotonic()
-
-        return {"num_written": num_written}
     except Exception:
         if pending_messages:
             _abort_messages(table, pending_messages)
@@ -240,7 +233,7 @@ def delete_write_paimon_checkpoint(
     if loaded is None:
         return False
     _, state = loaded
-    if not state["complete"]:
+    if state["next_offset"] != state["source"]["num_units"]:
         raise RuntimeError("Cannot delete an incomplete checkpoint.")
 
     deleted = False
@@ -296,19 +289,14 @@ def _commit_checkpoint(
 
 
 def _checkpoint_state(
-        operation_id, schema_id, update_cols, source_plan, next_offset,
-        num_written, checkpoint_id, complete):
+        operation_id, schema_id, update_cols, source_plan, next_offset):
     return {
         "version": _CHECKPOINT_VERSION,
-        "mode": _CHECKPOINT_MODE,
         "operation_id": operation_id,
         "schema_id": schema_id,
         "update_cols": list(update_cols),
         "source": dict(source_plan),
         "next_offset": next_offset,
-        "num_written": num_written,
-        "checkpoint_id": checkpoint_id,
-        "complete": complete,
     }
 
 
@@ -349,7 +337,7 @@ def _load_checkpoint(
     if restore_tag:
         _store_checkpoint_tag(
             catalog, target, checkpoint_tags, checkpoint,
-            state["checkpoint_id"])
+            checkpoint.commit_identifier)
     return checkpoint, state
 
 
@@ -359,26 +347,14 @@ def _read_checkpoint(snapshot, strict=True):
         return None
     try:
         state = json.loads(encoded)
-        required = {
-            "operation_id", "schema_id", "update_cols", "source",
-            "next_offset", "num_written", "checkpoint_id", "complete",
-        }
-        if (state.get("version") != _CHECKPOINT_VERSION
-                or state.get("mode") != _CHECKPOINT_MODE
-                or not required.issubset(state)
-                or not isinstance(state["source"], dict)
-                or not isinstance(state["complete"], bool)):
-            raise ValueError
-        for name in ("next_offset", "num_written", "checkpoint_id"):
-            if (isinstance(state[name], bool)
-                    or not isinstance(state[name], int)
-                    or state[name] < 0):
-                raise ValueError
-        num_units = state["source"].get("num_units")
-        if (not isinstance(num_units, int)
-                or state["next_offset"] > num_units
-                or (state["complete"]
-                    and state["next_offset"] != num_units)):
+        next_offset = state["next_offset"]
+        num_units = state["source"]["num_units"]
+        if (state["version"] != _CHECKPOINT_VERSION
+                or isinstance(next_offset, bool)
+                or not isinstance(next_offset, int)
+                or next_offset < 0
+                or not isinstance(num_units, int)
+                or next_offset > num_units):
             raise ValueError
         return state
     except Exception as error:
@@ -446,8 +422,6 @@ def _delete_tag(catalog, table, tag, ignore_missing=False):
 
 
 def _abort_messages(table, messages):
-    if not messages:
-        return
     commit = table.new_batch_write_builder().new_commit()
     try:
         commit.abort(messages)
@@ -458,8 +432,6 @@ def _abort_messages(table, messages):
 def _validate_operation_id(operation_id):
     if not isinstance(operation_id, str) or not operation_id.strip():
         raise ValueError("operation_id must be a non-empty string.")
-    if len(operation_id) > 256:
-        raise ValueError("operation_id must contain at most 256 characters.")
 
 
 def _digest(value):

--- a/paimon-python/pypaimon/ray/incremental_write.py
+++ b/paimon-python/pypaimon/ray/incremental_write.py
@@ -70,6 +70,10 @@ def incremental_write_paimon(
     if table.bucket_mode() != BucketMode.HASH_FIXED:
         raise ValueError(
             "incremental write_paimon requires a fixed-bucket target.")
+    if table.cross_partition_update:
+        raise ValueError(
+            "incremental write_paimon does not support cross-partition "
+            "updates.")
     if table.options.merge_engine() != MergeEngine.PARTIAL_UPDATE:
         raise ValueError(
             "incremental write_paimon requires "

--- a/paimon-python/pypaimon/ray/incremental_write.py
+++ b/paimon-python/pypaimon/ray/incremental_write.py
@@ -1,0 +1,479 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Resumable incremental Ray writes."""
+
+import hashlib
+import json
+import logging
+import time
+
+import pyarrow as pa
+
+from pypaimon.write.commit.conflict_detection import CommitConflictError
+
+logger = logging.getLogger(__name__)
+
+_CHECKPOINT_PROPERTY = "ray.write-paimon.checkpoint"
+_CHECKPOINT_MODE = "primary-key-source-offset"
+_CHECKPOINT_VERSION = 1
+_TAG_PREFIX = "_pypaimon_write_"
+
+
+def incremental_write_paimon(
+        source,
+        target,
+        catalog_options,
+        *,
+        operation_id,
+        commit_interval_seconds,
+        update_cols,
+        concurrency=None,
+        ray_remote_args=None):
+    """Write a replayable Paimon source with periodic checkpoints."""
+    from pypaimon.catalog.catalog_factory import CatalogFactory
+    from pypaimon.common.options.core_options import MergeEngine
+    from pypaimon.ray.offset_source import PaimonOffsetSource
+    from pypaimon.schema.data_types import PyarrowFieldParser
+    from pypaimon.table.bucket_mode import BucketMode
+    from pypaimon.write.ray_datasink import _prepare_primary_key_groups
+
+    if not isinstance(source, PaimonOffsetSource):
+        raise ValueError(
+            "incremental write_paimon requires a PaimonOffsetSource.")
+    _validate_operation_id(operation_id)
+    if (isinstance(commit_interval_seconds, bool)
+            or not isinstance(commit_interval_seconds, (int, float))
+            or commit_interval_seconds <= 0):
+        raise ValueError("commit_interval_seconds must be positive.")
+    if not update_cols:
+        raise ValueError("update_cols must be non-empty.")
+    update_cols = list(dict.fromkeys(update_cols))
+
+    catalog = CatalogFactory.create(catalog_options)
+    table = catalog.get_table(target)
+    if not table.is_primary_key_table:
+        raise ValueError(
+            "incremental write_paimon requires a primary-key target.")
+    if table.bucket_mode() != BucketMode.HASH_FIXED:
+        raise ValueError(
+            "incremental write_paimon requires a fixed-bucket target.")
+    if table.cross_partition_update:
+        raise ValueError(
+            "incremental write_paimon does not support cross-partition "
+            "updates.")
+    if table.options.merge_engine() != MergeEngine.PARTIAL_UPDATE:
+        raise ValueError(
+            "incremental write_paimon requires "
+            "'merge-engine'='partial-update'.")
+    if table.options.sequence_field():
+        raise ValueError(
+            "incremental write_paimon does not support sequence fields.")
+
+    primary_keys = list(table.primary_keys)
+    invalid = [name for name in update_cols if name not in table.field_names]
+    if invalid:
+        raise ValueError(
+            "update column {!r} is not in target {!r}.".format(
+                invalid[0], target))
+    key_updates = [name for name in update_cols if name in primary_keys]
+    if key_updates:
+        raise ValueError(
+            "primary-key column {!r} cannot be updated.".format(
+                key_updates[0]))
+    omitted_non_null = [
+        field.name for field in table.table_schema.fields
+        if (field.name not in primary_keys
+            and field.name not in update_cols
+            and not field.type.nullable)
+    ]
+    if omitted_non_null:
+        raise ValueError(
+            "unprovided partial-update column {!r} must be nullable.".format(
+                omitted_non_null[0]))
+
+    commit_user = _commit_user(operation_id)
+    checkpoint_tags = _checkpoint_tags(operation_id)
+    source_tag = _source_tag(operation_id, target)
+    retained = _get_tag(catalog, source.table_identifier, source_tag)
+    loaded = _load_checkpoint(
+        catalog, target, table, operation_id, update_cols,
+        commit_user, checkpoint_tags,
+        recover_without_tag=retained is not None)
+    checkpoint_snapshot, state = loaded if loaded is not None else (None, None)
+    latest_snapshot = table.snapshot_manager().get_latest_snapshot()
+    if (state is not None
+            and not state["complete"]
+            and latest_snapshot is not None
+            and latest_snapshot.id != checkpoint_snapshot.id):
+        raise RuntimeError("Concurrent target commit detected.")
+    planned_schema_id = (
+        state["schema_id"] if state is not None else table.table_schema.id)
+    base_snapshot = (
+        checkpoint_snapshot if checkpoint_snapshot is not None
+        else latest_snapshot)
+
+    bound = source._bind(
+        catalog,
+        checkpoint_plan=state["source"] if state is not None else None,
+        source_tag=source_tag if retained is not None else None,
+        retained_snapshot_id=(
+            retained.snapshot.id if retained is not None else None),
+    )
+    _ensure_tag(
+        catalog, source.table_identifier, source_tag,
+        bound.plan["snapshot_id"])
+
+    next_offset = state["next_offset"] if state is not None else 0
+    num_written = state["num_written"] if state is not None else 0
+    checkpoint_id = state["checkpoint_id"] if state is not None else 0
+    if next_offset > bound.num_units:
+        raise RuntimeError("Checkpoint is beyond the source unit count.")
+    if state is not None and state["complete"]:
+        return {"num_written": num_written}
+    if state is None:
+        checkpoint_id = 1
+        state = _checkpoint_state(
+            operation_id, planned_schema_id, update_cols,
+            bound.plan, 0, 0, checkpoint_id, bound.num_units == 0)
+        base_snapshot = _commit_checkpoint(
+            catalog, target, table, base_snapshot,
+            planned_schema_id, commit_user, checkpoint_tags,
+            checkpoint_id, [], state)
+        if state["complete"]:
+            return {"num_written": 0}
+
+    target_schema = PyarrowFieldParser.from_paimon_schema(
+        table.table_schema.fields)
+    required = primary_keys + update_cols
+
+    def to_write_batch(batch):
+        missing = [name for name in required if name not in batch.column_names]
+        if missing:
+            raise ValueError("source is missing columns {}.".format(missing))
+        arrays = [
+            batch.column(field.name).cast(field.type)
+            if field.name in required
+            else pa.nulls(batch.num_rows, type=field.type)
+            for field in target_schema
+        ]
+        return pa.Table.from_arrays(arrays, schema=target_schema)
+
+    pending_messages = []
+    pending_rows = 0
+    pending_offset = next_offset
+    last_commit_time = time.monotonic()
+
+    try:
+        for _, end in bound.windows(next_offset):
+            dataset = bound.read_window(pending_offset, end).map_batches(
+                to_write_batch, batch_format="pyarrow")
+            messages, rows = _prepare_primary_key_groups(
+                dataset,
+                table,
+                concurrency=concurrency,
+                ray_remote_args=ray_remote_args,
+            )
+            pending_messages.extend(messages)
+            pending_rows += rows
+            pending_offset = end
+            complete = end == bound.num_units
+            if (complete
+                    or time.monotonic() - last_commit_time
+                    >= commit_interval_seconds):
+                checkpoint_id += 1
+                state = _checkpoint_state(
+                    operation_id, planned_schema_id, update_cols,
+                    bound.plan, pending_offset,
+                    num_written + pending_rows, checkpoint_id, complete)
+                try:
+                    base_snapshot = _commit_checkpoint(
+                        catalog, target, table, base_snapshot,
+                        planned_schema_id, commit_user, checkpoint_tags,
+                        checkpoint_id, pending_messages, state)
+                except Exception:
+                    # Commit failures have a known or uncertain outcome; the
+                    # commit layer owns cleanup in the known case.
+                    pending_messages = []
+                    raise
+                num_written += pending_rows
+                pending_messages = []
+                pending_rows = 0
+                logger.info(
+                    "Committed incremental write %s at offset %d/%d.",
+                    operation_id, pending_offset, bound.num_units)
+                if not complete:
+                    last_commit_time = time.monotonic()
+
+        return {"num_written": num_written}
+    except Exception:
+        if pending_messages:
+            _abort_messages(table, pending_messages)
+        raise
+
+
+def delete_write_paimon_checkpoint(
+        target, catalog_options, operation_id):
+    """Delete a completed incremental write checkpoint."""
+    from pypaimon.catalog.catalog_factory import CatalogFactory
+
+    _validate_operation_id(operation_id)
+    catalog = CatalogFactory.create(catalog_options)
+    table = catalog.get_table(target)
+    loaded = _load_checkpoint(
+        catalog, target, table, operation_id, None,
+        _commit_user(operation_id), _checkpoint_tags(operation_id),
+        restore_tag=False, recover_without_tag=True)
+    if loaded is None:
+        return False
+    _, state = loaded
+    if not state["complete"]:
+        raise RuntimeError("Cannot delete an incomplete checkpoint.")
+
+    deleted = False
+    for tag in _checkpoint_tags(operation_id):
+        deleted = _delete_tag(catalog, target, tag, True) or deleted
+    source_table = state["source"]["table"]
+    deleted = _delete_tag(
+        catalog, source_table, _source_tag(operation_id, target), True
+    ) or deleted
+    return deleted
+
+
+def _commit_checkpoint(
+        catalog, target, table, base_snapshot, schema_id, commit_user,
+        checkpoint_tags, checkpoint_id, messages, state):
+    from pypaimon.write.table_commit import StreamTableCommit
+
+    properties = {
+        _CHECKPOINT_PROPERTY: json.dumps(
+            state, sort_keys=True, separators=(",", ":"))
+    }
+    commit = StreamTableCommit(table, commit_user, None)
+    commit.with_snapshot_properties(properties)
+    commit.protect_from_external_commits(base_snapshot, schema_id)
+    base_id = base_snapshot.id if base_snapshot is not None else 0
+    try:
+        try:
+            if messages:
+                commit.commit(messages, checkpoint_id)
+            else:
+                commit.commit_metadata(checkpoint_id)
+        except CommitConflictError:
+            raise
+        except Exception:
+            committed = _find_checkpoint_snapshot(
+                table, commit_user, checkpoint_id, base_id)
+            if committed is None:
+                raise
+            base_snapshot = committed
+        else:
+            base_snapshot = _find_checkpoint_snapshot(
+                table, commit_user, checkpoint_id, base_id)
+            if base_snapshot is None:
+                raise RuntimeError("Committed checkpoint snapshot is missing.")
+    finally:
+        try:
+            commit.close()
+        except Exception:
+            logger.warning("Failed to close checkpoint commit.", exc_info=True)
+    _store_checkpoint_tag(
+        catalog, target, checkpoint_tags, base_snapshot, checkpoint_id)
+    return base_snapshot
+
+
+def _checkpoint_state(
+        operation_id, schema_id, update_cols, source_plan, next_offset,
+        num_written, checkpoint_id, complete):
+    return {
+        "version": _CHECKPOINT_VERSION,
+        "mode": _CHECKPOINT_MODE,
+        "operation_id": operation_id,
+        "schema_id": schema_id,
+        "update_cols": list(update_cols),
+        "source": dict(source_plan),
+        "next_offset": next_offset,
+        "num_written": num_written,
+        "checkpoint_id": checkpoint_id,
+        "complete": complete,
+    }
+
+
+def _load_checkpoint(
+        catalog, target, table, operation_id, update_cols,
+        commit_user, checkpoint_tags, restore_tag=True,
+        recover_without_tag=False):
+    snapshots = [
+        tagged.snapshot for tagged in (
+            _get_tag(catalog, target, tag) for tag in checkpoint_tags)
+        if tagged is not None
+    ]
+    checkpoint = max(snapshots, key=lambda item: item.id) if snapshots else None
+    latest = table.snapshot_manager().get_latest_snapshot()
+    if latest is not None and (checkpoint is not None or recover_without_tag):
+        lower = checkpoint.id + 1 if checkpoint is not None else 1
+        for snapshot_id in range(latest.id, lower - 1, -1):
+            snapshot = table.snapshot_manager().get_snapshot_by_id(snapshot_id)
+            if (snapshot is not None
+                    and snapshot.commit_user == commit_user
+                    and _read_checkpoint(snapshot, strict=False) is not None):
+                checkpoint = snapshot
+                break
+    if checkpoint is None:
+        return None
+    state = _read_checkpoint(checkpoint)
+    if checkpoint.commit_user != commit_user:
+        raise RuntimeError("Checkpoint tag belongs to another writer.")
+    if state["operation_id"] != operation_id:
+        raise RuntimeError("operation_id hash collision.")
+    latest_schema = table.schema_manager.latest()
+    if latest_schema is None or state["schema_id"] != latest_schema.id:
+        raise RuntimeError("Target schema changed during incremental write.")
+    if update_cols is not None and state["update_cols"] != list(update_cols):
+        raise ValueError(
+            "operation_id {!r} was already used with update_cols {}.".format(
+                operation_id, state["update_cols"]))
+    if restore_tag:
+        _store_checkpoint_tag(
+            catalog, target, checkpoint_tags, checkpoint,
+            state["checkpoint_id"])
+    return checkpoint, state
+
+
+def _read_checkpoint(snapshot, strict=True):
+    encoded = (snapshot.properties or {}).get(_CHECKPOINT_PROPERTY)
+    if encoded is None:
+        return None
+    try:
+        state = json.loads(encoded)
+        required = {
+            "operation_id", "schema_id", "update_cols", "source",
+            "next_offset", "num_written", "checkpoint_id", "complete",
+        }
+        if (state.get("version") != _CHECKPOINT_VERSION
+                or state.get("mode") != _CHECKPOINT_MODE
+                or not required.issubset(state)
+                or not isinstance(state["source"], dict)
+                or not isinstance(state["complete"], bool)):
+            raise ValueError
+        for name in ("next_offset", "num_written", "checkpoint_id"):
+            if (isinstance(state[name], bool)
+                    or not isinstance(state[name], int)
+                    or state[name] < 0):
+                raise ValueError
+        num_units = state["source"].get("num_units")
+        if (not isinstance(num_units, int)
+                or state["next_offset"] > num_units
+                or (state["complete"]
+                    and state["next_offset"] != num_units)):
+            raise ValueError
+        return state
+    except Exception as error:
+        if not strict:
+            return None
+        raise RuntimeError("Invalid incremental write checkpoint.") from error
+
+
+def _find_checkpoint_snapshot(table, commit_user, checkpoint_id, after_id):
+    manager = table.snapshot_manager()
+    latest = manager.get_latest_snapshot()
+    if latest is None:
+        return None
+    for snapshot_id in range(latest.id, after_id, -1):
+        snapshot = manager.get_snapshot_by_id(snapshot_id)
+        if (snapshot is not None
+                and snapshot.commit_user == commit_user
+                and snapshot.commit_identifier == checkpoint_id
+                and _read_checkpoint(snapshot, strict=False) is not None):
+            return snapshot
+    return None
+
+
+def _store_checkpoint_tag(
+        catalog, target, checkpoint_tags, snapshot, checkpoint_id):
+    slot = checkpoint_id % 2
+    tag = checkpoint_tags[slot]
+    previous = _get_tag(catalog, target, tag)
+    if previous is None or previous.snapshot.id != snapshot.id:
+        if previous is not None:
+            _delete_tag(catalog, target, tag)
+        catalog.create_tag(target, tag, snapshot_id=snapshot.id)
+    _delete_tag(catalog, target, checkpoint_tags[1 - slot], True)
+
+
+def _ensure_tag(catalog, table, tag, snapshot_id):
+    previous = _get_tag(catalog, table, tag)
+    if previous is not None:
+        if previous.snapshot.id != snapshot_id:
+            raise ValueError(
+                "operation_id is bound to another source snapshot.")
+        return
+    catalog.create_tag(table, tag, snapshot_id=snapshot_id)
+
+
+def _get_tag(catalog, table, tag):
+    from pypaimon.catalog.catalog_exception import TagNotExistException
+
+    try:
+        return catalog.get_tag(table, tag)
+    except TagNotExistException:
+        return None
+
+
+def _delete_tag(catalog, table, tag, ignore_missing=False):
+    from pypaimon.catalog.catalog_exception import TagNotExistException
+
+    try:
+        catalog.delete_tag(table, tag)
+        return True
+    except TagNotExistException:
+        if not ignore_missing:
+            raise
+        return False
+
+
+def _abort_messages(table, messages):
+    if not messages:
+        return
+    commit = table.new_batch_write_builder().new_commit()
+    try:
+        commit.abort(messages)
+    finally:
+        commit.close()
+
+
+def _validate_operation_id(operation_id):
+    if not isinstance(operation_id, str) or not operation_id.strip():
+        raise ValueError("operation_id must be a non-empty string.")
+    if len(operation_id) > 256:
+        raise ValueError("operation_id must contain at most 256 characters.")
+
+
+def _digest(value):
+    return hashlib.sha256(value.encode("utf-8")).hexdigest()[:32]
+
+
+def _commit_user(operation_id):
+    return "pypaimon-ray-write-" + _digest(operation_id)
+
+
+def _checkpoint_tags(operation_id):
+    base = _TAG_PREFIX + _digest(operation_id)
+    return base + "_0", base + "_1"
+
+
+def _source_tag(operation_id, target):
+    return _TAG_PREFIX + _digest(target + "\0" + operation_id) + "_source"

--- a/paimon-python/pypaimon/ray/incremental_write.py
+++ b/paimon-python/pypaimon/ray/incremental_write.py
@@ -29,6 +29,7 @@ logger = logging.getLogger(__name__)
 
 _CHECKPOINT_PROPERTY = "ray.write-paimon.checkpoint"
 _CHECKPOINT_VERSION = 1
+_SPLITS_PER_WINDOW = 64
 _TAG_PREFIX = "_pypaimon_write_"
 
 
@@ -125,12 +126,16 @@ def incremental_write_paimon(
         checkpoint_snapshot if checkpoint_snapshot is not None
         else latest_snapshot)
 
+    splits_per_window = (
+        state["source"].get("splits_per_window", 1)
+        if state is not None else _SPLITS_PER_WINDOW)
     bound = source._bind(
         catalog,
         checkpoint_plan=state["source"] if state is not None else None,
         source_tag=source_tag if retained is not None else None,
         retained_snapshot_id=(
             retained.snapshot.id if retained is not None else None),
+        splits_per_window=splits_per_window,
     )
     _ensure_tag(
         catalog, source.table_identifier, source_tag,
@@ -177,8 +182,10 @@ def incremental_write_paimon(
     last_commit_time = time.monotonic()
 
     try:
-        for start in range(next_offset, bound.num_units):
-            end = start + 1
+        while pending_offset < bound.num_units:
+            end = min(
+                pending_offset + bound.plan["splits_per_window"],
+                bound.num_units)
             dataset = bound.read_window(pending_offset, end).map_batches(
                 to_write_batch, batch_format="pyarrow")
             messages = _write_primary_key_groups(
@@ -233,7 +240,8 @@ def delete_write_paimon_checkpoint(
     loaded = _load_checkpoint(
         catalog, target, table, operation_id, None,
         _commit_user(operation_id), _checkpoint_tags(operation_id),
-        restore_tag=False, recover_without_tag=True)
+        restore_tag=False, recover_without_tag=True,
+        validate_schema=False)
     if loaded is None:
         return False
     _, state = loaded
@@ -289,6 +297,10 @@ def _commit_checkpoint(
             logger.warning("Failed to close checkpoint commit.", exc_info=True)
     _store_checkpoint_tag(
         catalog, target, checkpoint_tags, base_snapshot, checkpoint_id)
+    if _read_checkpoint(base_snapshot) != state:
+        raise RuntimeError(
+            "Checkpoint was committed by another writer with different state.")
+    _validate_schema(table, schema_id)
     return base_snapshot
 
 
@@ -307,7 +319,7 @@ def _checkpoint_state(
 def _load_checkpoint(
         catalog, target, table, operation_id, update_cols,
         commit_user, checkpoint_tags, restore_tag=True,
-        recover_without_tag=False):
+        recover_without_tag=False, validate_schema=True):
     snapshots = [
         tagged.snapshot for tagged in (
             _get_tag(catalog, target, tag) for tag in checkpoint_tags)
@@ -331,9 +343,8 @@ def _load_checkpoint(
         raise RuntimeError("Checkpoint tag belongs to another writer.")
     if state["operation_id"] != operation_id:
         raise RuntimeError("operation_id hash collision.")
-    latest_schema = table.schema_manager.latest()
-    if latest_schema is None or state["schema_id"] != latest_schema.id:
-        raise RuntimeError("Target schema changed during incremental write.")
+    if validate_schema:
+        _validate_schema(table, state["schema_id"])
     if update_cols is not None and state["update_cols"] != list(update_cols):
         raise ValueError(
             "operation_id {!r} was already used with update_cols {}.".format(
@@ -353,12 +364,16 @@ def _read_checkpoint(snapshot, strict=True):
         state = json.loads(encoded)
         next_offset = state["next_offset"]
         num_units = state["source"]["num_units"]
+        splits_per_window = state["source"].get("splits_per_window", 1)
         if (state["version"] != _CHECKPOINT_VERSION
                 or isinstance(next_offset, bool)
                 or not isinstance(next_offset, int)
                 or next_offset < 0
                 or not isinstance(num_units, int)
-                or next_offset > num_units):
+                or next_offset > num_units
+                or isinstance(splits_per_window, bool)
+                or not isinstance(splits_per_window, int)
+                or splits_per_window < 1):
             raise ValueError
         return state
     except Exception as error:
@@ -431,6 +446,12 @@ def _abort_messages(table, messages):
         commit.abort(messages)
     finally:
         commit.close()
+
+
+def _validate_schema(table, schema_id):
+    latest = table.schema_manager.latest()
+    if latest is None or latest.id != schema_id:
+        raise RuntimeError("Target schema changed during incremental write.")
 
 
 def _validate_operation_id(operation_id):

--- a/paimon-python/pypaimon/ray/incremental_write.py
+++ b/paimon-python/pypaimon/ray/incremental_write.py
@@ -115,11 +115,6 @@ def incremental_write_paimon(
         recover_without_tag=retained is not None)
     checkpoint_snapshot, state = loaded if loaded is not None else (None, None)
     latest_snapshot = table.snapshot_manager().get_latest_snapshot()
-    if (state is not None
-            and state["next_offset"] < state["source"]["num_units"]
-            and latest_snapshot is not None
-            and latest_snapshot.id != checkpoint_snapshot.id):
-        raise RuntimeError("Concurrent target commit detected.")
     planned_schema_id = (
         state["schema_id"] if state is not None else table.table_schema.id)
     base_snapshot = (
@@ -269,7 +264,8 @@ def _commit_checkpoint(
     }
     commit = StreamTableCommit(table, commit_user, None)
     commit.with_snapshot_properties(properties)
-    commit.protect_from_external_commits(base_snapshot, schema_id)
+    commit.protect_from_external_commits(
+        base_snapshot, schema_id, allow_maintenance=True)
     base_id = base_snapshot.id if base_snapshot is not None else 0
     try:
         try:

--- a/paimon-python/pypaimon/ray/offset_source.py
+++ b/paimon-python/pypaimon/ray/offset_source.py
@@ -58,10 +58,9 @@ def _stable_units(units):
 
 
 class PaimonOffsetSource:
-    """A snapshot-pinned Paimon source processed in stable offset units.
+    """A snapshot-pinned source with stable offsets.
 
-    ``transform`` is rebuilt for each read window. It must be deterministic
-    and must not depend on rows from another window.
+    ``transform`` must be deterministic and window-local.
     """
 
     def __init__(

--- a/paimon-python/pypaimon/ray/offset_source.py
+++ b/paimon-python/pypaimon/ray/offset_source.py
@@ -47,6 +47,16 @@ def _code_identity(code):
     )
 
 
+def _stable_units(units):
+    """Order source units deterministically for checkpoint offsets."""
+    keyed = [
+        (hashlib.sha256(pickle.dumps(unit, protocol=4)).digest(), unit)
+        for unit in units
+    ]
+    keyed.sort(key=lambda item: item[0])
+    return [item[1] for item in keyed], tuple(item[0] for item in keyed)
+
+
 class PaimonOffsetSource:
     """A snapshot-pinned Paimon source processed in stable offset units.
 
@@ -118,10 +128,11 @@ class PaimonOffsetSource:
 
         read_type = read_builder.read_type()
         nested_name_paths = read_builder._nested_name_paths()
-        units = list(read_builder.new_scan().plan().splits())
+        units, unit_ids = _stable_units(
+            read_builder.new_scan().plan().splits())
         fingerprint = hashlib.sha256(pickle.dumps((
             self.table_identifier, snapshot_id, self.projection,
-            self.filter, self._transform_identity(), read_type, units),
+            self.filter, self._transform_identity(), read_type, unit_ids),
             protocol=4)).hexdigest()
         plan = {
             "table": self.table_identifier,

--- a/paimon-python/pypaimon/ray/offset_source.py
+++ b/paimon-python/pypaimon/ray/offset_source.py
@@ -20,8 +20,6 @@ import hashlib
 import pickle
 from typing import Any, Callable, List, Optional
 
-__all__ = ["PaimonOffsetSource"]
-
 
 class PaimonOffsetSource:
     """A snapshot-pinned Paimon source processed in stable offset units.

--- a/paimon-python/pypaimon/ray/offset_source.py
+++ b/paimon-python/pypaimon/ray/offset_source.py
@@ -17,13 +17,10 @@
 """Replayable Paimon source for resumable Ray writes."""
 
 import hashlib
-import marshal
 import pickle
-from typing import Any, Callable, Dict, List, Optional
+from typing import Any, Callable, List, Optional
 
 __all__ = ["PaimonOffsetSource"]
-
-_ROWS_PER_UNIT = 1_000_000
 
 
 class PaimonOffsetSource:
@@ -39,32 +36,16 @@ class PaimonOffsetSource:
             *,
             projection: Optional[List[str]] = None,
             filter=None,
-            transform: Optional[Callable[[Any], Any]] = None,
-            snapshot_id: Optional[int] = None,
-            ray_remote_args: Optional[Dict[str, Any]] = None,
-            concurrency: Optional[int] = None,
-            override_num_blocks: Optional[int] = None,
-            **read_args):
+            transform: Optional[Callable[[Any], Any]] = None):
         if not isinstance(table_identifier, str) or not table_identifier:
             raise ValueError("table_identifier is required.")
         if transform is not None and not callable(transform):
             raise ValueError("transform must be callable.")
-        if snapshot_id is not None and (
-                isinstance(snapshot_id, bool)
-                or not isinstance(snapshot_id, int)
-                or snapshot_id <= 0):
-            raise ValueError("snapshot_id must be a positive integer.")
         self.table_identifier = table_identifier
         self.projection = (
             list(projection) if projection is not None else None)
         self.filter = filter
         self.transform = transform
-        self.snapshot_id = snapshot_id
-        self.ray_remote_args = (
-            dict(ray_remote_args) if ray_remote_args is not None else None)
-        self.concurrency = concurrency
-        self.override_num_blocks = override_num_blocks
-        self.read_args = dict(read_args)
 
     def _bind(
             self,
@@ -83,12 +64,8 @@ class PaimonOffsetSource:
             raise ValueError(
                 "PaimonOffsetSource does not match the saved checkpoint.")
         snapshot_ids = {
-            value for value in (
-                self.snapshot_id,
-                checkpoint_snapshot_id,
-                retained_snapshot_id,
-            ) if value is not None
-        }
+            value for value in (checkpoint_snapshot_id, retained_snapshot_id)
+            if value is not None}
         if len(snapshot_ids) > 1:
             raise ValueError(
                 "PaimonOffsetSource snapshot differs from its checkpoint.")
@@ -116,139 +93,37 @@ class PaimonOffsetSource:
 
         read_type = read_builder.read_type()
         nested_name_paths = read_builder._nested_name_paths()
-        units = _build_offset_units(
-            table, read_builder.new_scan().plan().splits())
+        units = list(read_builder.new_scan().plan().splits())
+        import ray.cloudpickle as cloudpickle
+
+        try:
+            transform = cloudpickle.dumps(self.transform)
+        except Exception as error:
+            raise ValueError(
+                "PaimonOffsetSource transform must be serializable.") \
+                from error
+        fingerprint = hashlib.sha256(pickle.dumps((
+            self.table_identifier, snapshot_id, self.projection,
+            self.filter, transform, read_type, units), protocol=4)).hexdigest()
         plan = {
-            "kind": "paimon-units-v1",
             "table": self.table_identifier,
             "snapshot_id": snapshot_id,
-            "fingerprint": self._fingerprint(snapshot_id, units, read_type),
+            "fingerprint": fingerprint,
             "num_units": len(units),
         }
         if checkpoint_plan is not None and plan != checkpoint_plan:
             raise ValueError(
                 "PaimonOffsetSource does not match the saved checkpoint.")
-        return _BoundPaimonOffsetSource(
-            self, table, units, read_type, nested_name_paths, plan)
-
-    def _fingerprint(self, snapshot_id, units, read_type):
-        payload = (
-            self.table_identifier,
-            snapshot_id,
-            self.projection,
-            self.filter,
-            self._transform_identity(),
-            read_type,
-            units,
-            sorted(self.read_args.items()),
-        )
-        return hashlib.sha256(
-            pickle.dumps(payload, protocol=4)).hexdigest()
-
-    def _transform_identity(self):
-        if self.transform is None:
-            return None
-        try:
-            import ray.cloudpickle as cloudpickle
-
-            encoded = cloudpickle.dumps(self.transform)
-        except Exception:
-            function = getattr(self.transform, "__func__", self.transform)
-            code = getattr(function, "__code__", None)
-            if code is None:
-                call = getattr(self.transform, "__call__", None)
-                function = getattr(call, "__func__", call)
-                code = getattr(function, "__code__", None)
-            if code is None:
-                raise ValueError(
-                    "PaimonOffsetSource transform must be serializable.")
-            encoded = pickle.dumps((
-                getattr(function, "__module__", None),
-                getattr(function, "__qualname__", None),
-                marshal.dumps(code),
-                repr(getattr(function, "__defaults__", None)),
-                repr(getattr(function, "__kwdefaults__", None)),
-            ), protocol=4)
-        return hashlib.sha256(encoded).hexdigest()
-
-
-def _build_offset_units(table, splits):
-    from pypaimon.globalindex.indexed_split import IndexedSplit
-    from pypaimon.read.sliced_split import SlicedSplit
-    from pypaimon.read.split import DataSplit
-    from pypaimon.utils.range import Range
-
-    units = []
-    for split in splits:
-        if not isinstance(split, DataSplit):
-            units.append(split)
-            continue
-        if (table.options.data_evolution_enabled()
-                and all(data_file.first_row_id is not None
-                        for data_file in split.files)):
-            ranges = Range.sort_and_merge_overlap(
-                [data_file.row_id_range() for data_file in split.files],
-                True,
-                True,
-            )
-            for row_range in ranges:
-                for start in range(
-                        row_range.from_, row_range.to + 1, _ROWS_PER_UNIT):
-                    end = min(start + _ROWS_PER_UNIT - 1, row_range.to)
-                    units.append(IndexedSplit(split, [Range(start, end)]))
-            continue
-        if table.is_primary_key_table:
-            units.append(split)
-            continue
-
-        deletion_files = split.data_deletion_files
-        for index, data_file in enumerate(split.files):
-            deletion_file = (
-                deletion_files[index]
-                if deletion_files is not None else None)
-            single = DataSplit(
-                [data_file],
-                split.partition,
-                split.bucket,
-                raw_convertible=split.raw_convertible,
-                data_deletion_files=(
-                    [deletion_file] if deletion_file is not None else None),
-                snapshot_id=split.snapshot_id,
-            )
-            for start in range(0, data_file.row_count, _ROWS_PER_UNIT):
-                end = min(start + _ROWS_PER_UNIT, data_file.row_count)
-                if start == 0 and end == data_file.row_count:
-                    units.append(single)
-                else:
-                    units.append(SlicedSplit(
-                        single, {data_file.file_name: (start, end)}))
-    return units
-
-
-class _BoundPaimonOffsetSource:
-
-    def __init__(
-            self,
-            source,
-            table,
-            units,
-            read_type,
-            nested_name_paths,
-            plan):
-        self.source = source
-        self.table = table
-        self.units = units
-        self.read_type = read_type
-        self.nested_name_paths = nested_name_paths
+        self._table = table
+        self._units = units
+        self._read_type = read_type
+        self._nested_name_paths = nested_name_paths
         self.plan = plan
+        return self
 
     @property
     def num_units(self):
-        return len(self.units)
-
-    def windows(self, next_offset):
-        for start in range(next_offset, self.num_units):
-            yield start, start + 1
+        return len(self._units)
 
     def read_window(self, start, end):
         import ray.data
@@ -259,19 +134,13 @@ class _BoundPaimonOffsetSource:
         )
 
         provider = PreResolvedSplitProvider(
-            self.table,
-            self.units[start:end],
-            self.read_type,
-            predicate=self.source.filter,
-            nested_name_paths=self.nested_name_paths,
+            self._table,
+            self._units[start:end],
+            self._read_type,
+            predicate=self.filter,
+            nested_name_paths=self._nested_name_paths,
         )
-        dataset = ray.data.read_datasource(
-            RayDatasource(provider),
-            ray_remote_args=self.source.ray_remote_args,
-            concurrency=self.source.concurrency,
-            override_num_blocks=self.source.override_num_blocks,
-            **self.source.read_args,
-        )
-        if self.source.transform is not None:
-            dataset = self.source.transform(dataset)
+        dataset = ray.data.read_datasource(RayDatasource(provider))
+        if self.transform is not None:
+            dataset = self.transform(dataset)
         return dataset

--- a/paimon-python/pypaimon/ray/offset_source.py
+++ b/paimon-python/pypaimon/ray/offset_source.py
@@ -1,0 +1,277 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Replayable Paimon source for resumable Ray writes."""
+
+import hashlib
+import marshal
+import pickle
+from typing import Any, Callable, Dict, List, Optional
+
+__all__ = ["PaimonOffsetSource"]
+
+_ROWS_PER_UNIT = 1_000_000
+
+
+class PaimonOffsetSource:
+    """A snapshot-pinned Paimon source processed in stable offset units.
+
+    ``transform`` is rebuilt for each read window. It must be deterministic
+    and must not depend on rows from another window.
+    """
+
+    def __init__(
+            self,
+            table_identifier: str,
+            *,
+            projection: Optional[List[str]] = None,
+            filter=None,
+            transform: Optional[Callable[[Any], Any]] = None,
+            snapshot_id: Optional[int] = None,
+            ray_remote_args: Optional[Dict[str, Any]] = None,
+            concurrency: Optional[int] = None,
+            override_num_blocks: Optional[int] = None,
+            **read_args):
+        if not isinstance(table_identifier, str) or not table_identifier:
+            raise ValueError("table_identifier is required.")
+        if transform is not None and not callable(transform):
+            raise ValueError("transform must be callable.")
+        if snapshot_id is not None and (
+                isinstance(snapshot_id, bool)
+                or not isinstance(snapshot_id, int)
+                or snapshot_id <= 0):
+            raise ValueError("snapshot_id must be a positive integer.")
+        self.table_identifier = table_identifier
+        self.projection = (
+            list(projection) if projection is not None else None)
+        self.filter = filter
+        self.transform = transform
+        self.snapshot_id = snapshot_id
+        self.ray_remote_args = (
+            dict(ray_remote_args) if ray_remote_args is not None else None)
+        self.concurrency = concurrency
+        self.override_num_blocks = override_num_blocks
+        self.read_args = dict(read_args)
+
+    def _bind(
+            self,
+            catalog,
+            checkpoint_plan=None,
+            source_tag=None,
+            retained_snapshot_id=None):
+        from pypaimon.common.options.core_options import CoreOptions
+        from pypaimon.read.read_builder import ReadBuilder
+
+        checkpoint_snapshot_id = (
+            checkpoint_plan.get("snapshot_id")
+            if checkpoint_plan is not None else None)
+        if (checkpoint_plan is not None
+                and checkpoint_plan.get("table") != self.table_identifier):
+            raise ValueError(
+                "PaimonOffsetSource does not match the saved checkpoint.")
+        snapshot_ids = {
+            value for value in (
+                self.snapshot_id,
+                checkpoint_snapshot_id,
+                retained_snapshot_id,
+            ) if value is not None
+        }
+        if len(snapshot_ids) > 1:
+            raise ValueError(
+                "PaimonOffsetSource snapshot differs from its checkpoint.")
+
+        table = catalog.get_table(self.table_identifier)
+        snapshot_id = next(iter(snapshot_ids), None)
+        if snapshot_id is None:
+            latest = table.snapshot_manager().get_latest_snapshot()
+            snapshot_id = latest.id if latest is not None else None
+        if snapshot_id is None:
+            raise ValueError("PaimonOffsetSource requires a source snapshot.")
+
+        if source_tag is not None:
+            table = table.copy({CoreOptions.SCAN_TAG_NAME.key(): source_tag})
+        else:
+            table = table.copy({
+                CoreOptions.SCAN_SNAPSHOT_ID.key(): str(snapshot_id),
+            })
+
+        read_builder = ReadBuilder(table)
+        if self.filter is not None:
+            read_builder = read_builder.with_filter(self.filter)
+        if self.projection is not None:
+            read_builder = read_builder.with_projection(self.projection)
+
+        read_type = read_builder.read_type()
+        nested_name_paths = read_builder._nested_name_paths()
+        units = _build_offset_units(
+            table, read_builder.new_scan().plan().splits())
+        plan = {
+            "kind": "paimon-units-v1",
+            "table": self.table_identifier,
+            "snapshot_id": snapshot_id,
+            "fingerprint": self._fingerprint(snapshot_id, units, read_type),
+            "num_units": len(units),
+        }
+        if checkpoint_plan is not None and plan != checkpoint_plan:
+            raise ValueError(
+                "PaimonOffsetSource does not match the saved checkpoint.")
+        return _BoundPaimonOffsetSource(
+            self, table, units, read_type, nested_name_paths, plan)
+
+    def _fingerprint(self, snapshot_id, units, read_type):
+        payload = (
+            self.table_identifier,
+            snapshot_id,
+            self.projection,
+            self.filter,
+            self._transform_identity(),
+            read_type,
+            units,
+            sorted(self.read_args.items()),
+        )
+        return hashlib.sha256(
+            pickle.dumps(payload, protocol=4)).hexdigest()
+
+    def _transform_identity(self):
+        if self.transform is None:
+            return None
+        try:
+            import ray.cloudpickle as cloudpickle
+
+            encoded = cloudpickle.dumps(self.transform)
+        except Exception:
+            function = getattr(self.transform, "__func__", self.transform)
+            code = getattr(function, "__code__", None)
+            if code is None:
+                call = getattr(self.transform, "__call__", None)
+                function = getattr(call, "__func__", call)
+                code = getattr(function, "__code__", None)
+            if code is None:
+                raise ValueError(
+                    "PaimonOffsetSource transform must be serializable.")
+            encoded = pickle.dumps((
+                getattr(function, "__module__", None),
+                getattr(function, "__qualname__", None),
+                marshal.dumps(code),
+                repr(getattr(function, "__defaults__", None)),
+                repr(getattr(function, "__kwdefaults__", None)),
+            ), protocol=4)
+        return hashlib.sha256(encoded).hexdigest()
+
+
+def _build_offset_units(table, splits):
+    from pypaimon.globalindex.indexed_split import IndexedSplit
+    from pypaimon.read.sliced_split import SlicedSplit
+    from pypaimon.read.split import DataSplit
+    from pypaimon.utils.range import Range
+
+    units = []
+    for split in splits:
+        if not isinstance(split, DataSplit):
+            units.append(split)
+            continue
+        if (table.options.data_evolution_enabled()
+                and all(data_file.first_row_id is not None
+                        for data_file in split.files)):
+            ranges = Range.sort_and_merge_overlap(
+                [data_file.row_id_range() for data_file in split.files],
+                True,
+                True,
+            )
+            for row_range in ranges:
+                for start in range(
+                        row_range.from_, row_range.to + 1, _ROWS_PER_UNIT):
+                    end = min(start + _ROWS_PER_UNIT - 1, row_range.to)
+                    units.append(IndexedSplit(split, [Range(start, end)]))
+            continue
+        if table.is_primary_key_table:
+            units.append(split)
+            continue
+
+        deletion_files = split.data_deletion_files
+        for index, data_file in enumerate(split.files):
+            deletion_file = (
+                deletion_files[index]
+                if deletion_files is not None else None)
+            single = DataSplit(
+                [data_file],
+                split.partition,
+                split.bucket,
+                raw_convertible=split.raw_convertible,
+                data_deletion_files=(
+                    [deletion_file] if deletion_file is not None else None),
+                snapshot_id=split.snapshot_id,
+            )
+            for start in range(0, data_file.row_count, _ROWS_PER_UNIT):
+                end = min(start + _ROWS_PER_UNIT, data_file.row_count)
+                if start == 0 and end == data_file.row_count:
+                    units.append(single)
+                else:
+                    units.append(SlicedSplit(
+                        single, {data_file.file_name: (start, end)}))
+    return units
+
+
+class _BoundPaimonOffsetSource:
+
+    def __init__(
+            self,
+            source,
+            table,
+            units,
+            read_type,
+            nested_name_paths,
+            plan):
+        self.source = source
+        self.table = table
+        self.units = units
+        self.read_type = read_type
+        self.nested_name_paths = nested_name_paths
+        self.plan = plan
+
+    @property
+    def num_units(self):
+        return len(self.units)
+
+    def windows(self, next_offset):
+        for start in range(next_offset, self.num_units):
+            yield start, start + 1
+
+    def read_window(self, start, end):
+        import ray.data
+
+        from pypaimon.read.datasource.ray_datasource import RayDatasource
+        from pypaimon.read.datasource.split_provider import (
+            PreResolvedSplitProvider,
+        )
+
+        provider = PreResolvedSplitProvider(
+            self.table,
+            self.units[start:end],
+            self.read_type,
+            predicate=self.source.filter,
+            nested_name_paths=self.nested_name_paths,
+        )
+        dataset = ray.data.read_datasource(
+            RayDatasource(provider),
+            ray_remote_args=self.source.ray_remote_args,
+            concurrency=self.source.concurrency,
+            override_num_blocks=self.source.override_num_blocks,
+            **self.source.read_args,
+        )
+        if self.source.transform is not None:
+            dataset = self.source.transform(dataset)
+        return dataset

--- a/paimon-python/pypaimon/ray/offset_source.py
+++ b/paimon-python/pypaimon/ray/offset_source.py
@@ -18,7 +18,33 @@
 
 import hashlib
 import pickle
+import types
 from typing import Any, Callable, List, Optional
+
+
+def _code_identity(code):
+    def constant(value):
+        if isinstance(value, types.CodeType):
+            return _code_identity(value)
+        if isinstance(value, tuple):
+            return tuple(constant(item) for item in value)
+        if isinstance(value, frozenset):
+            return tuple(sorted(
+                (constant(item) for item in value), key=repr))
+        return value
+
+    return (
+        code.co_argcount,
+        getattr(code, "co_posonlyargcount", 0),
+        code.co_kwonlyargcount,
+        code.co_flags,
+        code.co_code,
+        tuple(constant(value) for value in code.co_consts),
+        code.co_names,
+        code.co_varnames,
+        code.co_freevars,
+        code.co_cellvars,
+    )
 
 
 class PaimonOffsetSource:
@@ -93,17 +119,10 @@ class PaimonOffsetSource:
         read_type = read_builder.read_type()
         nested_name_paths = read_builder._nested_name_paths()
         units = list(read_builder.new_scan().plan().splits())
-        import ray.cloudpickle as cloudpickle
-
-        try:
-            transform = cloudpickle.dumps(self.transform)
-        except Exception as error:
-            raise ValueError(
-                "PaimonOffsetSource transform must be serializable.") \
-                from error
         fingerprint = hashlib.sha256(pickle.dumps((
             self.table_identifier, snapshot_id, self.projection,
-            self.filter, transform, read_type, units), protocol=4)).hexdigest()
+            self.filter, self._transform_identity(), read_type, units),
+            protocol=4)).hexdigest()
         plan = {
             "table": self.table_identifier,
             "snapshot_id": snapshot_id,
@@ -123,6 +142,26 @@ class PaimonOffsetSource:
         self._nested_name_paths = nested_name_paths
         self.plan = plan
         return self
+
+    def _transform_identity(self):
+        if self.transform is None:
+            return None
+        function = getattr(
+            self.transform, "__func__",
+            getattr(self.transform, "func", self.transform))
+        code = getattr(function, "__code__", None)
+        if code is None:
+            call = getattr(self.transform, "__call__", None)
+            function = getattr(call, "__func__", call)
+            code = getattr(function, "__code__", None)
+        identity = (
+            getattr(function, "__module__", None),
+            getattr(function, "__qualname__", None),
+            _code_identity(code) if code is not None else None,
+            type(self.transform).__module__,
+            type(self.transform).__qualname__,
+        )
+        return hashlib.sha256(pickle.dumps(identity, protocol=4)).hexdigest()
 
     @property
     def num_units(self):

--- a/paimon-python/pypaimon/ray/offset_source.py
+++ b/paimon-python/pypaimon/ray/offset_source.py
@@ -50,7 +50,8 @@ class PaimonOffsetSource:
             catalog,
             checkpoint_plan=None,
             source_tag=None,
-            retained_snapshot_id=None):
+            retained_snapshot_id=None,
+            splits_per_window=1):
         from pypaimon.common.options.core_options import CoreOptions
         from pypaimon.read.read_builder import ReadBuilder
 
@@ -108,8 +109,12 @@ class PaimonOffsetSource:
             "snapshot_id": snapshot_id,
             "fingerprint": fingerprint,
             "num_units": len(units),
+            "splits_per_window": splits_per_window,
         }
-        if checkpoint_plan is not None and plan != checkpoint_plan:
+        expected_plan = dict(checkpoint_plan or {})
+        if checkpoint_plan is not None:
+            expected_plan.setdefault("splits_per_window", splits_per_window)
+        if checkpoint_plan is not None and plan != expected_plan:
             raise ValueError(
                 "PaimonOffsetSource does not match the saved checkpoint.")
         self._table = table

--- a/paimon-python/pypaimon/ray/ray_paimon.py
+++ b/paimon-python/pypaimon/ray/ray_paimon.py
@@ -315,7 +315,8 @@ def write_paimon(
             table options, ``"off"`` disables it, and ``"map_groups"``
             explicitly enables HASH_FIXED grouping.
         commit_mode: ``"atomic"`` or periodic ``"incremental"``.
-        operation_id: Stable resume ID for a ``PaimonOffsetSource``.
+        operation_id: Stable resume ID for a ``PaimonOffsetSource``; not
+            accepted for a plain Ray Dataset.
         commit_interval_seconds: Target interval between incremental commits.
         update_cols: Columns updated by an incremental primary-key write.
     """

--- a/paimon-python/pypaimon/ray/ray_paimon.py
+++ b/paimon-python/pypaimon/ray/ray_paimon.py
@@ -305,7 +305,7 @@ def write_paimon(
     because Ray write tasks create independent Paimon writers.
 
     Args:
-        dataset: The Ray Dataset to write.
+        dataset: The Ray Dataset or ``PaimonOffsetSource`` to write.
         table_identifier: Full table name, e.g. ``"db_name.table_name"``.
         catalog_options: Options passed to ``CatalogFactory.create()``.
         overwrite: If ``True``, overwrite existing data in the table.
@@ -314,8 +314,8 @@ def write_paimon(
         hash_fixed_precluster: Pre-clustering mode. ``"auto"`` follows
             table options, ``"off"`` disables it, and ``"map_groups"``
             explicitly enables HASH_FIXED grouping.
-        commit_mode: ``"atomic"`` or resumable ``"incremental"``.
-        operation_id: Stable ID used to resume an incremental write.
+        commit_mode: ``"atomic"`` or periodic ``"incremental"``.
+        operation_id: Stable resume ID for a ``PaimonOffsetSource``.
         commit_interval_seconds: Target interval between incremental commits.
         update_cols: Columns updated by an incremental primary-key write.
     """

--- a/paimon-python/pypaimon/ray/ray_paimon.py
+++ b/paimon-python/pypaimon/ray/ray_paimon.py
@@ -280,7 +280,7 @@ def _looks_like_blob_descriptor(column):
 
 
 def write_paimon(
-    dataset: "ray.data.Dataset",
+    dataset,
     table_identifier: str,
     catalog_options: Dict[str, str],
     *,
@@ -288,7 +288,11 @@ def write_paimon(
     concurrency: Optional[int] = None,
     ray_remote_args: Optional[Dict[str, Any]] = None,
     hash_fixed_precluster: str = "auto",
-) -> None:
+    commit_mode: str = "atomic",
+    operation_id: Optional[str] = None,
+    commit_interval_seconds: Optional[float] = None,
+    update_cols: Optional[List[str]] = None,
+):
     """Write a Ray Dataset to a Paimon table.
 
     HASH_FIXED rows are assigned to the correct bucket by the Paimon
@@ -311,8 +315,39 @@ def write_paimon(
             and reject HASH_FIXED primary-key tables. ``"map_groups"``
             writes each HASH_FIXED primary-key group in one task and
             preserves the legacy single-group memory bound.
+        commit_mode: ``"atomic"`` or resumable ``"incremental"``.
+        operation_id: Stable ID used to resume an incremental write.
+        commit_interval_seconds: Target interval between incremental commits.
+        update_cols: Columns updated by an incremental primary-key write.
     """
     _require_ray_data()
+
+    if commit_mode not in ("atomic", "incremental"):
+        raise ValueError("commit_mode must be 'atomic' or 'incremental'.")
+    if commit_mode == "incremental":
+        if overwrite:
+            raise ValueError("incremental write_paimon cannot overwrite.")
+        if commit_interval_seconds is None:
+            raise ValueError(
+                "commit_interval_seconds is required for incremental writes.")
+        from pypaimon.ray.incremental_write import incremental_write_paimon
+
+        return incremental_write_paimon(
+            dataset,
+            table_identifier,
+            catalog_options,
+            operation_id=operation_id,
+            commit_interval_seconds=commit_interval_seconds,
+            update_cols=update_cols,
+            concurrency=concurrency,
+            ray_remote_args=ray_remote_args,
+        )
+    if operation_id is not None or commit_interval_seconds is not None:
+        raise ValueError(
+            "operation_id and commit_interval_seconds require "
+            "commit_mode='incremental'.")
+    if update_cols is not None:
+        raise ValueError("update_cols requires commit_mode='incremental'.")
 
     from pypaimon.catalog.catalog_factory import CatalogFactory
     from pypaimon.write.ray_datasink import write_paimon_dataset

--- a/paimon-python/pypaimon/tests/ray_incremental_write_test.py
+++ b/paimon-python/pypaimon/tests/ray_incremental_write_test.py
@@ -14,6 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import itertools
 import json
 import os
 import shutil
@@ -152,6 +153,186 @@ class RayIncrementalWriteTest(unittest.TestCase):
             commit_interval_seconds=interval,
             update_cols=["feature"],
         )
+
+    def _dataset_write(
+            self, target, data, interval=10, operation_id=None):
+        dataset = (
+            data if hasattr(data, "map_batches")
+            else ray.data.from_arrow(data)
+        )
+        return write_paimon(
+            dataset,
+            target,
+            self.catalog_options,
+            commit_mode="incremental",
+            operation_id=operation_id,
+            commit_interval_seconds=interval,
+            update_cols=["feature"],
+        )
+
+    def _prepare_update(self, target, ids, features):
+        table = self.catalog.get_table(target)
+        writer = table.new_batch_write_builder().new_write()
+        try:
+            writer.write_arrow(pa.table({
+                "id": ids,
+                "payload": [None] * len(ids),
+                "feature": features,
+            }, schema=self.target_schema))
+            return writer.prepare_commit()
+        finally:
+            writer.close()
+
+    def test_ray_dataset_commits_periodically(self):
+        target, _ = self._create_tables()
+        updates = pa.table({
+            "id": list(range(1, 21)),
+            "feature": list(range(101, 121)),
+        }, schema=self.source_schema)
+        updates = ray.data.from_arrow([
+            updates.slice(0, 10), updates.slice(10, 10)])
+        before = self.catalog.get_table(
+            target).snapshot_manager().get_latest_snapshot().id
+
+        clock = itertools.count(step=10)
+        with mock.patch(
+                "pypaimon.ray.incremental_write.time.monotonic",
+                side_effect=lambda: next(clock)):
+            self._dataset_write(target, updates, interval=1)
+
+        after = self.catalog.get_table(
+            target).snapshot_manager().get_latest_snapshot().id
+        self.assertEqual(2, after - before)
+        self.assertEqual(
+            list(range(101, 121)),
+            self._read(target)["feature"].to_pylist(),
+        )
+
+    def test_ray_dataset_retry_recomputes_source(self):
+        target, _ = self._create_tables()
+        updates = pa.table({
+            "id": [1, 2],
+            "feature": [101, 102],
+        }, schema=self.source_schema)
+        first_group = self._prepare_update(target, [1], [101])
+
+        def fail_after_first_group(*_args, **kwargs):
+            kwargs["on_group_result"](first_group)
+            raise RuntimeError("injected worker failure")
+
+        clock = itertools.count(step=10)
+        with mock.patch(
+                "pypaimon.ray.incremental_write.time.monotonic",
+                side_effect=lambda: next(clock)), mock.patch(
+                "pypaimon.write.ray_datasink._write_primary_key_groups",
+                side_effect=fail_after_first_group):
+            with self.assertRaisesRegex(
+                    RuntimeError, "injected worker failure"):
+                self._dataset_write(target, updates, interval=1)
+
+        self.assertEqual(
+            [101, 20, 30], self._read(target)["feature"].to_pylist())
+
+        self._dataset_write(target, updates)
+        self.assertEqual(
+            [101, 102, 30], self._read(target)["feature"].to_pylist())
+
+    def test_ray_dataset_allows_compaction_between_commits(self):
+        target, _ = self._create_tables()
+        updates = pa.table({
+            "id": [1, 3],
+            "feature": [101, 103],
+        }, schema=self.source_schema)
+        updates = ray.data.from_arrow([
+            updates.slice(0, 1), updates.slice(1, 1)])
+        groups = [
+            self._prepare_update(target, [1], [101]),
+            self._prepare_update(target, [3], [103]),
+        ]
+
+        calls = 0
+
+        def compact_between_groups(*_args, **kwargs):
+            nonlocal calls
+            if calls == 1:
+                self._compact(target)
+            kwargs["on_group_result"](groups[calls])
+            calls += 1
+
+        clock = itertools.count(step=10)
+        with mock.patch(
+                "pypaimon.ray.incremental_write.time.monotonic",
+                side_effect=lambda: next(clock)), mock.patch(
+                "pypaimon.write.ray_datasink._write_primary_key_groups",
+                side_effect=compact_between_groups):
+            self._dataset_write(target, updates, interval=1)
+
+        self.assertEqual(
+            [101, 20, 103], self._read(target)["feature"].to_pylist())
+
+    def test_ray_dataset_rejects_operation_id(self):
+        target, _ = self._create_tables()
+        updates = pa.table({
+            "id": [1], "feature": [101],
+        }, schema=self.source_schema)
+
+        with self.assertRaisesRegex(
+                ValueError, "does not expose resumable source offsets"):
+            self._dataset_write(
+                target, updates, operation_id="not-resumable")
+
+    def test_partitioned_composite_key_dataset(self):
+        identifier = "default.partitioned_{}".format(uuid.uuid4().hex[:8])
+        schema = pa.schema([
+            pa.field("key", pa.string(), nullable=False),
+            pa.field("partition", pa.string(), nullable=False),
+            ("payload", pa.string()),
+            ("feature", pa.int32()),
+        ])
+        self.catalog.create_table(
+            identifier,
+            Schema.from_pyarrow_schema(
+                schema,
+                partition_keys=["partition"],
+                primary_keys=["key", "partition"],
+                options={
+                    "bucket": "4096",
+                    "merge-engine": "partial-update",
+                },
+            ),
+            False,
+        )
+        self._write(identifier, pa.table({
+            "key": ["a", "b"],
+            "partition": ["p1", "p1"],
+            "payload": ["keep-a", "keep-b"],
+            "feature": [1, 2],
+        }, schema=schema))
+        updates = pa.table({
+            "key": ["a", "b"],
+            "partition": ["p1", "p1"],
+            "feature": [101, 102],
+        })
+
+        write_paimon(
+            ray.data.from_arrow(updates),
+            identifier,
+            self.catalog_options,
+            commit_mode="incremental",
+            commit_interval_seconds=10,
+            update_cols=["feature"],
+        )
+
+        table = self.catalog.get_table(identifier)
+        builder = table.new_read_builder()
+        actual = builder.new_read().to_arrow(
+            builder.new_scan().plan().splits()).sort_by("key")
+        self.assertEqual({
+            "key": ["a", "b"],
+            "partition": ["p1", "p1"],
+            "payload": ["keep-a", "keep-b"],
+            "feature": [101, 102],
+        }, actual.to_pydict())
 
     def test_transform_identity_ignores_runtime_state(self):
         class RuntimeState:

--- a/paimon-python/pypaimon/tests/ray_incremental_write_test.py
+++ b/paimon-python/pypaimon/tests/ray_incremental_write_test.py
@@ -67,28 +67,28 @@ class RayIncrementalWriteTest(unittest.TestCase):
             ray.shutdown()
         shutil.rmtree(cls.tempdir, ignore_errors=True)
 
+    def _create_table(self, prefix, schema, **schema_options):
+        identifier = "default.{}_{}".format(
+            prefix, uuid.uuid4().hex[:8])
+        self.catalog.create_table(
+            identifier,
+            Schema.from_pyarrow_schema(schema, **schema_options),
+            False,
+        )
+        return identifier
+
     def _create_tables(self, source_rows=2):
-        suffix = uuid.uuid4().hex[:8]
-        target = "default.pk_target_{}".format(suffix)
-        source = "default.pk_source_{}".format(suffix)
-        self.catalog.create_table(
-            target,
-            Schema.from_pyarrow_schema(
-                self.target_schema,
-                primary_keys=["id"],
-                options={
-                    "bucket": "2",
-                    "merge-engine": "partial-update",
-                },
-            ),
-            False,
+        target = self._create_table(
+            "pk_target",
+            self.target_schema,
+            primary_keys=["id"],
+            options={
+                "bucket": "2",
+                "merge-engine": "partial-update",
+            },
         )
-        self.catalog.create_table(
-            source,
-            Schema.from_pyarrow_schema(
-                self.source_schema, partition_keys=["id"]),
-            False,
-        )
+        source = self._create_table(
+            "pk_source", self.source_schema, partition_keys=["id"])
         self._write(target, pa.table({
             "id": [1, 2, 3],
             "payload": ["a", "b", "c"],
@@ -134,16 +134,18 @@ class RayIncrementalWriteTest(unittest.TestCase):
             writer.close()
             commit.close()
 
-    def _read(self, identifier):
+    def _read(self, identifier, sort_by="id"):
         table = self.catalog.get_table(identifier)
         builder = table.new_read_builder()
         return builder.new_read().to_arrow(
-            builder.new_scan().plan().splits()).sort_by("id")
+            builder.new_scan().plan().splits()).sort_by(sort_by)
 
-    def _incremental_write(
-            self, target, source, operation_id, interval=10):
+    def _write_incrementally(
+            self, target, source, operation_id=None, interval=10):
         if isinstance(source, str):
             source = PaimonOffsetSource(source)
+        elif isinstance(source, pa.Table):
+            source = ray.data.from_arrow(source)
         return write_paimon(
             source,
             target,
@@ -154,21 +156,19 @@ class RayIncrementalWriteTest(unittest.TestCase):
             update_cols=["feature"],
         )
 
-    def _dataset_write(
-            self, target, data, interval=10, operation_id=None):
-        dataset = (
-            data if hasattr(data, "map_batches")
-            else ray.data.from_arrow(data)
-        )
-        return write_paimon(
-            dataset,
-            target,
-            self.catalog_options,
-            commit_mode="incremental",
-            operation_id=operation_id,
-            commit_interval_seconds=interval,
-            update_cols=["feature"],
-        )
+    @staticmethod
+    def _clock(*values):
+        side_effect = values or itertools.count(step=10)
+        return mock.patch(
+            "pypaimon.ray.incremental_write.time.monotonic",
+            side_effect=side_effect)
+
+    def _snapshot_id(self, target):
+        return self.catalog.get_table(
+            target).snapshot_manager().get_latest_snapshot().id
+
+    def _assert_features(self, target, expected):
+        self.assertEqual(expected, self._read(target)["feature"].to_pylist())
 
     def _prepare_update(self, target, ids, features):
         table = self.catalog.get_table(target)
@@ -191,22 +191,14 @@ class RayIncrementalWriteTest(unittest.TestCase):
         }, schema=self.source_schema)
         updates = ray.data.from_arrow([
             updates.slice(0, 10), updates.slice(10, 10)])
-        before = self.catalog.get_table(
-            target).snapshot_manager().get_latest_snapshot().id
+        before = self._snapshot_id(target)
 
-        clock = itertools.count(step=10)
-        with mock.patch(
-                "pypaimon.ray.incremental_write.time.monotonic",
-                side_effect=lambda: next(clock)):
-            self._dataset_write(target, updates, interval=1)
+        with self._clock():
+            self._write_incrementally(target, updates, interval=1)
 
-        after = self.catalog.get_table(
-            target).snapshot_manager().get_latest_snapshot().id
+        after = self._snapshot_id(target)
         self.assertEqual(2, after - before)
-        self.assertEqual(
-            list(range(101, 121)),
-            self._read(target)["feature"].to_pylist(),
-        )
+        self._assert_features(target, list(range(101, 121)))
 
     def test_ray_dataset_retry_recomputes_source(self):
         target, _ = self._create_tables()
@@ -220,22 +212,17 @@ class RayIncrementalWriteTest(unittest.TestCase):
             kwargs["on_group_result"](first_group)
             raise RuntimeError("injected worker failure")
 
-        clock = itertools.count(step=10)
-        with mock.patch(
-                "pypaimon.ray.incremental_write.time.monotonic",
-                side_effect=lambda: next(clock)), mock.patch(
+        with self._clock(), mock.patch(
                 "pypaimon.write.ray_datasink._write_primary_key_groups",
                 side_effect=fail_after_first_group):
             with self.assertRaisesRegex(
                     RuntimeError, "injected worker failure"):
-                self._dataset_write(target, updates, interval=1)
+                self._write_incrementally(target, updates, interval=1)
 
-        self.assertEqual(
-            [101, 20, 30], self._read(target)["feature"].to_pylist())
+        self._assert_features(target, [101, 20, 30])
 
-        self._dataset_write(target, updates)
-        self.assertEqual(
-            [101, 102, 30], self._read(target)["feature"].to_pylist())
+        self._write_incrementally(target, updates)
+        self._assert_features(target, [101, 102, 30])
 
     def test_ray_dataset_allows_compaction_between_commits(self):
         target, _ = self._create_tables()
@@ -259,16 +246,12 @@ class RayIncrementalWriteTest(unittest.TestCase):
             kwargs["on_group_result"](groups[calls])
             calls += 1
 
-        clock = itertools.count(step=10)
-        with mock.patch(
-                "pypaimon.ray.incremental_write.time.monotonic",
-                side_effect=lambda: next(clock)), mock.patch(
+        with self._clock(), mock.patch(
                 "pypaimon.write.ray_datasink._write_primary_key_groups",
                 side_effect=compact_between_groups):
-            self._dataset_write(target, updates, interval=1)
+            self._write_incrementally(target, updates, interval=1)
 
-        self.assertEqual(
-            [101, 20, 103], self._read(target)["feature"].to_pylist())
+        self._assert_features(target, [101, 20, 103])
 
     def test_ray_dataset_rejects_operation_id(self):
         target, _ = self._create_tables()
@@ -278,29 +261,25 @@ class RayIncrementalWriteTest(unittest.TestCase):
 
         with self.assertRaisesRegex(
                 ValueError, "does not expose resumable source offsets"):
-            self._dataset_write(
+            self._write_incrementally(
                 target, updates, operation_id="not-resumable")
 
     def test_partitioned_composite_key_dataset(self):
-        identifier = "default.partitioned_{}".format(uuid.uuid4().hex[:8])
         schema = pa.schema([
             pa.field("key", pa.string(), nullable=False),
             pa.field("partition", pa.string(), nullable=False),
             ("payload", pa.string()),
             ("feature", pa.int32()),
         ])
-        self.catalog.create_table(
-            identifier,
-            Schema.from_pyarrow_schema(
-                schema,
-                partition_keys=["partition"],
-                primary_keys=["key", "partition"],
-                options={
-                    "bucket": "4096",
-                    "merge-engine": "partial-update",
-                },
-            ),
-            False,
+        identifier = self._create_table(
+            "partitioned",
+            schema,
+            partition_keys=["partition"],
+            primary_keys=["key", "partition"],
+            options={
+                "bucket": "4096",
+                "merge-engine": "partial-update",
+            },
         )
         self._write(identifier, pa.table({
             "key": ["a", "b"],
@@ -323,16 +302,12 @@ class RayIncrementalWriteTest(unittest.TestCase):
             update_cols=["feature"],
         )
 
-        table = self.catalog.get_table(identifier)
-        builder = table.new_read_builder()
-        actual = builder.new_read().to_arrow(
-            builder.new_scan().plan().splits()).sort_by("key")
         self.assertEqual({
             "key": ["a", "b"],
             "partition": ["p1", "p1"],
             "payload": ["keep-a", "keep-b"],
             "feature": [101, 102],
-        }, actual.to_pydict())
+        }, self._read(identifier, "key").to_pydict())
 
     def test_transform_identity_ignores_runtime_state(self):
         class RuntimeState:
@@ -389,29 +364,26 @@ class RayIncrementalWriteTest(unittest.TestCase):
 
         with mock.patch(
                 "pypaimon.ray.incremental_write._SPLITS_PER_WINDOW", 1), \
-                mock.patch(
-                "pypaimon.ray.incremental_write.time.monotonic",
-                side_effect=[0, 11, 11]), mock.patch.object(
+                self._clock(0, 11, 11), mock.patch.object(
                 ray_datasink, "_write_primary_key_groups",
                 side_effect=fail_second_window):
             with self.assertRaisesRegex(
                     RuntimeError, "injected driver failure"):
-                self._incremental_write(target, source, operation_id)
+                self._write_incrementally(target, source, operation_id)
 
         partial = self._read(target).to_pydict()
         self.assertIn(partial["feature"], ([101, 20, 30], [10, 102, 30]))
 
         self._compact(target)
-        self._incremental_write(target, source, operation_id)
-        self.assertEqual([101, 102, 30], self._read(target)["feature"].to_pylist())
+        self._write_incrementally(target, source, operation_id)
+        self._assert_features(target, [101, 102, 30])
 
     def test_time_trigger_batches_completed_windows(self):
         target, source = self._create_tables(source_rows=4)
         operation_id = "time-{}".format(uuid.uuid4().hex)
         from pypaimon.write import ray_datasink
 
-        before = self.catalog.get_table(
-            target).snapshot_manager().get_latest_snapshot().id
+        before = self._snapshot_id(target)
         real_prepare = ray_datasink._write_primary_key_groups
         calls = 0
 
@@ -422,15 +394,12 @@ class RayIncrementalWriteTest(unittest.TestCase):
 
         with mock.patch(
                 "pypaimon.ray.incremental_write._SPLITS_PER_WINDOW", 2), \
-                mock.patch(
-                "pypaimon.ray.incremental_write.time.monotonic",
-                side_effect=[0, 11, 11]), mock.patch.object(
+                self._clock(0, 11, 11), mock.patch.object(
                 ray_datasink, "_write_primary_key_groups",
                 side_effect=count_windows):
-            self._incremental_write(target, source, operation_id)
+            self._write_incrementally(target, source, operation_id)
 
-        after = self.catalog.get_table(
-            target).snapshot_manager().get_latest_snapshot().id
+        after = self._snapshot_id(target)
         self.assertEqual(2, calls)
         self.assertEqual(3, after - before)
         self.assertEqual({
@@ -451,18 +420,12 @@ class RayIncrementalWriteTest(unittest.TestCase):
         operation_id = "empty-transform-{}".format(uuid.uuid4().hex)
         source = PaimonOffsetSource(source, transform=lambda data: data.limit(0))
 
-        self._incremental_write(target, source, operation_id)
-        snapshot_id = self.catalog.get_table(
-            target).snapshot_manager().get_latest_snapshot().id
+        self._write_incrementally(target, source, operation_id)
+        snapshot_id = self._snapshot_id(target)
 
-        self.assertEqual([10, 20, 30],
-                         self._read(target)["feature"].to_pylist())
-        self._incremental_write(target, source, operation_id)
-        self.assertEqual(
-            snapshot_id,
-            self.catalog.get_table(
-                target).snapshot_manager().get_latest_snapshot().id,
-        )
+        self._assert_features(target, [10, 20, 30])
+        self._write_incrementally(target, source, operation_id)
+        self.assertEqual(snapshot_id, self._snapshot_id(target))
         self.catalog.alter_table(target, [
             SchemaChange.add_column(
                 "later", AtomicType("STRING"))], False)
@@ -552,14 +515,13 @@ class RayIncrementalWriteTest(unittest.TestCase):
                         ray_datasink, "_write_primary_key_groups",
                         side_effect=mutate_target):
                     with self.assertRaisesRegex(RuntimeError, error):
-                        self._incremental_write(
+                        self._write_incrementally(
                             target, source,
                             "concurrent-{}".format(uuid.uuid4().hex))
 
                 expected = ([10, 20, 30, 40] if change == "data"
                             else [10, 20, 30])
-                self.assertEqual(
-                    expected, self._read(target)["feature"].to_pylist())
+                self._assert_features(target, expected)
 
 if __name__ == "__main__":
     unittest.main()

--- a/paimon-python/pypaimon/tests/ray_incremental_write_test.py
+++ b/paimon-python/pypaimon/tests/ray_incremental_write_test.py
@@ -35,6 +35,7 @@ from pypaimon.ray import (
     delete_write_paimon_checkpoint,
     write_paimon,
 )
+from pypaimon.ray.offset_source import _stable_units
 
 
 class RayIncrementalWriteTest(unittest.TestCase):
@@ -184,6 +185,12 @@ class RayIncrementalWriteTest(unittest.TestCase):
                 transform=changed_transform)._transform_identity(),
         )
 
+    def test_offset_units_have_stable_order(self):
+        first, first_ids = _stable_units([("p2", 2), ("p1", 1)])
+        second, second_ids = _stable_units([("p1", 1), ("p2", 2)])
+        self.assertEqual(first, second)
+        self.assertEqual(first_ids, second_ids)
+
     def test_resume_allows_compaction(self):
         target, source = self._create_tables()
         operation_id = "resume-{}".format(uuid.uuid4().hex)
@@ -211,7 +218,7 @@ class RayIncrementalWriteTest(unittest.TestCase):
                 self._incremental_write(target, source, operation_id)
 
         partial = self._read(target).to_pydict()
-        self.assertEqual([101, 20, 30], partial["feature"])
+        self.assertIn(partial["feature"], ([101, 20, 30], [10, 102, 30]))
 
         self._compact(target)
         self._incremental_write(target, source, operation_id)

--- a/paimon-python/pypaimon/tests/ray_incremental_write_test.py
+++ b/paimon-python/pypaimon/tests/ray_incremental_write_test.py
@@ -1,0 +1,353 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+import shutil
+import tempfile
+import unittest
+import uuid
+from unittest import mock
+
+import pyarrow as pa
+import pytest
+
+ray = pytest.importorskip("ray")
+
+from pypaimon import CatalogFactory, Schema
+from pypaimon.schema.data_types import AtomicType
+from pypaimon.schema.schema_change import SchemaChange
+from pypaimon.ray import (
+    PaimonOffsetSource,
+    delete_write_paimon_checkpoint,
+    write_paimon,
+)
+
+
+class RayIncrementalWriteTest(unittest.TestCase):
+
+    target_schema = pa.schema([
+        pa.field("id", pa.int64(), nullable=False),
+        ("payload", pa.string()),
+        ("feature", pa.int32()),
+    ])
+    source_schema = pa.schema([
+        ("id", pa.int64()),
+        ("feature", pa.int32()),
+    ])
+
+    @classmethod
+    def setUpClass(cls):
+        cls.tempdir = tempfile.mkdtemp()
+        cls.catalog_options = {
+            "warehouse": os.path.join(cls.tempdir, "warehouse")}
+        cls.catalog = CatalogFactory.create(cls.catalog_options)
+        cls.catalog.create_database("default", True)
+        if not ray.is_initialized():
+            ray.init(ignore_reinit_error=True, num_cpus=2)
+
+    @classmethod
+    def tearDownClass(cls):
+        if ray.is_initialized():
+            ray.shutdown()
+        shutil.rmtree(cls.tempdir, ignore_errors=True)
+
+    def _create_tables(self, source_rows=2):
+        suffix = uuid.uuid4().hex[:8]
+        target = "default.pk_target_{}".format(suffix)
+        source = "default.pk_source_{}".format(suffix)
+        self.catalog.create_table(
+            target,
+            Schema.from_pyarrow_schema(
+                self.target_schema,
+                primary_keys=["id"],
+                options={
+                    "bucket": "2",
+                    "merge-engine": "partial-update",
+                },
+            ),
+            False,
+        )
+        self.catalog.create_table(
+            source, Schema.from_pyarrow_schema(self.source_schema), False)
+        self._write(target, pa.table({
+            "id": [1, 2, 3],
+            "payload": ["a", "b", "c"],
+            "feature": [10, 20, 30],
+        }, schema=self.target_schema))
+        ids = list(range(1, source_rows + 1))
+        self._write(source, pa.table({
+            "id": ids,
+            "feature": [100 + value for value in ids],
+        }, schema=self.source_schema))
+        return target, source
+
+    def _write(self, identifier, data):
+        table = self.catalog.get_table(identifier)
+        builder = table.new_batch_write_builder()
+        writer = builder.new_write()
+        commit = builder.new_commit()
+        try:
+            writer.write_arrow(data)
+            commit.commit(writer.prepare_commit())
+        finally:
+            writer.close()
+            commit.close()
+
+    def _read(self, identifier):
+        table = self.catalog.get_table(identifier)
+        builder = table.new_read_builder()
+        return builder.new_read().to_arrow(
+            builder.new_scan().plan().splits()).sort_by("id")
+
+    def _incremental_write(self, target, source, operation_id, interval=10):
+        return write_paimon(
+            PaimonOffsetSource(source),
+            target,
+            self.catalog_options,
+            commit_mode="incremental",
+            operation_id=operation_id,
+            commit_interval_seconds=interval,
+            update_cols=["feature"],
+        )
+
+    def test_resumes_after_timed_commit(self):
+        target, source = self._create_tables()
+        operation_id = "resume-{}".format(uuid.uuid4().hex)
+        from pypaimon.write import ray_datasink
+
+        real_prepare = ray_datasink._prepare_primary_key_groups
+        calls = 0
+
+        def fail_second_window(*args, **kwargs):
+            nonlocal calls
+            calls += 1
+            if calls == 2:
+                raise RuntimeError("injected driver failure")
+            return real_prepare(*args, **kwargs)
+
+        with mock.patch(
+                "pypaimon.ray.offset_source._ROWS_PER_UNIT", 1), mock.patch(
+                "pypaimon.ray.incremental_write.time.monotonic",
+                side_effect=[0, 11, 11]), mock.patch.object(
+                ray_datasink, "_prepare_primary_key_groups",
+                side_effect=fail_second_window):
+            with self.assertRaisesRegex(
+                    RuntimeError, "injected driver failure"):
+                self._incremental_write(target, source, operation_id)
+
+        partial = self._read(target).to_pydict()
+        self.assertEqual([101, 20, 30], partial["feature"])
+
+        with mock.patch(
+                "pypaimon.ray.offset_source._ROWS_PER_UNIT", 1):
+            result = self._incremental_write(target, source, operation_id)
+
+        self.assertEqual({"num_written": 2}, result)
+        self.assertEqual([101, 102, 30], self._read(target)["feature"].to_pylist())
+
+    def test_time_trigger_batches_completed_windows(self):
+        target, source = self._create_tables(source_rows=3)
+        operation_id = "time-{}".format(uuid.uuid4().hex)
+        before = self.catalog.get_table(
+            target).snapshot_manager().get_latest_snapshot().id
+
+        with mock.patch(
+                "pypaimon.ray.offset_source._ROWS_PER_UNIT", 1), mock.patch(
+                "pypaimon.ray.incremental_write.time.monotonic",
+                side_effect=[0, 1, 11, 11]):
+            self._incremental_write(target, source, operation_id)
+
+        after = self.catalog.get_table(
+            target).snapshot_manager().get_latest_snapshot().id
+        self.assertEqual(3, after - before)
+
+    def test_inserts_into_empty_target_and_cleans_checkpoint(self):
+        target, source = self._create_tables()
+        empty_target = "default.pk_empty_{}".format(uuid.uuid4().hex[:8])
+        self.catalog.create_table(
+            empty_target,
+            Schema.from_pyarrow_schema(
+                self.target_schema,
+                primary_keys=["id"],
+                options={
+                    "bucket": "2",
+                    "merge-engine": "partial-update",
+                },
+            ),
+            False,
+        )
+        operation_id = "empty-{}".format(uuid.uuid4().hex)
+        result = self._incremental_write(
+            empty_target, source, operation_id)
+
+        self.assertEqual({"num_written": 2}, result)
+        self.assertEqual({
+            "id": [1, 2],
+            "payload": [None, None],
+            "feature": [101, 102],
+        }, self._read(empty_target).to_pydict())
+        self.assertTrue(delete_write_paimon_checkpoint(
+            empty_target, self.catalog_options, operation_id))
+        self.assertFalse(delete_write_paimon_checkpoint(
+            empty_target, self.catalog_options, operation_id))
+
+    def test_metadata_checkpoint_for_empty_transform(self):
+        target, source = self._create_tables()
+        operation_id = "empty-transform-{}".format(uuid.uuid4().hex)
+        source = PaimonOffsetSource(source, transform=lambda data: data.limit(0))
+
+        result = write_paimon(
+            source,
+            target,
+            self.catalog_options,
+            commit_mode="incremental",
+            operation_id=operation_id,
+            commit_interval_seconds=10,
+            update_cols=["feature"],
+        )
+        snapshot_id = self.catalog.get_table(
+            target).snapshot_manager().get_latest_snapshot().id
+
+        self.assertEqual({"num_written": 0}, result)
+        self.assertEqual([10, 20, 30],
+                         self._read(target)["feature"].to_pylist())
+        self.assertEqual(
+            {"num_written": 0},
+            write_paimon(
+                source,
+                target,
+                self.catalog_options,
+                commit_mode="incremental",
+                operation_id=operation_id,
+                commit_interval_seconds=10,
+                update_cols=["feature"],
+            ),
+        )
+        self.assertEqual(
+            snapshot_id,
+            self.catalog.get_table(
+                target).snapshot_manager().get_latest_snapshot().id,
+        )
+
+    def test_rejects_concurrent_target_write(self):
+        target, source = self._create_tables()
+        from pypaimon.write import ray_datasink
+
+        real_prepare = ray_datasink._prepare_primary_key_groups
+
+        def write_concurrently(*args, **kwargs):
+            self._write(target, pa.table({
+                "id": [4],
+                "payload": ["external"],
+                "feature": [40],
+            }, schema=self.target_schema))
+            return real_prepare(*args, **kwargs)
+
+        with mock.patch.object(
+                ray_datasink, "_prepare_primary_key_groups",
+                side_effect=write_concurrently):
+            with self.assertRaisesRegex(
+                    RuntimeError, "Concurrent target commit"):
+                self._incremental_write(
+                    target, source,
+                    "concurrent-{}".format(uuid.uuid4().hex))
+
+        self.assertEqual([10, 20, 30, 40],
+                         self._read(target)["feature"].to_pylist())
+
+    def test_uses_schema_planned_after_existing_ddl(self):
+        target, source = self._create_tables()
+        self.catalog.alter_table(
+            target,
+            [SchemaChange.add_column("extra", AtomicType("STRING"))],
+            False,
+        )
+
+        self._incremental_write(
+            target, source, "existing-ddl-{}".format(uuid.uuid4().hex))
+
+        self.assertEqual([101, 102, 30],
+                         self._read(target)["feature"].to_pylist())
+
+    def test_rejects_ddl_during_write(self):
+        target, source = self._create_tables()
+        from pypaimon.write import ray_datasink
+
+        real_prepare = ray_datasink._prepare_primary_key_groups
+
+        def alter_concurrently(*args, **kwargs):
+            self.catalog.alter_table(
+                target,
+                [SchemaChange.add_column("extra", AtomicType("STRING"))],
+                False,
+            )
+            return real_prepare(*args, **kwargs)
+
+        with mock.patch.object(
+                ray_datasink, "_prepare_primary_key_groups",
+                side_effect=alter_concurrently):
+            with self.assertRaisesRegex(RuntimeError, "schema change"):
+                self._incremental_write(
+                    target, source,
+                    "concurrent-ddl-{}".format(uuid.uuid4().hex))
+
+        self.assertEqual([10, 20, 30],
+                         self._read(target)["feature"].to_pylist())
+
+    def test_rejects_non_partial_update_target(self):
+        suffix = uuid.uuid4().hex[:8]
+        target = "default.pk_dedupe_{}".format(suffix)
+        source = "default.pk_source_{}".format(suffix)
+        self.catalog.create_table(
+            target,
+            Schema.from_pyarrow_schema(
+                self.target_schema, primary_keys=["id"],
+                options={"bucket": "1"}),
+            False,
+        )
+        self.catalog.create_table(
+            source, Schema.from_pyarrow_schema(self.source_schema), False)
+        with self.assertRaisesRegex(ValueError, "partial-update"):
+            self._incremental_write(
+                target, source, "reject-{}".format(suffix))
+
+    def test_rejects_unprovided_non_nullable_column(self):
+        suffix = uuid.uuid4().hex[:8]
+        target = "default.pk_not_null_{}".format(suffix)
+        source = "default.pk_source_{}".format(suffix)
+        schema = pa.schema([
+            pa.field("id", pa.int64(), nullable=False),
+            pa.field("payload", pa.string(), nullable=False),
+            ("feature", pa.int32()),
+        ])
+        self.catalog.create_table(
+            target,
+            Schema.from_pyarrow_schema(
+                schema, primary_keys=["id"], options={
+                    "bucket": "1",
+                    "merge-engine": "partial-update",
+                }),
+            False,
+        )
+        self.catalog.create_table(
+            source, Schema.from_pyarrow_schema(self.source_schema), False)
+        with self.assertRaisesRegex(ValueError, "payload.*nullable"):
+            self._incremental_write(
+                target, source, "non-null-{}".format(suffix))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/paimon-python/pypaimon/tests/ray_incremental_write_test.py
+++ b/paimon-python/pypaimon/tests/ray_incremental_write_test.py
@@ -111,6 +111,27 @@ class RayIncrementalWriteTest(unittest.TestCase):
             writer.close()
             commit.close()
 
+    def _compact(self, identifier):
+        data = self._read(identifier)
+        builder = self.catalog.get_table(
+            identifier).new_batch_write_builder().overwrite({})
+        writer = builder.new_write()
+        commit = builder.new_commit()
+        try:
+            writer.write_arrow(data)
+            file_commit = commit.file_store_commit
+            real_commit = file_commit._try_commit
+
+            def compact_commit(*args, **kwargs):
+                kwargs["commit_kind"] = "COMPACT"
+                return real_commit(*args, **kwargs)
+
+            file_commit._try_commit = compact_commit
+            commit.commit(writer.prepare_commit())
+        finally:
+            writer.close()
+            commit.close()
+
     def _read(self, identifier):
         table = self.catalog.get_table(identifier)
         builder = table.new_read_builder()
@@ -131,7 +152,7 @@ class RayIncrementalWriteTest(unittest.TestCase):
             update_cols=["feature"],
         )
 
-    def test_resumes_after_timed_commit(self):
+    def test_resume_allows_compaction(self):
         target, source = self._create_tables()
         operation_id = "resume-{}".format(uuid.uuid4().hex)
         from pypaimon.write import ray_datasink
@@ -160,6 +181,7 @@ class RayIncrementalWriteTest(unittest.TestCase):
         partial = self._read(target).to_pydict()
         self.assertEqual([101, 20, 30], partial["feature"])
 
+        self._compact(target)
         self._incremental_write(target, source, operation_id)
         self.assertEqual([101, 102, 30], self._read(target)["feature"].to_pylist())
 

--- a/paimon-python/pypaimon/tests/ray_incremental_write_test.py
+++ b/paimon-python/pypaimon/tests/ray_incremental_write_test.py
@@ -81,7 +81,11 @@ class RayIncrementalWriteTest(unittest.TestCase):
             False,
         )
         self.catalog.create_table(
-            source, Schema.from_pyarrow_schema(self.source_schema), False)
+            source,
+            Schema.from_pyarrow_schema(
+                self.source_schema, partition_keys=["id"]),
+            False,
+        )
         self._write(target, pa.table({
             "id": [1, 2, 3],
             "payload": ["a", "b", "c"],
@@ -112,9 +116,12 @@ class RayIncrementalWriteTest(unittest.TestCase):
         return builder.new_read().to_arrow(
             builder.new_scan().plan().splits()).sort_by("id")
 
-    def _incremental_write(self, target, source, operation_id, interval=10):
+    def _incremental_write(
+            self, target, source, operation_id, interval=10):
+        if isinstance(source, str):
+            source = PaimonOffsetSource(source)
         return write_paimon(
-            PaimonOffsetSource(source),
+            source,
             target,
             self.catalog_options,
             commit_mode="incremental",
@@ -128,7 +135,7 @@ class RayIncrementalWriteTest(unittest.TestCase):
         operation_id = "resume-{}".format(uuid.uuid4().hex)
         from pypaimon.write import ray_datasink
 
-        real_prepare = ray_datasink._prepare_primary_key_groups
+        real_prepare = ray_datasink._write_primary_key_groups
         calls = 0
 
         def fail_second_window(*args, **kwargs):
@@ -139,10 +146,9 @@ class RayIncrementalWriteTest(unittest.TestCase):
             return real_prepare(*args, **kwargs)
 
         with mock.patch(
-                "pypaimon.ray.offset_source._ROWS_PER_UNIT", 1), mock.patch(
                 "pypaimon.ray.incremental_write.time.monotonic",
                 side_effect=[0, 11, 11]), mock.patch.object(
-                ray_datasink, "_prepare_primary_key_groups",
+                ray_datasink, "_write_primary_key_groups",
                 side_effect=fail_second_window):
             with self.assertRaisesRegex(
                     RuntimeError, "injected driver failure"):
@@ -151,203 +157,91 @@ class RayIncrementalWriteTest(unittest.TestCase):
         partial = self._read(target).to_pydict()
         self.assertEqual([101, 20, 30], partial["feature"])
 
-        with mock.patch(
-                "pypaimon.ray.offset_source._ROWS_PER_UNIT", 1):
-            result = self._incremental_write(target, source, operation_id)
-
-        self.assertEqual({"num_written": 2}, result)
+        self._incremental_write(target, source, operation_id)
         self.assertEqual([101, 102, 30], self._read(target)["feature"].to_pylist())
 
     def test_time_trigger_batches_completed_windows(self):
-        target, source = self._create_tables(source_rows=3)
+        target, source = self._create_tables(source_rows=4)
         operation_id = "time-{}".format(uuid.uuid4().hex)
         before = self.catalog.get_table(
             target).snapshot_manager().get_latest_snapshot().id
 
         with mock.patch(
-                "pypaimon.ray.offset_source._ROWS_PER_UNIT", 1), mock.patch(
                 "pypaimon.ray.incremental_write.time.monotonic",
-                side_effect=[0, 1, 11, 11]):
+                side_effect=[0, 1, 11, 11, 11]):
             self._incremental_write(target, source, operation_id)
 
         after = self.catalog.get_table(
             target).snapshot_manager().get_latest_snapshot().id
         self.assertEqual(3, after - before)
-
-    def test_inserts_into_empty_target_and_cleans_checkpoint(self):
-        target, source = self._create_tables()
-        empty_target = "default.pk_empty_{}".format(uuid.uuid4().hex[:8])
-        self.catalog.create_table(
-            empty_target,
-            Schema.from_pyarrow_schema(
-                self.target_schema,
-                primary_keys=["id"],
-                options={
-                    "bucket": "2",
-                    "merge-engine": "partial-update",
-                },
-            ),
-            False,
-        )
-        operation_id = "empty-{}".format(uuid.uuid4().hex)
-        result = self._incremental_write(
-            empty_target, source, operation_id)
-
-        self.assertEqual({"num_written": 2}, result)
         self.assertEqual({
-            "id": [1, 2],
-            "payload": [None, None],
-            "feature": [101, 102],
-        }, self._read(empty_target).to_pydict())
+            "id": [1, 2, 3, 4],
+            "payload": ["a", "b", "c", None],
+            "feature": [101, 102, 103, 104],
+        }, self._read(target).to_pydict())
         self.assertTrue(delete_write_paimon_checkpoint(
-            empty_target, self.catalog_options, operation_id))
+            target, self.catalog_options, operation_id))
         self.assertFalse(delete_write_paimon_checkpoint(
-            empty_target, self.catalog_options, operation_id))
+            target, self.catalog_options, operation_id))
 
     def test_metadata_checkpoint_for_empty_transform(self):
         target, source = self._create_tables()
+        self.catalog.alter_table(target, [
+            SchemaChange.add_column(
+                "extra", AtomicType("STRING"))], False)
         operation_id = "empty-transform-{}".format(uuid.uuid4().hex)
         source = PaimonOffsetSource(source, transform=lambda data: data.limit(0))
 
-        result = write_paimon(
-            source,
-            target,
-            self.catalog_options,
-            commit_mode="incremental",
-            operation_id=operation_id,
-            commit_interval_seconds=10,
-            update_cols=["feature"],
-        )
+        self._incremental_write(target, source, operation_id)
         snapshot_id = self.catalog.get_table(
             target).snapshot_manager().get_latest_snapshot().id
 
-        self.assertEqual({"num_written": 0}, result)
         self.assertEqual([10, 20, 30],
                          self._read(target)["feature"].to_pylist())
-        self.assertEqual(
-            {"num_written": 0},
-            write_paimon(
-                source,
-                target,
-                self.catalog_options,
-                commit_mode="incremental",
-                operation_id=operation_id,
-                commit_interval_seconds=10,
-                update_cols=["feature"],
-            ),
-        )
+        self._incremental_write(target, source, operation_id)
         self.assertEqual(
             snapshot_id,
             self.catalog.get_table(
                 target).snapshot_manager().get_latest_snapshot().id,
         )
 
-    def test_rejects_concurrent_target_write(self):
-        target, source = self._create_tables()
+    def test_rejects_concurrent_target_changes(self):
         from pypaimon.write import ray_datasink
 
-        real_prepare = ray_datasink._prepare_primary_key_groups
+        real_prepare = ray_datasink._write_primary_key_groups
+        for change, error in (("data", "Concurrent target commit"),
+                              ("schema", "schema change")):
+            with self.subTest(change=change):
+                target, source = self._create_tables()
+                changed = False
 
-        def write_concurrently(*args, **kwargs):
-            self._write(target, pa.table({
-                "id": [4],
-                "payload": ["external"],
-                "feature": [40],
-            }, schema=self.target_schema))
-            return real_prepare(*args, **kwargs)
+                def mutate_target(*args, **kwargs):
+                    nonlocal changed
+                    if changed:
+                        return real_prepare(*args, **kwargs)
+                    changed = True
+                    if change == "data":
+                        self._write(target, pa.table({
+                            "id": [4], "payload": ["external"],
+                            "feature": [40]}, schema=self.target_schema))
+                    else:
+                        self.catalog.alter_table(target, [
+                            SchemaChange.add_column(
+                                "extra", AtomicType("STRING"))], False)
+                    return real_prepare(*args, **kwargs)
 
-        with mock.patch.object(
-                ray_datasink, "_prepare_primary_key_groups",
-                side_effect=write_concurrently):
-            with self.assertRaisesRegex(
-                    RuntimeError, "Concurrent target commit"):
-                self._incremental_write(
-                    target, source,
-                    "concurrent-{}".format(uuid.uuid4().hex))
+                with mock.patch.object(
+                        ray_datasink, "_write_primary_key_groups",
+                        side_effect=mutate_target):
+                    with self.assertRaisesRegex(RuntimeError, error):
+                        self._incremental_write(
+                            target, source,
+                            "concurrent-{}".format(uuid.uuid4().hex))
 
-        self.assertEqual([10, 20, 30, 40],
-                         self._read(target)["feature"].to_pylist())
-
-    def test_uses_schema_planned_after_existing_ddl(self):
-        target, source = self._create_tables()
-        self.catalog.alter_table(
-            target,
-            [SchemaChange.add_column("extra", AtomicType("STRING"))],
-            False,
-        )
-
-        self._incremental_write(
-            target, source, "existing-ddl-{}".format(uuid.uuid4().hex))
-
-        self.assertEqual([101, 102, 30],
-                         self._read(target)["feature"].to_pylist())
-
-    def test_rejects_ddl_during_write(self):
-        target, source = self._create_tables()
-        from pypaimon.write import ray_datasink
-
-        real_prepare = ray_datasink._prepare_primary_key_groups
-
-        def alter_concurrently(*args, **kwargs):
-            self.catalog.alter_table(
-                target,
-                [SchemaChange.add_column("extra", AtomicType("STRING"))],
-                False,
-            )
-            return real_prepare(*args, **kwargs)
-
-        with mock.patch.object(
-                ray_datasink, "_prepare_primary_key_groups",
-                side_effect=alter_concurrently):
-            with self.assertRaisesRegex(RuntimeError, "schema change"):
-                self._incremental_write(
-                    target, source,
-                    "concurrent-ddl-{}".format(uuid.uuid4().hex))
-
-        self.assertEqual([10, 20, 30],
-                         self._read(target)["feature"].to_pylist())
-
-    def test_rejects_non_partial_update_target(self):
-        suffix = uuid.uuid4().hex[:8]
-        target = "default.pk_dedupe_{}".format(suffix)
-        source = "default.pk_source_{}".format(suffix)
-        self.catalog.create_table(
-            target,
-            Schema.from_pyarrow_schema(
-                self.target_schema, primary_keys=["id"],
-                options={"bucket": "1"}),
-            False,
-        )
-        self.catalog.create_table(
-            source, Schema.from_pyarrow_schema(self.source_schema), False)
-        with self.assertRaisesRegex(ValueError, "partial-update"):
-            self._incremental_write(
-                target, source, "reject-{}".format(suffix))
-
-    def test_rejects_unprovided_non_nullable_column(self):
-        suffix = uuid.uuid4().hex[:8]
-        target = "default.pk_not_null_{}".format(suffix)
-        source = "default.pk_source_{}".format(suffix)
-        schema = pa.schema([
-            pa.field("id", pa.int64(), nullable=False),
-            pa.field("payload", pa.string(), nullable=False),
-            ("feature", pa.int32()),
-        ])
-        self.catalog.create_table(
-            target,
-            Schema.from_pyarrow_schema(
-                schema, primary_keys=["id"], options={
-                    "bucket": "1",
-                    "merge-engine": "partial-update",
-                }),
-            False,
-        )
-        self.catalog.create_table(
-            source, Schema.from_pyarrow_schema(self.source_schema), False)
-        with self.assertRaisesRegex(ValueError, "payload.*nullable"):
-            self._incremental_write(
-                target, source, "non-null-{}".format(suffix))
-
+                expected = ([10, 20, 30, 40] if change == "data"
+                            else [10, 20, 30])
+                self.assertEqual(
+                    expected, self._read(target)["feature"].to_pylist())
 
 if __name__ == "__main__":
     unittest.main()

--- a/paimon-python/pypaimon/tests/ray_incremental_write_test.py
+++ b/paimon-python/pypaimon/tests/ray_incremental_write_test.py
@@ -152,6 +152,38 @@ class RayIncrementalWriteTest(unittest.TestCase):
             update_cols=["feature"],
         )
 
+    def test_transform_identity_ignores_runtime_state(self):
+        class RuntimeState:
+
+            def __init__(self, token):
+                self.token = token
+
+        def source(token):
+            state = RuntimeState(token)
+
+            def transform(dataset):
+                if state.token:
+                    return dataset
+                return dataset
+
+            return PaimonOffsetSource(
+                "default.source", transform=transform)
+
+        self.assertEqual(
+            source("expired")._transform_identity(),
+            source("refreshed")._transform_identity(),
+        )
+
+        def changed_transform(dataset):
+            return dataset.limit(1)
+
+        self.assertNotEqual(
+            source("expired")._transform_identity(),
+            PaimonOffsetSource(
+                "default.source",
+                transform=changed_transform)._transform_identity(),
+        )
+
     def test_resume_allows_compaction(self):
         target, source = self._create_tables()
         operation_id = "resume-{}".format(uuid.uuid4().hex)

--- a/paimon-python/pypaimon/tests/ray_incremental_write_test.py
+++ b/paimon-python/pypaimon/tests/ray_incremental_write_test.py
@@ -14,6 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import json
 import os
 import shutil
 import tempfile
@@ -146,6 +147,8 @@ class RayIncrementalWriteTest(unittest.TestCase):
             return real_prepare(*args, **kwargs)
 
         with mock.patch(
+                "pypaimon.ray.incremental_write._SPLITS_PER_WINDOW", 1), \
+                mock.patch(
                 "pypaimon.ray.incremental_write.time.monotonic",
                 side_effect=[0, 11, 11]), mock.patch.object(
                 ray_datasink, "_write_primary_key_groups",
@@ -163,16 +166,30 @@ class RayIncrementalWriteTest(unittest.TestCase):
     def test_time_trigger_batches_completed_windows(self):
         target, source = self._create_tables(source_rows=4)
         operation_id = "time-{}".format(uuid.uuid4().hex)
+        from pypaimon.write import ray_datasink
+
         before = self.catalog.get_table(
             target).snapshot_manager().get_latest_snapshot().id
+        real_prepare = ray_datasink._write_primary_key_groups
+        calls = 0
+
+        def count_windows(*args, **kwargs):
+            nonlocal calls
+            calls += 1
+            return real_prepare(*args, **kwargs)
 
         with mock.patch(
+                "pypaimon.ray.incremental_write._SPLITS_PER_WINDOW", 2), \
+                mock.patch(
                 "pypaimon.ray.incremental_write.time.monotonic",
-                side_effect=[0, 1, 11, 11, 11]):
+                side_effect=[0, 11, 11]), mock.patch.object(
+                ray_datasink, "_write_primary_key_groups",
+                side_effect=count_windows):
             self._incremental_write(target, source, operation_id)
 
         after = self.catalog.get_table(
             target).snapshot_manager().get_latest_snapshot().id
+        self.assertEqual(2, calls)
         self.assertEqual(3, after - before)
         self.assertEqual({
             "id": [1, 2, 3, 4],
@@ -204,6 +221,65 @@ class RayIncrementalWriteTest(unittest.TestCase):
             self.catalog.get_table(
                 target).snapshot_manager().get_latest_snapshot().id,
         )
+        self.catalog.alter_table(target, [
+            SchemaChange.add_column(
+                "later", AtomicType("STRING"))], False)
+        self.assertTrue(delete_write_paimon_checkpoint(
+            target, self.catalog_options, operation_id))
+
+    def test_rejects_late_schema_change_and_mismatched_checkpoint(self):
+        from pypaimon.ray import incremental_write
+
+        target, source = self._create_tables(source_rows=1)
+        table = self.catalog.get_table(target)
+        base = table.snapshot_manager().get_latest_snapshot()
+        operation_id = "fence-{}".format(uuid.uuid4().hex)
+        plan = {
+            "table": source,
+            "snapshot_id": 1,
+            "fingerprint": "expected",
+            "num_units": 1,
+            "splits_per_window": 1,
+        }
+        state = incremental_write._checkpoint_state(
+            operation_id, table.table_schema.id, ["feature"], plan, 0)
+
+        def alter_schema(*_args, **_kwargs):
+            self.catalog.alter_table(target, [
+                SchemaChange.drop_column("feature")], False)
+
+        with mock.patch.object(
+                incremental_write, "_store_checkpoint_tag",
+                side_effect=alter_schema):
+            with self.assertRaisesRegex(RuntimeError, "schema change"):
+                incremental_write._commit_checkpoint(
+                    self.catalog, target, table, base,
+                    table.table_schema.id,
+                    incremental_write._commit_user(operation_id),
+                    incremental_write._checkpoint_tags(operation_id),
+                    1, [], state)
+
+        other_state = dict(state)
+        other_state["source"] = dict(plan, fingerprint="other")
+        committed = mock.Mock(
+            properties={incremental_write._CHECKPOINT_PROPERTY: json.dumps(
+                other_state)},
+            id=base.id + 2,
+        )
+        commit = mock.Mock()
+        with mock.patch(
+                "pypaimon.write.table_commit.StreamTableCommit",
+                return_value=commit), mock.patch.object(
+                incremental_write, "_find_checkpoint_snapshot",
+                return_value=committed), mock.patch.object(
+                incremental_write, "_store_checkpoint_tag"):
+            with self.assertRaisesRegex(RuntimeError, "different state"):
+                incremental_write._commit_checkpoint(
+                    self.catalog, target, table, base,
+                    table.table_schema.id,
+                    incremental_write._commit_user(operation_id),
+                    incremental_write._checkpoint_tags(operation_id),
+                    2, [], state)
 
     def test_rejects_concurrent_target_changes(self):
         from pypaimon.write import ray_datasink

--- a/paimon-python/pypaimon/write/file_store_commit.py
+++ b/paimon-python/pypaimon/write/file_store_commit.py
@@ -529,20 +529,16 @@ class FileStoreCommit:
             return SuccessResult()
 
         latest_snapshot_id = latest_snapshot.id if latest_snapshot else 0
-        latest_schema = self.table.schema_manager.latest()
-        latest_schema_id = latest_schema.id if latest_schema is not None else None
-        snapshot_conflict = (
-            self.expected_base_snapshot_id is not None
-            and not self._is_allowed_protected_base(latest_snapshot_id)
-        )
-        if (self.expected_base_snapshot_id is not None
-                and (snapshot_conflict
-                     or latest_schema_id != self.expected_schema_id)):
-            conflict = RuntimeError(
-                "Concurrent target commit or schema change detected.")
-            if retry_result is None or retry_result.exception is None:
-                raise CommitConflictError(str(conflict)) from conflict
-            raise conflict
+        if self.expected_base_snapshot_id is not None:
+            latest_schema = self.table.schema_manager.latest()
+            latest_schema_id = latest_schema.id if latest_schema else None
+            if (not self._is_allowed_protected_base(latest_snapshot_id)
+                    or latest_schema_id != self.expected_schema_id):
+                conflict = RuntimeError(
+                    "Concurrent target commit or schema change detected.")
+                if retry_result is None or retry_result.exception is None:
+                    raise CommitConflictError(str(conflict)) from conflict
+                raise conflict
 
         if (
             hash_index_base_snapshot is not None

--- a/paimon-python/pypaimon/write/file_store_commit.py
+++ b/paimon-python/pypaimon/write/file_store_commit.py
@@ -112,6 +112,7 @@ class FileStoreCommit:
         self.snapshot_properties = {}
         self.expected_base_snapshot_id = None
         self.expected_schema_id = None
+        self.allow_concurrent_maintenance = False
 
         self.snapshot_manager = table.snapshot_manager()
         self.manifest_file_manager = ManifestFileManager(table)
@@ -149,15 +150,18 @@ class FileStoreCommit:
     def with_snapshot_properties(self, properties):
         self.snapshot_properties = dict(properties or {})
 
-    def protect_from_external_commits(self, base_snapshot, schema_id):
+    def protect_from_external_commits(
+            self, base_snapshot, schema_id, allow_maintenance=False):
         self.expected_base_snapshot_id = (
             base_snapshot.id if base_snapshot is not None else 0)
         self.expected_schema_id = schema_id
+        self.allow_concurrent_maintenance = allow_maintenance
 
     def clear_commit_context(self):
         self.snapshot_properties = {}
         self.expected_base_snapshot_id = None
         self.expected_schema_id = None
+        self.allow_concurrent_maintenance = False
 
     def commit_metadata(self, commit_identifier: int):
         self._try_commit(
@@ -496,6 +500,20 @@ class FileStoreCommit:
             self._commit_retry_wait(retry_count)
             retry_count += 1
 
+    def _is_allowed_protected_base(self, latest_snapshot_id):
+        expected = self.expected_base_snapshot_id
+        if latest_snapshot_id == expected:
+            return True
+        if (not self.allow_concurrent_maintenance
+                or latest_snapshot_id < expected):
+            return False
+        for snapshot_id in range(expected + 1, latest_snapshot_id + 1):
+            snapshot = self.snapshot_manager.get_snapshot_by_id(snapshot_id)
+            if (snapshot is None
+                    or snapshot.commit_kind not in ("COMPACT", "ANALYZE")):
+                return False
+        return True
+
     def _try_commit_once(self, retry_result: Optional[RetryResult], commit_kind: str,
                          commit_entries: List[ManifestEntry],
                          changelog_entries: List[ManifestEntry],
@@ -513,8 +531,12 @@ class FileStoreCommit:
         latest_snapshot_id = latest_snapshot.id if latest_snapshot else 0
         latest_schema = self.table.schema_manager.latest()
         latest_schema_id = latest_schema.id if latest_schema is not None else None
+        snapshot_conflict = (
+            self.expected_base_snapshot_id is not None
+            and not self._is_allowed_protected_base(latest_snapshot_id)
+        )
         if (self.expected_base_snapshot_id is not None
-                and (latest_snapshot_id != self.expected_base_snapshot_id
+                and (snapshot_conflict
                      or latest_schema_id != self.expected_schema_id)):
             conflict = RuntimeError(
                 "Concurrent target commit or schema change detected.")

--- a/paimon-python/pypaimon/write/file_store_commit.py
+++ b/paimon-python/pypaimon/write/file_store_commit.py
@@ -109,6 +109,9 @@ class FileStoreCommit:
         self.table: FileStoreTable = table
         self.commit_user = commit_user
         self.commit_callbacks: List[CommitCallback] = commit_callbacks if commit_callbacks is not None else []
+        self.snapshot_properties = {}
+        self.expected_base_snapshot_id = None
+        self.expected_schema_id = None
 
         self.snapshot_manager = table.snapshot_manager()
         self.manifest_file_manager = ManifestFileManager(table)
@@ -143,9 +146,31 @@ class FileStoreCommit:
         table_rollback = table.catalog_environment.catalog_table_rollback()
         self.rollback = CommitRollback(table_rollback) if table_rollback is not None else None
 
+    def with_snapshot_properties(self, properties):
+        self.snapshot_properties = dict(properties or {})
+
+    def protect_from_external_commits(self, base_snapshot, schema_id):
+        self.expected_base_snapshot_id = (
+            base_snapshot.id if base_snapshot is not None else 0)
+        self.expected_schema_id = schema_id
+
+    def clear_commit_context(self):
+        self.snapshot_properties = {}
+        self.expected_base_snapshot_id = None
+        self.expected_schema_id = None
+
+    def commit_metadata(self, commit_identifier: int):
+        self._try_commit(
+            commit_kind="APPEND",
+            commit_identifier=commit_identifier,
+            commit_entries_plan=lambda _snapshot: [],
+            allow_empty=True,
+        )
+
     def commit(self, commit_messages: List[CommitMessage], commit_identifier: int):
         """Commit the given commit messages in normal append mode."""
         if not commit_messages:
+            self.clear_commit_context()
             return
 
         # Extract the minimum check_from_snapshot from commit messages
@@ -373,7 +398,7 @@ class FileStoreCommit:
     def _try_commit(self, commit_kind, commit_identifier, commit_entries_plan,
                     detect_conflicts=False, allow_rollback=False, index_deletes=None,
                     index_adds=None, changelog_entries=None,
-                    hash_index_base_snapshot=None):
+                    hash_index_base_snapshot=None, allow_empty=False):
 
         retry_count = 0
         retry_result = None
@@ -389,7 +414,11 @@ class FileStoreCommit:
 
             # No entries to commit (e.g. drop_partitions with no matching data): skip commit
             # to avoid creating manifest/snapshot with empty partition_stats (causes read errors).
-            if not commit_entries and not index_deletes and not index_adds:
+            if (not allow_empty
+                    and not commit_entries
+                    and not index_deletes
+                    and not index_adds):
+                self.clear_commit_context()
                 break
 
             result = self._try_commit_once(
@@ -435,6 +464,7 @@ class FileStoreCommit:
                         self.table.identifier,
                         commit_duration_ms,
                     )
+                self.clear_commit_context()
                 break
             else:
                 retry_result = result
@@ -481,6 +511,17 @@ class FileStoreCommit:
             return SuccessResult()
 
         latest_snapshot_id = latest_snapshot.id if latest_snapshot else 0
+        latest_schema = self.table.schema_manager.latest()
+        latest_schema_id = latest_schema.id if latest_schema is not None else None
+        if (self.expected_base_snapshot_id is not None
+                and (latest_snapshot_id != self.expected_base_snapshot_id
+                     or latest_schema_id != self.expected_schema_id)):
+            conflict = RuntimeError(
+                "Concurrent target commit or schema change detected.")
+            if retry_result is None or retry_result.exception is None:
+                raise CommitConflictError(str(conflict)) from conflict
+            raise conflict
+
         if (
             hash_index_base_snapshot is not None
             and latest_snapshot_id != hash_index_base_snapshot
@@ -646,6 +687,7 @@ class FileStoreCommit:
                 time_millis=int(time.time() * 1000),
                 next_row_id=next_row_id,
                 index_manifest=index_manifest,
+                properties=self.snapshot_properties,
             )
             # Generate partition statistics for the commit
             statistics = self._generate_partition_statistics(commit_entries)

--- a/paimon-python/pypaimon/write/ray_datasink.py
+++ b/paimon-python/pypaimon/write/ray_datasink.py
@@ -263,6 +263,66 @@ class PaimonDatasink(_DatasinkBase):
                 self._pending_commit_messages = []
 
 
+def _prepare_incremental_update(table, target, update_cols):
+    from pypaimon.common.options.core_options import MergeEngine
+    from pypaimon.schema.data_types import PyarrowFieldParser
+    from pypaimon.table.bucket_mode import BucketMode
+
+    if not update_cols:
+        raise ValueError("update_cols must be non-empty.")
+    update_cols = list(dict.fromkeys(update_cols))
+    if not (
+            table.is_primary_key_table
+            and table.bucket_mode() == BucketMode.HASH_FIXED
+            and table.options.merge_engine() == MergeEngine.PARTIAL_UPDATE):
+        raise ValueError(
+            "incremental write_paimon requires a fixed-bucket primary-key "
+            "target with 'merge-engine'='partial-update'.")
+    if table.cross_partition_update:
+        raise ValueError(
+            "incremental write_paimon does not support cross-partition "
+            "updates.")
+    if table.options.sequence_field():
+        raise ValueError(
+            "incremental write_paimon does not support sequence fields.")
+
+    primary_keys = list(table.primary_keys)
+    invalid = [
+        name for name in update_cols
+        if name not in table.field_names or name in primary_keys]
+    if invalid:
+        raise ValueError(
+            "update column {!r} must be a non-key column in target {!r}.".format(
+                invalid[0], target))
+    omitted_non_null = [
+        field.name for field in table.table_schema.fields
+        if (field.name not in primary_keys
+            and field.name not in update_cols
+            and not field.type.nullable)
+    ]
+    if omitted_non_null:
+        raise ValueError(
+            "unprovided partial-update column {!r} must be nullable.".format(
+                omitted_non_null[0]))
+
+    target_schema = PyarrowFieldParser.from_paimon_schema(
+        table.table_schema.fields)
+    required = primary_keys + update_cols
+
+    def to_write_batch(batch):
+        missing = [name for name in required if name not in batch.column_names]
+        if missing:
+            raise ValueError("source is missing columns {}.".format(missing))
+        arrays = [
+            batch.column(field.name).cast(field.type)
+            if field.name in required
+            else pa.nulls(batch.num_rows, type=field.type)
+            for field in target_schema
+        ]
+        return pa.Table.from_arrays(arrays, schema=target_schema)
+    return update_cols, to_write_batch
+
+
 def write_paimon_dataset(
     dataset,
     table,

--- a/paimon-python/pypaimon/write/ray_datasink.py
+++ b/paimon-python/pypaimon/write/ray_datasink.py
@@ -466,6 +466,7 @@ def _consume_write_results(
     message_col,
     error_col=None,
     prepare_only=False,
+    on_write_result=None,
 ):
     import pickle
 
@@ -481,9 +482,12 @@ def _consume_write_results(
             for blob, error in zip(messages, batch_errors):
                 commit_messages = pickle.loads(blob)
                 write_returns.append(commit_messages)
-                coordinator.add_pending_commit_messages(commit_messages)
+                if on_write_result is None:
+                    coordinator.add_pending_commit_messages(commit_messages)
                 if error is not None:
                     errors.append(error)
+                elif on_write_result is not None:
+                    on_write_result(commit_messages)
         if errors:
             raise RuntimeError(
                 "One or more Ray write tasks failed:\n{}".format(
@@ -492,7 +496,8 @@ def _consume_write_results(
             )
         if prepare_only:
             return [message for result in write_returns for message in result]
-        coordinator.on_write_complete(write_returns)
+        if on_write_result is None:
+            coordinator.on_write_complete(write_returns)
     except Exception as error:
         coordinator.on_write_failed(error)
         raise
@@ -552,6 +557,7 @@ def _write_primary_key_groups(
     bucket_extractor=None,
     postpone_bucket_plan=None,
     prepare_only=False,
+    on_group_result=None,
 ):
     import pickle
 
@@ -619,6 +625,7 @@ def _write_primary_key_groups(
             message_col,
             error_col,
             prepare_only,
+            on_group_result,
         )
     except Exception:
         if prepare_only:

--- a/paimon-python/pypaimon/write/ray_datasink.py
+++ b/paimon-python/pypaimon/write/ray_datasink.py
@@ -299,46 +299,10 @@ def _write_primary_key_groups(
     static_partition: Optional[Dict[str, Any]],
     concurrency: Optional[int],
     ray_remote_args: Optional[Dict[str, Any]],
-) -> None:
-    all_messages, _ = _prepare_primary_key_groups(
-        dataset,
-        table,
-        overwrite=overwrite,
-        static_partition=static_partition,
-        concurrency=concurrency,
-        ray_remote_args=ray_remote_args,
-    )
-
-    coordinator = PaimonDatasink(
-        table,
-        overwrite=overwrite,
-        static_partition=static_partition,
-    )
-    try:
-        coordinator.on_write_start()
-    except Exception:
-        _abort_primary_key_messages(table, all_messages)
-        raise
-    try:
-        coordinator.on_write_complete([all_messages])
-    except Exception as error:
-        coordinator.on_write_failed(error)
-        raise
-
-
-def _prepare_primary_key_groups(
-    dataset,
-    table,
-    *,
-    overwrite: bool = False,
-    static_partition: Optional[Dict[str, Any]] = None,
-    concurrency: Optional[int] = None,
-    ray_remote_args: Optional[Dict[str, Any]] = None,
+    prepare_only: bool = False,
 ):
-    """Write complete PK bucket groups and return uncommitted messages."""
     import inspect
     import pickle
-    import traceback
 
     from pypaimon.ray.shuffle import (
         _coerce_large_string_types,
@@ -347,43 +311,27 @@ def _prepare_primary_key_groups(
 
     grouped, bucket_col = _group_by_partition_bucket(dataset, table)
     message_col = "__paimon_commit_messages__"
-    count_col = "__paimon_row_count__"
-    error_col = "__paimon_write_error__"
     captured_table = table
 
     # Keep the writer inside the group UDF. Ray may split the UDF output
     # into multiple blocks, so only serialized commit messages leave it.
     def _write_group(group: pa.Table) -> pa.Table:
         if group.num_rows == 0:
-            return pa.table({
-                message_col: pa.array([], type=pa.binary()),
-                count_col: pa.array([], type=pa.int64()),
-                error_col: pa.array([], type=pa.string()),
-            })
+            return pa.table({message_col: pa.array([], type=pa.binary())})
 
         rows = _coerce_large_string_types(
             group.drop_columns([bucket_col])
         )
-        commit_messages = []
-        try:
-            worker_sink = PaimonDatasink(
-                captured_table,
-                overwrite=overwrite,
-                static_partition=static_partition,
-            )
-            commit_messages = worker_sink.write([rows], None)
-            encoded = pickle.dumps(commit_messages)
-            error = None
-        except Exception:
-            _abort_primary_key_messages(captured_table, commit_messages)
-            encoded = pickle.dumps([])
-            error = traceback.format_exc()
+        worker_sink = PaimonDatasink(
+            captured_table,
+            overwrite=overwrite,
+            static_partition=static_partition,
+        )
+        commit_messages = worker_sink.write([rows], None)
         return pa.table({
             message_col: pa.array(
-                [encoded], type=pa.binary()
-            ),
-            count_col: pa.array([rows.num_rows], type=pa.int64()),
-            error_col: pa.array([error], type=pa.string()),
+                [pickle.dumps(commit_messages)], type=pa.binary()
+            )
         })
 
     map_kwargs = {"batch_format": "pyarrow"}
@@ -402,57 +350,30 @@ def _prepare_primary_key_groups(
     if ray_remote_args:
         map_kwargs.update(ray_remote_args)
 
-    results = grouped.map_groups(_write_group, **map_kwargs)
-    all_messages = []
-    num_rows = 0
-    first_error = None
+    messages = grouped.map_groups(_write_group, **map_kwargs)
+    coordinator = None
+    if not prepare_only:
+        coordinator = PaimonDatasink(
+            table,
+            overwrite=overwrite,
+            static_partition=static_partition,
+        )
+        coordinator.on_write_start()
     try:
-        for batch in results.iter_batches(batch_format="pyarrow"):
-            blobs = batch.column(message_col).to_pylist()
-            counts = batch.column(count_col).to_pylist()
-            errors = batch.column(error_col).to_pylist()
-            for blob, count, error in zip(blobs, counts, errors):
-                if error is not None:
-                    if first_error is None:
-                        first_error = error
-                    continue
-                all_messages.extend(pickle.loads(blob))
-                num_rows += count
-        if first_error is not None:
-            raise RuntimeError(first_error)
-        return all_messages, num_rows
-    except Exception:
-        # Some Ray versions lose the schema while shuffling an empty Dataset.
-        # Check only on the failure path to avoid an extra source scan.
-        empty = False
-        if not all_messages:
+        write_returns = []
+        for batch in messages.iter_batches(batch_format="pyarrow"):
+            for blob in batch.column(message_col).to_pylist():
+                write_returns.append(pickle.loads(blob))
+        if prepare_only:
+            return [message for result in write_returns for message in result]
+        coordinator.on_write_complete(write_returns)
+    except Exception as error:
+        if prepare_only:
             try:
-                empty = dataset.limit(1).count() == 0
+                if dataset.limit(1).count() == 0:
+                    return []
             except Exception:
                 pass
-        if empty:
-            return [], 0
-        _abort_primary_key_messages(table, all_messages)
+        else:
+            coordinator.on_write_failed(error)
         raise
-
-
-def _abort_primary_key_messages(table, messages):
-    if not messages:
-        return
-    commit = table.new_batch_write_builder().new_commit()
-    try:
-        try:
-            commit.abort(messages)
-        except Exception:
-            logger.warning(
-                "Failed to abort primary-key commit messages.",
-                exc_info=True,
-            )
-    finally:
-        try:
-            commit.close()
-        except Exception:
-            logger.warning(
-                "Failed to close primary-key abort commit.",
-                exc_info=True,
-            )

--- a/paimon-python/pypaimon/write/ray_datasink.py
+++ b/paimon-python/pypaimon/write/ray_datasink.py
@@ -300,8 +300,45 @@ def _write_primary_key_groups(
     concurrency: Optional[int],
     ray_remote_args: Optional[Dict[str, Any]],
 ) -> None:
+    all_messages, _ = _prepare_primary_key_groups(
+        dataset,
+        table,
+        overwrite=overwrite,
+        static_partition=static_partition,
+        concurrency=concurrency,
+        ray_remote_args=ray_remote_args,
+    )
+
+    coordinator = PaimonDatasink(
+        table,
+        overwrite=overwrite,
+        static_partition=static_partition,
+    )
+    try:
+        coordinator.on_write_start()
+    except Exception:
+        _abort_primary_key_messages(table, all_messages)
+        raise
+    try:
+        coordinator.on_write_complete([all_messages])
+    except Exception as error:
+        coordinator.on_write_failed(error)
+        raise
+
+
+def _prepare_primary_key_groups(
+    dataset,
+    table,
+    *,
+    overwrite: bool = False,
+    static_partition: Optional[Dict[str, Any]] = None,
+    concurrency: Optional[int] = None,
+    ray_remote_args: Optional[Dict[str, Any]] = None,
+):
+    """Write complete PK bucket groups and return uncommitted messages."""
     import inspect
     import pickle
+    import traceback
 
     from pypaimon.ray.shuffle import (
         _coerce_large_string_types,
@@ -310,27 +347,43 @@ def _write_primary_key_groups(
 
     grouped, bucket_col = _group_by_partition_bucket(dataset, table)
     message_col = "__paimon_commit_messages__"
+    count_col = "__paimon_row_count__"
+    error_col = "__paimon_write_error__"
     captured_table = table
 
     # Keep the writer inside the group UDF. Ray may split the UDF output
     # into multiple blocks, so only serialized commit messages leave it.
     def _write_group(group: pa.Table) -> pa.Table:
         if group.num_rows == 0:
-            return pa.table({message_col: pa.array([], type=pa.binary())})
+            return pa.table({
+                message_col: pa.array([], type=pa.binary()),
+                count_col: pa.array([], type=pa.int64()),
+                error_col: pa.array([], type=pa.string()),
+            })
 
         rows = _coerce_large_string_types(
             group.drop_columns([bucket_col])
         )
-        worker_sink = PaimonDatasink(
-            captured_table,
-            overwrite=overwrite,
-            static_partition=static_partition,
-        )
-        commit_messages = worker_sink.write([rows], None)
+        commit_messages = []
+        try:
+            worker_sink = PaimonDatasink(
+                captured_table,
+                overwrite=overwrite,
+                static_partition=static_partition,
+            )
+            commit_messages = worker_sink.write([rows], None)
+            encoded = pickle.dumps(commit_messages)
+            error = None
+        except Exception:
+            _abort_primary_key_messages(captured_table, commit_messages)
+            encoded = pickle.dumps([])
+            error = traceback.format_exc()
         return pa.table({
             message_col: pa.array(
-                [pickle.dumps(commit_messages)], type=pa.binary()
-            )
+                [encoded], type=pa.binary()
+            ),
+            count_col: pa.array([rows.num_rows], type=pa.int64()),
+            error_col: pa.array([error], type=pa.string()),
         })
 
     map_kwargs = {"batch_format": "pyarrow"}
@@ -349,19 +402,57 @@ def _write_primary_key_groups(
     if ray_remote_args:
         map_kwargs.update(ray_remote_args)
 
-    messages = grouped.map_groups(_write_group, **map_kwargs)
-    coordinator = PaimonDatasink(
-        table,
-        overwrite=overwrite,
-        static_partition=static_partition,
-    )
-    coordinator.on_write_start()
+    results = grouped.map_groups(_write_group, **map_kwargs)
+    all_messages = []
+    num_rows = 0
+    first_error = None
     try:
-        write_returns = []
-        for batch in messages.iter_batches(batch_format="pyarrow"):
-            for blob in batch.column(message_col).to_pylist():
-                write_returns.append(pickle.loads(blob))
-        coordinator.on_write_complete(write_returns)
-    except Exception as error:
-        coordinator.on_write_failed(error)
+        for batch in results.iter_batches(batch_format="pyarrow"):
+            blobs = batch.column(message_col).to_pylist()
+            counts = batch.column(count_col).to_pylist()
+            errors = batch.column(error_col).to_pylist()
+            for blob, count, error in zip(blobs, counts, errors):
+                if error is not None:
+                    if first_error is None:
+                        first_error = error
+                    continue
+                all_messages.extend(pickle.loads(blob))
+                num_rows += count
+        if first_error is not None:
+            raise RuntimeError(first_error)
+        return all_messages, num_rows
+    except Exception:
+        # Some Ray versions lose the schema while shuffling an empty Dataset.
+        # Check only on the failure path to avoid an extra source scan.
+        empty = False
+        if not all_messages:
+            try:
+                empty = dataset.limit(1).count() == 0
+            except Exception:
+                pass
+        if empty:
+            return [], 0
+        _abort_primary_key_messages(table, all_messages)
         raise
+
+
+def _abort_primary_key_messages(table, messages):
+    if not messages:
+        return
+    commit = table.new_batch_write_builder().new_commit()
+    try:
+        try:
+            commit.abort(messages)
+        except Exception:
+            logger.warning(
+                "Failed to abort primary-key commit messages.",
+                exc_info=True,
+            )
+    finally:
+        try:
+            commit.close()
+        except Exception:
+            logger.warning(
+                "Failed to close primary-key abort commit.",
+                exc_info=True,
+            )

--- a/paimon-python/pypaimon/write/table_commit.py
+++ b/paimon-python/pypaimon/write/table_commit.py
@@ -65,9 +65,10 @@ class TableCommit:
         self.file_store_commit.with_snapshot_properties(properties)
         return self
 
-    def protect_from_external_commits(self, base_snapshot, schema_id):
+    def protect_from_external_commits(
+            self, base_snapshot, schema_id, allow_maintenance=False):
         self.file_store_commit.protect_from_external_commits(
-            base_snapshot, schema_id)
+            base_snapshot, schema_id, allow_maintenance)
         return self
 
     def _commit(self, commit_messages: List[CommitMessage], commit_identifier: int = BATCH_COMMIT_IDENTIFIER):

--- a/paimon-python/pypaimon/write/table_commit.py
+++ b/paimon-python/pypaimon/write/table_commit.py
@@ -61,6 +61,15 @@ class TableCommit:
         """Register a callback to be invoked after each successful commit."""
         self._commit_callbacks.append(callback)
 
+    def with_snapshot_properties(self, properties):
+        self.file_store_commit.with_snapshot_properties(properties)
+        return self
+
+    def protect_from_external_commits(self, base_snapshot, schema_id):
+        self.file_store_commit.protect_from_external_commits(
+            base_snapshot, schema_id)
+        return self
+
     def _commit(self, commit_messages: List[CommitMessage], commit_identifier: int = BATCH_COMMIT_IDENTIFIER):
         non_empty_messages = [msg for msg in commit_messages if not msg.is_empty()]
 
@@ -80,6 +89,7 @@ class TableCommit:
                 )
             else:
                 if not non_empty_messages:
+                    self.file_store_commit.clear_commit_context()
                     return
                 logger.info(
                     "Committing table %s, %d non-empty messages",
@@ -146,3 +156,6 @@ class StreamTableCommit(TableCommit):
 
     def commit(self, commit_messages: List[CommitMessage], commit_identifier: int):
         self._commit(commit_messages, commit_identifier)
+
+    def commit_metadata(self, commit_identifier: int):
+        self.file_store_commit.commit_metadata(commit_identifier)


### PR DESCRIPTION
### Purpose

Allow long-running Ray primary-key updates to commit periodically and resume after a driver restart.

### Changes

- add `PaimonOffsetSource` with a pinned source snapshot and stable offsets;
- add `commit_mode="incremental"`, `operation_id`, `commit_interval_seconds`, and `update_cols` to `write_paimon`;
- store source progress in the same target snapshot as each data commit;
- retain the source snapshot and latest checkpoint with internal tags;
- reject concurrent target commits and schema changes;
- add `delete_write_paimon_checkpoint` for completed operations.

The default atomic path is unchanged. Incremental mode currently supports fixed-bucket primary-key targets using `merge-engine=partial-update`; sequence fields and cross-partition updates are not supported.

### Tests

- real Ray E2E: time-triggered commits, restart recovery, empty results, inserts, concurrent commits, and schema changes;
- existing Ray write and commit regression suites;
- project flake8 and `git diff --check`.
