### PR TITLE
[hive] Unescape partition path values when building Hive split predicate

### DIFF
--- a/paimon-hive/paimon-hive-connector-common/src/main/java/org/apache/paimon/hive/utils/HiveSplitGenerator.java
+++ b/paimon-hive/paimon-hive-connector-common/src/main/java/org/apache/paimon/hive/utils/HiveSplitGenerator.java
@@ -18,6 +18,7 @@
 
 package org.apache.paimon.hive.utils;
 
+import org.apache.paimon.fs.Path;
 import org.apache.paimon.hive.HiveConnectorOptions;
 import org.apache.paimon.hive.mapred.PaimonInputSplit;
 import org.apache.paimon.io.DataFileMeta;
@@ -31,6 +32,7 @@ import org.apache.paimon.table.source.InnerTableScan;
 import org.apache.paimon.tag.TagPreview;
 import org.apache.paimon.types.RowType;
 import org.apache.paimon.utils.BinPacking;
+import org.apache.paimon.utils.PartitionPathUtils;
 
 import org.apache.hadoop.hive.conf.HiveConf;
 import org.apache.hadoop.mapred.InputSplit;
@@ -135,17 +137,13 @@ public class HiveSplitGenerator {
             String defaultPartName) {
         Set<String> partitionKeySet = new HashSet<>(partitionKeys);
         LinkedHashMap<String, String> partition = new LinkedHashMap<>();
-        for (String s : partitionDir.split("/")) {
-            s = s.trim();
-            if (s.isEmpty()) {
-                continue;
-            }
-            String[] kv = s.split("=");
-            if (kv.length != 2) {
-                continue;
-            }
-            if (partitionKeySet.contains(kv[0])) {
-                partition.put(kv[0], kv[1]);
+        // the directory names are escaped by PartitionPathUtils#escapePathName when the partition
+        // is created, so they must be unescaped to get back the raw partition values
+        LinkedHashMap<String, String> spec =
+                PartitionPathUtils.extractPartitionSpecFromPath(new Path(partitionDir));
+        for (Map.Entry<String, String> entry : spec.entrySet()) {
+            if (partitionKeySet.contains(entry.getKey())) {
+                partition.put(entry.getKey(), entry.getValue());
             }
         }
         if (partition.isEmpty() || partition.size() != partitionKeys.size()) {

--- a/paimon-hive/paimon-hive-connector-common/src/test/java/org/apache/paimon/hive/HiveSplitGeneratorTest.java
+++ b/paimon-hive/paimon-hive-connector-common/src/test/java/org/apache/paimon/hive/HiveSplitGeneratorTest.java
@@ -22,6 +22,8 @@ import org.apache.paimon.CoreOptions;
 import org.apache.paimon.catalog.CatalogContext;
 import org.apache.paimon.data.BinaryRow;
 import org.apache.paimon.data.BinaryRowWriter;
+import org.apache.paimon.data.BinaryString;
+import org.apache.paimon.data.GenericRow;
 import org.apache.paimon.fs.FileIO;
 import org.apache.paimon.fs.Path;
 import org.apache.paimon.hive.utils.HiveSplitGenerator;
@@ -33,6 +35,9 @@ import org.apache.paimon.schema.TableSchema;
 import org.apache.paimon.table.AppendOnlyFileStoreTable;
 import org.apache.paimon.table.CatalogEnvironment;
 import org.apache.paimon.table.FileStoreTable;
+import org.apache.paimon.table.sink.BatchTableCommit;
+import org.apache.paimon.table.sink.BatchTableWrite;
+import org.apache.paimon.table.sink.BatchWriteBuilder;
 import org.apache.paimon.table.source.DataSplit;
 import org.apache.paimon.types.DataField;
 import org.apache.paimon.types.IntType;
@@ -40,7 +45,9 @@ import org.apache.paimon.types.VarCharType;
 import org.apache.paimon.utils.TraceableFileIO;
 
 import org.apache.hadoop.hive.conf.HiveConf;
+import org.apache.hadoop.mapred.InputSplit;
 import org.apache.hadoop.mapred.JobConf;
+import org.apache.hadoop.mapreduce.lib.input.FileInputFormat;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
@@ -71,6 +78,26 @@ public class HiveSplitGeneratorTest {
                     Collections.singletonList("id"),
                     Collections.emptyMap(),
                     "");
+
+    private static final TableSchema PARTITIONED_TABLE_SCHEMA =
+            new TableSchema(
+                    0,
+                    SCHEMA_FIELDS,
+                    2,
+                    Collections.singletonList("pt"),
+                    Collections.emptyList(),
+                    Collections.emptyMap(),
+                    "");
+
+    /** Partition value holding a character that {@code escapePathName} rewrites. */
+    private static final String ESCAPED_PARTITION_VALUE = "2026-01-01 00:00";
+
+    /** Directory name Paimon writes for {@link #ESCAPED_PARTITION_VALUE}. */
+    private static final String ESCAPED_PARTITION_DIR = "pt=2026-01-01 00%3A00";
+
+    private static final String PLAIN_PARTITION_VALUE = "plain";
+
+    private static final String PLAIN_PARTITION_DIR = "pt=plain";
 
     @TempDir java.nio.file.Path tempDir;
 
@@ -131,6 +158,53 @@ public class HiveSplitGeneratorTest {
             totalFiles += dataSplit.dataFiles().size();
         }
         assertThat(totalFiles).isEqualTo(10);
+    }
+
+    @Test
+    public void testGenerateSplitsForEscapedPartitionValue() throws Exception {
+        FileStoreTable table = createPartitionedTableWithTwoPartitions();
+
+        // Hive hands back the escaped directory registered in the metastore
+        assertThat(fileIO.exists(new Path(tablePath, ESCAPED_PARTITION_DIR))).isTrue();
+
+        InputSplit[] splits = generateSplits(table, ESCAPED_PARTITION_DIR);
+        assertThat(splits).hasSize(1);
+    }
+
+    @Test
+    public void testGenerateSplitsForPlainPartitionValue() throws Exception {
+        FileStoreTable table = createPartitionedTableWithTwoPartitions();
+
+        assertThat(fileIO.exists(new Path(tablePath, PLAIN_PARTITION_DIR))).isTrue();
+
+        InputSplit[] splits = generateSplits(table, PLAIN_PARTITION_DIR);
+        assertThat(splits).hasSize(1);
+    }
+
+    private InputSplit[] generateSplits(FileStoreTable table, String partitionDir) {
+        JobConf jobConf = new JobConf();
+        jobConf.set(FileInputFormat.INPUT_DIR, tablePath + "/" + partitionDir);
+        return HiveSplitGenerator.generateSplits(table, jobConf, 1);
+    }
+
+    private FileStoreTable createPartitionedTableWithTwoPartitions() throws Exception {
+        FileStoreTable table = createFileStoreTable(PARTITIONED_TABLE_SCHEMA);
+        BatchWriteBuilder writeBuilder = table.newBatchWriteBuilder();
+        try (BatchTableWrite write = writeBuilder.newWrite();
+                BatchTableCommit commit = writeBuilder.newCommit()) {
+            write.write(
+                    GenericRow.of(
+                            1,
+                            BinaryString.fromString("a"),
+                            BinaryString.fromString(ESCAPED_PARTITION_VALUE)));
+            write.write(
+                    GenericRow.of(
+                            2,
+                            BinaryString.fromString("b"),
+                            BinaryString.fromString(PLAIN_PARTITION_VALUE)));
+            commit.commit(write.prepareCommit());
+        }
+        return table;
     }
 
     private FileStoreTable createFileStoreTable(TableSchema tableSchema) throws Exception {


### PR DESCRIPTION

### Purpose

fix #9077

- `HiveSplitGenerator.createPartitionPredicate()` parsed the Hive input dir with `split("/")` and `split("=")` and never unescaped the values.
- Partition directories are escaped when registered, so a value such as `2026-01-01 00:00` reaches the predicate as `2026-01-01 00%3A00`, matches nothing, and the Hive query silently returns zero rows.
- Use `PartitionPathUtils.extractPartitionSpecFromPath()`, which unescapes; this was the last production site parsing a partition path by hand.
- Values needing no escaping are unaffected; the tag branch and `Optional.empty()` fallback are untouched.

### Tests

- Added `HiveSplitGeneratorTest#testGenerateSplitsForEscapedPartitionValue` (escaped value now matches) and `#testGenerateSplitsForPlainPartitionValue` (regression).
- Reverting the fix fails only the escaped-value test; `generateSplits` had no prior coverage, so this adds cases rather than changing existing ones.
- `mvn -pl paimon-hive/paimon-hive-connector-common clean install` — 102 unit tests and 83 `*ITCase` tests passed.
