### PR TITLE
[spark] Reject null migration options map values

### DIFF
--- a/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/procedure/MigrateDatabaseProcedure.java
+++ b/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/procedure/MigrateDatabaseProcedure.java
@@ -59,7 +59,7 @@ public class MigrateDatabaseProcedure extends BaseProcedure {
                 ProcedureParameter.required("database", StringType),
                 ProcedureParameter.optional("options", StringType),
                 ProcedureParameter.optional(
-                        "options_map", DataTypes.createMapType(StringType, StringType)),
+                        "options_map", DataTypes.createMapType(StringType, StringType, false)),
                 ProcedureParameter.optional("parallelism", IntegerType),
             };
 
@@ -127,9 +127,12 @@ public class MigrateDatabaseProcedure extends BaseProcedure {
         HashMap<String, String> map = new HashMap<>();
         if (mapData != null) {
             for (int index = 0; index < mapData.numElements(); index++) {
-                map.put(
-                        mapData.keyArray().getUTF8String(index).toString(),
-                        mapData.valueArray().getUTF8String(index).toString());
+                String key = mapData.keyArray().getUTF8String(index).toString();
+                if (mapData.valueArray().isNullAt(index)) {
+                    throw new IllegalArgumentException(
+                            String.format("Option value for key '%s' cannot be null", key));
+                }
+                map.put(key, mapData.valueArray().getUTF8String(index).toString());
             }
         }
         return map;

--- a/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/procedure/MigrateTableProcedure.java
+++ b/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/procedure/MigrateTableProcedure.java
@@ -60,7 +60,7 @@ public class MigrateTableProcedure extends BaseProcedure {
                 ProcedureParameter.optional("delete_origin", BooleanType),
                 ProcedureParameter.optional("target_table", StringType),
                 ProcedureParameter.optional(
-                        "options_map", DataTypes.createMapType(StringType, StringType)),
+                        "options_map", DataTypes.createMapType(StringType, StringType, false)),
                 ProcedureParameter.optional("parallelism", IntegerType),
             };
 
@@ -135,9 +135,12 @@ public class MigrateTableProcedure extends BaseProcedure {
         HashMap<String, String> map = new HashMap<>();
         if (mapData != null) {
             for (int index = 0; index < mapData.numElements(); index++) {
-                map.put(
-                        mapData.keyArray().getUTF8String(index).toString(),
-                        mapData.valueArray().getUTF8String(index).toString());
+                String key = mapData.keyArray().getUTF8String(index).toString();
+                if (mapData.valueArray().isNullAt(index)) {
+                    throw new IllegalArgumentException(
+                            String.format("Option value for key '%s' cannot be null", key));
+                }
+                map.put(key, mapData.valueArray().getUTF8String(index).toString());
             }
         }
         return map;

--- a/paimon-spark/paimon-spark-common/src/test/java/org/apache/paimon/spark/procedure/MigrateProcedureOptionsTest.java
+++ b/paimon-spark/paimon-spark-common/src/test/java/org/apache/paimon/spark/procedure/MigrateProcedureOptionsTest.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.spark.procedure;
+
+import org.apache.spark.sql.catalyst.util.ArrayBasedMapData;
+import org.apache.spark.sql.catalyst.util.GenericArrayData;
+import org.apache.spark.sql.catalyst.util.MapData;
+import org.apache.spark.unsafe.types.UTF8String;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/** Tests for migration procedure options. */
+public class MigrateProcedureOptionsTest {
+
+    @Test
+    public void testRejectNullOptionValue() {
+        MapData optionsMap =
+                new ArrayBasedMapData(
+                        new GenericArrayData(new Object[] {UTF8String.fromString("file.format")}),
+                        new GenericArrayData(new Object[] {null}));
+
+        assertThatThrownBy(() -> MigrateTableProcedure.mapDataToHashMap(optionsMap))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Option value for key 'file.format' cannot be null");
+        assertThatThrownBy(() -> MigrateDatabaseProcedure.mapDataToHashMap(optionsMap))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Option value for key 'file.format' cannot be null");
+    }
+}

--- a/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/procedure/MigrateDatabaseProcedureTest.scala
+++ b/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/procedure/MigrateDatabaseProcedureTest.scala
@@ -21,12 +21,23 @@ package org.apache.paimon.spark.procedure
 import org.apache.paimon.spark.PaimonHiveTestBase
 
 import org.apache.spark.sql.Row
+import org.assertj.core.api.Assertions.assertThatThrownBy
 
 import java.util.concurrent.ThreadLocalRandom
 
 class MigrateDatabaseProcedureTest extends PaimonHiveTestBase {
 
   private val random = ThreadLocalRandom.current().nextInt(10000)
+
+  test("Paimon migrate database procedure: reject null options_map values") {
+    assertThatThrownBy(
+      () => spark.sql(s"""CALL sys.migrate_database(
+                         |  source_type => 'hive',
+                         |  database => '$hiveDbName',
+                         |  options_map => map('file.format', CAST(NULL AS STRING)))""".stripMargin))
+      .hasMessageContaining("Cannot cast")
+      .hasMessageContaining("options_map")
+  }
 
   Seq("parquet", "orc", "avro").foreach(
     format => {

--- a/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/procedure/MigrateTableProcedureTest.scala
+++ b/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/procedure/MigrateTableProcedureTest.scala
@@ -29,6 +29,16 @@ class MigrateTableProcedureTest extends PaimonHiveTestBase {
 
   private val random = ThreadLocalRandom.current().nextInt(10000)
 
+  test("Paimon migrate table procedure: reject null options_map values") {
+    assertThatThrownBy(
+      () => spark.sql(s"""CALL sys.migrate_table(
+                         |  source_type => 'hive',
+                         |  table => '$hiveDbName.source_table',
+                         |  options_map => map('file.format', CAST(NULL AS STRING)))""".stripMargin))
+      .hasMessageContaining("Cannot cast")
+      .hasMessageContaining("options_map")
+  }
+
   Seq("parquet", "orc", "avro").foreach(
     format => {
       test(s"Paimon migrate table procedure: migrate $format non-partitioned table") {


### PR DESCRIPTION
### Purpose

Reject null values in `options_map` for `migrate_table` and `migrate_database`.

- Declare `options_map` values as non-nullable in procedure parameters.
- Add runtime validation to return a clear error instead of a `NullPointerException` if a nullable `MapData` bypasses SQL analysis.


### Tests

- Add SQL-level and direct conversion regression coverage.