### PR TITLE
[common] Fix ClassCastException when computing row size for blob fields

### DIFF
--- a/paimon-common/src/main/java/org/apache/paimon/types/InternalRowToSizeVisitor.java
+++ b/paimon-common/src/main/java/org/apache/paimon/types/InternalRowToSizeVisitor.java
@@ -20,6 +20,9 @@ package org.apache.paimon.types;
 
 import org.apache.paimon.data.Blob;
 import org.apache.paimon.data.BlobData;
+import org.apache.paimon.data.BlobDescriptor;
+import org.apache.paimon.data.BlobRef;
+import org.apache.paimon.data.BlobView;
 import org.apache.paimon.data.DataGetters;
 import org.apache.paimon.data.InternalArray;
 import org.apache.paimon.data.InternalMap;
@@ -34,6 +37,7 @@ public class InternalRowToSizeVisitor
         implements DataTypeVisitor<BiFunction<DataGetters, Integer, Integer>> {
 
     public static final int NULL_SIZE = 0;
+    private static final int UNKNOWN_SIZE = 1;
 
     @Override
     public BiFunction<DataGetters, Integer, Integer> visit(CharType charType) {
@@ -234,12 +238,21 @@ public class InternalRowToSizeVisitor
                 Blob blob = row.getBlob(index);
                 if (blob instanceof BlobData) {
                     return ((BlobData) blob).toData().length;
-                } else {
-                    // BlobRef and BlobView
-                    return Math.toIntExact(blob.toDescriptor().length());
+                } else if (blob instanceof BlobRef) {
+                    return descriptorLength(blob.toDescriptor());
+                } else if (blob instanceof BlobView) {
+                    BlobView view = (BlobView) blob;
+                    return view.isResolved()
+                            ? descriptorLength(view.toDescriptor())
+                            : view.viewStruct().serialize().length;
                 }
+                return UNKNOWN_SIZE;
             }
         };
+    }
+
+    private static int descriptorLength(BlobDescriptor descriptor) {
+        return descriptor.length() < 0 ? UNKNOWN_SIZE : Math.toIntExact(descriptor.length());
     }
 
     @Override

--- a/paimon-common/src/main/java/org/apache/paimon/types/InternalRowToSizeVisitor.java
+++ b/paimon-common/src/main/java/org/apache/paimon/types/InternalRowToSizeVisitor.java
@@ -18,6 +18,8 @@
 
 package org.apache.paimon.types;
 
+import org.apache.paimon.data.Blob;
+import org.apache.paimon.data.BlobData;
 import org.apache.paimon.data.DataGetters;
 import org.apache.paimon.data.InternalArray;
 import org.apache.paimon.data.InternalMap;
@@ -229,7 +231,13 @@ public class InternalRowToSizeVisitor
             if (row.isNullAt(index)) {
                 return NULL_SIZE;
             } else {
-                return Math.toIntExact(row.getVariant(index).sizeInBytes());
+                Blob blob = row.getBlob(index);
+                if (blob instanceof BlobData) {
+                    return ((BlobData) blob).toData().length;
+                } else {
+                    // BlobRef and BlobView
+                    return Math.toIntExact(blob.toDescriptor().length());
+                }
             }
         };
     }

--- a/paimon-common/src/test/java/org/apache/paimon/types/InternalRowToSizeVisitorTest.java
+++ b/paimon-common/src/test/java/org/apache/paimon/types/InternalRowToSizeVisitorTest.java
@@ -18,14 +18,18 @@
 
 package org.apache.paimon.types;
 
+import org.apache.paimon.catalog.Identifier;
 import org.apache.paimon.data.BinaryString;
 import org.apache.paimon.data.Blob;
+import org.apache.paimon.data.BlobDescriptor;
+import org.apache.paimon.data.BlobViewStruct;
 import org.apache.paimon.data.DataGetters;
 import org.apache.paimon.data.Decimal;
 import org.apache.paimon.data.GenericArray;
 import org.apache.paimon.data.GenericMap;
 import org.apache.paimon.data.GenericRow;
 import org.apache.paimon.data.Timestamp;
