### PR TITLE
[python] Inherit watermark in PyPaimon commits

### DIFF
--- a/paimon-python/pypaimon/tests/file_store_commit_test.py
+++ b/paimon-python/pypaimon/tests/file_store_commit_test.py
@@ -140,7 +140,8 @@ class TestFileStoreCommit(unittest.TestCase):
     def _run_manifest_commit_attempt(self, commit_side_effect=None,
                                      commit_result=None, retry_result=None,
                                      existing_manifests=None,
-                                     merged_manifests=None):
+                                     merged_manifests=None,
+                                     latest_watermark=None):
         file_store_commit = self._create_file_store_commit()
         self.mock_table.identifier = 'default.test_table'
         self.mock_table.table_schema.id = 7
@@ -179,6 +180,7 @@ class TestFileStoreCommit(unittest.TestCase):
             uuid='base-snapshot-uuid',
             total_record_count=10,
             index_manifest=None,
+            watermark=latest_watermark,
         )
         commit_entry = Mock(kind=0)
         commit_entry.file.row_count = 2
@@ -191,6 +193,18 @@ class TestFileStoreCommit(unittest.TestCase):
             latest_snapshot=latest_snapshot,
         )
         return file_store_commit, result
+
+    def test_append_commit_inherits_watermark(
+            self, mock_manifest_list_manager, mock_manifest_file_manager):
+        file_store_commit, result = self._run_manifest_commit_attempt(
+            commit_result=True,
+            latest_watermark=123,
+        )
+
+        self.assertTrue(result.is_success())
+        committed_snapshot = (
+            file_store_commit.snapshot_commit.commit.call_args[0][1])
+        self.assertEqual(123, committed_snapshot.watermark)
 
     def test_false_atomic_commit_retains_manifest_merge_result(
             self, mock_manifest_list_manager, mock_manifest_file_manager):
@@ -750,6 +764,7 @@ class TestFileStoreCommit(unittest.TestCase):
         latest_snapshot.uuid = "base-snapshot-uuid"
         latest_snapshot.total_record_count = 10
         latest_snapshot.index_manifest = "index-manifest-existing"
+        latest_snapshot.watermark = None
 
         commit_entry = Mock()
         commit_entry.kind = 0

--- a/paimon-python/pypaimon/write/file_store_commit.py
+++ b/paimon-python/pypaimon/write/file_store_commit.py
@@ -742,6 +742,8 @@ class FileStoreCommit:
                 commit_identifier=commit_identifier,
                 commit_kind=commit_kind,
                 time_millis=int(time.time() * 1000),
+                watermark=(
+                    latest_snapshot.watermark if latest_snapshot else None),
                 next_row_id=next_row_id,
                 index_manifest=index_manifest,
             )


### PR DESCRIPTION
## What

Make PyPaimon commits inherit the watermark from the latest snapshot.

## Why

Paimon snapshots may omit the watermark only when neither the current commit nor the previous snapshot has one. PyPaimon currently creates every new snapshot without copying the latest watermark, which breaks watermark continuity in mixed Java/Python write histories and can invalidate watermark-based time travel.

## Impact

After this change, a PyPaimon commit following a watermark-bearing Java/Flink snapshot preserves that watermark. Tables whose history has never carried a watermark continue to write snapshots without one.

## Tests

- `python3 -m pytest pypaimon/tests/file_store_commit_test.py -q`
- `python3 -m pytest pypaimon/tests/reader_append_only_test.py::AoReaderTest::test_commit_retry_filter -q`
- `flake8 --config=./dev/cfg.ini pypaimon/write/file_store_commit.py pypaimon/tests/file_store_commit_test.py`
- `git diff --check`
