### PR TITLE
[python][ray] Add periodic commits to write_paimon

### DIFF
--- a/docs/docs/pypaimon/ray-data.md
+++ b/docs/docs/pypaimon/ray-data.md
@@ -277,6 +277,28 @@ overlapping buckets or sequence numbers for those modes.
   HASH_FIXED grouping. This option does not enable HASH_DYNAMIC or
   CROSS_PARTITION primary-key writes.
 
+### Incremental write
+
+Use time-based commits for long-running partial updates:
+
+```python
+write_paimon(
+    updates,
+    "database_name.target",
+    {"warehouse": "/path/to/warehouse"},
+    commit_mode="incremental",
+    update_cols=["feature"],
+    commit_interval_seconds=600,
+)
+```
+
+The target must be a fixed-bucket primary-key table using
+`merge-engine=partial-update`; source rows must contain the primary key and
+updated columns. Completed commits remain visible after failure; retrying
+reruns the Ray Dataset. The interval is a target and may be exceeded while a
+Ray block is still running. Do not modify the target concurrently; compaction
+is allowed.
+
 ### `TableWrite.write_ray()` (lower-level)
 
 If you have already constructed a `table_write` from a write builder, you can

--- a/docs/docs/pypaimon/ray-data.md
+++ b/docs/docs/pypaimon/ray-data.md
@@ -298,7 +298,6 @@ updated columns. Completed commits remain visible after failure; retrying
 reruns the Ray Dataset. The interval is a target and may be exceeded while a
 group is still writing. This mode requires Ray 2.33 or later. Concurrent partial
 updates are allowed, but updates to the same field have no deterministic winner.
-Schema changes fail the write.
 
 ### `TableWrite.write_ray()` (lower-level)
 

--- a/docs/docs/pypaimon/ray-data.md
+++ b/docs/docs/pypaimon/ray-data.md
@@ -296,8 +296,9 @@ The target must be a fixed-bucket primary-key table using
 `merge-engine=partial-update`; source rows must contain the primary key and
 updated columns. Completed commits remain visible after failure; retrying
 reruns the Ray Dataset. The interval is a target and may be exceeded while a
-Ray block is still running. Concurrent partial updates are allowed, but updates
-to the same field have no deterministic winner. Schema changes fail the write.
+window is still running. This mode requires Ray 2.33 or later. Concurrent
+partial updates are allowed, but updates to the same field have no deterministic
+winner. Schema changes fail the write.
 
 ### `TableWrite.write_ray()` (lower-level)
 

--- a/docs/docs/pypaimon/ray-data.md
+++ b/docs/docs/pypaimon/ray-data.md
@@ -296,8 +296,8 @@ The target must be a fixed-bucket primary-key table using
 `merge-engine=partial-update`; source rows must contain the primary key and
 updated columns. Completed commits remain visible after failure; retrying
 reruns the Ray Dataset. The interval is a target and may be exceeded while a
-Ray block is still running. Do not modify the target concurrently; compaction
-is allowed.
+Ray block is still running. Concurrent partial updates are allowed, but updates
+to the same field have no deterministic winner. Schema changes fail the write.
 
 ### `TableWrite.write_ray()` (lower-level)
 

--- a/docs/docs/pypaimon/ray-data.md
+++ b/docs/docs/pypaimon/ray-data.md
@@ -279,7 +279,13 @@ overlapping buckets or sequence numbers for those modes.
 
 ### Incremental write
 
