### PR TITLE
[spark] Recompute bucket number for postpone overwrite

### DIFF
--- a/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/SparkPostponeStagedCommitter.scala
+++ b/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/SparkPostponeStagedCommitter.scala
@@ -105,16 +105,23 @@ private[spark] class SparkPostponeStagedCommitter(
         return passThroughMessages
       }
 
-      val existingBuckets: Map[BinaryRow, Int] = baseSnapshotId
-        .map(
-          id =>
-            PostponeUtils
-              .getKnownNumBuckets(table, id, touchedPartitions.asJava)
-              .asScala
-              .iterator
-              .map { case (partition, buckets) => partition -> buckets.intValue() }
-              .toMap)
-        .getOrElse(Map.empty[BinaryRow, Int])
+      // Overwrite removes the previous partition contents, so its bucket layout must not
+      // constrain the replacement data. It is also unnecessary to scan the old layout here.
+      val existingBuckets: Map[BinaryRow, Int] =
+        if (overwritePartitionSpec.isDefined) {
+          Map.empty
+        } else {
+          baseSnapshotId
+            .map(
+              id =>
+                PostponeUtils
+                  .getKnownNumBuckets(table, id, touchedPartitions.asJava)
+                  .asScala
+                  .iterator
+                  .map { case (partition, buckets) => partition -> buckets.intValue() }
+                  .toMap)
+            .getOrElse(Map.empty[BinaryRow, Int])
+        }
       val decisions = touchedPartitions.map {
         partition =>
           val stage = stats(partition)

--- a/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/sql/PostponeBucketTableTest.scala
+++ b/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/sql/PostponeBucketTableTest.scala
@@ -643,7 +643,7 @@ class PostponeBucketTableTest extends PaimonSparkTestBase {
     }
   }
 
-  test("Postpone bucket table: overwrite excludes existing postpone rows from inference") {
+  test("Postpone bucket table: overwrite recomputes bucket number from staged batch") {
     Seq(
       (
         "static",
@@ -690,13 +690,23 @@ class PostponeBucketTableTest extends PaimonSparkTestBase {
                   |""".stripMargin)
             assert(SparkTable(loadTable("t")).useV2Write)
 
-            sql("""
-                  |INSERT INTO t SELECT
-                  |id AS k,
-                  |CAST(id AS STRING) AS v,
-                  |0 AS pt
-                  |FROM range (0, 1000)
-                  |""".stripMargin)
+            withSparkSQLConf("spark.paimon.postpone.batch-write-fixed-bucket" -> "true") {
+              sql("""
+                    |INSERT INTO t SELECT
+                    |id AS k,
+                    |CAST(id AS STRING) AS v,
+                    |0 AS pt
+                    |FROM range (0, 1000)
+                    |""".stripMargin)
+            }
+            assert(
+              PostponeUtils
+                .getKnownNumBuckets(loadTable("t"))
+                .get(BinaryRow.singleColumn(0)) == 16)
+
+            withSparkSQLConf("spark.paimon.postpone.batch-write-fixed-bucket" -> "false") {
+              sql("INSERT INTO t VALUES (2000, 'historical-postpone', 0)")
+            }
 
             withSparkSQLConf(
               "spark.paimon.postpone.batch-write-fixed-bucket" -> "true",
@@ -705,9 +715,10 @@ class PostponeBucketTableTest extends PaimonSparkTestBase {
             }
 
             checkAnswer(sql("SELECT count(*), sum(k) FROM t"), Seq(Row(100L, 104950L)))
-            checkAnswer(
-              sql("SELECT distinct(bucket) FROM `t$buckets` WHERE partition = '{0}'"),
-              Seq(Row(0)))
+            assert(
+              PostponeUtils
+                .getKnownNumBuckets(loadTable("t"))
+                .get(BinaryRow.singleColumn(0)) == 1)
             checkAnswer(sql("SELECT count(*) FROM `t$buckets` WHERE bucket = -2"), Seq(Row(0L)))
           }
         }


### PR DESCRIPTION
### Purpose

INSERT OVERWRITE removes the previous contents, so the existing bucket layout should not constrain the replacement data.

This change skips loading existing bucket metadata for overwrite and infers the fixed bucket number from the newly staged batch. Append and rescale behavior remain unchanged.

### Tests

`PostponeBucketTableTest`: 28 tests passed.