### PR TITLE
[core] Optimize field matching in DataEvolutionFileStoreScan.evolutionStats with HashMap

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/operation/DataEvolutionFileStoreScan.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/DataEvolutionFileStoreScan.java
@@ -48,9 +48,11 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Comparator;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Map;
 import java.util.Queue;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
@@ -274,7 +276,6 @@ public class DataEvolutionFileStoreScan extends AppendOnlyFileStoreScan {
         return ids;
     }
 
-    /** TODO: Optimize implementation of this method. */
     @VisibleForTesting
     static EvolutionStats evolutionStats(
             TableSchema schema,
@@ -301,6 +302,8 @@ public class DataEvolutionFileStoreScan extends AppendOnlyFileStoreScan {
         metas.sort(Comparator.comparingLong(maxSeqFunc).reversed());
 
         int[] allFields = schema.fields().stream().mapToInt(DataField::id).toArray();
+        DataType[] targetTypes =
+                schema.fields().stream().map(DataField::type).toArray(DataType[]::new);
         int fieldsCount = schema.fields().size();
         int[] rowOffsets = new int[fieldsCount];
         int[] fieldOffsets = new int[fieldsCount];
@@ -319,6 +322,8 @@ public class DataEvolutionFileStoreScan extends AppendOnlyFileStoreScan {
             nullCounts[i] = stats.nullCounts();
         }
 
+        // number of fields not resolved yet; stop scanning files once all are resolved
+        int unresolvedFields = fieldsCount;
         for (int i = 0; i < metas.size(); i++) {
             DataFileMeta fileMeta = metas.get(i).file();
 
@@ -327,41 +332,45 @@ public class DataEvolutionFileStoreScan extends AppendOnlyFileStoreScan {
 
             TableSchema dataFileSchemaWithStats = dataFileSchema.project(fileMeta.valueStatsCols());
 
-            int[] fieldIds =
-                    dataFileSchema.logicalRowType().getFields().stream()
-                            .mapToInt(DataField::id)
-                            .toArray();
+            List<DataField> fileFields = dataFileSchema.fields();
+            List<DataField> statsFields = dataFileSchemaWithStats.fields();
+            // fieldId -> index maps for O(1) lookup, avoiding linear scans of the
+            // file's column list for every target field
+            Map<Integer, Integer> fileFieldIndexes = new HashMap<>(fileFields.size() * 2);
+            for (int k = 0; k < fileFields.size(); k++) {
+                fileFieldIndexes.put(fileFields.get(k).id(), k);
+            }
+            Map<Integer, Integer> statsFieldIndexes = new HashMap<>(statsFields.size() * 2);
+            for (int k = 0; k < statsFields.size(); k++) {
+                statsFieldIndexes.put(statsFields.get(k).id(), k);
+            }
 
-            int[] fieldIdsWithStats =
-                    dataFileSchemaWithStats.logicalRowType().getFields().stream()
-                            .mapToInt(DataField::id)
-                            .toArray();
-
-            loop1:
             for (int j = 0; j < fieldsCount; j++) {
                 if (rowOffsets[j] != -1) {
                     continue;
                 }
                 int targetFieldId = allFields[j];
-                DataType targetType = schema.fields().get(j).type();
-                for (int fieldId : fieldIds) {
-                    if (targetFieldId == fieldId) {
-                        for (int k = 0; k < fieldIdsWithStats.length; k++) {
-                            if (fieldId == fieldIdsWithStats[k]) {
-                                DataType fileType = dataFileSchemaWithStats.fields().get(k).type();
-                                if (!fileType.equalsIgnoreFieldId(targetType)) {
-                                    typeMismatchedFieldIds.add(targetFieldId);
-                                    continue loop1;
-                                }
-                                rowOffsets[j] = i;
-                                fieldOffsets[j] = k;
-                                continue loop1;
-                            }
-                        }
-                        rowOffsets[j] = -2;
-                        continue loop1;
-                    }
+                if (!fileFieldIndexes.containsKey(targetFieldId)) {
+                    continue;
                 }
+                Integer statsIndex = statsFieldIndexes.get(targetFieldId);
+                if (statsIndex == null) {
+                    // field exists in the file but has no stats
+                    rowOffsets[j] = -2;
+                    unresolvedFields--;
+                    continue;
+                }
+                DataType fileType = statsFields.get(statsIndex).type();
+                if (!fileType.equalsIgnoreFieldId(targetTypes[j])) {
+                    typeMismatchedFieldIds.add(targetFieldId);
+                    continue;
+                }
+                rowOffsets[j] = i;
+                fieldOffsets[j] = statsIndex;
+                unresolvedFields--;
+            }
+            if (unresolvedFields == 0) {
+                break;
             }
         }
 


### PR DESCRIPTION
### Purpose

Optimize scan planning for data-evolution tables with wide schemas.

On a production table (1027 columns, ~19856 active files in one snapshot forming ~17670 row-id groups), `DataEvolutionFileStoreScan.postFilterManifestEntries` is extremely slow. Each row-id group calls `filterByStats(group)` -> `evolutionStats()`, whose field matching is a triple nested linear scan: for every target field it linearly scans the file's field ids, and on a hit linearly scans the stats field ids again. For a group with K files covering F columns this is O(F * K * F) comparisons, repeated per group, single-threaded.

### Changes

In `evolutionStats`:
- Build a `fieldId -> index` HashMap per file for both the file schema and the stats schema, turning each lookup into O(1).
- Track the number of unresolved fields and stop iterating files once every field is resolved.
- Precompute target field types once instead of calling `schema.fields().get(j).type()` per lookup.

Behavior is preserved:
- Fields are still resolved from the highest-sequence-number file first (metas sorted desc, first hit wins).
- `-2` (field present without stats) and type-mismatch semantics are unchanged, including the blob/vector `excludedFileFieldIds` fixup.

### Verification

- `DataEvolutionFileStoreScanTest`: 8/8 passed
- `DataEvolutionTableTest`: 42/42 passed