### PR TITLE
[cdc] Fix NPE when metadata columns are used with debezium-bson format

### DIFF
--- a/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/action/cdc/format/debezium/DebeziumBsonRecordParser.java
+++ b/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/action/cdc/format/debezium/DebeziumBsonRecordParser.java
@@ -109,6 +109,10 @@ public class DebeziumBsonRecordParser extends DebeziumJsonRecordParser {
 
     @Override
     protected void setRoot(CdcSourceRecord record) {
+        // Store current record for metadata access. Assign the field directly instead of calling
+        // super.setRoot, because DebeziumJsonRecordParser#setRoot also parses the Debezium value
+        // schema, which carries no field information for BSON documents.
+        this.currentRecord = record;
         root = (JsonNode) record.getValue();
         if (root.has(FIELD_SCHEMA)) {
             root = root.get(FIELD_PAYLOAD);

--- a/paimon-flink/paimon-flink-cdc/src/test/java/org/apache/paimon/flink/action/cdc/format/debezium/DebeziumBsonRecordParserTest.java
+++ b/paimon-flink/paimon-flink-cdc/src/test/java/org/apache/paimon/flink/action/cdc/format/debezium/DebeziumBsonRecordParserTest.java
@@ -18,14 +18,17 @@
 
 package org.apache.paimon.flink.action.cdc.format.debezium;
 
+import org.apache.paimon.flink.action.cdc.CdcMetadataConverter;
 import org.apache.paimon.flink.action.cdc.CdcSourceRecord;
 import org.apache.paimon.flink.action.cdc.TypeMapping;
 import org.apache.paimon.flink.action.cdc.format.DataFormat;
+import org.apache.paimon.flink.action.cdc.kafka.KafkaMetadataConverter;
 import org.apache.paimon.flink.action.cdc.watermark.MessageQueueCdcTimestampExtractor;
 import org.apache.paimon.flink.sink.cdc.CdcRecord;
 import org.apache.paimon.flink.sink.cdc.CdcSchema;
 import org.apache.paimon.flink.sink.cdc.RichCdcMultiplexRecord;
 import org.apache.paimon.schema.Schema;
+import org.apache.paimon.types.DataField;
 import org.apache.paimon.types.RowKind;
 import org.apache.paimon.utils.JsonSerdeUtil;
 import org.apache.paimon.utils.StringUtils;
@@ -51,6 +54,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 /** Test for DebeziumBsonRecordParser. */
 public class DebeziumBsonRecordParserTest {
@@ -225,6 +229,38 @@ public class DebeziumBsonRecordParserTest {
 
             MessageQueueCdcTimestampExtractor extractor = new MessageQueueCdcTimestampExtractor();
             Assertions.assertTrue(extractor.extractTimestamp(cdcRecord) > 0);
+        }
+    }
+
+    @Test
+    public void extractRecordWithMetadataColumns() throws Exception {
+        DebeziumBsonRecordParser parser =
+                new DebeziumBsonRecordParser(TypeMapping.defaultMapping(), Collections.emptyList());
+        parser.withMetadataConverters(
+                new CdcMetadataConverter[] {
+                    new KafkaMetadataConverter.TopicConverter(),
+                    new KafkaMetadataConverter.OffsetConverter()
+                });
+
+        Assertions.assertFalse(insertList.isEmpty());
+        for (CdcSourceRecord cdcRecord : insertList) {
+            List<RichCdcMultiplexRecord> records = new ArrayList<>();
+            parser.flatMap(cdcRecord, new ListCollector<>(records));
+            Assertions.assertEquals(1, records.size());
+
+            Map<String, String> expected = new HashMap<>(beforeEvent);
+            expected.put("topic", "topic");
+            expected.put("offset", "0");
+
+            CdcRecord result = records.get(0).toRichCdcRecord().toCdcRecord();
+            Assertions.assertEquals(RowKind.INSERT, result.kind());
+            Assertions.assertEquals(expected, result.data());
+
+            List<String> fieldNames =
+                    records.get(0).buildSchema().fields().stream()
+                            .map(DataField::name)
+                            .collect(Collectors.toList());
+            Assertions.assertTrue(fieldNames.containsAll(Arrays.asList("topic", "offset")));
         }
     }
 


### PR DESCRIPTION

### Purpose

fix #9054

- `DebeziumBsonRecordParser#setRoot` overrides `AbstractRecordParser#setRoot` without storing the record, so `evalMetadataColumns` passes a null `currentRecord` to the converters. Using `--metadata_column` with `value.format=debezium-bson` throws NPE on the first record.
- Assign `currentRecord` directly instead of calling `super.setRoot`: `DebeziumJsonRecordParser#setRoot` also parses the Debezium value schema, which BSON events do not carry.
- The sibling parsers already store the record; #7315 added only the consumer to the BSON parser.
- Without metadata columns the converter array is empty, so behavior is unchanged.

### Tests

- Added `DebeziumBsonRecordParserTest#extractRecordWithMetadataColumns`, asserting the `topic` and `offset` values and schema columns. It fails with NPE before the fix.
- `mvn -pl paimon-flink/paimon-flink-cdc -Pflink1 -Dtest='!*ITCase' clean install` (JDK 11): 148 tests passed in each of the two surefire executions.
- Kafka/MongoDB/MySQL `*ITCase` need Docker and were not run locally — covered by CI.


