### PR TITLE
[fs] Delegate tryToWriteAtomic through FileIO wrappers

### DIFF
--- a/paimon-common/src/main/java/org/apache/paimon/fs/ResolvingFileIO.java
+++ b/paimon-common/src/main/java/org/apache/paimon/fs/ResolvingFileIO.java
@@ -110,6 +110,13 @@ public class ResolvingFileIO implements FileIO {
     }
 
     @Override
+    public boolean tryToWriteAtomic(Path path, String content) throws IOException {
+        // the interface default (temp file + rename) would bypass the resolved FileIO's atomic
+        // override
+        return wrap(() -> fileIO(path).tryToWriteAtomic(path, content));
+    }
+
+    @Override
     public String createBlobPresignedUrl(
             Path tableRoot, BlobDescriptor descriptor, Duration validity) throws IOException {
         return wrap(

--- a/paimon-common/src/main/java/org/apache/paimon/fs/cache/CachingFileIO.java
+++ b/paimon-common/src/main/java/org/apache/paimon/fs/cache/CachingFileIO.java
@@ -181,6 +181,12 @@ public class CachingFileIO implements FileIO {
     }
 
     @Override
+    public boolean tryToWriteAtomic(Path path, String content) throws IOException {
+        // the interface default (temp file + rename) would bypass the delegate's atomic override
+        return delegate.tryToWriteAtomic(path, content);
+    }
+
+    @Override
     public String createBlobPresignedUrl(
             Path tableRoot, BlobDescriptor descriptor, Duration validity) throws IOException {
         return delegate.createBlobPresignedUrl(tableRoot, descriptor, validity);

--- a/paimon-common/src/main/java/org/apache/paimon/rest/RESTTokenFileIO.java
+++ b/paimon-common/src/main/java/org/apache/paimon/rest/RESTTokenFileIO.java
@@ -153,6 +153,13 @@ public class RESTTokenFileIO implements FileIO {
     }
 
     @Override
+    public boolean tryToWriteAtomic(Path path, String content) throws IOException {
+        // the interface default (temp file + rename) would bypass the inner FileIO's atomic
+        // override
+        return fileIO().tryToWriteAtomic(path, content);
+    }
+
+    @Override
     public String createBlobPresignedUrl(
             Path tableRoot, BlobDescriptor descriptor, Duration validity) throws IOException {
         if (!path.equals(tableRoot)) {

--- a/paimon-common/src/test/java/org/apache/paimon/fs/ResolvingFileIOTest.java
+++ b/paimon-common/src/test/java/org/apache/paimon/fs/ResolvingFileIOTest.java
@@ -36,8 +36,10 @@ import java.util.concurrent.Future;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -164,5 +166,22 @@ public class ResolvingFileIOTest {
                 "https://example",
                 resolvingFileIO.createBlobPresignedUrl(tableRoot, descriptor, validity));
         verify(delegate).createBlobPresignedUrl(tableRoot, descriptor, validity);
+    }
+
+    @Test
+    public void testTryToWriteAtomicReachesResolvedOverride() throws IOException {
+        FileIO delegate = mock(FileIO.class);
+        FileIOLoader loader = mock(FileIOLoader.class);
+        when(loader.load(any())).thenReturn(delegate);
+        when(loader.getScheme()).thenReturn("oss");
+        resolvingFileIO.configure(CatalogContext.create(new Options(), loader, null));
+
+        Path target = new Path("oss://bucket/table/snapshot/LATEST");
+        when(delegate.tryToWriteAtomic(target, "content")).thenReturn(true);
+
+        assertTrue(resolvingFileIO.tryToWriteAtomic(target, "content"));
+        verify(delegate).tryToWriteAtomic(target, "content");
+        // the interface default would have written a temp file and renamed it instead
+        verify(delegate, never()).rename(any(), any());
     }
 }

--- a/paimon-common/src/test/java/org/apache/paimon/fs/cache/CachingFileIOTest.java
+++ b/paimon-common/src/test/java/org/apache/paimon/fs/cache/CachingFileIOTest.java
@@ -49,7 +49,9 @@ import static org.apache.paimon.options.CatalogOptions.LOCAL_CACHE_ENABLED;
 import static org.apache.paimon.options.CatalogOptions.LOCAL_CACHE_MAX_SIZE;
 import static org.apache.paimon.options.CatalogOptions.LOCAL_CACHE_WHITELIST;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -85,6 +87,24 @@ class CachingFileIOTest {
         assertThat(cachingIO.createBlobPresignedUrl(tableRoot, descriptor, validity))
                 .isEqualTo("https://example");
         verify(delegate).createBlobPresignedUrl(tableRoot, descriptor, validity);
+    }
+
+    @Test
+    void testTryToWriteAtomicReachesDelegateOverride() throws IOException {
+        FileIO delegate = mock(FileIO.class);
+        CachingFileIO cachingIO =
+                newCachingFileIO(
+                        delegate,
+                        new LocalMemoryCacheManager(1024, 64),
+                        EnumSet.of(FileType.DATA),
+                        64);
+        Path target = new Path("oss://bucket/table/snapshot/LATEST");
+        when(delegate.tryToWriteAtomic(target, "content")).thenReturn(true);
+
+        assertThat(cachingIO.tryToWriteAtomic(target, "content")).isTrue();
+        verify(delegate).tryToWriteAtomic(target, "content");
+        // the interface default would have written a temp file and renamed it instead
+        verify(delegate, never()).rename(any(), any());
     }
 
     private CachingFileIO newCachingFileIO(

--- a/paimon-common/src/test/java/org/apache/paimon/rest/RESTTokenFileIOTest.java
+++ b/paimon-common/src/test/java/org/apache/paimon/rest/RESTTokenFileIOTest.java
@@ -32,11 +32,13 @@ import org.junit.jupiter.api.Test;
 import java.io.IOException;
 import java.time.Duration;
 import java.util.Collections;
+import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -77,5 +79,37 @@ class RESTTokenFileIOTest {
                                         new Path("oss://bucket/other"), descriptor, validity))
                 .isInstanceOf(IOException.class)
                 .hasMessageContaining("bound table root");
+    }
+
+    @Test
+    void testTryToWriteAtomicReachesInnerOverride() throws IOException {
+        Path tableRoot = new Path("oss://bucket/table");
+        FileIO delegate = mock(FileIO.class);
+        FileIOLoader loader = mock(FileIOLoader.class);
+        when(loader.load(any())).thenReturn(delegate);
+        when(loader.getScheme()).thenReturn("oss");
+        RESTApi api = mock(RESTApi.class);
+        Identifier identifier = Identifier.create("db", "table");
+        // a unique token, so the static token-keyed FileIO cache cannot serve another test's
+        // delegate
+        when(api.loadTableToken(identifier))
+                .thenReturn(
+                        new GetTableTokenResponse(
+                                Collections.singletonMap("token", UUID.randomUUID().toString()),
+                                Long.MAX_VALUE));
+        RESTTokenFileIO fileIO =
+                new RESTTokenFileIO(
+                        CatalogContext.create(new Options(), loader, null),
+                        api,
+                        identifier,
+                        tableRoot);
+
+        Path target = new Path("oss://bucket/table/snapshot/LATEST");
+        when(delegate.tryToWriteAtomic(target, "content")).thenReturn(true);
+
+        assertThat(fileIO.tryToWriteAtomic(target, "content")).isTrue();
+        verify(delegate).tryToWriteAtomic(target, "content");
+        // the interface default would have written a temp file and renamed it instead
+        verify(delegate, never()).rename(any(), any());
     }
 }


### PR DESCRIPTION
  ### Purpose

  Three `FileIO` wrappers delegate every primitive to an underlying FileIO, but not
  `tryToWriteAtomic`. Callers therefore run the interface default — write a temp file, then
  `rename` — even when the underlying FileIO overrides the method with something genuinely atomic:
  `OSSFileIO` implements it as a server-side conditional put (`x-oss-forbid-overwrite`), and OSS
  rename is copy-and-delete, so the default is a non-atomic check-then-act there.

  The wrappers, and the atomicity-sensitive callers that actually run on top of each:

  - `CachingFileIO` — applied in `AbstractCatalog` for every catalog type when
    `local-cache.enabled=true`. On a filesystem catalog this sits under
    `RenamingSnapshotCommit` (snapshot commit) and `SchemaManager` (schema file commit), whose
    correctness is exactly "two concurrent writers, one wins".
  - `ResolvingFileIO` — same exposure when `resolving-file-io.enabled=true`.
  - `RESTTokenFileIO` — every REST-catalog table's data FileIO. Snapshot and schema commits go
    through the REST server's own CAS and are not affected, but client-side direct writes still
    rely on this method — e.g. `IcebergCommitCallback` publishing Iceberg-compatible metadata
    files next to the table.

  The fourth wrapper, `PluginFileIO`, already delegates this method; this brings the remaining
  three in line, each following its class's existing delegation shape.