### PR TITLE
[flink] Report which required argument is missing in action factories

### DIFF
--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/action/CreateTagFromTimestampActionFactory.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/action/CreateTagFromTimestampActionFactory.java
@@ -38,7 +38,7 @@ public class CreateTagFromTimestampActionFactory implements ActionFactory {
 
     @Override
     public Optional<Action> create(MultipleParameterToolAdapter params) {
-        Long timestamp = Long.parseLong(params.get(TIMESTAMP));
+        Long timestamp = Long.parseLong(params.getRequired(TIMESTAMP));
         String timeRetained = params.get(TIME_RETAINED);
         Map<String, String> catalogConfig = catalogConfigMap(params);
 

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/action/CreateTagFromWatermarkActionFactory.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/action/CreateTagFromWatermarkActionFactory.java
@@ -39,8 +39,8 @@ public class CreateTagFromWatermarkActionFactory implements ActionFactory {
 
     @Override
     public Optional<Action> create(MultipleParameterToolAdapter params) {
-        String tag = params.get(TAG);
-        Long watermark = Long.parseLong(params.get(WATERMARK));
+        String tag = params.getRequired(TAG);
+        Long watermark = Long.parseLong(params.getRequired(WATERMARK));
         String timeRetained = params.get(TIME_RETAINED);
         Map<String, String> catalogConfig = catalogConfigMap(params);
 

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/action/MergeIntoActionFactory.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/action/MergeIntoActionFactory.java
@@ -80,7 +80,7 @@ public class MergeIntoActionFactory implements ActionFactory {
         action.withMergeCondition(params.getRequired(ON));
 
         List<String> actions =
-                Arrays.stream(params.get(MERGE_ACTIONS).split(","))
+                Arrays.stream(params.getRequired(MERGE_ACTIONS).split(","))
                         .map(String::trim)
                         .collect(Collectors.toList());
         if (actions.contains(MATCHED_UPSERT)) {

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/action/CreateTagFromTimestampActionFactoryTest.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/action/CreateTagFromTimestampActionFactoryTest.java
@@ -1,0 +1,70 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.flink.action;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/** Tests for {@link CreateTagFromTimestampActionFactory#create}. */
+public class CreateTagFromTimestampActionFactoryTest extends ActionITCaseBase {
+
+    @Test
+    public void testMissingTimestampReportsRequiredArgument() {
+        assertThatThrownBy(
+                        () ->
+                                createAction(
+                                        CreateTagFromTimestampAction.class,
+                                        "create_tag_from_timestamp",
+                                        "--warehouse",
+                                        warehouse,
+                                        "--database",
+                                        database,
+                                        "--table",
+                                        tableName,
+                                        "--tag",
+                                        "tag_1"))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("Argument 'timestamp' is required");
+    }
+
+    @Test
+    public void testCreateWithTimestamp() {
+        assertThatCode(
+                        () ->
+                                assertThat(
+                                                createAction(
+                                                        CreateTagFromTimestampAction.class,
+                                                        "create_tag_from_timestamp",
+                                                        "--warehouse",
+                                                        warehouse,
+                                                        "--database",
+                                                        database,
+                                                        "--table",
+                                                        tableName,
+                                                        "--tag",
+                                                        "tag_1",
+                                                        "--timestamp",
+                                                        "1000"))
+                                        .isNotNull())
+                .doesNotThrowAnyException();
+    }
+}

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/action/CreateTagFromWatermarkActionFactoryTest.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/action/CreateTagFromWatermarkActionFactoryTest.java
@@ -1,0 +1,89 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.flink.action;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/** Tests for {@link CreateTagFromWatermarkActionFactory#create}. */
+public class CreateTagFromWatermarkActionFactoryTest extends ActionITCaseBase {
+
+    @Test
+    public void testMissingWatermarkReportsRequiredArgument() {
+        assertThatThrownBy(
+                        () ->
+                                createAction(
+                                        CreateTagFromWatermarkAction.class,
+                                        "create_tag_from_watermark",
+                                        "--warehouse",
+                                        warehouse,
+                                        "--database",
+                                        database,
+                                        "--table",
+                                        tableName,
+                                        "--tag",
+                                        "tag_1"))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("Argument 'watermark' is required");
+    }
+
+    @Test
+    public void testMissingTagReportsRequiredArgument() {
+        assertThatThrownBy(
+                        () ->
+                                createAction(
+                                        CreateTagFromWatermarkAction.class,
+                                        "create_tag_from_watermark",
+                                        "--warehouse",
+                                        warehouse,
+                                        "--database",
+                                        database,
+                                        "--table",
+                                        tableName,
+                                        "--watermark",
+                                        "1000"))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("Argument 'tag' is required");
+    }
+
+    @Test
+    public void testCreateWithTagAndWatermark() {
+        assertThatCode(
+                        () ->
+                                assertThat(
+                                                createAction(
+                                                        CreateTagFromWatermarkAction.class,
+                                                        "create_tag_from_watermark",
+                                                        "--warehouse",
+                                                        warehouse,
+                                                        "--database",
+                                                        database,
+                                                        "--table",
+                                                        tableName,
+                                                        "--tag",
+                                                        "tag_1",
+                                                        "--watermark",
+                                                        "1000"))
+                                        .isNotNull())
+                .doesNotThrowAnyException();
+    }
+}

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/action/MergeIntoActionFactoryTest.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/action/MergeIntoActionFactoryTest.java
@@ -1,0 +1,98 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.flink.action;
+
+import org.apache.paimon.types.DataType;
+import org.apache.paimon.types.DataTypes;
+import org.apache.paimon.types.RowType;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+import java.util.HashMap;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/** Tests for {@link MergeIntoActionFactory#create}. */
+public class MergeIntoActionFactoryTest extends ActionITCaseBase {
+
+    @BeforeEach
+    public void setUp() throws Exception {
+        // merge_into loads the target table before parsing --merge_actions, so it must exist and
+        // must have primary keys
+        DataType[] fieldTypes = new DataType[] {DataTypes.INT(), DataTypes.STRING()};
+        RowType rowType = RowType.of(fieldTypes, new String[] {"k", "v"});
+        createFileStoreTable(
+                rowType,
+                Collections.emptyList(),
+                Collections.singletonList("k"),
+                Collections.emptyList(),
+                new HashMap<>());
+    }
+
+    @Test
+    public void testMissingMergeActionsReportsRequiredArgument() {
+        assertThatThrownBy(
+                        () ->
+                                createAction(
+                                        MergeIntoAction.class,
+                                        "merge_into",
+                                        "--warehouse",
+                                        warehouse,
+                                        "--database",
+                                        database,
+                                        "--table",
+                                        tableName,
+                                        "--source_table",
+                                        "S",
+                                        "--on",
+                                        "T.k = S.k"))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("Argument 'merge_actions' is required");
+    }
+
+    @Test
+    public void testCreateWithMergeActions() {
+        assertThatCode(
+                        () ->
+                                assertThat(
+                                                createAction(
+                                                        MergeIntoAction.class,
+                                                        "merge_into",
+                                                        "--warehouse",
+                                                        warehouse,
+                                                        "--database",
+                                                        database,
+                                                        "--table",
+                                                        tableName,
+                                                        "--source_table",
+                                                        "S",
+                                                        "--on",
+                                                        "T.k = S.k",
+                                                        "--merge_actions",
+                                                        "matched-upsert",
+                                                        "--matched_upsert_set",
+                                                        "v = S.v"))
+                                        .isNotNull())
+                .doesNotThrowAnyException();
+    }
+}


### PR DESCRIPTION
### Purpose

fix #9058

- Omitting a required action argument produces an exception that does not say **which** argument is missing: `merge_into` throws a bare `NullPointerException`, `create_tag_from_timestamp` and `create_tag_from_watermark` throw `NumberFormatException: null`.
- Those four arguments (`merge_actions`, `timestamp`, `tag`, `watermark`) are read with `params.get(...)` and dereferenced at once.
- Their sibling arguments already use `params.getRequired(...)`, which reports `Argument '<name>' is required.`; `DropPartitionActionFactory` enforces the same contract.
- Same defect class as #8611, which fixed only the `migrate_*` factories.

### Tests

- Added `MergeIntoActionFactoryTest`, `CreateTagFromTimestampActionFactoryTest` and `CreateTagFromWatermarkActionFactoryTest` (7 tests). The four missing-argument tests fail without this change.
- `mvn -pl paimon-flink/paimon-flink-common -Pflink1 -DfailIfNoTests=false clean install` — BUILD SUCCESS, 2258 tests, 0 failures, 8 skipped.
