### PR TITLE
[docs] Fix full-text index option defaults and search query examples

### DIFF
--- a/docs/docs/flink/procedures.md
+++ b/docs/docs/flink/procedures.md
@@ -1164,7 +1164,7 @@ All available procedures are listed below.
          CALL sys.full_text_search(<br/>
             `table` => 'default.articles',<br/>
             `column` => 'content',<br/>
-            query => '{"match":{"column":"content","terms":"paimon lake"}}',<br/>
+            query => '{"match":{"query":"paimon lake"}}',<br/>
             top_k => 10,<br/>
             projection => 'id,content,__paimon_search_score')
       </td>

--- a/docs/docs/primary-key-table/global-index.mdx
+++ b/docs/docs/primary-key-table/global-index.mdx
@@ -414,7 +414,7 @@ SELECT id, content, __paimon_search_score
 FROM full_text_search(
     'items',
     'content',
-    '{"match":{"column":"content","terms":"paimon lake"}}',
+    '{"match":{"query":"paimon lake"}}',
     10
 )
 ORDER BY __paimon_search_score DESC;
@@ -431,7 +431,7 @@ relevance score is required. `top_k` must be between 1 and 10,000.
 CALL sys.full_text_search(
     `table` => 'default.items',
     `column` => 'content',
-    query => '{"match":{"column":"content","terms":"paimon lake"}}',
+    query => '{"match":{"query":"paimon lake"}}',
     top_k => 10,
     projection => 'id,content,__paimon_search_score'
 );
@@ -480,7 +480,7 @@ FROM hybrid_search(
         'options', map())),
     array(named_struct(
         'column', 'content',
-        'query', '{"match":{"column":"content","terms":"paimon lake"}}',
+        'query', '{"match":{"query":"paimon lake"}}',
         'limit', 20,
         'weight', 1.0f,
         'options', map())),

--- a/paimon-full-text/README.md
+++ b/paimon-full-text/README.md
@@ -129,7 +129,7 @@ scores through its configured `rrf`, `weighted_score`, or `mrr` ranker.
 CALL sys.full_text_search(
     `table` => 'default.articles',
     `column` => 'content',
-    query => '{"match":{"column":"content","terms":"paimon lake"}}',
+    query => '{"match":{"query":"paimon lake"}}',
     top_k => 10,
     projection => 'id,content,__paimon_search_score'
 );
@@ -178,16 +178,18 @@ Available tokenizer options:
 | Option | Default | Description |
 |--------|---------|-------------|
 | `full-text.tokenizer` | `default` | Tokenizer used by the full-text index. Supported values: `default`, `simple`, `whitespace`, `raw`, `ngram`, `jieba`. |
-| `full-text.ngram.min-gram` | `2` | Minimum gram length for the `ngram` tokenizer. |
-| `full-text.ngram.max-gram` | `2` | Maximum gram length for the `ngram` tokenizer. |
+| `full-text.ngram.min-gram` | `3` | Minimum gram length for the `ngram` tokenizer. |
+| `full-text.ngram.max-gram` | `3` | Maximum gram length for the `ngram` tokenizer. |
 | `full-text.ngram.prefix-only` | `false` | Whether the `ngram` tokenizer only emits prefix ngrams. |
+| `full-text.jieba.search-mode` | `true` | Whether the `jieba` tokenizer uses search mode. |
+| `full-text.jieba.ordinal-position` | `true` | Whether the `jieba` tokenizer uses ordinal positions. |
 | `full-text.lower-case` | `true` | Whether configurable tokenizers lowercase emitted tokens. |
 | `full-text.max-token-length` | `40` | Maximum token length kept by configurable tokenizers. |
-| `full-text.ascii-folding` | `false` | Whether to normalize non-ASCII Latin characters to ASCII. |
-| `full-text.stem` | `false` | Whether to apply stemming to emitted tokens. |
+| `full-text.ascii-folding` | `true` | Whether to normalize non-ASCII Latin characters to ASCII. |
+| `full-text.stem` | `true` | Whether to apply stemming to emitted tokens. |
 | `full-text.language` | `english` | Language used by stemming and built-in stop word filters. |
-| `full-text.remove-stop-words` | `false` | Whether to remove built-in stop words for the configured language. |
-| `full-text.stop-words` | ` ` | Semicolon-separated custom stop words to remove. |
+| `full-text.remove-stop-words` | `true` | Whether to remove built-in stop words for the configured language. |
+| `full-text.stop-words` | empty | Semicolon-separated custom stop words to remove. Requires `full-text.remove-stop-words=true`. |
 | `full-text.with-position` | `true` | Whether to store term positions for phrase queries. |
 
 Tokenizer settings are persisted in each global index file's metadata. Readers use that metadata


### PR DESCRIPTION
### Purpose

fix #9061

- Copying the primary-key full-text examples fails with `invalid query: full-text query column 'content' is not configured for this index`. The column is a procedure/API argument, not a JSON field (`full-text.mdx` Notes). From #8659; corrected in 5 places.
- `docs/primary-key-table/global-index` delegates analyzer options to this README, whose `Default` column still holds pre-`full-text` Tantivy values: `stem`/`remove-stop-words`/`ascii-folding` say `false`, 0.1.0 defaults them `true`; `ngram.min-gram`/`max-gram` say `2` but default to `3` — a two-character `ngram` query from this table returns zero rows. Adds missing `jieba` rows.

### Tests

- Docs only — no test added.
- Defaults checked against `paimon-full-text-index` 0.1.0, comparing search hits of default vs. explicit-option indexes (macOS aarch64 / JDK 11): min/max-gram, `ascii-folding`, `stem`, `remove-stop-words`, the `stop-words` constraint and `jieba.search-mode`. `jieba.ordinal-position` mirrors `full-text.mdx`.
- Query examples replayed against the native reader: the documented one throws, the corrected returns rows.
