### PR TITLE
[hive] Fix ClassCastException when reading BLOB columns

### DIFF
--- a/paimon-hive/paimon-hive-connector-common/src/main/java/org/apache/paimon/hive/objectinspector/PaimonBlobObjectInspector.java
+++ b/paimon-hive/paimon-hive-connector-common/src/main/java/org/apache/paimon/hive/objectinspector/PaimonBlobObjectInspector.java
@@ -1,0 +1,57 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.hive.objectinspector;
+
+import org.apache.paimon.data.Blob;
+
+import org.apache.hadoop.hive.serde2.objectinspector.primitive.AbstractPrimitiveJavaObjectInspector;
+import org.apache.hadoop.hive.serde2.objectinspector.primitive.BinaryObjectInspector;
+import org.apache.hadoop.hive.serde2.typeinfo.TypeInfoFactory;
+import org.apache.hadoop.io.BytesWritable;
+
+/** {@link AbstractPrimitiveJavaObjectInspector} for BLOB type. */
+public class PaimonBlobObjectInspector extends AbstractPrimitiveJavaObjectInspector
+        implements BinaryObjectInspector, WriteableObjectInspector {
+
+    public PaimonBlobObjectInspector() {
+        super(TypeInfoFactory.binaryTypeInfo);
+    }
+
+    @Override
+    public byte[] getPrimitiveJavaObject(Object o) {
+        if (o == null) {
+            return null;
+        }
+        return o instanceof Blob ? ((Blob) o).toData() : (byte[]) o;
+    }
+
+    @Override
+    public BytesWritable getPrimitiveWritableObject(Object o) {
+        byte[] bytes = getPrimitiveJavaObject(o);
+        return bytes == null ? null : new BytesWritable(bytes);
+    }
+
+    @Override
+    public Blob convert(Object value) {
+        if (value == null) {
+            return null;
+        }
+        return value instanceof Blob ? (Blob) value : Blob.fromData((byte[]) value);
+    }
+}

--- a/paimon-hive/paimon-hive-connector-common/src/main/java/org/apache/paimon/hive/objectinspector/PaimonObjectInspectorFactory.java
+++ b/paimon-hive/paimon-hive-connector-common/src/main/java/org/apache/paimon/hive/objectinspector/PaimonObjectInspectorFactory.java
@@ -54,10 +54,11 @@ public class PaimonObjectInspectorFactory {
             case FLOAT:
             case DOUBLE:
             case BINARY:
-            case BLOB:
             case VARBINARY:
                 return PrimitiveObjectInspectorFactory.getPrimitiveJavaObjectInspector(
                         (PrimitiveTypeInfo) HiveTypeUtils.toTypeInfo(logicalType));
+            case BLOB:
+                return new PaimonBlobObjectInspector();
             case DECIMAL:
                 DecimalType decimalType = (DecimalType) logicalType;
                 return new PaimonDecimalObjectInspector(

--- a/paimon-hive/paimon-hive-connector-common/src/test/java/org/apache/paimon/hive/objectinspector/PaimonBlobObjectInspectorTest.java
+++ b/paimon-hive/paimon-hive-connector-common/src/test/java/org/apache/paimon/hive/objectinspector/PaimonBlobObjectInspectorTest.java
@@ -18,11 +18,11 @@
 
 package org.apache.paimon.hive.objectinspector;
 
+import org.apache.paimon.data.Blob;
 import org.apache.paimon.types.DataTypes;
 
 import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspector;
 import org.apache.hadoop.hive.serde2.objectinspector.PrimitiveObjectInspector;
-import org.apache.hadoop.hive.serde2.objectinspector.primitive.JavaBinaryObjectInspector;
 import org.apache.hadoop.io.BytesWritable;
 import org.junit.jupiter.api.Test;
 
@@ -75,6 +75,32 @@ public class PaimonBlobObjectInspectorTest {
     public void testCreateObjectInspector() {
         PrimitiveObjectInspector oi =
                 (PrimitiveObjectInspector) PaimonObjectInspectorFactory.create(DataTypes.BLOB());
-        assertThat(oi).isInstanceOf(JavaBinaryObjectInspector.class);
+        assertThat(oi).isInstanceOf(PaimonBlobObjectInspector.class);
+    }
+
+    @Test
+    public void testGetPrimitiveJavaObjectFromBlob() {
+        PrimitiveObjectInspector oi =
+                (PrimitiveObjectInspector) PaimonObjectInspectorFactory.create(DataTypes.BLOB());
+        byte[] data = new byte[] {1, 2, 3, 4};
+        assertThat((byte[]) oi.getPrimitiveJavaObject(Blob.fromData(data))).isEqualTo(data);
+    }
+
+    @Test
+    public void testGetPrimitiveWritableObjectFromBlob() {
+        PrimitiveObjectInspector oi =
+                (PrimitiveObjectInspector) PaimonObjectInspectorFactory.create(DataTypes.BLOB());
+        byte[] data = new byte[] {1, 2, 3, 4};
+        assertThat(oi.getPrimitiveWritableObject(Blob.fromData(data)))
+                .isEqualTo(new BytesWritable(data));
+    }
+
+    @Test
+    public void testConvert() {
+        WriteableObjectInspector oi =
+                (WriteableObjectInspector) PaimonObjectInspectorFactory.create(DataTypes.BLOB());
+        byte[] data = new byte[] {1, 2, 3, 4};
+        assertThat(((Blob) oi.convert(data)).toData()).isEqualTo(data);
+        assertThat(oi.convert(null)).isNull();
     }
 }


### PR DESCRIPTION

### Purpose

fix #9076

- `PaimonObjectInspectorFactory` returned Hive's `JavaBinaryObjectInspector` for `BLOB`, which casts its input to `byte[]`, but the read path passes a `Blob` (`InternalRow.createFieldGetter` -> `row.getBlob(pos)`). Every Hive `SELECT` on a BLOB column failed with `ClassCastException`.
- Add `PaimonBlobObjectInspector`, mirroring the sibling inspectors, converting `Blob` to `byte[]` on read; `convert()` covers the opposite (write) direction of the same type.
- Keeps `TypeInfoFactory.binaryTypeInfo`, so the Hive-facing column type and writable class are unchanged.
- Spark (`DataConverter`) and Flink (`FlinkRowDataWithBlob`) already convert at the engine boundary. Follow-up to #8070.

### Tests

- Extended `PaimonBlobObjectInspectorTest` with `testGetPrimitiveJavaObjectFromBlob`, `testGetPrimitiveWritableObjectFromBlob` and `testConvert`; all three fail with the reported `ClassCastException` before this change.
- `mvn -pl paimon-hive/paimon-hive-connector-common clean install` — 103 unit tests and 83 `*ITCase` tests passed, including `HiveOnMrReadITCase`, `HiveOnTezReadITCase` and `HiveWriteITCase`.
