### PR TITLE
[hive] Fix Hive read failure for CHAR/VARCHAR columns exceeding Hive length limits

### DIFF
--- a/paimon-hive/paimon-hive-connector-common/src/main/java/org/apache/paimon/hive/objectinspector/PaimonObjectInspectorFactory.java
+++ b/paimon-hive/paimon-hive-connector-common/src/main/java/org/apache/paimon/hive/objectinspector/PaimonObjectInspectorFactory.java
@@ -32,6 +32,8 @@ import org.apache.paimon.types.TimeType;
 import org.apache.paimon.types.VarCharType;
 import org.apache.paimon.types.VectorType;
 
+import org.apache.hadoop.hive.common.type.HiveChar;
+import org.apache.hadoop.hive.common.type.HiveVarchar;
 import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspector;
 import org.apache.hadoop.hive.serde2.objectinspector.primitive.PrimitiveObjectInspectorFactory;
 import org.apache.hadoop.hive.serde2.typeinfo.PrimitiveTypeInfo;
@@ -64,10 +66,14 @@ public class PaimonObjectInspectorFactory {
                         decimalType.getPrecision(), decimalType.getScale());
             case CHAR:
                 CharType charType = (CharType) logicalType;
-                return new PaimonCharObjectInspector(charType.getLength());
+                if (charType.getLength() > HiveChar.MAX_CHAR_LENGTH) {
+                    return new PaimonStringObjectInspector();
+                } else {
+                    return new PaimonCharObjectInspector(charType.getLength());
+                }
             case VARCHAR:
                 VarCharType varCharType = (VarCharType) logicalType;
-                if (varCharType.getLength() == VarCharType.MAX_LENGTH) {
+                if (varCharType.getLength() > HiveVarchar.MAX_VARCHAR_LENGTH) {
                     return new PaimonStringObjectInspector();
                 } else {
                     return new PaimonVarcharObjectInspector(varCharType.getLength());

--- a/paimon-hive/paimon-hive-connector-common/src/test/java/org/apache/paimon/hive/objectinspector/PaimonObjectInspectorFactoryTest.java
+++ b/paimon-hive/paimon-hive-connector-common/src/test/java/org/apache/paimon/hive/objectinspector/PaimonObjectInspectorFactoryTest.java
@@ -21,7 +21,10 @@ package org.apache.paimon.hive.objectinspector;
 import org.apache.paimon.data.BinaryString;
 import org.apache.paimon.data.GenericMap;
 import org.apache.paimon.types.DataTypes;
+import org.apache.paimon.types.VarCharType;
 
+import org.apache.hadoop.hive.common.type.HiveChar;
+import org.apache.hadoop.hive.common.type.HiveVarchar;
 import org.apache.hadoop.hive.serde2.objectinspector.MapObjectInspector;
 import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspector;
 import org.junit.jupiter.api.Test;
@@ -67,5 +70,41 @@ public class PaimonObjectInspectorFactoryTest {
         assertThat(inspector.getAllStructFieldRefs()).hasSize(2);
         assertThat(inspector.getStructFieldRef("tags").getFieldObjectInspector().getTypeName())
                 .isEqualTo("map<string,int>");
+    }
+
+    @Test
+    public void testCreateCharVarcharObjectInspectorExceedingHiveLimit() {
+        assertThat(
+                        PaimonObjectInspectorFactory.create(
+                                        DataTypes.CHAR(HiveChar.MAX_CHAR_LENGTH + 1))
+                                .getTypeName())
+                .isEqualTo("string");
+        assertThat(
+                        PaimonObjectInspectorFactory.create(
+                                        DataTypes.VARCHAR(HiveVarchar.MAX_VARCHAR_LENGTH + 1))
+                                .getTypeName())
+                .isEqualTo("string");
+        // the reproducing case of issue #1565
+        assertThat(
+                        PaimonObjectInspectorFactory.create(
+                                        DataTypes.VARCHAR(VarCharType.MAX_LENGTH - 1))
+                                .getTypeName())
+                .isEqualTo("string");
+    }
+
+    @Test
+    public void testCreateCharVarcharObjectInspectorWithinHiveLimit() {
+        assertThat(
+                        PaimonObjectInspectorFactory.create(
+                                        DataTypes.CHAR(HiveChar.MAX_CHAR_LENGTH))
+                                .getTypeName())
+                .isEqualTo("char(" + HiveChar.MAX_CHAR_LENGTH + ")");
+        assertThat(
+                        PaimonObjectInspectorFactory.create(
+                                        DataTypes.VARCHAR(HiveVarchar.MAX_VARCHAR_LENGTH))
+                                .getTypeName())
+                .isEqualTo("varchar(" + HiveVarchar.MAX_VARCHAR_LENGTH + ")");
+        assertThat(PaimonObjectInspectorFactory.create(DataTypes.STRING()).getTypeName())
+                .isEqualTo("string");
     }
 }


### PR DESCRIPTION

### Purpose

fix #9074

- `PaimonObjectInspectorFactory.create()` built `PaimonCharObjectInspector`/`PaimonVarcharObjectInspector` with the raw Paimon length, so a `CHAR(>255)` or `VARCHAR(>65535)` column made every Hive read of that table throw `RuntimeException: ... out of allowed range`.
- Clamp both to `PaimonStringObjectInspector` under the same conditions as the sibling `HiveTypeUtils.PaimonToHiveTypeVisitor`, so the inspector matches the `string` type `HiveTypeUtils.toTypeInfo()` already returns.
- That clamp came from #1568 (fix #1565) but was never applied to this factory, so the `varchar(2147483646)` case from #1565 still fails today.
- Lengths within the Hive limits are unchanged.

### Tests

- Added `PaimonObjectInspectorFactoryTest#testCreateCharVarcharObjectInspectorExceedingHiveLimit` and `#testCreateCharVarcharObjectInspectorWithinHiveLimit`.
- `mvn -pl paimon-hive/paimon-hive-connector-common clean install` passed on JDK 11 — 102 unit tests and 83 `*ITCase` tests, plus checkstyle, spotless and enforcer.
- Reverting the fix and rerunning makes the three new positive assertions fail with the original exception.


