### PR TITLE
[hive] Support multiset type in hive writes

### DIFF
--- a/paimon-hive/paimon-hive-connector-common/src/main/java/org/apache/paimon/hive/SchemaVisitor.java
+++ b/paimon-hive/paimon-hive-connector-common/src/main/java/org/apache/paimon/hive/SchemaVisitor.java
@@ -21,7 +21,9 @@ package org.apache.paimon.hive;
 import org.apache.paimon.types.ArrayType;
 import org.apache.paimon.types.DataField;
 import org.apache.paimon.types.DataType;
+import org.apache.paimon.types.IntType;
 import org.apache.paimon.types.MapType;
+import org.apache.paimon.types.MultisetType;
 import org.apache.paimon.types.RowType;
 
 import org.apache.paimon.shade.guava30.com.google.common.collect.Lists;
@@ -89,6 +91,16 @@ public abstract class SchemaVisitor<P, R> {
                 P valuePartner = partner != null ? accessors.mapValuePartner(partner) : null;
                 valueResult = visit(map.getValueType(), valuePartner, visitor, accessors);
                 return visitor.map(map, partner, keyResult, valueResult);
+
+            case MULTISET:
+                // a multiset is represented as a map from element to its count, the same mapping
+                // used by PaimonObjectInspectorFactory on the read side
+                MultisetType multiset = (MultisetType) type;
+                return visit(
+                        new MapType(type.isNullable(), multiset.getElementType(), new IntType()),
+                        partner,
+                        visitor,
+                        accessors);
 
             default:
                 return visitor.primitive(type, partner);

--- a/paimon-hive/paimon-hive-connector-common/src/test/java/org/apache/paimon/hive/PaimonSerDeTest.java
+++ b/paimon-hive/paimon-hive-connector-common/src/test/java/org/apache/paimon/hive/PaimonSerDeTest.java
@@ -19,20 +19,31 @@
 package org.apache.paimon.hive;
 
 import org.apache.paimon.data.GenericRow;
+import org.apache.paimon.data.InternalMap;
+import org.apache.paimon.data.InternalRow;
 import org.apache.paimon.fs.Path;
 import org.apache.paimon.fs.local.LocalFileIO;
 import org.apache.paimon.hive.objectinspector.PaimonInternalRowObjectInspector;
 import org.apache.paimon.schema.Schema;
 import org.apache.paimon.schema.SchemaManager;
+import org.apache.paimon.types.DataType;
+import org.apache.paimon.types.DataTypes;
+import org.apache.paimon.types.RowType;
 
 import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspector;
+import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspectorFactory;
 import org.apache.hadoop.hive.serde2.objectinspector.StructField;
+import org.apache.hadoop.hive.serde2.objectinspector.StructObjectInspector;
+import org.apache.hadoop.hive.serde2.objectinspector.primitive.PrimitiveObjectInspectorFactory;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Properties;
 
 import static org.apache.paimon.hive.RandomGenericRowDataGenerator.FIELD_COMMENTS;
@@ -71,11 +82,51 @@ public class PaimonSerDeTest {
         assertThat(serDe.deserialize(container)).isEqualTo(rowData);
     }
 
+    @Test
+    public void testSerializeMultiset() throws Exception {
+        RowType rowType =
+                RowType.of(
+                        new DataType[] {DataTypes.INT(), DataTypes.MULTISET(DataTypes.STRING())},
+                        new String[] {"id", "tags"});
+        PaimonSerDe serDe = createInitializedSerDe(rowType);
+
+        // hive represents a multiset column as map<element, count>
+        StructObjectInspector sourceInspector =
+                ObjectInspectorFactory.getStandardStructObjectInspector(
+                        Arrays.asList("id", "tags"),
+                        Arrays.asList(
+                                PrimitiveObjectInspectorFactory.javaIntObjectInspector,
+                                ObjectInspectorFactory.getStandardMapObjectInspector(
+                                        PrimitiveObjectInspectorFactory.javaStringObjectInspector,
+                                        PrimitiveObjectInspectorFactory.javaIntObjectInspector)));
+
+        Map<String, Integer> tags = new LinkedHashMap<>();
+        tags.put("apple", 2);
+        tags.put("banana", 1);
+
+        InternalRow row =
+                ((RowDataContainer) serDe.serialize(Arrays.asList(1, tags), sourceInspector)).get();
+
+        assertThat(row.getInt(0)).isEqualTo(1);
+        InternalMap actual = row.getMap(1);
+        assertThat(actual.size()).isEqualTo(tags.size());
+        Map<String, Integer> actualTags = new HashMap<>();
+        for (int i = 0; i < actual.size(); i++) {
+            actualTags.put(
+                    actual.keyArray().getString(i).toString(), actual.valueArray().getInt(i));
+        }
+        assertThat(actualTags).isEqualTo(tags);
+    }
+
     private PaimonSerDe createInitializedSerDe() throws Exception {
+        return createInitializedSerDe(ROW_TYPE);
+    }
+
+    private PaimonSerDe createInitializedSerDe(RowType rowType) throws Exception {
         new SchemaManager(LocalFileIO.create(), new Path(tempDir.toString()))
                 .createTable(
                         new Schema(
-                                ROW_TYPE.getFields(),
+                                rowType.getFields(),
                                 Collections.emptyList(),
                                 Collections.emptyList(),
                                 new HashMap<>(),


### PR DESCRIPTION

### Purpose

fix #9078

- #8949 added multiset support to the read side (`PaimonObjectInspectorFactory`), but the write-side dispatcher `SchemaVisitor.visit()` branches on `ROW`/`ARRAY`/`MAP` only.
- `MULTISET` falls through to `default: visitor.primitive(...)`, so `HiveDeserializer.primitive()` throws `ClassCastException: StandardMapObjectInspector cannot be cast to PrimitiveObjectInspector` on the first row — reads work, writes do not.
- Visit `MULTISET` as `MapType(elementType, IntType)`, the mapping `PaimonObjectInspectorFactory` already uses. Other type branches are untouched.

### Tests

- Added `PaimonSerDeTest#testSerializeMultiset`: serializes `id INT, tags MULTISET<STRING>` through a Hive `StandardStructObjectInspector` and asserts the resulting `InternalMap`.
- Reverting the fix fails only the new test, with the exception above; no existing test covered the multiset write path, so this cannot regress CI.
- `mvn -pl paimon-hive/paimon-hive-connector-common clean install` — 101 unit tests and 83 `*ITCase` tests passed, including `HiveWriteITCase`.
