### PR TITLE
[core] Cache projected schemas for data evolution stats

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/operation/DataEvolutionFileStoreScan.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/DataEvolutionFileStoreScan.java
@@ -71,6 +71,8 @@ import static org.apache.paimon.utils.DataEvolutionUtils.retrieveAnchorFile;
 /** {@link FileStoreScan} for data-evolution enabled table. */
 public class DataEvolutionFileStoreScan extends AppendOnlyFileStoreScan {
 
+    private static final int NO_STATS_FIELD_INDEX = -1;
+
     private boolean dropStats = false;
     @Nullable private RowType readType;
     private final boolean deletionVectorsEnabled;
@@ -292,6 +294,8 @@ public class DataEvolutionFileStoreScan extends AppendOnlyFileStoreScan {
         metas.sort(Comparator.comparingLong(maxSeqFunc).reversed());
 
         int[] allFields = schema.fields().stream().mapToInt(DataField::id).toArray();
+        DataType[] targetTypes =
+                schema.fields().stream().map(DataField::type).toArray(DataType[]::new);
         int fieldsCount = schema.fields().size();
         int[] rowOffsets = new int[fieldsCount];
         int[] fieldOffsets = new int[fieldsCount];
@@ -310,39 +314,39 @@ public class DataEvolutionFileStoreScan extends AppendOnlyFileStoreScan {
             nullCounts[i] = stats.nullCounts();
         }
 
+        int unresolvedFields = fieldsCount;
         for (int i = 0; i < metas.size(); i++) {
             DataFileMeta fileMeta = metas.get(i).file();
             ProjectedFileSchema projectedFileSchema =
                     evolutionStatsCache.get(scanTableSchema, fileMeta);
-            TableSchema dataFileSchemaWithStats = projectedFileSchema.dataFileSchemaWithStats();
-            int[] fieldIds = projectedFileSchema.fieldIds();
-            int[] fieldIdsWithStats = projectedFileSchema.fieldIdsWithStats();
+            DataType[] statsFieldTypes = projectedFileSchema.statsFieldTypes();
+            Map<Integer, Integer> statsFieldIndexes = projectedFileSchema.statsFieldIndexes();
 
-            loop1:
             for (int j = 0; j < fieldsCount; j++) {
                 if (rowOffsets[j] != -1) {
                     continue;
                 }
                 int targetFieldId = allFields[j];
-                DataType targetType = schema.fields().get(j).type();
-                for (int fieldId : fieldIds) {
-                    if (targetFieldId == fieldId) {
-                        for (int k = 0; k < fieldIdsWithStats.length; k++) {
-                            if (fieldId == fieldIdsWithStats[k]) {
-                                DataType fileType = dataFileSchemaWithStats.fields().get(k).type();
-                                if (!fileType.equalsIgnoreFieldId(targetType)) {
-                                    typeMismatchedFieldIds.add(targetFieldId);
-                                    continue loop1;
-                                }
-                                rowOffsets[j] = i;
-                                fieldOffsets[j] = k;
-                                continue loop1;
-                            }
-                        }
-                        rowOffsets[j] = -2;
-                        continue loop1;
-                    }
+                Integer statsIndex = statsFieldIndexes.get(targetFieldId);
+                if (statsIndex == null) {
+                    continue;
                 }
+                if (statsIndex == NO_STATS_FIELD_INDEX) {
+                    rowOffsets[j] = -2;
+                    unresolvedFields--;
+                    continue;
+                }
+                DataType fileType = statsFieldTypes[statsIndex];
+                if (!fileType.equalsIgnoreFieldId(targetTypes[j])) {
+                    typeMismatchedFieldIds.add(targetFieldId);
+                    continue;
+                }
+                rowOffsets[j] = i;
+                fieldOffsets[j] = statsIndex;
+                unresolvedFields--;
+            }
+            if (unresolvedFields == 0) {
+                break;
             }
         }
 
@@ -392,51 +396,47 @@ public class DataEvolutionFileStoreScan extends AppendOnlyFileStoreScan {
                 Triple<Long, List<String>, List<String>> key) {
             TableSchema dataFileSchema = scanTableSchema.apply(key.f0).project(key.f1);
             TableSchema dataFileSchemaWithStats = dataFileSchema.project(key.f2);
-            int[] fieldIds =
-                    dataFileSchema.logicalRowType().getFields().stream()
-                            .mapToInt(DataField::id)
-                            .toArray();
-            int[] fieldIdsWithStats =
-                    dataFileSchemaWithStats.logicalRowType().getFields().stream()
-                            .mapToInt(DataField::id)
-                            .toArray();
-            return new ProjectedFileSchema(
-                    dataFileSchema, dataFileSchemaWithStats, fieldIds, fieldIdsWithStats);
+            List<DataField> fields = dataFileSchema.fields();
+            Map<Integer, Integer> statsFieldIndexes = new HashMap<>(fields.size() * 2);
+            for (DataField field : fields) {
+                statsFieldIndexes.put(field.id(), NO_STATS_FIELD_INDEX);
+            }
+            List<DataField> statsFields = dataFileSchemaWithStats.fields();
+            DataType[] statsFieldTypes = new DataType[statsFields.size()];
+            for (int i = 0; i < statsFields.size(); i++) {
+                DataField statsField = statsFields.get(i);
+                statsFieldIndexes.put(statsField.id(), i);
+                statsFieldTypes[i] = statsField.type();
+            }
+            return new ProjectedFileSchema(dataFileSchema, statsFieldTypes, statsFieldIndexes);
         }
     }
 
     private static class ProjectedFileSchema {
 
         private final TableSchema dataFileSchema;
-        private final TableSchema dataFileSchemaWithStats;
-        private final int[] fieldIds;
-        private final int[] fieldIdsWithStats;
+        private final DataType[] statsFieldTypes;
+        private final Map<Integer, Integer> statsFieldIndexes;
 
         private ProjectedFileSchema(
                 TableSchema dataFileSchema,
-                TableSchema dataFileSchemaWithStats,
-                int[] fieldIds,
-                int[] fieldIdsWithStats) {
+                DataType[] statsFieldTypes,
+                Map<Integer, Integer> statsFieldIndexes) {
             this.dataFileSchema = dataFileSchema;
-            this.dataFileSchemaWithStats = dataFileSchemaWithStats;
-            this.fieldIds = fieldIds;
-            this.fieldIdsWithStats = fieldIdsWithStats;
+            this.statsFieldTypes = statsFieldTypes;
+            this.statsFieldIndexes = statsFieldIndexes;
         }
 
         private TableSchema dataFileSchema() {
             return dataFileSchema;
         }
 
-        private TableSchema dataFileSchemaWithStats() {
-            return dataFileSchemaWithStats;
+        private DataType[] statsFieldTypes() {
+            return statsFieldTypes;
         }
 
-        private int[] fieldIds() {
-            return fieldIds;
-        }
-
-        private int[] fieldIdsWithStats() {
-            return fieldIdsWithStats;
+        private Map<Integer, Integer> statsFieldIndexes() {
+            return statsFieldIndexes;
         }
     }
 

--- a/paimon-core/src/main/java/org/apache/paimon/operation/DataEvolutionFileStoreScan.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/DataEvolutionFileStoreScan.java
@@ -320,14 +320,14 @@ public class DataEvolutionFileStoreScan extends AppendOnlyFileStoreScan {
             ProjectedFileSchema projectedFileSchema =
                     evolutionStatsCache.get(scanTableSchema, fileMeta);
             DataType[] statsFieldTypes = projectedFileSchema.statsFieldTypes();
-            Map<Integer, Integer> statsFieldIndexes = projectedFileSchema.statsFieldIndexes();
+            Map<Integer, Integer> fieldIdToStatsIndex = projectedFileSchema.fieldIdToStatsIndex();
 
             for (int j = 0; j < fieldsCount; j++) {
                 if (rowOffsets[j] != -1) {
                     continue;
                 }
                 int targetFieldId = allFields[j];
-                Integer statsIndex = statsFieldIndexes.get(targetFieldId);
+                Integer statsIndex = fieldIdToStatsIndex.get(targetFieldId);
                 if (statsIndex == null) {
                     continue;
                 }
@@ -397,18 +397,18 @@ public class DataEvolutionFileStoreScan extends AppendOnlyFileStoreScan {
             TableSchema dataFileSchema = scanTableSchema.apply(key.f0).project(key.f1);
             TableSchema dataFileSchemaWithStats = dataFileSchema.project(key.f2);
             List<DataField> fields = dataFileSchema.fields();
-            Map<Integer, Integer> statsFieldIndexes = new HashMap<>(fields.size() * 2);
+            Map<Integer, Integer> fieldIdToStatsIndex = new HashMap<>(fields.size() * 2);
             for (DataField field : fields) {
-                statsFieldIndexes.put(field.id(), NO_STATS_FIELD_INDEX);
+                fieldIdToStatsIndex.put(field.id(), NO_STATS_FIELD_INDEX);
             }
             List<DataField> statsFields = dataFileSchemaWithStats.fields();
             DataType[] statsFieldTypes = new DataType[statsFields.size()];
             for (int i = 0; i < statsFields.size(); i++) {
                 DataField statsField = statsFields.get(i);
-                statsFieldIndexes.put(statsField.id(), i);
+                fieldIdToStatsIndex.put(statsField.id(), i);
                 statsFieldTypes[i] = statsField.type();
             }
-            return new ProjectedFileSchema(dataFileSchema, statsFieldTypes, statsFieldIndexes);
+            return new ProjectedFileSchema(dataFileSchema, statsFieldTypes, fieldIdToStatsIndex);
         }
     }
 
@@ -416,15 +416,15 @@ public class DataEvolutionFileStoreScan extends AppendOnlyFileStoreScan {
 
         private final TableSchema dataFileSchema;
         private final DataType[] statsFieldTypes;
-        private final Map<Integer, Integer> statsFieldIndexes;
+        private final Map<Integer, Integer> fieldIdToStatsIndex;
 
         private ProjectedFileSchema(
                 TableSchema dataFileSchema,
                 DataType[] statsFieldTypes,
-                Map<Integer, Integer> statsFieldIndexes) {
+                Map<Integer, Integer> fieldIdToStatsIndex) {
             this.dataFileSchema = dataFileSchema;
             this.statsFieldTypes = statsFieldTypes;
-            this.statsFieldIndexes = statsFieldIndexes;
+            this.fieldIdToStatsIndex = fieldIdToStatsIndex;
         }
 
         private TableSchema dataFileSchema() {
@@ -435,8 +435,8 @@ public class DataEvolutionFileStoreScan extends AppendOnlyFileStoreScan {
             return statsFieldTypes;
         }
 
-        private Map<Integer, Integer> statsFieldIndexes() {
-            return statsFieldIndexes;
+        private Map<Integer, Integer> fieldIdToStatsIndex() {
+            return fieldIdToStatsIndex;
         }
     }
 

--- a/paimon-core/src/main/java/org/apache/paimon/operation/DataEvolutionFileStoreScan.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/DataEvolutionFileStoreScan.java
@@ -40,6 +40,7 @@ import org.apache.paimon.utils.Pair;
 import org.apache.paimon.utils.Range;
 import org.apache.paimon.utils.RangeHelper;
 import org.apache.paimon.utils.SnapshotManager;
+import org.apache.paimon.utils.Triple;
 
 import javax.annotation.Nullable;
 
@@ -48,9 +49,11 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Comparator;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Map;
 import java.util.Queue;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
@@ -76,6 +79,7 @@ public class DataEvolutionFileStoreScan extends AppendOnlyFileStoreScan {
     // per-file column pruning in postFilterManifestEntries.
     private final ConcurrentMap<Pair<Long, List<String>>, Set<Integer>> fileFieldIdsCache =
             new ConcurrentHashMap<>();
+    private final EvolutionStatsCache evolutionStatsCache = new EvolutionStatsCache();
 
     public DataEvolutionFileStoreScan(
             ManifestsReader manifestsReader,
@@ -206,7 +210,8 @@ public class DataEvolutionFileStoreScan extends AppendOnlyFileStoreScan {
     }
 
     private boolean filterByStats(List<ManifestEntry> entries) {
-        EvolutionStats stats = evolutionStats(schema, this::scanTableSchema, entries);
+        EvolutionStats stats =
+                evolutionStats(schema, this::scanTableSchema, entries, evolutionStatsCache);
         return inputFilter.test(
                 stats.rowCount(), stats.minValues(), stats.maxValues(), stats.nullCounts());
     }
@@ -258,19 +263,23 @@ public class DataEvolutionFileStoreScan extends AppendOnlyFileStoreScan {
                 pair -> fileFieldIds(this::scanTableSchema, entry.file()));
     }
 
-    /** TODO: Optimize implementation of this method. */
     @VisibleForTesting
     static EvolutionStats evolutionStats(
             TableSchema schema,
             Function<Long, TableSchema> scanTableSchema,
-            List<ManifestEntry> metas) {
+            List<ManifestEntry> metas,
+            EvolutionStatsCache evolutionStatsCache) {
         Set<Integer> excludedFileFieldIds =
                 metas.stream()
                         .filter(
                                 entry ->
                                         isBlobFile(entry.file().fileName())
                                                 || isVectorStoreFile(entry.file().fileName()))
-                        .flatMap(entry -> fileFieldIds(scanTableSchema, entry.file()).stream())
+                        .flatMap(
+                                entry ->
+                                        evolutionStatsCache.get(scanTableSchema, entry.file())
+                                                .dataFileSchema().fields().stream()
+                                                .map(DataField::id))
                         .collect(Collectors.toSet());
         // exclude blob and vector-store files, useless for predicate eval
         metas =
@@ -303,21 +312,11 @@ public class DataEvolutionFileStoreScan extends AppendOnlyFileStoreScan {
 
         for (int i = 0; i < metas.size(); i++) {
             DataFileMeta fileMeta = metas.get(i).file();
-
-            TableSchema dataFileSchema =
-                    scanTableSchema.apply(fileMeta.schemaId()).project(fileMeta.writeCols());
-
-            TableSchema dataFileSchemaWithStats = dataFileSchema.project(fileMeta.valueStatsCols());
-
-            int[] fieldIds =
-                    dataFileSchema.logicalRowType().getFields().stream()
-                            .mapToInt(DataField::id)
-                            .toArray();
-
-            int[] fieldIdsWithStats =
-                    dataFileSchemaWithStats.logicalRowType().getFields().stream()
-                            .mapToInt(DataField::id)
-                            .toArray();
+            ProjectedFileSchema projectedFileSchema =
+                    evolutionStatsCache.get(scanTableSchema, fileMeta);
+            TableSchema dataFileSchemaWithStats = projectedFileSchema.dataFileSchemaWithStats();
+            int[] fieldIds = projectedFileSchema.fieldIds();
+            int[] fieldIdsWithStats = projectedFileSchema.fieldIdsWithStats();
 
             loop1:
             for (int j = 0; j < fieldsCount; j++) {
@@ -368,6 +367,77 @@ public class DataEvolutionFileStoreScan extends AppendOnlyFileStoreScan {
         finalMax.setRows(max);
         finalNullCounts.setRows(nullCounts);
         return new EvolutionStats(groupRowCount, finalMin, finalMax, finalNullCounts);
+    }
+
+    @VisibleForTesting
+    static class EvolutionStatsCache {
+
+        private final Map<Triple<Long, List<String>, List<String>>, ProjectedFileSchema> cache =
+                new HashMap<>();
+
+        private ProjectedFileSchema get(
+                Function<Long, TableSchema> scanTableSchema, DataFileMeta fileMeta) {
+            Triple<Long, List<String>, List<String>> key =
+                    Triple.of(fileMeta.schemaId(), fileMeta.writeCols(), fileMeta.valueStatsCols());
+            return cache.computeIfAbsent(key, ignored -> projectFileSchema(scanTableSchema, key));
+        }
+
+        @VisibleForTesting
+        int size() {
+            return cache.size();
+        }
+
+        private static ProjectedFileSchema projectFileSchema(
+                Function<Long, TableSchema> scanTableSchema,
+                Triple<Long, List<String>, List<String>> key) {
+            TableSchema dataFileSchema = scanTableSchema.apply(key.f0).project(key.f1);
+            TableSchema dataFileSchemaWithStats = dataFileSchema.project(key.f2);
+            int[] fieldIds =
+                    dataFileSchema.logicalRowType().getFields().stream()
+                            .mapToInt(DataField::id)
+                            .toArray();
+            int[] fieldIdsWithStats =
+                    dataFileSchemaWithStats.logicalRowType().getFields().stream()
+                            .mapToInt(DataField::id)
+                            .toArray();
+            return new ProjectedFileSchema(
+                    dataFileSchema, dataFileSchemaWithStats, fieldIds, fieldIdsWithStats);
+        }
+    }
+
+    private static class ProjectedFileSchema {
+
+        private final TableSchema dataFileSchema;
+        private final TableSchema dataFileSchemaWithStats;
+        private final int[] fieldIds;
+        private final int[] fieldIdsWithStats;
+
+        private ProjectedFileSchema(
+                TableSchema dataFileSchema,
+                TableSchema dataFileSchemaWithStats,
+                int[] fieldIds,
+                int[] fieldIdsWithStats) {
+            this.dataFileSchema = dataFileSchema;
+            this.dataFileSchemaWithStats = dataFileSchemaWithStats;
+            this.fieldIds = fieldIds;
+            this.fieldIdsWithStats = fieldIdsWithStats;
+        }
+
+        private TableSchema dataFileSchema() {
+            return dataFileSchema;
+        }
+
+        private TableSchema dataFileSchemaWithStats() {
+            return dataFileSchemaWithStats;
+        }
+
+        private int[] fieldIds() {
+            return fieldIds;
+        }
+
+        private int[] fieldIdsWithStats() {
+            return fieldIdsWithStats;
+        }
     }
 
     /** Note: Keep this thread-safe. */

--- a/paimon-core/src/main/java/org/apache/paimon/operation/DataEvolutionFileStoreScan.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/DataEvolutionFileStoreScan.java
@@ -40,7 +40,6 @@ import org.apache.paimon.utils.Pair;
 import org.apache.paimon.utils.Range;
 import org.apache.paimon.utils.RangeHelper;
 import org.apache.paimon.utils.SnapshotManager;
-import org.apache.paimon.utils.Triple;
 
 import javax.annotation.Nullable;
 
@@ -49,11 +48,9 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Comparator;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
-import java.util.Map;
 import java.util.Queue;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
@@ -70,8 +67,6 @@ import static org.apache.paimon.utils.DataEvolutionUtils.retrieveAnchorFile;
 
 /** {@link FileStoreScan} for data-evolution enabled table. */
 public class DataEvolutionFileStoreScan extends AppendOnlyFileStoreScan {
-
-    private static final int NO_STATS_FIELD_INDEX = -1;
 
     private boolean dropStats = false;
     @Nullable private RowType readType;
@@ -317,32 +312,31 @@ public class DataEvolutionFileStoreScan extends AppendOnlyFileStoreScan {
         int unresolvedFields = fieldsCount;
         for (int i = 0; i < metas.size(); i++) {
             DataFileMeta fileMeta = metas.get(i).file();
-            ProjectedFileSchema projectedFileSchema =
+            EvolutionStatsCache.ProjectedFileSchema projectedFileSchema =
                     evolutionStatsCache.get(scanTableSchema, fileMeta);
-            DataType[] statsFieldTypes = projectedFileSchema.statsFieldTypes();
-            Map<Integer, Integer> fieldIdToStatsIndex = projectedFileSchema.fieldIdToStatsIndex();
 
             for (int j = 0; j < fieldsCount; j++) {
                 if (rowOffsets[j] != -1) {
                     continue;
                 }
                 int targetFieldId = allFields[j];
-                Integer statsIndex = fieldIdToStatsIndex.get(targetFieldId);
-                if (statsIndex == null) {
+                EvolutionStatsCache.FileFieldStats fileFieldStats =
+                        projectedFileSchema.fieldStats(targetFieldId);
+                if (fileFieldStats == null) {
                     continue;
                 }
-                if (statsIndex == NO_STATS_FIELD_INDEX) {
+                if (!fileFieldStats.hasStats()) {
                     rowOffsets[j] = -2;
                     unresolvedFields--;
                     continue;
                 }
-                DataType fileType = statsFieldTypes[statsIndex];
+                DataType fileType = fileFieldStats.type();
                 if (!fileType.equalsIgnoreFieldId(targetTypes[j])) {
                     typeMismatchedFieldIds.add(targetFieldId);
                     continue;
                 }
                 rowOffsets[j] = i;
-                fieldOffsets[j] = statsIndex;
+                fieldOffsets[j] = fileFieldStats.index();
                 unresolvedFields--;
             }
             if (unresolvedFields == 0) {
@@ -371,73 +365,6 @@ public class DataEvolutionFileStoreScan extends AppendOnlyFileStoreScan {
         finalMax.setRows(max);
         finalNullCounts.setRows(nullCounts);
         return new EvolutionStats(groupRowCount, finalMin, finalMax, finalNullCounts);
-    }
-
-    @VisibleForTesting
-    static class EvolutionStatsCache {
-
-        private final Map<Triple<Long, List<String>, List<String>>, ProjectedFileSchema> cache =
-                new HashMap<>();
-
-        private ProjectedFileSchema get(
-                Function<Long, TableSchema> scanTableSchema, DataFileMeta fileMeta) {
-            Triple<Long, List<String>, List<String>> key =
-                    Triple.of(fileMeta.schemaId(), fileMeta.writeCols(), fileMeta.valueStatsCols());
-            return cache.computeIfAbsent(key, ignored -> projectFileSchema(scanTableSchema, key));
-        }
-
-        @VisibleForTesting
-        int size() {
-            return cache.size();
-        }
-
-        private static ProjectedFileSchema projectFileSchema(
-                Function<Long, TableSchema> scanTableSchema,
-                Triple<Long, List<String>, List<String>> key) {
-            TableSchema dataFileSchema = scanTableSchema.apply(key.f0).project(key.f1);
-            TableSchema dataFileSchemaWithStats = dataFileSchema.project(key.f2);
-            List<DataField> fields = dataFileSchema.fields();
-            Map<Integer, Integer> fieldIdToStatsIndex = new HashMap<>(fields.size() * 2);
-            for (DataField field : fields) {
-                fieldIdToStatsIndex.put(field.id(), NO_STATS_FIELD_INDEX);
-            }
-            List<DataField> statsFields = dataFileSchemaWithStats.fields();
-            DataType[] statsFieldTypes = new DataType[statsFields.size()];
-            for (int i = 0; i < statsFields.size(); i++) {
-                DataField statsField = statsFields.get(i);
-                fieldIdToStatsIndex.put(statsField.id(), i);
-                statsFieldTypes[i] = statsField.type();
-            }
-            return new ProjectedFileSchema(dataFileSchema, statsFieldTypes, fieldIdToStatsIndex);
-        }
-    }
-
-    private static class ProjectedFileSchema {
-
-        private final TableSchema dataFileSchema;
-        private final DataType[] statsFieldTypes;
-        private final Map<Integer, Integer> fieldIdToStatsIndex;
-
-        private ProjectedFileSchema(
-                TableSchema dataFileSchema,
-                DataType[] statsFieldTypes,
-                Map<Integer, Integer> fieldIdToStatsIndex) {
-            this.dataFileSchema = dataFileSchema;
-            this.statsFieldTypes = statsFieldTypes;
-            this.fieldIdToStatsIndex = fieldIdToStatsIndex;
-        }
-
-        private TableSchema dataFileSchema() {
-            return dataFileSchema;
-        }
-
-        private DataType[] statsFieldTypes() {
-            return statsFieldTypes;
-        }
-
-        private Map<Integer, Integer> fieldIdToStatsIndex() {
-            return fieldIdToStatsIndex;
-        }
     }
 
     /** Note: Keep this thread-safe. */

--- a/paimon-core/src/main/java/org/apache/paimon/operation/EvolutionStatsCache.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/EvolutionStatsCache.java
@@ -1,0 +1,161 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.operation;
+
+import org.apache.paimon.annotation.VisibleForTesting;
+import org.apache.paimon.io.DataFileMeta;
+import org.apache.paimon.schema.TableSchema;
+import org.apache.paimon.types.DataField;
+import org.apache.paimon.types.DataType;
+
+import javax.annotation.Nullable;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.function.Function;
+
+import static org.apache.paimon.utils.Preconditions.checkNotNull;
+
+/**
+ * Scan-local cache for data evolution stats projections.
+ *
+ * <p>This class is not thread-safe. It is only accessed from the single-threaded post-filter phase
+ * of {@link AbstractFileStoreScan#plan()}.
+ */
+class EvolutionStatsCache {
+
+    private final Map<CacheKey, ProjectedFileSchema> cache = new HashMap<>();
+
+    ProjectedFileSchema get(Function<Long, TableSchema> scanTableSchema, DataFileMeta fileMeta) {
+        CacheKey key =
+                new CacheKey(fileMeta.schemaId(), fileMeta.writeCols(), fileMeta.valueStatsCols());
+        return cache.computeIfAbsent(key, ignored -> projectFileSchema(scanTableSchema, key));
+    }
+
+    @VisibleForTesting
+    int size() {
+        return cache.size();
+    }
+
+    private static ProjectedFileSchema projectFileSchema(
+            Function<Long, TableSchema> scanTableSchema, CacheKey key) {
+        TableSchema dataFileSchema = scanTableSchema.apply(key.schemaId).project(key.writeColumns);
+        TableSchema dataFileSchemaWithStats = dataFileSchema.project(key.valueStatsColumns);
+        List<DataField> fields = dataFileSchema.fields();
+        Map<Integer, FileFieldStats> fieldStats = new HashMap<>(fields.size() * 2);
+        for (DataField field : fields) {
+            fieldStats.put(field.id(), FileFieldStats.withoutStats());
+        }
+        List<DataField> statsFields = dataFileSchemaWithStats.fields();
+        for (int i = 0; i < statsFields.size(); i++) {
+            DataField statsField = statsFields.get(i);
+            fieldStats.put(statsField.id(), FileFieldStats.withStats(i, statsField.type()));
+        }
+        return new ProjectedFileSchema(dataFileSchema, fieldStats);
+    }
+
+    static class ProjectedFileSchema {
+
+        private final TableSchema dataFileSchema;
+        private final Map<Integer, FileFieldStats> fieldStats;
+
+        private ProjectedFileSchema(
+                TableSchema dataFileSchema, Map<Integer, FileFieldStats> fieldStats) {
+            this.dataFileSchema = dataFileSchema;
+            this.fieldStats = fieldStats;
+        }
+
+        TableSchema dataFileSchema() {
+            return dataFileSchema;
+        }
+
+        @Nullable
+        FileFieldStats fieldStats(int fieldId) {
+            return fieldStats.get(fieldId);
+        }
+    }
+
+    static class FileFieldStats {
+
+        private static final FileFieldStats WITHOUT_STATS = new FileFieldStats(0, null);
+
+        private final int index;
+        @Nullable private final DataType type;
+
+        private FileFieldStats(int index, @Nullable DataType type) {
+            this.index = index;
+            this.type = type;
+        }
+
+        static FileFieldStats withoutStats() {
+            return WITHOUT_STATS;
+        }
+
+        static FileFieldStats withStats(int index, DataType type) {
+            return new FileFieldStats(index, type);
+        }
+
+        boolean hasStats() {
+            return type != null;
+        }
+
+        int index() {
+            checkNotNull(type, "Stats index is unavailable for a field without stats.");
+            return index;
+        }
+
+        DataType type() {
+            return checkNotNull(type, "Stats type is unavailable for a field without stats.");
+        }
+    }
+
+    private static class CacheKey {
+
+        private final long schemaId;
+        private final List<String> writeColumns;
+        private final List<String> valueStatsColumns;
+
+        private CacheKey(long schemaId, List<String> writeColumns, List<String> valueStatsColumns) {
+            this.schemaId = schemaId;
+            this.writeColumns = writeColumns;
+            this.valueStatsColumns = valueStatsColumns;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
+            CacheKey cacheKey = (CacheKey) o;
+            return schemaId == cacheKey.schemaId
+                    && Objects.equals(writeColumns, cacheKey.writeColumns)
+                    && Objects.equals(valueStatsColumns, cacheKey.valueStatsColumns);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(schemaId, writeColumns, valueStatsColumns);
+        }
+    }
+}

--- a/paimon-core/src/test/java/org/apache/paimon/operation/DataEvolutionFileStoreScanTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/operation/DataEvolutionFileStoreScanTest.java
@@ -147,6 +147,56 @@ public class DataEvolutionFileStoreScanTest {
     }
 
     @Test
+    public void testEvolutionStatsCacheSeparatesStatsProjections() {
+        Schema schema = createSchema("f0", "f1");
+        TableSchema tableSchema = TableSchema.create(0L, schema);
+        schemas.put(0L, tableSchema);
+        EvolutionStatsCache cache = new EvolutionStatsCache();
+
+        ManifestEntry f0StatsEntry =
+                createManifestEntryWithDifferentCols(
+                        0L,
+                        new String[] {"f0", "f1"},
+                        new String[] {"f0"},
+                        createSimpleStats(
+                                GenericRow.of(1),
+                                GenericRow.of(5),
+                                createBinaryArray(new int[] {0}),
+                                new int[] {0}));
+        ManifestEntry f1StatsEntry =
+                createManifestEntryWithDifferentCols(
+                        0L,
+                        new String[] {"f0", "f1"},
+                        new String[] {"f1"},
+                        createSimpleStats(
+                                GenericRow.of(BinaryString.fromString("a")),
+                                GenericRow.of(BinaryString.fromString("z")),
+                                createBinaryArray(new int[] {0}),
+                                new int[] {1}));
+
+        EvolutionStats f0Stats =
+                DataEvolutionFileStoreScan.evolutionStats(
+                        tableSchema,
+                        scanTableSchema,
+                        Collections.singletonList(f0StatsEntry),
+                        cache);
+        EvolutionStats f1Stats =
+                DataEvolutionFileStoreScan.evolutionStats(
+                        tableSchema,
+                        scanTableSchema,
+                        Collections.singletonList(f1StatsEntry),
+                        cache);
+
+        DataEvolutionRow f0Min = (DataEvolutionRow) f0Stats.minValues();
+        DataEvolutionRow f1Min = (DataEvolutionRow) f1Stats.minValues();
+        assertThat(f0Min.getInt(0)).isEqualTo(1);
+        assertThat(f0Min.isNullAt(1)).isTrue();
+        assertThat(f1Min.isNullAt(0)).isTrue();
+        assertThat(f1Min.getString(1).toString()).isEqualTo("a");
+        assertThat(cache.size()).isEqualTo(2);
+    }
+
+    @Test
     public void testEvolutionStatsMultipleFiles() {
         Schema schema = createSchema("f0", "f1", "f2");
         TableSchema tableSchema = TableSchema.create(0L, schema);

--- a/paimon-core/src/test/java/org/apache/paimon/operation/DataEvolutionFileStoreScanTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/operation/DataEvolutionFileStoreScanTest.java
@@ -30,6 +30,7 @@ import org.apache.paimon.manifest.FileKind;
 import org.apache.paimon.manifest.FileSource;
 import org.apache.paimon.manifest.ManifestEntry;
 import org.apache.paimon.operation.DataEvolutionFileStoreScan.EvolutionStats;
+import org.apache.paimon.operation.DataEvolutionFileStoreScan.EvolutionStatsCache;
 import org.apache.paimon.predicate.Predicate;
 import org.apache.paimon.predicate.PredicateBuilder;
 import org.apache.paimon.reader.DataEvolutionArray;
@@ -49,6 +50,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
@@ -83,7 +85,10 @@ public class DataEvolutionFileStoreScanTest {
 
         EvolutionStats result =
                 DataEvolutionFileStoreScan.evolutionStats(
-                        tableSchema, scanTableSchema, Collections.singletonList(entry));
+                        tableSchema,
+                        scanTableSchema,
+                        Collections.singletonList(entry),
+                        new EvolutionStatsCache());
 
         assertThat(result).isNotNull();
         assertThat(result.minValues()).isInstanceOf(DataEvolutionRow.class);
@@ -108,6 +113,37 @@ public class DataEvolutionFileStoreScanTest {
 
         assertThat(minRow.getFieldCount()).isEqualTo(2);
         assertThat(maxRow.getFieldCount()).isEqualTo(2);
+    }
+
+    @Test
+    public void testEvolutionStatsReusesProjectedSchema() {
+        Schema schema = createSchema("f0", "f1");
+        TableSchema tableSchema = TableSchema.create(0L, schema);
+        schemas.put(0L, tableSchema);
+
+        AtomicInteger schemaLoads = new AtomicInteger();
+        Function<Long, TableSchema> countingScanTableSchema =
+                schemaId -> {
+                    schemaLoads.incrementAndGet();
+                    return schemas.get(schemaId);
+                };
+        EvolutionStatsCache cache = new EvolutionStatsCache();
+        ManifestEntry entry =
+                createManifestEntry(
+                        0L,
+                        createSimpleStats(
+                                GenericRow.of(1, BinaryString.fromString("a")),
+                                GenericRow.of(5, BinaryString.fromString("z")),
+                                createBinaryArray(new int[] {0, 1}),
+                                new int[] {0, 1}));
+
+        DataEvolutionFileStoreScan.evolutionStats(
+                tableSchema, countingScanTableSchema, Collections.singletonList(entry), cache);
+        DataEvolutionFileStoreScan.evolutionStats(
+                tableSchema, countingScanTableSchema, Collections.singletonList(entry), cache);
+
+        assertThat(schemaLoads).hasValue(1);
+        assertThat(cache.size()).isEqualTo(1);
     }
 
     @Test
@@ -138,7 +174,8 @@ public class DataEvolutionFileStoreScanTest {
         List<ManifestEntry> entries = Arrays.asList(entry2, entry1);
 
         EvolutionStats result =
-                DataEvolutionFileStoreScan.evolutionStats(tableSchema, scanTableSchema, entries);
+                DataEvolutionFileStoreScan.evolutionStats(
+                        tableSchema, scanTableSchema, entries, new EvolutionStatsCache());
 
         assertThat(result).isNotNull();
         DataEvolutionRow minRow = (DataEvolutionRow) result.minValues();
@@ -188,7 +225,7 @@ public class DataEvolutionFileStoreScanTest {
 
         EvolutionStats result =
                 DataEvolutionFileStoreScan.evolutionStats(
-                        evolvedTableSchema, scanTableSchema, entries);
+                        evolvedTableSchema, scanTableSchema, entries, new EvolutionStatsCache());
 
         assertThat(result).isNotNull();
         DataEvolutionRow minRow = (DataEvolutionRow) result.minValues();
@@ -241,7 +278,8 @@ public class DataEvolutionFileStoreScanTest {
         List<ManifestEntry> entries = Arrays.asList(entry1, entry2);
 
         EvolutionStats result =
-                DataEvolutionFileStoreScan.evolutionStats(tableSchema, scanTableSchema, entries);
+                DataEvolutionFileStoreScan.evolutionStats(
+                        tableSchema, scanTableSchema, entries, new EvolutionStatsCache());
 
         assertThat(result).isNotNull();
         DataEvolutionRow minRow = (DataEvolutionRow) result.minValues();
@@ -303,7 +341,8 @@ public class DataEvolutionFileStoreScanTest {
                 DataEvolutionFileStoreScan.evolutionStats(
                         evolvedTableSchema,
                         scanTableSchema,
-                        Arrays.asList(oldTypeEntry, newTypeEntry));
+                        Arrays.asList(oldTypeEntry, newTypeEntry),
+                        new EvolutionStatsCache());
 
         DataEvolutionRow minRow = (DataEvolutionRow) result.minValues();
         DataEvolutionRow maxRow = (DataEvolutionRow) result.maxValues();
@@ -338,7 +377,8 @@ public class DataEvolutionFileStoreScanTest {
                 DataEvolutionFileStoreScan.evolutionStats(
                         evolvedTableSchema,
                         scanTableSchema,
-                        Collections.singletonList(preAlterFile));
+                        Collections.singletonList(preAlterFile),
+                        new EvolutionStatsCache());
 
         Predicate onChangedColumn =
                 new PredicateBuilder(evolvedTableSchema.logicalRowType()).equal(0, 50L);
@@ -387,7 +427,10 @@ public class DataEvolutionFileStoreScanTest {
 
         EvolutionStats result =
                 DataEvolutionFileStoreScan.evolutionStats(
-                        tableSchema, scanTableSchema, Arrays.asList(dataEntry, vectorEntry));
+                        tableSchema,
+                        scanTableSchema,
+                        Arrays.asList(dataEntry, vectorEntry),
+                        new EvolutionStatsCache());
 
         DataEvolutionArray nullCounts = (DataEvolutionArray) result.nullCounts();
         assertThat(nullCounts.isNullAt(2)).isTrue();

--- a/paimon-core/src/test/java/org/apache/paimon/operation/DataEvolutionFileStoreScanTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/operation/DataEvolutionFileStoreScanTest.java
@@ -30,7 +30,6 @@ import org.apache.paimon.manifest.FileKind;
 import org.apache.paimon.manifest.FileSource;
 import org.apache.paimon.manifest.ManifestEntry;
 import org.apache.paimon.operation.DataEvolutionFileStoreScan.EvolutionStats;
-import org.apache.paimon.operation.DataEvolutionFileStoreScan.EvolutionStatsCache;
 import org.apache.paimon.predicate.Predicate;
 import org.apache.paimon.predicate.PredicateBuilder;
 import org.apache.paimon.reader.DataEvolutionArray;


### PR DESCRIPTION
### Purpose

`DataEvolutionFileStoreScan.evolutionStats` runs once per Row-ID group and repeatedly resolves the same projected file schemas and field positions. This becomes expensive for wide data-evolution tables with many groups, even when the snapshot contains only a few distinct physical column layouts.

This change adds a scan-local cache keyed by `(schemaId, writeCols, valueStatsCols)`. Each cache entry reuses:

- the projected data-file schema;
- a physical field-ID to stats-offset map, where `-1` represents a physically present field without stats;
- the projected stats field types.

The lookup map is built only on a projection-cache miss, rather than once per file or Row-ID group. `evolutionStats` also precomputes target field types and stops scanning older files after all fields have been resolved.

`evolutionStats` accepts the cache explicitly. Normal scan planning passes one cache across all Row-ID groups, while standalone tests can pass a fresh cache.

### Benchmark

Replayed a real-world metadata snapshot with:

- 1,027 fields;
- 19,856 active files;
- 17,670 Row-ID groups;
- the original query predicate and a limit of 1,000.

Hot-run averages:

- `master`: 45.71 seconds;
- projected-schema cache before cached field lookups: 10.70 seconds;
- final implementation: 4.65 seconds.

The final implementation is 9.83x faster than `master` and 2.30x faster than the initial projected-schema-cache implementation. All variants produced zero candidate files.

### Tests

- `mvn -pl paimon-core -am -Pfast-build -DfailIfNoTests=false -DwildcardSuites=none -Dtest=DataEvolutionFileStoreScanTest test`
- `mvn -pl paimon-core -am -Pfast-build -DfailIfNoTests=false -DwildcardSuites=none -Dtest='*DataEvolution*Test' test` (208 tests)
- Replayed the wide-table metadata snapshot twice; all runs returned the same candidate files.