-Use time-based commits for long-running partial updates:
+By default, `write_paimon` publishes one snapshot after the entire Ray Dataset
+finishes. A late failure therefore leaves none of that write visible. Incremental
+mode periodically commits completed primary-key groups, so long-running jobs do
+not need to split the Dataset into batches and keep their completed commits if a
+later group fails.
+
+Use time-based commits for partial updates:
 
 ```python
 write_paimon(
@@ -294,10 +300,12 @@ write_paimon(
 
 The target must be a fixed-bucket primary-key table using
 `merge-engine=partial-update`; source rows must contain the primary key and
-updated columns. Completed commits remain visible after failure; retrying
-reruns the Ray Dataset. The interval is a target and may be exceeded while a
-group is still writing. This mode requires Ray 2.33 or later. Concurrent partial
-updates are allowed, but updates to the same field have no deterministic winner.
+updated columns. Existing keys are updated and new keys are inserted. This mode
+does not checkpoint source progress, so retrying reruns the Ray Dataset and
+upserts previously committed keys again. The interval is a target and may be
+exceeded while a group is still writing. This mode requires Ray 2.33 or later.
+Concurrent partial updates are allowed, but updates to the same field have no
+deterministic winner.
 
 ### `TableWrite.write_ray()` (lower-level)
 

--- a/docs/docs/pypaimon/ray-data.md
+++ b/docs/docs/pypaimon/ray-data.md
@@ -296,9 +296,9 @@ The target must be a fixed-bucket primary-key table using
 `merge-engine=partial-update`; source rows must contain the primary key and
 updated columns. Completed commits remain visible after failure; retrying
 reruns the Ray Dataset. The interval is a target and may be exceeded while a
-window is still running. This mode requires Ray 2.33 or later. Concurrent
-partial updates are allowed, but updates to the same field have no deterministic
-winner. Schema changes fail the write.
+group is still writing. This mode requires Ray 2.33 or later. Concurrent partial
+updates are allowed, but updates to the same field have no deterministic winner.
+Schema changes fail the write.
 
 ### `TableWrite.write_ray()` (lower-level)
 

--- a/paimon-python/pypaimon/ray/incremental_write.py
+++ b/paimon-python/pypaimon/ray/incremental_write.py
@@ -147,8 +147,7 @@ class _PeriodicDatasetCommitter:
         self._pending = []
         commit_id = self._next_commit_id
         base_id = self._base_snapshot.id if self._base_snapshot else 0
-        self._commit.protect_from_external_commits(
-            self._base_snapshot, self._schema_id, allow_maintenance=True)
+        self._commit.protect_from_schema_changes(self._schema_id)
         self._commit.commit(messages, commit_id)
         committed = _find_committed_snapshot(
             self._table, self._commit_user, commit_id, base_id)

--- a/paimon-python/pypaimon/ray/incremental_write.py
+++ b/paimon-python/pypaimon/ray/incremental_write.py
@@ -60,6 +60,7 @@ def _write_dataset_periodically(
     committer = _PeriodicDatasetCommitter(
         table,
         table.table_schema.id,
+        commit_interval_seconds,
     )
     windows = _dataset_windows(dataset, commit_interval_seconds)
     try:
@@ -74,7 +75,7 @@ def _write_dataset_periodically(
                     ray_remote_args=ray_remote_args,
                     on_group_result=committer.add_group,
                 )
-                committer.commit()
+            committer.commit()
         except Exception:
             # Preserve successful groups produced before a worker failure.
             committer.commit()
@@ -131,9 +132,11 @@ def _dataset_windows(dataset, interval):
 
 class _PeriodicDatasetCommitter:
 
-    def __init__(self, table, schema_id):
+    def __init__(self, table, schema_id, commit_interval_seconds):
         self._table = table
         self._schema_id = schema_id
+        self._commit_interval = commit_interval_seconds
+        self._last_commit = time.monotonic()
         builder = table.new_stream_write_builder()
         self._commit = builder.new_commit()
         self._callback = _SnapshotCallback()
@@ -144,6 +147,10 @@ class _PeriodicDatasetCommitter:
     def add_group(self, messages):
         self._pending.extend(
             message for message in messages if not message.is_empty())
+        if (self._pending
+                and time.monotonic() - self._last_commit
+                >= self._commit_interval):
+            self.commit()
 
     def commit(self):
         if not self._pending:
@@ -158,6 +165,7 @@ class _PeriodicDatasetCommitter:
             raise RuntimeError("Committed periodic write snapshot is missing.")
         _validate_schema(self._table, self._schema_id)
         self._next_commit_id += 1
+        self._last_commit = time.monotonic()
 
     def abort_pending(self):
         if not self._pending:

--- a/paimon-python/pypaimon/ray/incremental_write.py
+++ b/paimon-python/pypaimon/ray/incremental_write.py
@@ -1,0 +1,200 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Periodic commits for Ray Dataset writes."""
+
+import logging
+import time
+
+logger = logging.getLogger(__name__)
+
+
+def incremental_write_paimon(
+        dataset,
+        target,
+        catalog_options,
+        *,
+        commit_interval_seconds,
+        update_cols,
+        concurrency=None,
+        ray_remote_args=None):
+    """Commit a primary-key update Dataset in time-based windows."""
+    from pypaimon.catalog.catalog_factory import CatalogFactory
+    from pypaimon.write.ray_datasink import _prepare_incremental_update
+
+    if (isinstance(commit_interval_seconds, bool)
+            or not isinstance(commit_interval_seconds, (int, float))
+            or commit_interval_seconds <= 0):
+        raise ValueError("commit_interval_seconds must be positive.")
+
+    table = CatalogFactory.create(catalog_options).get_table(target)
+    to_write_batch = _prepare_incremental_update(table, target, update_cols)
+    dataset = dataset.map_batches(to_write_batch, batch_format="pyarrow")
+    _write_dataset_periodically(
+        dataset,
+        table,
+        commit_interval_seconds,
+        concurrency,
+        ray_remote_args,
+    )
+
+
+def _write_dataset_periodically(
+        dataset, table, commit_interval_seconds, concurrency,
+        ray_remote_args):
+    from pypaimon.write.ray_datasink import _write_primary_key_groups
+
+    committer = _PeriodicDatasetCommitter(
+        table,
+        table.snapshot_manager().get_latest_snapshot(),
+        table.table_schema.id,
+    )
+    windows = _dataset_windows(dataset, commit_interval_seconds)
+    try:
+        try:
+            for window in windows:
+                _write_primary_key_groups(
+                    window,
+                    table,
+                    overwrite=False,
+                    static_partition=None,
+                    concurrency=concurrency,
+                    ray_remote_args=ray_remote_args,
+                    on_group_result=committer.add_group,
+                )
+                committer.commit()
+        except Exception:
+            # Preserve successful groups produced before a worker failure.
+            committer.commit()
+            raise
+    except Exception:
+        committer.abort_pending()
+        raise
+    finally:
+        windows.close()
+        committer.close()
+
+
+def _dataset_windows(dataset, interval):
+    """Yield time windows without copying Ray blocks through the driver."""
+    import ray.data
+
+    bundles = []
+    source = dataset.iter_internal_ref_bundles()
+    last_window = time.monotonic()
+    try:
+        for bundle in source:
+            bundles.append(bundle)
+            if time.monotonic() - last_window < interval:
+                continue
+            current, bundles = bundles, []
+            try:
+                yield ray.data.from_arrow_refs([
+                    ref for item in current for ref in item.block_refs])
+            finally:
+                for item in current:
+                    item.destroy_if_owned()
+            last_window = time.monotonic()
+        if bundles:
+            current, bundles = bundles, []
+            try:
+                yield ray.data.from_arrow_refs([
+                    ref for item in current for ref in item.block_refs])
+            finally:
+                for item in current:
+                    item.destroy_if_owned()
+    finally:
+        for item in bundles:
+            item.destroy_if_owned()
+        close = getattr(source, "close", None)
+        if close is not None:
+            close()
+
+
+class _PeriodicDatasetCommitter:
+
+    def __init__(self, table, base_snapshot, schema_id):
+        self._table = table
+        self._base_snapshot = base_snapshot
+        self._schema_id = schema_id
+        builder = table.new_stream_write_builder()
+        self._commit_user = builder.commit_user
+        self._commit = builder.new_commit()
+        self._pending = []
+        self._next_commit_id = 1
+
+    def add_group(self, messages):
+        self._pending.extend(
+            message for message in messages if not message.is_empty())
+
+    def commit(self):
+        if not self._pending:
+            return
+        messages = self._pending
+        self._pending = []
+        commit_id = self._next_commit_id
+        base_id = self._base_snapshot.id if self._base_snapshot else 0
+        self._commit.protect_from_external_commits(
+            self._base_snapshot, self._schema_id, allow_maintenance=True)
+        self._commit.commit(messages, commit_id)
+        committed = _find_committed_snapshot(
+            self._table, self._commit_user, commit_id, base_id)
+        if committed is None:
+            raise RuntimeError("Committed periodic write snapshot is missing.")
+        self._base_snapshot = committed
+        _validate_schema(self._table, self._schema_id)
+        self._next_commit_id += 1
+
+    def abort_pending(self):
+        if not self._pending:
+            return
+        messages = self._pending
+        self._pending = []
+        _abort_messages(self._table, messages)
+
+    def close(self):
+        try:
+            self._commit.close()
+        except Exception:
+            logger.warning("Failed to close periodic write commit.", exc_info=True)
+
+
+def _find_committed_snapshot(table, commit_user, commit_id, after_id):
+    manager = table.snapshot_manager()
+    latest = manager.get_latest_snapshot()
+    if latest is None:
+        return None
+    for snapshot_id in range(latest.id, after_id, -1):
+        snapshot = manager.get_snapshot_by_id(snapshot_id)
+        if (snapshot is not None
+                and snapshot.commit_user == commit_user
+                and snapshot.commit_identifier == commit_id):
+            return snapshot
+    return None
+
+
+def _abort_messages(table, messages):
+    commit = table.new_batch_write_builder().new_commit()
+    try:
+        commit.abort(messages)
+    finally:
+        commit.close()
+
+
+def _validate_schema(table, schema_id):
+    latest = table.schema_manager.latest()
+    if latest is None or latest.id != schema_id:
+        raise RuntimeError("Target schema changed during incremental write.")

--- a/paimon-python/pypaimon/ray/incremental_write.py
+++ b/paimon-python/pypaimon/ray/incremental_write.py
@@ -59,7 +59,6 @@ def _write_dataset_periodically(
 
     committer = _PeriodicDatasetCommitter(
         table,
-        table.snapshot_manager().get_latest_snapshot(),
         table.table_schema.id,
     )
     windows = _dataset_windows(dataset, commit_interval_seconds)
@@ -92,8 +91,14 @@ def _dataset_windows(dataset, interval):
     """Yield time windows without copying Ray blocks through the driver."""
     import ray.data
 
+    iter_bundles = getattr(dataset, "iter_internal_ref_bundles", None)
+    from_refs = getattr(ray.data, "from_arrow_refs", None)
+    if iter_bundles is None or from_refs is None:
+        raise RuntimeError(
+            "incremental write_paimon requires Ray 2.33 or later.")
+
     bundles = []
-    source = dataset.iter_internal_ref_bundles()
+    source = iter_bundles()
     last_window = time.monotonic()
     try:
         for bundle in source:
@@ -102,7 +107,7 @@ def _dataset_windows(dataset, interval):
                 continue
             current, bundles = bundles, []
             try:
-                yield ray.data.from_arrow_refs([
+                yield from_refs([
                     ref for item in current for ref in item.block_refs])
             finally:
                 for item in current:
@@ -111,7 +116,7 @@ def _dataset_windows(dataset, interval):
         if bundles:
             current, bundles = bundles, []
             try:
-                yield ray.data.from_arrow_refs([
+                yield from_refs([
                     ref for item in current for ref in item.block_refs])
             finally:
                 for item in current:
@@ -126,13 +131,13 @@ def _dataset_windows(dataset, interval):
 
 class _PeriodicDatasetCommitter:
 
-    def __init__(self, table, base_snapshot, schema_id):
+    def __init__(self, table, schema_id):
         self._table = table
-        self._base_snapshot = base_snapshot
         self._schema_id = schema_id
         builder = table.new_stream_write_builder()
-        self._commit_user = builder.commit_user
         self._commit = builder.new_commit()
+        self._callback = _SnapshotCallback()
+        self._commit.add_commit_callback(self._callback)
         self._pending = []
         self._next_commit_id = 1
 
@@ -146,14 +151,11 @@ class _PeriodicDatasetCommitter:
         messages = self._pending
         self._pending = []
         commit_id = self._next_commit_id
-        base_id = self._base_snapshot.id if self._base_snapshot else 0
         self._commit.protect_from_schema_changes(self._schema_id)
         self._commit.commit(messages, commit_id)
-        committed = _find_committed_snapshot(
-            self._table, self._commit_user, commit_id, base_id)
+        committed = self._callback.pop(commit_id)
         if committed is None:
             raise RuntimeError("Committed periodic write snapshot is missing.")
-        self._base_snapshot = committed
         _validate_schema(self._table, self._schema_id)
         self._next_commit_id += 1
 
@@ -171,18 +173,19 @@ class _PeriodicDatasetCommitter:
             logger.warning("Failed to close periodic write commit.", exc_info=True)
 
 
-def _find_committed_snapshot(table, commit_user, commit_id, after_id):
-    manager = table.snapshot_manager()
-    latest = manager.get_latest_snapshot()
-    if latest is None:
-        return None
-    for snapshot_id in range(latest.id, after_id, -1):
-        snapshot = manager.get_snapshot_by_id(snapshot_id)
-        if (snapshot is not None
-                and snapshot.commit_user == commit_user
-                and snapshot.commit_identifier == commit_id):
-            return snapshot
-    return None
+class _SnapshotCallback:
+
+    def __init__(self):
+        self._snapshots = {}
+
+    def call(self, context):
+        self._snapshots[context.identifier] = context.snapshot
+
+    def pop(self, commit_id):
+        return self._snapshots.pop(commit_id, None)
+
+    def close(self):
+        pass
 
 
 def _abort_messages(table, messages):

--- a/paimon-python/pypaimon/ray/incremental_write.py
+++ b/paimon-python/pypaimon/ray/incremental_write.py
@@ -59,7 +59,6 @@ def _write_dataset_periodically(
 
     committer = _PeriodicDatasetCommitter(
         table,
-        table.table_schema.id,
         commit_interval_seconds,
     )
     windows = _dataset_windows(dataset, commit_interval_seconds)
@@ -132,9 +131,8 @@ def _dataset_windows(dataset, interval):
 
 class _PeriodicDatasetCommitter:
 
-    def __init__(self, table, schema_id, commit_interval_seconds):
+    def __init__(self, table, commit_interval_seconds):
         self._table = table
-        self._schema_id = schema_id
         self._commit_interval = commit_interval_seconds
         self._last_commit = time.monotonic()
         builder = table.new_stream_write_builder()
@@ -158,12 +156,10 @@ class _PeriodicDatasetCommitter:
         messages = self._pending
         self._pending = []
         commit_id = self._next_commit_id
-        self._commit.protect_from_schema_changes(self._schema_id)
         self._commit.commit(messages, commit_id)
         committed = self._callback.pop(commit_id)
         if committed is None:
             raise RuntimeError("Committed periodic write snapshot is missing.")
-        _validate_schema(self._table, self._schema_id)
         self._next_commit_id += 1
         self._last_commit = time.monotonic()
 
@@ -202,9 +198,3 @@ def _abort_messages(table, messages):
         commit.abort(messages)
     finally:
         commit.close()
-
-
-def _validate_schema(table, schema_id):
-    latest = table.schema_manager.latest()
-    if latest is None or latest.id != schema_id:
-        raise RuntimeError("Target schema changed during incremental write.")

--- a/paimon-python/pypaimon/ray/ray_paimon.py
+++ b/paimon-python/pypaimon/ray/ray_paimon.py
@@ -329,7 +329,8 @@ def write_paimon(
                 "commit_interval_seconds is required for incremental writes.")
         if hash_fixed_precluster not in ("auto", "map_groups"):
             raise ValueError(
-                "incremental write_paimon requires HASH_FIXED grouping.")
+                "incremental write_paimon always groups HASH_FIXED updates; "
+                "hash_fixed_precluster must be 'auto' or 'map_groups'.")
         from pypaimon.ray.incremental_write import incremental_write_paimon
 
         return incremental_write_paimon(

--- a/paimon-python/pypaimon/ray/ray_paimon.py
+++ b/paimon-python/pypaimon/ray/ray_paimon.py
@@ -288,6 +288,9 @@ def write_paimon(
     concurrency: Optional[int] = None,
     ray_remote_args: Optional[Dict[str, Any]] = None,
     hash_fixed_precluster: str = "auto",
+    commit_mode: str = "atomic",
+    commit_interval_seconds: Optional[float] = None,
+    update_cols: Optional[List[str]] = None,
 ) -> None:
     """Write a Ray Dataset to a Paimon table.
 
@@ -310,8 +313,38 @@ def write_paimon(
         hash_fixed_precluster: Pre-clustering mode. ``"auto"`` follows
             table options, ``"off"`` disables it, and ``"map_groups"``
             explicitly enables HASH_FIXED grouping.
+        commit_mode: ``"atomic"`` or time-based ``"incremental"``.
+        commit_interval_seconds: Target interval between incremental commits.
+        update_cols: Columns updated by an incremental primary-key write.
     """
     _require_ray_data()
+
+    if commit_mode not in ("atomic", "incremental"):
+        raise ValueError("commit_mode must be 'atomic' or 'incremental'.")
+    if commit_mode == "incremental":
+        if overwrite:
+            raise ValueError("incremental write_paimon cannot overwrite.")
+        if commit_interval_seconds is None:
+            raise ValueError(
+                "commit_interval_seconds is required for incremental writes.")
+        if hash_fixed_precluster not in ("auto", "map_groups"):
+            raise ValueError(
+                "incremental write_paimon requires HASH_FIXED grouping.")
+        from pypaimon.ray.incremental_write import incremental_write_paimon
+
+        return incremental_write_paimon(
+            dataset,
+            table_identifier,
+            catalog_options,
+            commit_interval_seconds=commit_interval_seconds,
+            update_cols=update_cols,
+            concurrency=concurrency,
+            ray_remote_args=ray_remote_args,
+        )
+    if commit_interval_seconds is not None or update_cols is not None:
+        raise ValueError(
+            "commit_interval_seconds and update_cols require "
+            "commit_mode='incremental'.")
 
     from pypaimon.catalog.catalog_factory import CatalogFactory
     from pypaimon.write.ray_datasink import write_paimon_dataset

--- a/paimon-python/pypaimon/tests/ray_incremental_write_test.py
+++ b/paimon-python/pypaimon/tests/ray_incremental_write_test.py
@@ -29,8 +29,6 @@ ray = pytest.importorskip("ray")
 
 from pypaimon import CatalogFactory, Schema
 from pypaimon.ray import write_paimon
-from pypaimon.schema.data_types import AtomicType
-from pypaimon.schema.schema_change import SchemaChange
 
 
 class RayIncrementalWriteTest(unittest.TestCase):
@@ -401,30 +399,6 @@ class RayIncrementalWriteTest(unittest.TestCase):
             "feature_a": [101],
             "feature_b": [202],
         }, self._read(target).to_pydict())
-
-    def test_rejects_schema_change(self):
-        from pypaimon.write import ray_datasink
-
-        target = self._create_target()
-        real_write = ray_datasink._write_primary_key_groups
-
-        def alter_schema(*args, **kwargs):
-            self.catalog.alter_table(target, [
-                SchemaChange.add_column(
-                    "extra", AtomicType("STRING"))], False)
-            return real_write(*args, **kwargs)
-
-        with mock.patch.object(
-                ray_datasink,
-                "_write_primary_key_groups",
-                side_effect=alter_schema):
-            with self.assertRaisesRegex(RuntimeError, "schema changed"):
-                self._write_incrementally(target, pa.table({
-                    "id": [1], "feature": [101],
-                }, schema=self.source_schema))
-
-        self._assert_features(target, [10, 20, 30])
-
 
 if __name__ == "__main__":
     unittest.main()

--- a/paimon-python/pypaimon/tests/ray_incremental_write_test.py
+++ b/paimon-python/pypaimon/tests/ray_incremental_write_test.py
@@ -307,39 +307,82 @@ class RayIncrementalWriteTest(unittest.TestCase):
                 "id": [1], "feature": [101],
             }, schema=self.source_schema))
 
-    def test_rejects_concurrent_target_changes(self):
+    def test_merges_concurrent_partial_updates(self):
         from pypaimon.write import ray_datasink
 
+        schema = pa.schema([
+            pa.field("id", pa.int64(), nullable=False),
+            ("payload", pa.string()),
+            ("feature_a", pa.int32()),
+            ("feature_b", pa.int32()),
+        ])
+        target = self._create_table(
+            "concurrent_target",
+            schema,
+            primary_keys=["id"],
+            options={"bucket": "2", "merge-engine": "partial-update"},
+        )
+        self._write(target, pa.table({
+            "id": [1],
+            "payload": ["keep"],
+            "feature_a": [1],
+            "feature_b": [2],
+        }, schema=schema))
         real_write = ray_datasink._write_primary_key_groups
-        for change, error in (("data", "Concurrent target commit"),
-                              ("schema", "schema change")):
-            with self.subTest(change=change):
-                target = self._create_target()
 
-                def mutate_target(*args, **kwargs):
-                    if change == "data":
-                        self._write(target, pa.table({
-                            "id": [4],
-                            "payload": ["external"],
-                            "feature": [40],
-                        }, schema=self.target_schema))
-                    else:
-                        self.catalog.alter_table(target, [
-                            SchemaChange.add_column(
-                                "extra", AtomicType("STRING"))], False)
-                    return real_write(*args, **kwargs)
+        def concurrent_update(*args, **kwargs):
+            self._write(target, pa.table({
+                "id": [1],
+                "payload": [None],
+                "feature_a": [None],
+                "feature_b": [202],
+            }, schema=schema))
+            return real_write(*args, **kwargs)
 
-                with mock.patch.object(
-                        ray_datasink,
-                        "_write_primary_key_groups",
-                        side_effect=mutate_target):
-                    with self.assertRaisesRegex(RuntimeError, error):
-                        self._write_incrementally(target, pa.table({
-                            "id": [1], "feature": [101],
-                        }, schema=self.source_schema))
+        with mock.patch.object(
+                ray_datasink,
+                "_write_primary_key_groups",
+                side_effect=concurrent_update):
+            write_paimon(
+                ray.data.from_arrow(pa.table({
+                    "id": [1], "feature_a": [101],
+                })),
+                target,
+                self.catalog_options,
+                commit_mode="incremental",
+                commit_interval_seconds=10,
+                update_cols=["feature_a"],
+            )
 
-                expected = [10, 20, 30, 40] if change == "data" else [10, 20, 30]
-                self._assert_features(target, expected)
+        self.assertEqual({
+            "id": [1],
+            "payload": ["keep"],
+            "feature_a": [101],
+            "feature_b": [202],
+        }, self._read(target).to_pydict())
+
+    def test_rejects_schema_change(self):
+        from pypaimon.write import ray_datasink
+
+        target = self._create_target()
+        real_write = ray_datasink._write_primary_key_groups
+
+        def alter_schema(*args, **kwargs):
+            self.catalog.alter_table(target, [
+                SchemaChange.add_column(
+                    "extra", AtomicType("STRING"))], False)
+            return real_write(*args, **kwargs)
+
+        with mock.patch.object(
+                ray_datasink,
+                "_write_primary_key_groups",
+                side_effect=alter_schema):
+            with self.assertRaisesRegex(RuntimeError, "schema changed"):
+                self._write_incrementally(target, pa.table({
+                    "id": [1], "feature": [101],
+                }, schema=self.source_schema))
+
+        self._assert_features(target, [10, 20, 30])
 
 
 if __name__ == "__main__":

--- a/paimon-python/pypaimon/tests/ray_incremental_write_test.py
+++ b/paimon-python/pypaimon/tests/ray_incremental_write_test.py
@@ -176,10 +176,41 @@ class RayIncrementalWriteTest(unittest.TestCase):
         with self._clock():
             self._write_incrementally(target, updates, interval=1)
 
-        self.assertEqual(2, self._snapshot_id(target) - before)
+        self.assertGreaterEqual(self._snapshot_id(target) - before, 2)
         self._assert_features(target, list(range(101, 121)))
         self.assertEqual(["a", "b", "c"] + [None] * 17,
                          self._read(target)["payload"].to_pylist())
+
+    def test_materialized_slow_write_commits_periodically(self):
+        target = self._create_target()
+        updates = pa.table({
+            "id": [1, 2],
+            "feature": [101, 102],
+        }, schema=self.source_schema)
+        updates = ray.data.from_arrow([
+            updates.slice(0, 1), updates.slice(1, 1)]).materialize()
+        groups = [
+            self._prepare_update(target, [1], [101]),
+            self._prepare_update(target, [2], [102]),
+        ]
+        now = [0]
+
+        def slow_write(*_args, **kwargs):
+            now[0] = 20
+            kwargs["on_group_result"](groups[0])
+            now[0] = 21
+            kwargs["on_group_result"](groups[1])
+
+        before = self._snapshot_id(target)
+        with mock.patch(
+                "pypaimon.ray.incremental_write.time.monotonic",
+                side_effect=lambda: now[0]), mock.patch(
+                "pypaimon.write.ray_datasink._write_primary_key_groups",
+                side_effect=slow_write):
+            self._write_incrementally(target, updates, interval=10)
+
+        self.assertEqual(2, self._snapshot_id(target) - before)
+        self._assert_features(target, [101, 102, 30])
 
     def test_failure_keeps_completed_groups(self):
         target = self._create_target()

--- a/paimon-python/pypaimon/tests/ray_incremental_write_test.py
+++ b/paimon-python/pypaimon/tests/ray_incremental_write_test.py
@@ -1,0 +1,346 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import itertools
+import os
+import shutil
+import tempfile
+import unittest
+import uuid
+from unittest import mock
+
+import pyarrow as pa
+import pytest
+
+ray = pytest.importorskip("ray")
+
+from pypaimon import CatalogFactory, Schema
+from pypaimon.ray import write_paimon
+from pypaimon.schema.data_types import AtomicType
+from pypaimon.schema.schema_change import SchemaChange
+
+
+class RayIncrementalWriteTest(unittest.TestCase):
+
+    target_schema = pa.schema([
+        pa.field("id", pa.int64(), nullable=False),
+        ("payload", pa.string()),
+        ("feature", pa.int32()),
+    ])
+    source_schema = pa.schema([
+        ("id", pa.int64()),
+        ("feature", pa.int32()),
+    ])
+
+    @classmethod
+    def setUpClass(cls):
+        cls.tempdir = tempfile.mkdtemp()
+        cls.catalog_options = {
+            "warehouse": os.path.join(cls.tempdir, "warehouse")}
+        cls.catalog = CatalogFactory.create(cls.catalog_options)
+        cls.catalog.create_database("default", True)
+        if not ray.is_initialized():
+            ray.init(ignore_reinit_error=True, num_cpus=2)
+
+    @classmethod
+    def tearDownClass(cls):
+        if ray.is_initialized():
+            ray.shutdown()
+        shutil.rmtree(cls.tempdir, ignore_errors=True)
+
+    def _create_table(self, prefix, schema, **schema_options):
+        identifier = "default.{}_{}".format(prefix, uuid.uuid4().hex[:8])
+        self.catalog.create_table(
+            identifier,
+            Schema.from_pyarrow_schema(schema, **schema_options),
+            False,
+        )
+        return identifier
+
+    def _create_target(self):
+        target = self._create_table(
+            "pk_target",
+            self.target_schema,
+            primary_keys=["id"],
+            options={
+                "bucket": "2",
+                "merge-engine": "partial-update",
+            },
+        )
+        self._write(target, pa.table({
+            "id": [1, 2, 3],
+            "payload": ["a", "b", "c"],
+            "feature": [10, 20, 30],
+        }, schema=self.target_schema))
+        return target
+
+    def _write(self, identifier, data):
+        table = self.catalog.get_table(identifier)
+        builder = table.new_batch_write_builder()
+        writer = builder.new_write()
+        commit = builder.new_commit()
+        try:
+            writer.write_arrow(data)
+            commit.commit(writer.prepare_commit())
+        finally:
+            writer.close()
+            commit.close()
+
+    def _compact(self, identifier):
+        data = self._read(identifier)
+        builder = self.catalog.get_table(
+            identifier).new_batch_write_builder().overwrite({})
+        writer = builder.new_write()
+        commit = builder.new_commit()
+        try:
+            writer.write_arrow(data)
+            real_commit = commit.file_store_commit._try_commit
+
+            def compact_commit(*args, **kwargs):
+                kwargs["commit_kind"] = "COMPACT"
+                return real_commit(*args, **kwargs)
+
+            commit.file_store_commit._try_commit = compact_commit
+            commit.commit(writer.prepare_commit())
+        finally:
+            writer.close()
+            commit.close()
+
+    def _read(self, identifier, sort_by="id"):
+        table = self.catalog.get_table(identifier)
+        builder = table.new_read_builder()
+        return builder.new_read().to_arrow(
+            builder.new_scan().plan().splits()).sort_by(sort_by)
+
+    def _write_incrementally(self, target, source, interval=10):
+        if isinstance(source, pa.Table):
+            source = ray.data.from_arrow(source)
+        return write_paimon(
+            source,
+            target,
+            self.catalog_options,
+            commit_mode="incremental",
+            commit_interval_seconds=interval,
+            update_cols=["feature"],
+        )
+
+    @staticmethod
+    def _clock(*values):
+        return mock.patch(
+            "pypaimon.ray.incremental_write.time.monotonic",
+            side_effect=values or itertools.count(step=10))
+
+    def _snapshot_id(self, target):
+        return self.catalog.get_table(
+            target).snapshot_manager().get_latest_snapshot().id
+
+    def _assert_features(self, target, expected):
+        self.assertEqual(expected, self._read(target)["feature"].to_pylist())
+
+    def _prepare_update(self, target, ids, features):
+        table = self.catalog.get_table(target)
+        writer = table.new_batch_write_builder().new_write()
+        try:
+            writer.write_arrow(pa.table({
+                "id": ids,
+                "payload": [None] * len(ids),
+                "feature": features,
+            }, schema=self.target_schema))
+            return writer.prepare_commit()
+        finally:
+            writer.close()
+
+    def test_commits_periodically(self):
+        target = self._create_target()
+        updates = pa.table({
+            "id": list(range(1, 21)),
+            "feature": list(range(101, 121)),
+        }, schema=self.source_schema)
+        updates = ray.data.from_arrow([
+            updates.slice(0, 10), updates.slice(10, 10)])
+        before = self._snapshot_id(target)
+
+        with self._clock():
+            self._write_incrementally(target, updates, interval=1)
+
+        self.assertEqual(2, self._snapshot_id(target) - before)
+        self._assert_features(target, list(range(101, 121)))
+        self.assertEqual(["a", "b", "c"] + [None] * 17,
+                         self._read(target)["payload"].to_pylist())
+
+    def test_failure_keeps_completed_groups(self):
+        target = self._create_target()
+        updates = pa.table({
+            "id": [1, 2],
+            "feature": [101, 102],
+        }, schema=self.source_schema)
+        first_group = self._prepare_update(target, [1], [101])
+
+        def fail_after_first_group(*_args, **kwargs):
+            kwargs["on_group_result"](first_group)
+            raise RuntimeError("injected worker failure")
+
+        with self._clock(), mock.patch(
+                "pypaimon.write.ray_datasink._write_primary_key_groups",
+                side_effect=fail_after_first_group):
+            with self.assertRaisesRegex(
+                    RuntimeError, "injected worker failure"):
+                self._write_incrementally(target, updates, interval=1)
+
+        self._assert_features(target, [101, 20, 30])
+
+    def test_allows_compaction_between_commits(self):
+        target = self._create_target()
+        updates = pa.table({
+            "id": [1, 3],
+            "feature": [101, 103],
+        }, schema=self.source_schema)
+        updates = ray.data.from_arrow([
+            updates.slice(0, 1), updates.slice(1, 1)])
+        groups = [
+            self._prepare_update(target, [1], [101]),
+            self._prepare_update(target, [3], [103]),
+        ]
+        calls = 0
+
+        def compact_between_groups(*_args, **kwargs):
+            nonlocal calls
+            if calls == 1:
+                self._compact(target)
+            kwargs["on_group_result"](groups[calls])
+            calls += 1
+
+        with self._clock(), mock.patch(
+                "pypaimon.write.ray_datasink._write_primary_key_groups",
+                side_effect=compact_between_groups):
+            self._write_incrementally(target, updates, interval=1)
+
+        self._assert_features(target, [101, 20, 103])
+
+    def test_partitioned_composite_key(self):
+        schema = pa.schema([
+            pa.field("key", pa.string(), nullable=False),
+            pa.field("partition", pa.string(), nullable=False),
+            ("payload", pa.string()),
+            ("feature", pa.int32()),
+        ])
+        target = self._create_table(
+            "partitioned",
+            schema,
+            partition_keys=["partition"],
+            primary_keys=["key", "partition"],
+            options={
+                "bucket": "4096",
+                "merge-engine": "partial-update",
+            },
+        )
+        self._write(target, pa.table({
+            "key": ["a", "b"],
+            "partition": ["p1", "p1"],
+            "payload": ["keep-a", "keep-b"],
+            "feature": [1, 2],
+        }, schema=schema))
+
+        write_paimon(
+            ray.data.from_arrow(pa.table({
+                "key": ["a", "b"],
+                "partition": ["p1", "p1"],
+                "feature": [101, 102],
+            })),
+            target,
+            self.catalog_options,
+            commit_mode="incremental",
+            commit_interval_seconds=10,
+            update_cols=["feature"],
+        )
+
+        self.assertEqual(["keep-a", "keep-b"],
+                         self._read(target, "key")["payload"].to_pylist())
+        self.assertEqual([101, 102],
+                         self._read(target, "key")["feature"].to_pylist())
+
+    def test_validates_incremental_mode(self):
+        target = self._create_target()
+        updates = ray.data.from_arrow(pa.table({
+            "id": [1], "feature": [101],
+        }, schema=self.source_schema))
+
+        cases = [
+            ({"commit_mode": "unknown"}, "commit_mode"),
+            ({"commit_mode": "incremental"}, "commit_interval_seconds"),
+            ({"commit_mode": "incremental",
+              "commit_interval_seconds": 0,
+              "update_cols": ["feature"]}, "must be positive"),
+            ({"commit_mode": "incremental",
+              "commit_interval_seconds": 10,
+              "update_cols": ["feature"],
+              "overwrite": True}, "cannot overwrite"),
+        ]
+        for options, error in cases:
+            with self.subTest(options=options):
+                with self.assertRaisesRegex(ValueError, error):
+                    write_paimon(
+                        updates, target, self.catalog_options, **options)
+
+    def test_requires_partial_update_target(self):
+        target = self._create_table(
+            "deduplicate_target",
+            self.target_schema,
+            primary_keys=["id"],
+            options={"bucket": "2"},
+        )
+        with self.assertRaisesRegex(ValueError, "partial-update"):
+            self._write_incrementally(target, pa.table({
+                "id": [1], "feature": [101],
+            }, schema=self.source_schema))
+
+    def test_rejects_concurrent_target_changes(self):
+        from pypaimon.write import ray_datasink
+
+        real_write = ray_datasink._write_primary_key_groups
+        for change, error in (("data", "Concurrent target commit"),
+                              ("schema", "schema change")):
+            with self.subTest(change=change):
+                target = self._create_target()
+
+                def mutate_target(*args, **kwargs):
+                    if change == "data":
+                        self._write(target, pa.table({
+                            "id": [4],
+                            "payload": ["external"],
+                            "feature": [40],
+                        }, schema=self.target_schema))
+                    else:
+                        self.catalog.alter_table(target, [
+                            SchemaChange.add_column(
+                                "extra", AtomicType("STRING"))], False)
+                    return real_write(*args, **kwargs)
+
+                with mock.patch.object(
+                        ray_datasink,
+                        "_write_primary_key_groups",
+                        side_effect=mutate_target):
+                    with self.assertRaisesRegex(RuntimeError, error):
+                        self._write_incrementally(target, pa.table({
+                            "id": [1], "feature": [101],
+                        }, schema=self.source_schema))
+
+                expected = [10, 20, 30, 40] if change == "data" else [10, 20, 30]
+                self._assert_features(target, expected)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/paimon-python/pypaimon/tests/ray_incremental_write_test.py
+++ b/paimon-python/pypaimon/tests/ray_incremental_write_test.py
@@ -288,12 +288,22 @@ class RayIncrementalWriteTest(unittest.TestCase):
               "commit_interval_seconds": 10,
               "update_cols": ["feature"],
               "overwrite": True}, "cannot overwrite"),
+            ({"commit_mode": "incremental",
+              "commit_interval_seconds": 10,
+              "update_cols": ["feature"],
+              "hash_fixed_precluster": "off"}, "always groups HASH_FIXED"),
         ]
         for options, error in cases:
             with self.subTest(options=options):
                 with self.assertRaisesRegex(ValueError, error):
                     write_paimon(
                         updates, target, self.catalog_options, **options)
+
+    def test_requires_ray_windowing_api(self):
+        from pypaimon.ray.incremental_write import _dataset_windows
+
+        with self.assertRaisesRegex(RuntimeError, "Ray 2.33"):
+            next(_dataset_windows(object(), 1))
 
     def test_requires_partial_update_target(self):
         target = self._create_table(

--- a/paimon-python/pypaimon/tests/write/commit_callback_test.py
+++ b/paimon-python/pypaimon/tests/write/commit_callback_test.py
@@ -91,6 +91,33 @@ class CommitCallbackTest(unittest.TestCase):
         table_write.close()
         table_commit.close()
 
+    def test_callback_invoked_when_retry_finds_commit(self):
+        table = self._create_table('test_callback_after_uncertain_commit')
+        builder = table.new_batch_write_builder()
+        table_write = builder.new_write()
+        table_commit = builder.new_commit()
+        callback = RecordingCallback()
+        table_commit.add_commit_callback(callback)
+
+        table_write.write_arrow(pa.Table.from_pydict({
+            'id': [1], 'name': ['a'], 'dt': ['p1'],
+        }, schema=self.pa_schema))
+        real_commit = table_commit.file_store_commit.snapshot_commit.commit
+
+        def commit_then_lose_response(*args):
+            self.assertTrue(real_commit(*args))
+            raise TimeoutError('lost commit response')
+
+        table_commit.file_store_commit.snapshot_commit.commit = (
+            commit_then_lose_response)
+        table_commit.file_store_commit._commit_retry_wait = lambda _: None
+        table_commit.commit(table_write.prepare_commit())
+
+        self.assertEqual(1, len(callback.contexts))
+        self.assertEqual(1, callback.contexts[0].snapshot.id)
+        table_write.close()
+        table_commit.close()
+
     def test_callback_receives_correct_snapshot_data(self):
         table = self._create_table('test_callback_snapshot_data', partition_keys=['dt'])
         write_builder = table.new_batch_write_builder()

--- a/paimon-python/pypaimon/write/file_store_commit.py
+++ b/paimon-python/pypaimon/write/file_store_commit.py
@@ -170,9 +170,7 @@ class FileStoreCommit:
         self.table: FileStoreTable = table
         self.commit_user = commit_user
         self.commit_callbacks: List[CommitCallback] = commit_callbacks if commit_callbacks is not None else []
-        self.expected_base_snapshot_id = None
         self.expected_schema_id = None
-        self.allow_concurrent_maintenance = False
 
         self.snapshot_manager = table.snapshot_manager()
         self.manifest_file_manager = ManifestFileManager(table)
@@ -207,17 +205,11 @@ class FileStoreCommit:
         table_rollback = table.catalog_environment.catalog_table_rollback()
         self.rollback = CommitRollback(table_rollback) if table_rollback is not None else None
 
-    def protect_from_external_commits(
-            self, base_snapshot, schema_id, allow_maintenance=False):
-        self.expected_base_snapshot_id = (
-            base_snapshot.id if base_snapshot is not None else 0)
+    def protect_from_schema_changes(self, schema_id):
         self.expected_schema_id = schema_id
-        self.allow_concurrent_maintenance = allow_maintenance
 
     def clear_commit_context(self):
-        self.expected_base_snapshot_id = None
         self.expected_schema_id = None
-        self.allow_concurrent_maintenance = False
 
     def commit(self, commit_messages: List[CommitMessage], commit_identifier: int):
         """Commit the given commit messages in normal append mode."""
@@ -560,20 +552,6 @@ class FileStoreCommit:
             self._commit_retry_wait(retry_count)
             retry_count += 1
 
-    def _is_allowed_protected_base(self, latest_snapshot_id):
-        expected = self.expected_base_snapshot_id
-        if latest_snapshot_id == expected:
-            return True
-        if (not self.allow_concurrent_maintenance
-                or latest_snapshot_id < expected):
-            return False
-        for snapshot_id in range(expected + 1, latest_snapshot_id + 1):
-            snapshot = self.snapshot_manager.get_snapshot_by_id(snapshot_id)
-            if (snapshot is None
-                    or snapshot.commit_kind not in ("COMPACT", "ANALYZE")):
-                return False
-        return True
-
     def _try_commit_once(self, retry_result: Optional[RetryResult], commit_kind: str,
                          commit_entries: List[ManifestEntry],
                          changelog_entries: List[ManifestEntry],
@@ -590,13 +568,11 @@ class FileStoreCommit:
             return SuccessResult()
 
         latest_snapshot_id = latest_snapshot.id if latest_snapshot else 0
-        if self.expected_base_snapshot_id is not None:
+        if self.expected_schema_id is not None:
             latest_schema = self.table.schema_manager.latest()
             latest_schema_id = latest_schema.id if latest_schema else None
-            if (not self._is_allowed_protected_base(latest_snapshot_id)
-                    or latest_schema_id != self.expected_schema_id):
-                conflict = RuntimeError(
-                    "Concurrent target commit or schema change detected.")
+            if latest_schema_id != self.expected_schema_id:
+                conflict = RuntimeError("Target schema changed during write.")
                 if retry_result is None or retry_result.exception is None:
                     raise CommitConflictError(str(conflict)) from conflict
                 raise conflict

--- a/paimon-python/pypaimon/write/file_store_commit.py
+++ b/paimon-python/pypaimon/write/file_store_commit.py
@@ -170,6 +170,9 @@ class FileStoreCommit:
         self.table: FileStoreTable = table
         self.commit_user = commit_user
         self.commit_callbacks: List[CommitCallback] = commit_callbacks if commit_callbacks is not None else []
+        self.expected_base_snapshot_id = None
+        self.expected_schema_id = None
+        self.allow_concurrent_maintenance = False
 
         self.snapshot_manager = table.snapshot_manager()
         self.manifest_file_manager = ManifestFileManager(table)
@@ -204,9 +207,22 @@ class FileStoreCommit:
         table_rollback = table.catalog_environment.catalog_table_rollback()
         self.rollback = CommitRollback(table_rollback) if table_rollback is not None else None
 
+    def protect_from_external_commits(
+            self, base_snapshot, schema_id, allow_maintenance=False):
+        self.expected_base_snapshot_id = (
+            base_snapshot.id if base_snapshot is not None else 0)
+        self.expected_schema_id = schema_id
+        self.allow_concurrent_maintenance = allow_maintenance
+
+    def clear_commit_context(self):
+        self.expected_base_snapshot_id = None
+        self.expected_schema_id = None
+        self.allow_concurrent_maintenance = False
+
     def commit(self, commit_messages: List[CommitMessage], commit_identifier: int):
         """Commit the given commit messages in normal append mode."""
         if not commit_messages:
+            self.clear_commit_context()
             return
 
         # Extract the minimum check_from_snapshot from commit messages
@@ -457,6 +473,7 @@ class FileStoreCommit:
             # No entries to commit (e.g. drop_partitions with no matching data): skip commit
             # to avoid creating manifest/snapshot with empty partition_stats (causes read errors).
             if not commit_entries and not index_deletes and not index_adds:
+                self.clear_commit_context()
                 break
 
             result = self._try_commit_once(
@@ -503,6 +520,7 @@ class FileStoreCommit:
                         self.table.identifier,
                         commit_duration_ms,
                     )
+                self.clear_commit_context()
                 break
             else:
                 retry_result = result
@@ -542,6 +560,20 @@ class FileStoreCommit:
             self._commit_retry_wait(retry_count)
             retry_count += 1
 
+    def _is_allowed_protected_base(self, latest_snapshot_id):
+        expected = self.expected_base_snapshot_id
+        if latest_snapshot_id == expected:
+            return True
+        if (not self.allow_concurrent_maintenance
+                or latest_snapshot_id < expected):
+            return False
+        for snapshot_id in range(expected + 1, latest_snapshot_id + 1):
+            snapshot = self.snapshot_manager.get_snapshot_by_id(snapshot_id)
+            if (snapshot is None
+                    or snapshot.commit_kind not in ("COMPACT", "ANALYZE")):
+                return False
+        return True
+
     def _try_commit_once(self, retry_result: Optional[RetryResult], commit_kind: str,
                          commit_entries: List[ManifestEntry],
                          changelog_entries: List[ManifestEntry],
@@ -558,6 +590,17 @@ class FileStoreCommit:
             return SuccessResult()
 
         latest_snapshot_id = latest_snapshot.id if latest_snapshot else 0
+        if self.expected_base_snapshot_id is not None:
+            latest_schema = self.table.schema_manager.latest()
+            latest_schema_id = latest_schema.id if latest_schema else None
+            if (not self._is_allowed_protected_base(latest_snapshot_id)
+                    or latest_schema_id != self.expected_schema_id):
+                conflict = RuntimeError(
+                    "Concurrent target commit or schema change detected.")
+                if retry_result is None or retry_result.exception is None:
+                    raise CommitConflictError(str(conflict)) from conflict
+                raise conflict
+
         if (
             hash_index_base_snapshot is not None
             and latest_snapshot_id != hash_index_base_snapshot

--- a/paimon-python/pypaimon/write/file_store_commit.py
+++ b/paimon-python/pypaimon/write/file_store_commit.py
@@ -564,7 +564,13 @@ class FileStoreCommit:
                          hash_index_base_snapshot=None,
                          commit_result_may_be_uncertain: bool = False) -> CommitResult:
         start_millis = int(time.time() * 1000)
-        if self._is_duplicate_commit(retry_result, latest_snapshot, commit_identifier, commit_kind):
+        duplicate = self._find_duplicate_commit(
+            retry_result, latest_snapshot, commit_identifier, commit_kind)
+        if duplicate is not None:
+            # Overwrite entries may be replanned during retry.
+            if commit_kind == "APPEND":
+                self._notify_commit_callbacks(
+                    duplicate, commit_entries, commit_identifier)
             return SuccessResult()
 
         latest_snapshot_id = latest_snapshot.id if latest_snapshot else 0
@@ -832,14 +838,8 @@ class FileStoreCommit:
             commit_kind,
         )
 
-        if self.commit_callbacks:
-            context = CommitCallbackContext(
-                snapshot=snapshot_data,
-                commit_entries=commit_entries,
-                identifier=commit_identifier,
-            )
-            for callback in self.commit_callbacks:
-                callback.call(context)
+        self._notify_commit_callbacks(
+            snapshot_data, commit_entries, commit_identifier)
 
         return SuccessResult()
 
@@ -890,7 +890,9 @@ class FileStoreCommit:
         return self.manifest_file_manager.rolling_write(
             commit_entries, self.manifest_target_size, base_name)
 
-    def _is_duplicate_commit(self, retry_result, latest_snapshot, commit_identifier, commit_kind) -> bool:
+    def _find_duplicate_commit(
+            self, retry_result, latest_snapshot, commit_identifier,
+            commit_kind):
         if retry_result is not None and latest_snapshot is not None:
             start_check_snapshot_id = 1  # Snapshot.FIRST_SNAPSHOT_ID
             if retry_result.latest_snapshot is not None:
@@ -905,8 +907,20 @@ class FileStoreCommit:
                         f"Commit already completed (snapshot {snapshot_id}), "
                         f"user: {self.commit_user}, identifier: {commit_identifier}"
                     )
-                    return True
-        return False
+                    return snapshot
+        return None
+
+    def _notify_commit_callbacks(
+            self, snapshot, commit_entries, commit_identifier):
+        if not self.commit_callbacks:
+            return
+        context = CommitCallbackContext(
+            snapshot=snapshot,
+            commit_entries=commit_entries,
+            identifier=commit_identifier,
+        )
+        for callback in self.commit_callbacks:
+            callback.call(context)
 
     def _create_dynamic_partition_filter(self, commit_messages: List[CommitMessage]):
         """Build a partition filter from the unique partitions present in commit_messages."""

--- a/paimon-python/pypaimon/write/file_store_commit.py
+++ b/paimon-python/pypaimon/write/file_store_commit.py
@@ -170,7 +170,6 @@ class FileStoreCommit:
         self.table: FileStoreTable = table
         self.commit_user = commit_user
         self.commit_callbacks: List[CommitCallback] = commit_callbacks if commit_callbacks is not None else []
-        self.expected_schema_id = None
 
         self.snapshot_manager = table.snapshot_manager()
         self.manifest_file_manager = ManifestFileManager(table)
@@ -205,16 +204,9 @@ class FileStoreCommit:
         table_rollback = table.catalog_environment.catalog_table_rollback()
         self.rollback = CommitRollback(table_rollback) if table_rollback is not None else None
 
-    def protect_from_schema_changes(self, schema_id):
-        self.expected_schema_id = schema_id
-
-    def clear_commit_context(self):
-        self.expected_schema_id = None
-
     def commit(self, commit_messages: List[CommitMessage], commit_identifier: int):
         """Commit the given commit messages in normal append mode."""
         if not commit_messages:
-            self.clear_commit_context()
             return
 
         # Extract the minimum check_from_snapshot from commit messages
@@ -465,7 +457,6 @@ class FileStoreCommit:
             # No entries to commit (e.g. drop_partitions with no matching data): skip commit
             # to avoid creating manifest/snapshot with empty partition_stats (causes read errors).
             if not commit_entries and not index_deletes and not index_adds:
-                self.clear_commit_context()
                 break
 
             result = self._try_commit_once(
@@ -512,7 +503,6 @@ class FileStoreCommit:
                         self.table.identifier,
                         commit_duration_ms,
                     )
-                self.clear_commit_context()
                 break
             else:
                 retry_result = result
@@ -574,15 +564,6 @@ class FileStoreCommit:
             return SuccessResult()
 
         latest_snapshot_id = latest_snapshot.id if latest_snapshot else 0
-        if self.expected_schema_id is not None:
-            latest_schema = self.table.schema_manager.latest()
-            latest_schema_id = latest_schema.id if latest_schema else None
-            if latest_schema_id != self.expected_schema_id:
-                conflict = RuntimeError("Target schema changed during write.")
-                if retry_result is None or retry_result.exception is None:
-                    raise CommitConflictError(str(conflict)) from conflict
-                raise conflict
-
         if (
             hash_index_base_snapshot is not None
             and latest_snapshot_id != hash_index_base_snapshot

--- a/paimon-python/pypaimon/write/ray_datasink.py
+++ b/paimon-python/pypaimon/write/ray_datasink.py
@@ -263,6 +263,67 @@ class PaimonDatasink(_DatasinkBase):
                 self._pending_commit_messages = []
 
 
+def _prepare_incremental_update(table, target, update_cols):
+    from pypaimon.common.options.core_options import MergeEngine
+    from pypaimon.schema.data_types import PyarrowFieldParser
+    from pypaimon.table.bucket_mode import BucketMode
+
+    if not update_cols:
+        raise ValueError("update_cols must be non-empty.")
+    update_cols = list(dict.fromkeys(update_cols))
+    if not (
+            table.is_primary_key_table
+            and table.bucket_mode() == BucketMode.HASH_FIXED
+            and table.options.merge_engine() == MergeEngine.PARTIAL_UPDATE):
+        raise ValueError(
+            "incremental write_paimon requires a fixed-bucket primary-key "
+            "target with 'merge-engine'='partial-update'.")
+    if table.cross_partition_update:
+        raise ValueError(
+            "incremental write_paimon does not support cross-partition "
+            "updates.")
+    if table.options.sequence_field():
+        raise ValueError(
+            "incremental write_paimon does not support sequence fields.")
+
+    primary_keys = list(table.primary_keys)
+    invalid = [
+        name for name in update_cols
+        if name not in table.field_names or name in primary_keys]
+    if invalid:
+        raise ValueError(
+            "update column {!r} must be a non-key column in target {!r}.".format(
+                invalid[0], target))
+    omitted_non_null = [
+        field.name for field in table.table_schema.fields
+        if (field.name not in primary_keys
+            and field.name not in update_cols
+            and not field.type.nullable)
+    ]
+    if omitted_non_null:
+        raise ValueError(
+            "unprovided partial-update column {!r} must be nullable.".format(
+                omitted_non_null[0]))
+
+    target_schema = PyarrowFieldParser.from_paimon_schema(
+        table.table_schema.fields)
+    required = primary_keys + update_cols
+
+    def to_write_batch(batch):
+        missing = [name for name in required if name not in batch.column_names]
+        if missing:
+            raise ValueError("source is missing columns {}.".format(missing))
+        arrays = [
+            batch.column(field.name).cast(field.type)
+            if field.name in required
+            else pa.nulls(batch.num_rows, type=field.type)
+            for field in target_schema
+        ]
+        return pa.Table.from_arrays(arrays, schema=target_schema)
+
+    return to_write_batch
+
+
 def write_paimon_dataset(
     dataset,
     table,
@@ -465,6 +526,7 @@ def _consume_write_results(
     coordinator,
     message_col,
     error_col=None,
+    on_write_result=None,
 ) -> None:
     import pickle
 
@@ -479,17 +541,21 @@ def _consume_write_results(
             )
             for blob, error in zip(messages, batch_errors):
                 commit_messages = pickle.loads(blob)
-                write_returns.append(commit_messages)
-                coordinator.add_pending_commit_messages(commit_messages)
+                if on_write_result is None:
+                    write_returns.append(commit_messages)
+                    coordinator.add_pending_commit_messages(commit_messages)
                 if error is not None:
                     errors.append(error)
+                elif on_write_result is not None:
+                    on_write_result(commit_messages)
         if errors:
             raise RuntimeError(
                 "One or more Ray write tasks failed:\n{}".format(
                     "\n".join(errors)
                 )
             )
-        coordinator.on_write_complete(write_returns)
+        if on_write_result is None:
+            coordinator.on_write_complete(write_returns)
     except Exception as error:
         coordinator.on_write_failed(error)
         raise
@@ -548,6 +614,7 @@ def _write_primary_key_groups(
     ray_remote_args: Optional[Dict[str, Any]],
     bucket_extractor=None,
     postpone_bucket_plan=None,
+    on_group_result=None,
 ) -> None:
     import pickle
 
@@ -609,5 +676,5 @@ def _write_primary_key_groups(
     )
     coordinator.on_write_start()
     _consume_write_results(
-        messages, coordinator, message_col, error_col
+        messages, coordinator, message_col, error_col, on_group_result
     )

--- a/paimon-python/pypaimon/write/ray_datasink.py
+++ b/paimon-python/pypaimon/write/ray_datasink.py
@@ -674,7 +674,8 @@ def _write_primary_key_groups(
         overwrite=overwrite,
         static_partition=static_partition,
     )
-    coordinator.on_write_start()
+    if on_group_result is None:
+        coordinator.on_write_start()
     _consume_write_results(
         messages, coordinator, message_col, error_col, on_group_result
     )

--- a/paimon-python/pypaimon/write/table_commit.py
+++ b/paimon-python/pypaimon/write/table_commit.py
@@ -61,10 +61,8 @@ class TableCommit:
         """Register a callback to be invoked after each successful commit."""
         self._commit_callbacks.append(callback)
 
-    def protect_from_external_commits(
-            self, base_snapshot, schema_id, allow_maintenance=False):
-        self.file_store_commit.protect_from_external_commits(
-            base_snapshot, schema_id, allow_maintenance)
+    def protect_from_schema_changes(self, schema_id):
+        self.file_store_commit.protect_from_schema_changes(schema_id)
         return self
 
     def _commit(self, commit_messages: List[CommitMessage], commit_identifier: int = BATCH_COMMIT_IDENTIFIER):

--- a/paimon-python/pypaimon/write/table_commit.py
+++ b/paimon-python/pypaimon/write/table_commit.py
@@ -61,10 +61,6 @@ class TableCommit:
         """Register a callback to be invoked after each successful commit."""
         self._commit_callbacks.append(callback)
 
-    def protect_from_schema_changes(self, schema_id):
-        self.file_store_commit.protect_from_schema_changes(schema_id)
-        return self
-
     def _commit(self, commit_messages: List[CommitMessage], commit_identifier: int = BATCH_COMMIT_IDENTIFIER):
         non_empty_messages = [msg for msg in commit_messages if not msg.is_empty()]
 
@@ -84,7 +80,6 @@ class TableCommit:
                 )
             else:
                 if not non_empty_messages:
-                    self.file_store_commit.clear_commit_context()
                     return
                 logger.info(
                     "Committing table %s, %d non-empty messages",

--- a/paimon-python/pypaimon/write/table_commit.py
+++ b/paimon-python/pypaimon/write/table_commit.py
@@ -61,6 +61,12 @@ class TableCommit:
         """Register a callback to be invoked after each successful commit."""
         self._commit_callbacks.append(callback)
 
+    def protect_from_external_commits(
+            self, base_snapshot, schema_id, allow_maintenance=False):
+        self.file_store_commit.protect_from_external_commits(
+            base_snapshot, schema_id, allow_maintenance)
+        return self
+
     def _commit(self, commit_messages: List[CommitMessage], commit_identifier: int = BATCH_COMMIT_IDENTIFIER):
         non_empty_messages = [msg for msg in commit_messages if not msg.is_empty()]
 
@@ -80,6 +86,7 @@ class TableCommit:
                 )
             else:
                 if not non_empty_messages:
+                    self.file_store_commit.clear_commit_context()
                     return
                 logger.info(
                     "Committing table %s, %d non-empty messages",


### PR DESCRIPTION
### Purpose

`write_paimon` normally publishes one snapshot after the entire Ray Dataset finishes. For a job that runs for hours or days, a late failure leaves none of that write visible, so users must manually split the input and call `write_paimon` batch by batch.

This PR makes that batching internal. With `commit_mode="incremental"`, completed primary-key groups are committed at a target time interval. If a later group fails, earlier commits remain visible.

This is periodic commit, not source checkpoint recovery. Retrying reruns the Ray Dataset from the beginning and upserts already committed keys again.

### Changes

- add `commit_mode="incremental"`, `commit_interval_seconds`, and `update_cols` to `write_paimon`;
- periodically commit completed fixed-bucket primary-key groups;
- update existing keys and insert new keys using `merge-engine=partial-update`;
- retain completed commits after a later worker failure;
- allow concurrent partial updates to different fields.

The target must be a fixed-bucket primary-key table using `merge-engine=partial-update`. Incremental mode requires Ray 2.33 or later. Concurrent jobs updating the same field must not rely on a deterministic winner.

### Tests

- real Ray E2E for periodic commits, upserts, worker failure, full retry, concurrent partial updates, 4096 buckets, partitioned composite keys, and compaction;
- deterministic regression for a materialized Dataset whose group writes exceed the interval;
- Hangzhou staging DLF + OSS E2E covering two periodic snapshots, concurrent updates to different fields, injected failure, full retry, and preserved non-updated columns;
- uncertain-commit callback, Ray sink, shuffle, and table commit regressions;
- project flake8 and `git diff --check`.

Latest local validation: 100 passed with Ray 2.56.1.
