### PR TITLE
[core][python] Support skipping manifest merge on write

### DIFF
--- a/docs/generated/core_configuration.html
+++ b/docs/generated/core_configuration.html
@@ -1054,6 +1054,12 @@ Mainly to resolve data skew on primary keys. We recommend starting with 64 mb wh
             <td>To avoid frequent manifest merges, this parameter specifies the minimum number of ManifestFileMeta to merge.<br />Note: when 'manifest-sort.enabled' is true, this minimum-count gate is only applied to the trailing sub-segment of a section that exceeds 'manifest-sort.max-rewrite-size'. Small under-budget sections are sorted and rewritten directly, so two small manifest files may be merged into one even when their count is below this threshold and full compaction is not triggered.</td>
         </tr>
         <tr>
+            <td><h5>manifest.merge-on-write</h5></td>
+            <td style="word-wrap: break-word;">true</td>
+            <td>Boolean</td>
+            <td>Whether to merge existing manifest files during APPEND and OVERWRITE commits. Disable only when manifest compaction is handled separately.</td>
+        </tr>
+        <tr>
             <td><h5>manifest.target-file-size</h5></td>
             <td style="word-wrap: break-word;">8 mb</td>
             <td>MemorySize</td>

--- a/paimon-api/src/main/java/org/apache/paimon/CoreOptions.java
+++ b/paimon-api/src/main/java/org/apache/paimon/CoreOptions.java
@@ -558,6 +558,14 @@ public class CoreOptions implements Serializable {
                                                     + "compaction is not triggered.")
                                     .build());
 
+    public static final ConfigOption<Boolean> MANIFEST_MERGE_ON_WRITE =
+            key("manifest.merge-on-write")
+                    .booleanType()
+                    .defaultValue(true)
+                    .withDescription(
+                            "Whether to merge existing manifest files during APPEND and OVERWRITE commits. "
+                                    + "Disable only when manifest compaction is handled separately.");
+
     public static final ConfigOption<Boolean> MANIFEST_SORT_ENABLED =
             key("manifest-sort.enabled")
                     .booleanType()
