### PR TITLE
[flink] Fix Flink version detection for key-only deletes on non-release versions

### DIFF
--- a/paimon-flink/paimon-flink2-common/src/main/java/org/apache/paimon/flink/utils/ChangelogModeUtils.java
+++ b/paimon-flink/paimon-flink2-common/src/main/java/org/apache/paimon/flink/utils/ChangelogModeUtils.java
@@ -40,9 +40,18 @@ public class ChangelogModeUtils {
     }
 
     private static boolean isFlink21OrAbove() {
-        String version = EnvironmentInformation.getVersion();
+        return isVersionAtLeast21(EnvironmentInformation.getVersion());
+    }
+
+    /**
+     * Flink version strings are not always {@code major.minor.patch}: builds from a release branch
+     * or master are published as {@code 2.2-SNAPSHOT}. Split on both {@code .} and {@code -} so
+     * that the major/minor prefix is read in all of those shapes.
+     */
+    // visible for testing
+    static boolean isVersionAtLeast21(String version) {
         try {
-            String[] parts = version.split("\\.");
+            String[] parts = version.split("[.-]");
             int major = Integer.parseInt(parts[0]);
             int minor = Integer.parseInt(parts[1]);
             return major > 2 || (major == 2 && minor >= 1);

--- a/paimon-flink/paimon-flink2-common/src/test/java/org/apache/paimon/flink/utils/ChangelogModeUtilsTest.java
+++ b/paimon-flink/paimon-flink2-common/src/test/java/org/apache/paimon/flink/utils/ChangelogModeUtilsTest.java
@@ -1,0 +1,62 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.flink.utils;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Tests for {@link ChangelogModeUtils}. */
+public class ChangelogModeUtilsTest {
+
+    @ParameterizedTest
+    @ValueSource(
+            strings = {
+                "2.1.0",
+                "2.2.0",
+                "3.0.0",
+                "2.1.0-amzn-0",
+                "2.1-SNAPSHOT",
+                "2.2-SNAPSHOT",
+                "2.10-SNAPSHOT"
+            })
+    void testVersionAtLeast21(String version) {
+        assertThat(ChangelogModeUtils.isVersionAtLeast21(version)).isTrue();
+    }
+
+    @ParameterizedTest
+    @ValueSource(
+            strings = {
+                "2.0.0",
+                "2.0-SNAPSHOT",
+                "2.0-vvr-11.2-SNAPSHOT",
+                "2.0-rc1",
+                "1.20.1",
+                "1.20-SNAPSHOT",
+                "1.20-vvr-11.2-SNAPSHOT",
+                "<unknown>",
+                "",
+                "2",
+                "not-a-version"
+            })
+    void testVersionBelow21(String version) {
+        assertThat(ChangelogModeUtils.isVersionAtLeast21(version)).isFalse();
+    }
+}


### PR DESCRIPTION
### Purpose

fix #9052

- `ChangelogModeUtils.isFlink21OrAbove()` split `EnvironmentInformation.getVersion()` on `.` only, leaving `2-SNAPSHOT` as the minor part. The `NumberFormatException` was swallowed, so key-only deletes were disabled on a runtime that has the FLIP-510 API, while the log claimed `requires Flink 2.1+ (current version: 2.2-SNAPSHOT)`.
- This hits Flink built from a release branch or master: the ASF snapshot repository publishes `flink-runtime` as `2.1-SNAPSHOT` and `2.2-SNAPSHOT`. Released `2.1.0` was never affected.
- Split on `.` and `-` instead. One-directional: `2.0-SNAPSHOT`, `2.0-rc1`, `2.0-vvr-11.2-SNAPSHOT` still return `false`, keeping the Flink 2.0 `NoSuchMethodError` guard.
- `E2eTestBase.safelyParseVersion()` already acknowledges suffixed Flink versions.

### Tests

- Added `ChangelogModeUtilsTest#testVersionAtLeast21` / `#testVersionBelow21`.
- `mvn -pl paimon-flink/paimon-flink2-common -Pflink2 clean install` — 18 tests passed.