+import org.apache.paimon.utils.UriReader;
 
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
@@ -196,15 +200,44 @@ public class InternalRowToSizeVisitorTest {
 
     @Test
     void testBlobSize() {
+        Assertions.assertThat(blobSize(Blob.fromData(new byte[] {1, 2, 3}))).isEqualTo(3);
+        Assertions.assertThat(blobSize(null)).isEqualTo(0);
+    }
+
+    @Test
+    void testBlobRefSize() {
+        Assertions.assertThat(
+                        blobSize(
+                                Blob.fromDescriptor(
+                                        UriReader.fromHttp(),
+                                        new BlobDescriptor("https://example.com/blob", 0, 3))))
+                .isEqualTo(3);
+        Assertions.assertThat(blobSize(Blob.fromHttp("https://example.com/blob"))).isEqualTo(1);
+    }
+
+    @Test
+    void testUnresolvedBlobViewSize() {
+        BlobViewStruct viewStruct = new BlobViewStruct(Identifier.create("db", "t"), 1, 2L);
+        Assertions.assertThat(blobSize(Blob.fromView(viewStruct)))
+                .isEqualTo(viewStruct.serialize().length);
+    }
+
+    @Test
+    void testBlobStreamSize() {
+        Assertions.assertThat(
+                        blobSize(
+                                Blob.fromInputStream(
+                                        () -> {
+                                            throw new AssertionError();
+                                        })))
+                .isEqualTo(1);
+    }
+
+    private int blobSize(Blob blob) {
         RowType rowType = RowType.builder().field("b", DataTypes.BLOB()).build();
         InternalRowToSizeVisitor visitor = new InternalRowToSizeVisitor();
         BiFunction<DataGetters, Integer, Integer> calculator =
                 rowType.getFieldTypes().get(0).accept(visitor);
-
-        GenericRow row = GenericRow.of(Blob.fromData(new byte[] {1, 2, 3}));
-        Assertions.assertThat(calculator.apply(row, 0)).isEqualTo(3);
-
-        GenericRow nullRow = GenericRow.of(new Object[] {null});
-        Assertions.assertThat(calculator.apply(nullRow, 0)).isEqualTo(0);
+        return calculator.apply(GenericRow.of(blob), 0);
     }
 }

--- a/paimon-common/src/test/java/org/apache/paimon/types/InternalRowToSizeVisitorTest.java
+++ b/paimon-common/src/test/java/org/apache/paimon/types/InternalRowToSizeVisitorTest.java
@@ -19,6 +19,7 @@
 package org.apache.paimon.types;
 
 import org.apache.paimon.data.BinaryString;
+import org.apache.paimon.data.Blob;
 import org.apache.paimon.data.DataGetters;
 import org.apache.paimon.data.Decimal;
 import org.apache.paimon.data.GenericArray;
@@ -191,5 +192,19 @@ public class InternalRowToSizeVisitorTest {
         Assertions.assertThat(feildSizeCalculator.get(22).apply(row, 22)).isEqualTo(6);
 
         Assertions.assertThat(feildSizeCalculator.get(23).apply(row, 23)).isEqualTo(0);
+    }
+
+    @Test
+    void testBlobSize() {
+        RowType rowType = RowType.builder().field("b", DataTypes.BLOB()).build();
+        InternalRowToSizeVisitor visitor = new InternalRowToSizeVisitor();
+        BiFunction<DataGetters, Integer, Integer> calculator =
+                rowType.getFieldTypes().get(0).accept(visitor);
+
+        GenericRow row = GenericRow.of(Blob.fromData(new byte[] {1, 2, 3}));
+        Assertions.assertThat(calculator.apply(row, 0)).isEqualTo(3);
+
+        GenericRow nullRow = GenericRow.of(new Object[] {null});
+        Assertions.assertThat(calculator.apply(nullRow, 0)).isEqualTo(0);
     }
 }


### PR DESCRIPTION
### Purpose
- Flink writes check for each row's size in `RangeShuffle` to balance range partitions.
- However for blog fields the size calculator wrongly reads blog with `getVariant` instead of `getBlob`, causing `ClassCastException` tables with blob columns.
- Fix it by using getBlob instead

### Tests
 - UT