@@ -3351,6 +3359,10 @@ public class CoreOptions implements Serializable {
 
     public int manifestMergeMinCount() {
         return options.get(MANIFEST_MERGE_MIN_COUNT);
+    }
+
+    public boolean manifestMergeOnWrite() {
+        return options.get(MANIFEST_MERGE_ON_WRITE);
     }
 
     public MergeEngine mergeEngine() {

--- a/paimon-core/src/main/java/org/apache/paimon/operation/FileStoreCommitImpl.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/FileStoreCommitImpl.java
@@ -1143,6 +1143,9 @@ public class FileStoreCommitImpl implements FileStoreCommit {
         String indexManifest = null;
         List<ManifestFileMeta> mergeBeforeManifests = new ArrayList<>();
         List<ManifestFileMeta> mergeAfterManifests = new ArrayList<>();
+        boolean skipManifestMergeOnWrite =
+                !options.manifestMergeOnWrite()
+                        && (commitKind == CommitKind.APPEND || commitKind == CommitKind.OVERWRITE);
         boolean skipManifestMergeOnRetry = false;
         long nextRowIdStart = firstRowIdStart;
         try {
@@ -1167,6 +1170,8 @@ public class FileStoreCommitImpl implements FileStoreCommit {
                 mergeBeforeManifests = emptyList();
                 mergeAfterManifests = emptyList();
                 oldIndexManifest = null;
+            } else if (skipManifestMergeOnWrite) {
+                mergeAfterManifests = mergeBeforeManifests;
             } else {
                 ManifestMergeReuse manifestMergeReuse =
                         tryReuseManifestMergeResult(retryResult, mergeBeforeManifests);
@@ -1324,7 +1329,7 @@ public class FileStoreCommitImpl implements FileStoreCommit {
                     latestSnapshot,
                     baseDataFiles,
                     null,
-                    skipManifestMergeOnRetry
+                    skipManifestMergeOnWrite || skipManifestMergeOnRetry
                             ? null
                             : new ManifestMergeResult(mergeBeforeManifests, mergeAfterManifests));
         }

--- a/paimon-core/src/test/java/org/apache/paimon/operation/FileStoreCommitTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/operation/FileStoreCommitTest.java
@@ -1283,6 +1283,44 @@ public class FileStoreCommitTest {
     }
 
     @Test
+    public void testSkipManifestMergeOnWrite() throws Exception {
+        Map<String, String> options = new HashMap<>();
+        options.put(CoreOptions.MANIFEST_MERGE_MIN_COUNT.key(), "2");
+        options.put(CoreOptions.MANIFEST_MERGE_ON_WRITE.key(), "false");
+        TestFileStore store = createStore(false, options);
+
+        List<KeyValue> keyValues = generateDataList(1);
+        BinaryRow partition = gen.getPartition(keyValues.get(0));
+        store.commitData(keyValues, s -> partition, kv -> 0);
+        store.overwriteData(keyValues, s -> partition, kv -> 0, Collections.emptyMap());
+        store.commitData(keyValues, s -> partition, kv -> 0);
+
+        Snapshot latest = checkNotNull(store.snapshotManager().latestSnapshot());
+        assertThat(store.manifestListFactory().create().readDataManifests(latest)).hasSize(3);
+
+        try (FileStoreCommitImpl commit = store.newCommit()) {
+            commit.tryCommitOnce(
+                    null,
+                    Collections.emptyList(),
+                    Collections.emptyList(),
+                    Collections.emptyList(),
+                    Long.MAX_VALUE,
+                    null,
+                    Collections.emptyMap(),
+                    Snapshot.CommitKind.COMPACT,
+                    false,
+                    latest,
+                    true,
+                    null);
+        }
+
+        latest = checkNotNull(store.snapshotManager().latestSnapshot());
+        assertThat(latest.commitKind()).isEqualTo(Snapshot.CommitKind.COMPACT);
+        assertThat(store.manifestListFactory().create().readDataManifests(latest))
+                .hasSizeLessThan(3);
+    }
+
+    @Test
     public void testRtasAppendAfterTruncateResetsInheritedIndexAndStats() throws Exception {
         TestFileStore store = createStore(false, 1, CoreOptions.ChangelogProducer.NONE);
         BinaryRow partition = gen.getPartition(gen.next());

--- a/paimon-python/pypaimon/common/options/core_options.py
+++ b/paimon-python/pypaimon/common/options/core_options.py
@@ -298,6 +298,16 @@ class CoreOptions:
         )
     )
 
+    MANIFEST_MERGE_ON_WRITE: ConfigOption[bool] = (
+        ConfigOptions.key("manifest.merge-on-write")
+        .boolean_type()
+        .default_value(True)
+        .with_description(
+            "Whether to merge existing manifest files during APPEND and OVERWRITE commits. "
+            "Disable only when manifest compaction is handled separately."
+        )
+    )
+
     # File format options
     FILE_FORMAT: ConfigOption[str] = (
         ConfigOptions.key("file.format")
@@ -1146,6 +1156,9 @@ class CoreOptions:
 
     def manifest_merge_min_count(self, default=None):
         return self.options.get(CoreOptions.MANIFEST_MERGE_MIN_COUNT, default)
+
+    def manifest_merge_on_write(self, default=None):
+        return self.options.get(CoreOptions.MANIFEST_MERGE_ON_WRITE, default)
 
     def file_format(self, default=None):
         return self.options.get(CoreOptions.FILE_FORMAT, default)

--- a/paimon-python/pypaimon/tests/file_store_commit_test.py
+++ b/paimon-python/pypaimon/tests/file_store_commit_test.py
@@ -47,6 +47,7 @@ class TestFileStoreCommit(unittest.TestCase):
         self.mock_table.file_io = Mock()
         self.mock_table.options.manifest_target_size.return_value = 8 * 1024 * 1024
         self.mock_table.options.manifest_merge_min_count.return_value = 30
+        self.mock_table.options.manifest_merge_on_write.return_value = True
 
         # Mock snapshot commit
         self.mock_snapshot_commit = Mock()

--- a/paimon-python/pypaimon/tests/write/table_write_test.py
+++ b/paimon-python/pypaimon/tests/write/table_write_test.py
@@ -424,6 +424,54 @@ class TableWriteTest(unittest.TestCase):
         actual = table_read.to_arrow(splits).sort_by('user_id')
         self.assertEqual(expected, actual)
 
+    def test_skip_manifest_merge_on_write(self):
+        schema = Schema.from_pyarrow_schema(
+            self.pa_schema,
+            partition_keys=['dt'],
+            options={
+                'manifest.merge-min-count': '2',
+                'manifest.merge-on-write': 'false',
+            },
+        )
+        self.catalog.create_table('default.test_skip_manifest_merge_on_write', schema, False)
+        table = self.catalog.get_table('default.test_skip_manifest_merge_on_write')
+
+        def row(i):
+            return pa.Table.from_pydict({
+                'user_id': [i + 1],
+                'item_id': [1000 + i],
+                'behavior': ['click'],
+                'dt': ['p1'],
+            }, schema=self.pa_schema)
+
+        for i in range(3):
+            self._commit_arrow(table, row(i))
+
+        manifest_list_manager = ManifestListManager(table)
+        snapshot = table.snapshot_manager().get_latest_snapshot()
+        self.assertEqual(3, len(manifest_list_manager.read_all(snapshot)))
+
+        write_builder = table.new_batch_write_builder()
+        table_write = write_builder.new_write()
+        table_commit = write_builder.new_commit()
+        original_try_commit = table_commit.file_store_commit._try_commit
+        table_commit.file_store_commit._try_commit = (
+            lambda commit_kind, *args, **kwargs: original_try_commit(
+                "COMPACT", *args, **kwargs
+            )
+        )
+        table_write.write_arrow(row(3))
+        table_commit.commit(table_write.prepare_commit())
+        table_write.close()
+        table_commit.close()
+
+        snapshot = table.snapshot_manager().get_latest_snapshot()
+        base_manifests = manifest_list_manager.read(snapshot.base_manifest_list)
+        delta_manifests = manifest_list_manager.read(snapshot.delta_manifest_list)
+        self.assertEqual("COMPACT", snapshot.commit_kind)
+        self.assertEqual(1, len(base_manifests))
+        self.assertEqual(1, len(delta_manifests))
+
     def test_multi_prepare_commit_pk(self):
         schema = Schema.from_pyarrow_schema(self.pa_schema, partition_keys=['dt'], primary_keys=['user_id', 'dt'],
                                             options={'bucket': '2'})

--- a/paimon-python/pypaimon/write/file_store_commit.py
+++ b/paimon-python/pypaimon/write/file_store_commit.py
@@ -118,6 +118,7 @@ class FileStoreCommit:
 
         self.manifest_target_size = table.options.manifest_target_size()
         self.manifest_merge_min_count = table.options.manifest_merge_min_count()
+        self.manifest_merge_on_write = table.options.manifest_merge_on_write()
         self.manifest_file_merger = ManifestFileMerger(
             self.manifest_file_manager,
             self.manifest_target_size,
@@ -626,8 +627,11 @@ class FileStoreCommit:
                     total_record_count += previous_record_count
             else:
                 existing_manifest_files = []
-            merged_manifest_files, merge_new_files = self.manifest_file_merger.merge(
-                existing_manifest_files)
+            if not self.manifest_merge_on_write and commit_kind in ("APPEND", "OVERWRITE"):
+                merged_manifest_files = existing_manifest_files
+            else:
+                merged_manifest_files, merge_new_files = self.manifest_file_merger.merge(
+                    existing_manifest_files)
             self.manifest_list_manager.write(base_manifest_list, merged_manifest_files)
 
             delta_record_count = 0


### PR DESCRIPTION
### Purpose

Allow tables with a dedicated compaction job to skip manifest merge work in regular write commits.

This adds `manifest.merge-on-write`, which defaults to `true`. When disabled, APPEND and OVERWRITE commits preserve existing manifests without merging them. COMPACT commits and explicit manifest compaction continue to merge manifests. Java and PyPaimon use the same option and behavior.

### Tests

- `FileStoreCommitTest#testManifestCompact+testSkipManifestMergeOnWrite`
- `pytest -q pypaimon/tests/file_store_commit_test.py pypaimon/tests/write/table_write_test.py` (62 passed)
- Java Spotless; Python flake8 and compileall; `git diff --check`