### PR TITLE
[python] Support BLOBs in primary-key tables.

### DIFF
--- a/paimon-python/conftest.py
+++ b/paimon-python/conftest.py
@@ -6,15 +6,20 @@
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#   http://www.apache.org/licenses/LICENSE-2.0
 #
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+"""Top-level pytest hooks for pypaimon tests."""
 
 import os
+import sys
+import types
 
 import pytest
 
@@ -22,6 +27,23 @@ import pytest
 _NATIVE_PLAN_ENV = "PYPAIMON_TEST_NATIVE_PLAN"
 _native_plan_count = 0
 _force_native_for_test = False
+
+
+def _skip_package_init() -> bool:
+    return os.environ.get("PYPAIMON_SKIP_PACKAGE_INIT", "").lower() in (
+        "1",
+        "true",
+        "yes",
+    )
+
+
+# This hook must live outside the ``pypaimon`` package. Pytest imports a
+# package-scoped conftest through ``pypaimon.__init__``, which is too late to
+# bypass optional top-level imports for dependency-light unit test runs.
+if _skip_package_init() and "pypaimon" not in sys.modules:
+    _pypaimon = types.ModuleType("pypaimon")
+    _pypaimon.__path__ = [os.path.join(os.path.dirname(__file__), "pypaimon")]
+    sys.modules["pypaimon"] = _pypaimon
 
 
 def _native_plan_enabled():

--- a/paimon-python/pypaimon/blob/__init__.py
+++ b/paimon-python/pypaimon/blob/__init__.py
@@ -1,0 +1,16 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.

--- a/paimon-python/pypaimon/blob/managed_blob_reference_collector.py
+++ b/paimon-python/pypaimon/blob/managed_blob_reference_collector.py
@@ -1,0 +1,153 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from typing import List, Set
+
+import pyarrow as pa
+
+from pypaimon.blob.managed_blob_reference_file import (
+    ManagedBlobReferenceFile,
+    Reference,
+)
+from pypaimon.schema.data_types import (
+    DataField,
+    is_array_blob_type,
+    is_blob_file_field,
+    is_blob_type,
+    is_map_blob_type,
+)
+from pypaimon.table.row.blob import Blob, BlobDescriptor, BlobRef
+
+
+class ManagedBlobReferenceCollector:
+    """Collect managed BLOB pack references from rows written to one data file."""
+
+    _RETRACT_KINDS = frozenset({1, 3})
+
+    def __init__(
+            self,
+            file_io,
+            data_file_path: str,
+            value_fields: List[DataField],
+            managed_blob_fields: Set[str]):
+        self._file_io = file_io
+        self._sidecar_path = ManagedBlobReferenceFile.sidecar_path(data_file_path)
+        self._field_specs = []
+        for field in value_fields:
+            if field.name not in managed_blob_fields:
+                continue
+            if not is_blob_file_field(field):
+                continue
+            if is_blob_type(field.type):
+                kind = "scalar"
+            elif is_array_blob_type(field.type):
+                kind = "array"
+            elif is_map_blob_type(field.type):
+                kind = "map"
+            else:
+                continue
+            self._field_specs.append((field.name, kind))
+        self._descriptor_uris: Set[str] = set()
+        self._closed = False
+
+    def collect_table(self, data: pa.Table, value_kind_column: str = "_VALUE_KIND") -> None:
+        if self._closed:
+            raise RuntimeError("Managed BLOB reference collector is already closed.")
+        if not self._field_specs:
+            return
+        if value_kind_column not in data.schema.names:
+            raise ValueError("Missing value kind column %r." % value_kind_column)
+
+        kinds = data.column(value_kind_column).to_pylist()
+        for row_idx, kind in enumerate(kinds):
+            if kind in self._RETRACT_KINDS:
+                continue
+            for field_name, field_kind in self._field_specs:
+                if field_name not in data.schema.names:
+                    continue
+                self._collect_value(data.column(field_name)[row_idx], field_kind)
+
+    def close(self) -> str:
+        if self._closed:
+            return self._sidecar_path.rsplit("/", 1)[-1]
+        references: List[Reference] = []
+        for descriptor_uri in self._descriptor_uris:
+            reference = ManagedBlobReferenceFile.from_descriptor_uri(descriptor_uri)
+            if reference is not None:
+                references.append(reference)
+        self._descriptor_uris.clear()
+        try:
+            ManagedBlobReferenceFile.write(self._file_io, self._sidecar_path, references)
+        except Exception:
+            self.abort()
+            raise
+        self._closed = True
+        return self._sidecar_path.rsplit("/", 1)[-1]
+
+    def abort(self) -> None:
+        self._file_io.delete_quietly(self._sidecar_path)
+        self._descriptor_uris.clear()
+        self._closed = True
+
+    def _collect_value(self, value, field_kind: str) -> None:
+        if value is None:
+            return
+        if hasattr(value, "as_py"):
+            value = value.as_py()
+        if value is None:
+            return
+        if field_kind == "scalar":
+            self._collect_descriptor_bytes(value)
+            return
+        if field_kind == "array":
+            if not hasattr(value, "__iter__") or isinstance(value, (bytes, bytearray, str)):
+                return
+            for element in value:
+                if element is not None:
+                    self._collect_descriptor_bytes(element)
+            return
+        if field_kind == "map":
+            for _, map_value in _map_items(value):
+                if map_value is not None:
+                    self._collect_descriptor_bytes(map_value)
+
+    def _collect_descriptor_bytes(self, raw) -> None:
+        if isinstance(raw, BlobRef):
+            self._descriptor_uris.add(raw.to_descriptor().uri)
+            return
+        if isinstance(raw, Blob):
+            descriptor = raw.to_descriptor()
+            if descriptor.uri.endswith(ManagedBlobReferenceFile.MANAGED_BLOB_SUFFIX):
+                self._descriptor_uris.add(descriptor.uri)
+            return
+        if isinstance(raw, (bytes, bytearray)):
+            # Values in a managed BLOB data-file column are descriptors by
+            # contract. Parse them non-heuristically so legacy v1 descriptors
+            # (which have no magic header) contribute their pack reference.
+            descriptor = BlobDescriptor.deserialize(bytes(raw))
+            if descriptor.uri.endswith(ManagedBlobReferenceFile.MANAGED_BLOB_SUFFIX):
+                self._descriptor_uris.add(descriptor.uri)
+
+
+def _map_items(value):
+    if value is None:
+        return []
+    if isinstance(value, dict):
+        return value.items()
+    if hasattr(value, "items"):
+        return value.items()
+    return list(value)

--- a/paimon-python/pypaimon/blob/managed_blob_reference_file.py
+++ b/paimon-python/pypaimon/blob/managed_blob_reference_file.py
@@ -1,0 +1,168 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+import io
+import struct
+import zlib
+from typing import List, Optional, Tuple
+
+from pypaimon.index.pk.primary_key_index_source_meta import (
+    _decode_modified_utf8,
+    _encode_modified_utf8,
+)
+
+
+class ManagedBlobReferenceFile:
+    """Versioned metadata listing managed BLOB packs referenced by one data file."""
+
+    MAGIC = 0x50424C52
+    VERSION = 1
+    MANAGED_BLOB_SUFFIX = ".managed.blob"
+    REFERENCE_FILE_SUFFIX = ".blobref"
+
+    @staticmethod
+    def from_descriptor_uri(descriptor_uri: str) -> Optional["Reference"]:
+        if not descriptor_uri.endswith(ManagedBlobReferenceFile.MANAGED_BLOB_SUFFIX):
+            return None
+        parent, _, name = descriptor_uri.rpartition("/")
+        if not parent or not name:
+            return None
+        return Reference(parent, name)
+
+    @staticmethod
+    def sidecar_path(data_file_path: str) -> str:
+        return data_file_path + ManagedBlobReferenceFile.REFERENCE_FILE_SUFFIX
+
+    @staticmethod
+    def sidecar_name(data_file_name: str) -> str:
+        return data_file_name + ManagedBlobReferenceFile.REFERENCE_FILE_SUFFIX
+
+    @staticmethod
+    def write(file_io, path: str, references: List["Reference"]) -> None:
+        normalized = sorted(
+            references,
+            key=lambda ref: (ref.storage_root_id, ref.relative_path),
+        )
+        unique: List[Reference] = []
+        for reference in normalized:
+            if not unique or reference != unique[-1]:
+                unique.append(reference)
+
+        payload = io.BytesIO()
+        payload.write(struct.pack(">B", ManagedBlobReferenceFile.VERSION))
+        payload.write(struct.pack(">i", len(unique)))
+        for reference in unique:
+            _write_modified_utf(payload, reference.storage_root_id)
+            _write_modified_utf(payload, reference.relative_path)
+
+        payload_bytes = payload.getvalue()
+        checksum = zlib.crc32(payload_bytes) & 0xFFFFFFFF
+        checksum_signed = (
+            checksum if checksum < 0x80000000 else checksum - 0x100000000
+        )
+        try:
+            with file_io.new_output_stream(path) as out:
+                out.write(struct.pack(">i", ManagedBlobReferenceFile.MAGIC))
+                out.write(payload_bytes)
+                out.write(struct.pack(">i", checksum_signed))
+        except Exception:
+            file_io.delete_quietly(path)
+            raise
+
+    @staticmethod
+    def read(file_io, path: str) -> List["Reference"]:
+        with file_io.new_input_stream(path) as stream:
+            data = stream.read()
+        if len(data) < 8:
+            raise IOError("Invalid managed BLOB reference file: too short")
+        magic = struct.unpack_from(">i", data, 0)[0]
+        if magic != ManagedBlobReferenceFile.MAGIC:
+            raise IOError("Invalid managed BLOB reference file magic: %s" % magic)
+
+        offset = 4
+        version = data[offset]
+        offset += 1
+        if version != ManagedBlobReferenceFile.VERSION:
+            raise IOError("Unsupported managed BLOB reference file version: %s" % version)
+
+        count = struct.unpack_from(">i", data, offset)[0]
+        offset += 4
+        if count < 0:
+            raise IOError("Invalid managed BLOB reference count: %s" % count)
+
+        references: List[Reference] = []
+        for _ in range(count):
+            root, offset = _read_modified_utf(data, offset)
+            rel, offset = _read_modified_utf(data, offset)
+            references.append(Reference(root, rel))
+
+        if offset + 4 > len(data):
+            raise IOError("Invalid managed BLOB reference file checksum")
+        expected_checksum = struct.unpack_from(">i", data, offset)[0] & 0xFFFFFFFF
+        actual_checksum = zlib.crc32(data[4:offset]) & 0xFFFFFFFF
+        if expected_checksum != actual_checksum:
+            raise IOError(
+                "Invalid managed BLOB reference file checksum. Expected %s but computed %s."
+                % (expected_checksum, actual_checksum))
+        if offset + 4 != len(data):
+            raise IOError("Unexpected trailing bytes in managed BLOB reference file.")
+        return references
+
+
+class Reference:
+    """Exact identity of a managed BLOB payload pack."""
+
+    __slots__ = ("storage_root_id", "relative_path")
+
+    def __init__(self, storage_root_id: str, relative_path: str):
+        if not storage_root_id:
+            raise ValueError("Managed BLOB storage root must not be empty.")
+        if not relative_path or "/" in relative_path or relative_path in (".", ".."):
+            raise ValueError(
+                "Managed BLOB relative path must be a file name: %s." % relative_path)
+        self.storage_root_id = storage_root_id
+        self.relative_path = relative_path
+
+    def __eq__(self, other) -> bool:
+        if not isinstance(other, Reference):
+            return False
+        return (
+            self.storage_root_id == other.storage_root_id
+            and self.relative_path == other.relative_path
+        )
+
+    def __repr__(self) -> str:
+        return "%s/%s" % (self.storage_root_id, self.relative_path)
+
+
+def _write_modified_utf(out: io.BytesIO, value: str) -> None:
+    encoded = _encode_modified_utf8(value)
+    if len(encoded) > 65535:
+        raise ValueError("Modified UTF-8 string is too long.")
+    out.write(struct.pack(">H", len(encoded)))
+    out.write(encoded)
+
+
+def _read_modified_utf(data: bytes, offset: int) -> Tuple[str, int]:
+    if offset + 2 > len(data):
+        raise IOError("Truncated modified UTF-8 length.")
+    length = struct.unpack_from(">H", data, offset)[0]
+    offset += 2
+    end = offset + length
+    if end > len(data):
+        raise IOError("Truncated modified UTF-8 payload.")
+    return _decode_modified_utf8(data[offset:end]), end

--- a/paimon-python/pypaimon/blob/primary_key_blob_externalizer.py
+++ b/paimon-python/pypaimon/blob/primary_key_blob_externalizer.py
@@ -1,0 +1,374 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+import uuid
+from typing import Callable, List, Optional, Set
+
+import pyarrow as pa
+
+from pypaimon.blob.managed_blob_reference_file import ManagedBlobReferenceFile
+from pypaimon.common.options.core_options import CoreOptions
+from pypaimon.schema.data_types import (
+    AtomicType,
+    DataField,
+    is_array_blob_type,
+    is_blob_type,
+    is_map_blob_type,
+)
+from pypaimon.table.row.blob import Blob, BlobData, BlobDescriptor
+from pypaimon.table.row.generic_row import GenericRow, RowKind
+from pypaimon.write.blob_format_writer import BlobFormatWriter
+
+
+class PrimaryKeyBlobExternalizer:
+    """Externalize primary-key managed BLOB values before they enter the write buffer."""
+
+    def __init__(
+            self,
+            file_io,
+            value_fields: List[DataField],
+            managed_blob_fields: Set[str],
+            new_pack_path: Callable[[], str],
+            target_file_size: int,
+            copy_buffer_size: int,
+            data_file_prefix: str,
+            descriptor_reader_factory=None):
+        if target_file_size <= 0:
+            raise ValueError("Managed BLOB target file size must be positive.")
+        unknown = set(managed_blob_fields)
+        self._file_io = file_io
+        self._field_specs = []
+        self._uncommitted_packs: List[str] = []
+        self._data_file_prefix = data_file_prefix
+        for field in value_fields:
+            if field.name not in managed_blob_fields:
+                continue
+            unknown.discard(field.name)
+            if is_blob_type(field.type):
+                kind = "scalar"
+            elif is_array_blob_type(field.type):
+                kind = "array"
+            elif is_map_blob_type(field.type):
+                kind = "map"
+            else:
+                raise ValueError(
+                    "Managed BLOB field '%s' must be BLOB, ARRAY<BLOB> or MAP<X, BLOB>, "
+                    "but was %s." % (field.name, field.type))
+            self._field_specs.append(
+                _ManagedBlobField(
+                    field.name,
+                    field.type,
+                    kind,
+                    _ManagedBlobPackWriter(
+                        file_io,
+                        new_pack_path,
+                        target_file_size,
+                        self._uncommitted_packs,
+                        copy_buffer_size,
+                        descriptor_reader_factory,
+                    ),
+                ))
+        if unknown:
+            raise ValueError(
+                "Managed BLOB fields do not exist in value type: %s." % sorted(unknown))
+
+    @property
+    def enabled(self) -> bool:
+        return bool(self._field_specs)
+
+    def externalize_record_batch(self, batch: pa.RecordBatch) -> pa.RecordBatch:
+        if not self.enabled:
+            return batch
+        columns = list(batch.columns)
+        names = list(batch.schema.names)
+        schema_fields = list(batch.schema)
+        changed = False
+        try:
+            for field_spec in self._field_specs:
+                if field_spec.name not in names:
+                    continue
+                idx = names.index(field_spec.name)
+                new_column = field_spec.externalize_column(columns[idx])
+                if new_column is not columns[idx]:
+                    columns[idx] = new_column
+                    original_field = schema_fields[idx]
+                    schema_fields[idx] = pa.field(
+                        original_field.name,
+                        new_column.type,
+                        nullable=original_field.nullable,
+                        metadata=original_field.metadata,
+                    )
+                    changed = True
+        except Exception:
+            self.abort()
+            raise
+        if not changed:
+            return batch
+        return pa.RecordBatch.from_arrays(columns, schema=pa.schema(schema_fields))
+
+    def stage_commit(self) -> List[str]:
+        """Close packs but retain their ownership until the outer prepare succeeds."""
+        try:
+            for field_spec in self._field_specs:
+                field_spec.pack_writer.close_current()
+            return list(self._uncommitted_packs)
+        except Exception:
+            self.abort()
+            raise
+
+    def validate_commit(self, staged_packs: List[str]) -> None:
+        if self._uncommitted_packs != staged_packs:
+            raise RuntimeError("Managed BLOB packs changed while commit was staged.")
+
+    def complete_commit(self, staged_packs: List[str]) -> None:
+        self.validate_commit(staged_packs)
+        self._uncommitted_packs.clear()
+
+    def prepare_commit(self) -> None:
+        staged_packs = self.stage_commit()
+        self.complete_commit(staged_packs)
+
+    def abort(self) -> None:
+        for field_spec in self._field_specs:
+            field_spec.pack_writer.abort_current()
+        for path in self._uncommitted_packs:
+            self._file_io.delete_quietly(path)
+        self._uncommitted_packs.clear()
+
+    def close(self) -> None:
+        self.abort()
+        factory = self._field_specs[0].pack_writer.descriptor_reader_factory \
+            if self._field_specs else None
+        if getattr(factory, "_blob_descriptor_owned", False):
+            close = getattr(factory, "close", None)
+            if callable(close):
+                close()
+
+
+class _ManagedBlobField:
+    __slots__ = ("name", "data_type", "kind", "pack_writer")
+
+    def __init__(self, name, data_type, kind, pack_writer):
+        self.name = name
+        self.data_type = data_type
+        self.kind = kind
+        self.pack_writer = pack_writer
+
+    def externalize_column(self, column: pa.Array) -> pa.Array:
+        if self.kind == "scalar":
+            return self._externalize_scalar(column)
+        if self.kind == "array":
+            return self._externalize_array(column)
+        return self._externalize_map(column)
+
+    def _externalize_scalar(self, column: pa.Array) -> pa.Array:
+        values = column.to_pylist()
+        out = []
+        changed = False
+        for value in values:
+            if value is None:
+                out.append(None)
+                continue
+            blob = _to_blob_value(
+                value,
+                self.pack_writer.file_io,
+                self.pack_writer.descriptor_reader_factory,
+            )
+            descriptor = self.pack_writer.write(blob)
+            out.append(descriptor.serialize())
+            changed = True
+        if not changed:
+            return column
+        return pa.array(out, type=column.type)
+
+    def _externalize_array(self, column: pa.Array) -> pa.Array:
+        values = column.to_pylist()
+        out = []
+        changed = False
+        for value in values:
+            if value is None:
+                out.append(None)
+                continue
+            elements = []
+            local_changed = False
+            for element in value:
+                if element is None:
+                    elements.append(None)
+                    continue
+                blob = _to_blob_value(
+                    element,
+                    self.pack_writer.file_io,
+                    self.pack_writer.descriptor_reader_factory,
+                )
+                descriptor = self.pack_writer.write(blob)
+                elements.append(descriptor.serialize())
+                local_changed = True
+            out.append(elements if local_changed else value)
+            changed = changed or local_changed
+        if not changed:
+            return column
+        return pa.array(out, type=column.type)
+
+    def _externalize_map(self, column: pa.Array) -> pa.Array:
+        values = column.to_pylist()
+        out = []
+        changed = False
+        for value in values:
+            if value is None:
+                out.append(None)
+                continue
+            items = []
+            local_changed = False
+            for key, map_value in _map_items(value):
+                if map_value is None:
+                    items.append((key, None))
+                    continue
+                blob = _to_blob_value(
+                    map_value,
+                    self.pack_writer.file_io,
+                    self.pack_writer.descriptor_reader_factory,
+                )
+                descriptor = self.pack_writer.write(blob)
+                items.append((key, descriptor.serialize()))
+                local_changed = True
+            out.append(items if local_changed else value)
+            changed = changed or local_changed
+        if not changed:
+            return column
+        return pa.array(out, type=column.type)
+
+
+class _ManagedBlobPackWriter:
+    def __init__(
+            self,
+            file_io,
+            new_pack_path: Callable[[], str],
+            target_file_size: int,
+            uncommitted_packs: List[str],
+            copy_buffer_size: int,
+            descriptor_reader_factory=None):
+        self.file_io = file_io
+        self._new_pack_path = new_pack_path
+        self._target_file_size = target_file_size
+        self._uncommitted_packs = uncommitted_packs
+        self._copy_buffer_size = copy_buffer_size
+        self.descriptor_reader_factory = descriptor_reader_factory
+        self._current_path: Optional[str] = None
+        self._output_stream = None
+        self._writer: Optional[BlobFormatWriter] = None
+        self._last_descriptor: Optional[BlobDescriptor] = None
+
+    def write(self, blob: Blob) -> BlobDescriptor:
+        if self._writer is None:
+            self._open_current()
+        self._last_descriptor = None
+        row = GenericRow(
+            [blob],
+            [DataField(0, "blob", AtomicType("BLOB"))],
+            RowKind.INSERT,
+        )
+        self._writer.add_element(row)
+        descriptor = self._last_descriptor
+        if descriptor is None:
+            raise IOError("Managed BLOB writer did not produce a descriptor.")
+        if self._writer.reach_target_size(self._target_file_size):
+            self.close_current()
+        return descriptor
+
+    def _open_current(self) -> None:
+        self._current_path = self._new_pack_path()
+        self._uncommitted_packs.append(self._current_path)
+        self._output_stream = self.file_io.new_output_stream(self._current_path)
+
+        def _consumer(_field_name, descriptor):
+            self._last_descriptor = descriptor
+            return False
+
+        self._writer = BlobFormatWriter(
+            self._output_stream,
+            blob_consumer=_consumer,
+            file_path=self._current_path,
+            copy_buffer_size=self._copy_buffer_size,
+        )
+
+    def close_current(self) -> None:
+        if self._writer is None:
+            return
+        try:
+            self._writer.close()
+        finally:
+            self._writer = None
+            self._output_stream = None
+            self._current_path = None
+
+    def abort_current(self) -> None:
+        if self._writer is not None:
+            try:
+                self._writer.close()
+            except Exception:
+                pass
+        if self._output_stream is not None:
+            try:
+                if hasattr(self._output_stream, "close"):
+                    self._output_stream.close()
+            except Exception:
+                pass
+        self._writer = None
+        self._output_stream = None
+        self._current_path = None
+
+
+def _to_blob_value(value, file_io, descriptor_reader_factory=None) -> Blob:
+    if isinstance(value, Blob):
+        return value
+    if hasattr(value, "as_py"):
+        value = value.as_py()
+    if isinstance(value, str):
+        value = value.encode("utf-8")
+    if isinstance(value, bytearray):
+        value = bytes(value)
+    if isinstance(value, bytes):
+        factory = descriptor_reader_factory or file_io.uri_reader_factory
+        force_descriptor = bool(
+            getattr(factory, "force_descriptor_bytes", False))
+        if force_descriptor or BlobDescriptor.is_blob_descriptor(value):
+            return Blob.from_descriptor_bytes(
+                value, uri_reader_factory=factory)
+        return BlobData(value)
+    raise ValueError(
+        "Blob field value must be bytes/blob or serialized BlobDescriptor bytes, "
+        "got %s." % type(value)
+    )
+
+
+def _map_items(value):
+    if isinstance(value, dict):
+        return list(value.items())
+    if hasattr(value, "items"):
+        return list(value.items())
+    return list(value)
+
+
+def new_managed_blob_path(path_factory, partition, bucket, options: CoreOptions) -> str:
+    prefix = CoreOptions.data_file_prefix(options)
+    file_name = "%s%s-0%s" % (
+        prefix,
+        uuid.uuid4(),
+        ManagedBlobReferenceFile.MANAGED_BLOB_SUFFIX,
+    )
+    bucket_path = path_factory.bucket_path(partition, bucket)
+    return "%s/%s" % (bucket_path.rstrip("/"), file_name)

--- a/paimon-python/pypaimon/common/options/core_options.py
+++ b/paimon-python/pypaimon/common/options/core_options.py
@@ -409,6 +409,16 @@ class CoreOptions:
         )
     )
 
+    BLOB_DESCRIPTOR_SOURCE_TABLE: ConfigOption[str] = (
+        ConfigOptions.key("blob-descriptor.source-table")
+        .string_type()
+        .no_default_value()
+        .with_description(
+            "Source table whose FileIO is used to read descriptor-backed BLOB "
+            "content copied into managed BLOB storage."
+        )
+    )
+
     BLOB_VIEW_FIELD: ConfigOption[str] = (
         ConfigOptions.key("blob-view-field")
         .string_type()
@@ -1216,9 +1226,15 @@ class CoreOptions:
         value = self.options.get(CoreOptions.BLOB_DESCRIPTOR_FIELD, default)
         return CoreOptions._parse_field_set(value)
 
+    def blob_descriptor_source_table(self, default=None):
+        return self.options.get(CoreOptions.BLOB_DESCRIPTOR_SOURCE_TABLE, default)
+
     def blob_view_fields(self, default=None):
         value = self.options.get(CoreOptions.BLOB_VIEW_FIELD, default)
         return CoreOptions._parse_field_set(value)
+
+    def blob_inline_fields(self, default=None):
+        return self.blob_descriptor_fields(default).union(self.blob_view_fields(default))
 
     def blob_field(self, default=None):
         value = self.options.get(CoreOptions.BLOB_FIELD, default)

--- a/paimon-python/pypaimon/common/uri_reader.py
+++ b/paimon-python/pypaimon/common/uri_reader.py
@@ -110,6 +110,7 @@ class UriReaderFactory:
     def __init__(self, catalog_options: Union[Options, dict]) -> None:
         self.catalog_options = catalog_options if isinstance(catalog_options, Options) else Options(catalog_options)
         self._readers = LRUCache(CatalogOptions.BLOB_FILE_IO_DEFAULT_CACHE_SIZE)
+        self._owned_file_ios = []
         self._readers_lock = rwlock.RWLockFair()
 
     def create(self, input_uri: str) -> UriReader:
@@ -148,12 +149,32 @@ class UriReaderFactory:
             from pypaimon.common.file_io import FileIO
             uri_string = parsed_uri.geturl()
             file_io = FileIO.get(uri_string, self.catalog_options)
+            self._owned_file_ios.append(file_io)
             return UriReader.from_file(file_io)
         except Exception as e:
             raise RuntimeError(f"Failed to create reader for URI {parsed_uri.geturl()}") from e
 
     def clear_cache(self) -> None:
-        self._readers.clear()
+        wlock = self._readers_lock.gen_wlock()
+        wlock.acquire()
+        try:
+            file_ios = self._owned_file_ios
+            self._owned_file_ios = []
+            self._readers.clear()
+        finally:
+            wlock.release()
+        first_error = None
+        for file_io in file_ios:
+            try:
+                file_io.close()
+            except Exception as error:
+                if first_error is None:
+                    first_error = error
+        if first_error is not None:
+            raise first_error
+
+    def close(self) -> None:
+        self.clear_cache()
 
     def get_cache_size(self) -> int:
         return len(self._readers)
@@ -165,4 +186,6 @@ class UriReaderFactory:
 
     def __setstate__(self, state):
         self.__dict__.update(state)
+        if not hasattr(self, '_owned_file_ios'):
+            self._owned_file_ios = []
         self._readers_lock = rwlock.RWLockFair()

--- a/paimon-python/pypaimon/index/dynamic_bucket.py
+++ b/paimon-python/pypaimon/index/dynamic_bucket.py
@@ -107,6 +107,16 @@ class _PartitionIndex:
         self.total_bucket_list = list(bucket_information)
         self.target_bucket_row_number = target_bucket_row_number
 
+    def copy(self) -> "_PartitionIndex":
+        copied = _PartitionIndex(
+            dict(self.hash_to_bucket),
+            dict(self.non_full_bucket_information),
+            self.target_bucket_row_number,
+        )
+        copied.total_bucket_set = set(self.total_bucket_set)
+        copied.total_bucket_list = list(self.total_bucket_list)
+        return copied
+
     def assign(
         self,
         key_hash: int,
@@ -194,6 +204,10 @@ class HashBucketAssigner:
         )
         self.max_bucket_id = 0
         self._partition_indexes: Dict[Tuple, _PartitionIndex] = {}
+        self._round_original_partition_indexes: Dict[
+            Tuple, Optional[_PartitionIndex]
+        ] = {}
+        self._round_original_max_bucket_id: Optional[int] = None
 
     def assign(self, partition: Tuple, partition_hash: int, key_hash: int) -> int:
         return self.assign_with_status(partition, partition_hash, key_hash)[0]
@@ -226,6 +240,15 @@ class HashBucketAssigner:
             self._validate_assigner(partition_hash, key_hash)
             requested_by_partition.setdefault(partition, set()).add(key_hash)
 
+        if requested_by_partition and self._round_original_max_bucket_id is None:
+            self._round_original_max_bucket_id = self.max_bucket_id
+        for partition in requested_by_partition:
+            if partition not in self._round_original_partition_indexes:
+                index = self._partition_indexes.get(partition)
+                self._round_original_partition_indexes[partition] = (
+                    index.copy() if index is not None else None
+                )
+
         for partition, requested in requested_by_partition.items():
             index = self._partition_indexes.get(partition)
             if index is None:
@@ -257,6 +280,26 @@ class HashBucketAssigner:
             self.max_bucket_id = max(self.max_bucket_id, bucket)
             results.append((bucket, is_new))
         return results
+
+    def release_prepared(self) -> None:
+        self._round_original_partition_indexes.clear()
+        self._round_original_max_bucket_id = None
+
+    def refresh_snapshot(self, snapshot=None) -> None:
+        if snapshot is None:
+            snapshot = self.table.snapshot_manager().get_latest_snapshot()
+        self.snapshot = snapshot
+
+    def abort(self) -> None:
+        for partition, index in self._round_original_partition_indexes.items():
+            if index is None:
+                self._partition_indexes.pop(partition, None)
+            else:
+                self._partition_indexes[partition] = index
+        if self._round_original_max_bucket_id is not None:
+            self.max_bucket_id = self._round_original_max_bucket_id
+        self._round_original_partition_indexes.clear()
+        self._round_original_max_bucket_id = None
 
     def _validate_assigner(self, partition_hash: int, key_hash: int) -> None:
         expected_assigner = compute_assigner(
@@ -409,6 +452,9 @@ class DynamicBucketIndexMaintainer:
             Tuple[Tuple, int], Tuple[Set[int], Optional[IndexManifestEntry], bool]
         ] = {}
         self._new_paths: List[str] = []
+        self._round_original_states: Dict[
+            Tuple[Tuple, int], Tuple[Set[int], Optional[IndexManifestEntry], bool]
+        ] = {}
 
     def notify_new_record(
         self, partition: Tuple, bucket: int, key_hash: int
@@ -419,6 +465,9 @@ class DynamicBucketIndexMaintainer:
             hashes, old_entry = self._load_bucket(partition, bucket)
             state = (hashes, old_entry, False)
         hashes, old_entry, modified = state
+        if key not in self._round_original_states:
+            self._round_original_states[key] = (
+                set(hashes), old_entry, modified)
         previous_size = len(hashes)
         hashes.add(to_signed_int32(key_hash))
         self._states[key] = (hashes, old_entry, modified or len(hashes) != previous_size)
@@ -447,11 +496,21 @@ class DynamicBucketIndexMaintainer:
     def release_prepared(self) -> None:
         """Release files after their commit messages leave writer ownership."""
         self._new_paths.clear()
+        self._round_original_states.clear()
+
+    def refresh_snapshot(self, snapshot=None) -> None:
+        if snapshot is None:
+            snapshot = self.table.snapshot_manager().get_latest_snapshot()
+        self.snapshot = snapshot
+        self.base_snapshot_id = snapshot.id if snapshot is not None else 0
 
     def abort(self) -> None:
         for path in self._new_paths:
             self.table.file_io.delete_quietly(path)
         self._new_paths.clear()
+        for key, (hashes, old_entry, modified) in self._round_original_states.items():
+            self._states[key] = (set(hashes), old_entry, modified)
+        self._round_original_states.clear()
 
     def _load_bucket(
         self, partition: Tuple, bucket: int

--- a/paimon-python/pypaimon/read/read_builder.py
+++ b/paimon-python/pypaimon/read/read_builder.py
@@ -24,7 +24,8 @@ from pypaimon.read.explain_render import render_predicate
 from pypaimon.read.query_auth_split import QueryAuthSplit
 from pypaimon.read.scan_stats import ScanStats
 from pypaimon.read.split import Split
-from pypaimon.read.table_read import TableRead
+from pypaimon.read.table_read import (TableRead,
+                                      validate_primary_key_blob_predicate)
 from pypaimon.read.table_scan import TableScan
 from pypaimon.schema.data_types import DataField
 from pypaimon.table.special_fields import SpecialFields
@@ -80,6 +81,7 @@ class ReadBuilder:
         return self
 
     def new_scan(self) -> TableScan:
+        validate_primary_key_blob_predicate(self.table, self._predicate)
         scan = TableScan(
             table=self.table,
             predicate=self._predicate,

--- a/paimon-python/pypaimon/read/reader/blob_descriptor_convert_reader.py
+++ b/paimon-python/pypaimon/read/reader/blob_descriptor_convert_reader.py
@@ -174,7 +174,10 @@ class BlobInlineConvertReader(RecordBatchReader):
             if field_name not in batch.schema.names:
                 continue
             values = [self._normalize_blob_to_bytes(v) for v in batch.column(field_name).to_pylist()]
-            blobs = [Blob.from_bytes(v, self._table.file_io) for v in values]
+            blobs = [
+                self._descriptor_field_to_blob(value, self._table.file_io)
+                for value in values
+            ]
 
             if self._blob_parallelism > 1:
                 converted_values = self._table.file_io.read_blobs_concurrent(
@@ -200,7 +203,7 @@ class BlobInlineConvertReader(RecordBatchReader):
 
             for idx, value in enumerate(values):
                 file_io = field_file_ios[idx] or self._table.file_io
-                blob = Blob.from_bytes(value, file_io)
+                blob = self._descriptor_field_to_blob(value, file_io)
                 if self._blob_parallelism > 1:
                     converted_values.append(None)
                     if blob is not None:
@@ -239,5 +242,16 @@ class BlobInlineConvertReader(RecordBatchReader):
             value = bytes(value)
         return value
 
+    @staticmethod
+    def _descriptor_field_to_blob(value, file_io):
+        value = BlobInlineConvertReader._normalize_blob_to_bytes(value)
+        if value is None:
+            return None
+        return Blob.from_descriptor_bytes(value, file_io=file_io)
+
     def close(self):
-        self._inner.close()
+        try:
+            self._inner.close()
+        finally:
+            if self._blob_view_lookup is not None:
+                self._blob_view_lookup.close()

--- a/paimon-python/pypaimon/read/reader/field_indices.py
+++ b/paimon-python/pypaimon/read/reader/field_indices.py
@@ -19,13 +19,13 @@
 
 from typing import Any, Iterable, List, Optional, Sequence, Set
 
-from pypaimon.schema.data_types import DataField, VectorType
+from pypaimon.schema.data_types import DataField, VectorType, is_blob_file_field
 
 
 def blob_field_indices(fields: List[DataField]) -> Set[int]:
     return {
         i for i, f in enumerate(fields)
-        if hasattr(f.type, 'type') and f.type.type == 'BLOB'
+        if is_blob_file_field(f)
     }
 
 

--- a/paimon-python/pypaimon/read/reader/managed_blob_convert_record_reader.py
+++ b/paimon-python/pypaimon/read/reader/managed_blob_convert_record_reader.py
@@ -1,0 +1,430 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from typing import Any, Iterable, Optional, Set
+
+import pyarrow as pa
+
+from pypaimon.read.reader.iface.record_batch_reader import RecordBatchReader
+from pypaimon.read.reader.iface.record_iterator import RecordIterator
+from pypaimon.read.reader.iface.record_reader import RecordReader
+from pypaimon.table.row.blob import Blob, BlobViewStruct
+from pypaimon.table.row.internal_row import InternalRow
+from pypaimon.table.row.offset_row import OffsetRow
+
+
+class ManagedBlobConvertBatchReader(RecordBatchReader):
+    """Resolve PK managed and inline BLOB references in Arrow batches."""
+
+    def __init__(
+            self,
+            inner: RecordBatchReader,
+            file_io,
+            blob_field_names: Iterable[str],
+            descriptor_field_names: Optional[Iterable[str]] = None,
+            view_field_names: Optional[Iterable[str]] = None,
+            table=None,
+            blob_as_descriptor: bool = False):
+        self._inner = inner
+        self._file_io = file_io
+        self._blob_field_names = frozenset(blob_field_names)
+        self._descriptor_field_names = frozenset(descriptor_field_names or ())
+        self._view_field_names = frozenset(view_field_names or ())
+        self._blob_as_descriptor = blob_as_descriptor
+        self._view_resolver = _BlobViewResolver(table) if self._view_field_names else None
+        self._adopt_metadata(inner)
+
+    def read_arrow_batch(self) -> Optional[pa.RecordBatch]:
+        batch = self._inner.read_arrow_batch()
+        if batch is None:
+            return None
+        return convert_primary_key_blob_batch(
+            batch,
+            self._file_io,
+            self._blob_field_names,
+            self._descriptor_field_names,
+            self._view_field_names,
+            self._blob_as_descriptor,
+            self._view_resolver,
+        )
+
+    def close(self) -> None:
+        try:
+            self._inner.close()
+        finally:
+            if self._view_resolver is not None:
+                self._view_resolver.close()
+
+
+def convert_managed_blob_batch(
+        batch: pa.RecordBatch,
+        file_io,
+        blob_field_names: Set[str]) -> pa.RecordBatch:
+    if not blob_field_names:
+        return batch
+    columns = []
+    changed = False
+    for field in batch.schema:
+        column = batch.column(field.name)
+        if field.name not in blob_field_names:
+            columns.append(column)
+            continue
+        values = [_resolve_blob_payload(value, file_io) for value in column.to_pylist()]
+        columns.append(pa.array(values, type=field.type))
+        changed = True
+    if not changed:
+        return batch
+    return pa.RecordBatch.from_arrays(columns, schema=batch.schema)
+
+
+def convert_primary_key_blob_batch(
+        batch: pa.RecordBatch,
+        file_io,
+        managed_blob_field_names: Set[str],
+        descriptor_field_names: Set[str],
+        view_field_names: Set[str],
+        blob_as_descriptor: bool,
+        view_resolver=None) -> pa.RecordBatch:
+    """Resolve PK BLOB values after merge, filtering, projection and limit."""
+    if view_resolver is not None:
+        view_resolver.preload_batch(batch, view_field_names)
+
+    columns = []
+    changed = False
+    for field in batch.schema:
+        column = batch.column(field.name)
+        values = None
+        if field.name in managed_blob_field_names and not blob_as_descriptor:
+            values = [_resolve_blob_payload(value, file_io) for value in column.to_pylist()]
+        elif field.name in descriptor_field_names and not blob_as_descriptor:
+            values = [_resolve_descriptor_payload(value, file_io) for value in column.to_pylist()]
+        elif field.name in view_field_names and view_resolver is not None:
+            values = [
+                view_resolver.resolve(value, blob_as_descriptor)
+                for value in column.to_pylist()
+            ]
+
+        if values is None:
+            columns.append(column)
+            continue
+        columns.append(pa.array(values, type=field.type))
+        changed = True
+
+    if not changed:
+        return batch
+    return pa.RecordBatch.from_arrays(columns, schema=batch.schema)
+
+
+class ManagedBlobConvertRecordReader(RecordReader[InternalRow]):
+    """Resolve PK managed and inline BLOB references in InternalRow batches."""
+
+    def __init__(
+            self,
+            inner: RecordReader[InternalRow],
+            file_io,
+            blob_field_indices: Optional[Iterable[int]] = None,
+            descriptor_field_indices: Optional[Iterable[int]] = None,
+            view_field_indices: Optional[Iterable[int]] = None,
+            table=None,
+            blob_as_descriptor: bool = False):
+        self._inner = inner
+        self._file_io = file_io
+        self._blob_field_indices: Set[int] = (
+            frozenset(blob_field_indices) if blob_field_indices is not None else frozenset()
+        )
+        self._descriptor_field_indices: Set[int] = frozenset(
+            descriptor_field_indices or ())
+        self._view_field_indices: Set[int] = frozenset(view_field_indices or ())
+        self._blob_as_descriptor = blob_as_descriptor
+        self._view_resolver = _BlobViewResolver(table) if self._view_field_indices else None
+
+    def read_batch(self) -> Optional[RecordIterator[InternalRow]]:
+        inner_batch = self._inner.read_batch()
+        if inner_batch is None:
+            return None
+        return _ManagedBlobConvertIterator(
+            inner_batch,
+            self._file_io,
+            self._blob_field_indices,
+            self._descriptor_field_indices,
+            self._view_field_indices,
+            self._blob_as_descriptor,
+            self._view_resolver,
+        )
+
+    def close(self) -> None:
+        try:
+            self._inner.close()
+        finally:
+            if self._view_resolver is not None:
+                self._view_resolver.close()
+
+
+class _ManagedBlobConvertIterator(RecordIterator[InternalRow]):
+    def __init__(
+            self,
+            inner: RecordIterator[InternalRow],
+            file_io,
+            blob_field_indices: Set[int],
+            descriptor_field_indices: Set[int],
+            view_field_indices: Set[int],
+            blob_as_descriptor: bool,
+            view_resolver):
+        self._inner = inner
+        self._file_io = file_io
+        self._blob_field_indices = blob_field_indices
+        self._descriptor_field_indices = descriptor_field_indices
+        self._view_field_indices = view_field_indices
+        self._blob_as_descriptor = blob_as_descriptor
+        self._view_resolver = view_resolver
+
+    def next(self) -> Optional[InternalRow]:
+        row = self._inner.next()
+        if row is None:
+            return None
+        if not (self._blob_field_indices
+                or self._descriptor_field_indices
+                or self._view_field_indices):
+            return row
+        if isinstance(row, OffsetRow):
+            return _convert_offset_row(
+                row,
+                self._file_io,
+                self._blob_field_indices,
+                self._descriptor_field_indices,
+                self._view_field_indices,
+                self._blob_as_descriptor,
+                self._view_resolver,
+            )
+        return _ConvertedRow(
+            row,
+            self._file_io,
+            self._blob_field_indices,
+            self._descriptor_field_indices,
+            self._view_field_indices,
+            self._blob_as_descriptor,
+            self._view_resolver,
+        )
+
+
+def _resolve_blob_payload(value: Any, file_io) -> Any:
+    if value is None:
+        return None
+    if hasattr(value, "as_py"):
+        value = value.as_py()
+    if value is None:
+        return None
+    if isinstance(value, (bytes, bytearray)):
+        blob = Blob.from_descriptor_bytes(bytes(value), file_io)
+        return blob.to_data() if blob is not None else None
+    if isinstance(value, dict):
+        return {
+            key: _resolve_blob_payload(map_value, file_io)
+            for key, map_value in value.items()
+        }
+    if isinstance(value, list):
+        if value and isinstance(value[0], tuple) and len(value[0]) == 2:
+            return [
+                (key, _resolve_blob_payload(map_value, file_io))
+                for key, map_value in value
+            ]
+        return [
+            _resolve_blob_payload(element, file_io) if element is not None else None
+            for element in value
+        ]
+    if isinstance(value, tuple):
+        if len(value) == 2 and not isinstance(value[0], (bytes, bytearray)):
+            key, map_value = value
+            return key, _resolve_blob_payload(map_value, file_io)
+    return value
+
+
+def _resolve_descriptor_payload(value: Any, file_io) -> Any:
+    if value is None:
+        return None
+    if hasattr(value, "as_py"):
+        value = value.as_py()
+    if value is None:
+        return None
+    blob = Blob.from_descriptor_bytes(bytes(value), file_io)
+    return blob.to_data() if blob is not None else None
+
+
+def _convert_offset_row(
+        row: OffsetRow,
+        file_io,
+        blob_field_indices: Set[int],
+        descriptor_field_indices: Set[int],
+        view_field_indices: Set[int],
+        blob_as_descriptor: bool,
+        view_resolver) -> OffsetRow:
+    values = list(row.row_tuple[row.offset:row.offset + row.arity])
+    changed = False
+    for pos in blob_field_indices if not blob_as_descriptor else ():
+        if pos >= len(values):
+            continue
+        converted = _resolve_blob_payload(values[pos], file_io)
+        if converted is not values[pos]:
+            values[pos] = converted
+            changed = True
+    for pos in descriptor_field_indices if not blob_as_descriptor else ():
+        if pos >= len(values):
+            continue
+        converted = _resolve_descriptor_payload(values[pos], file_io)
+        if converted is not values[pos]:
+            values[pos] = converted
+            changed = True
+    if view_resolver is not None:
+        view_resolver.preload_values(
+            values[pos] for pos in view_field_indices if pos < len(values))
+        for pos in view_field_indices:
+            if pos >= len(values):
+                continue
+            converted = view_resolver.resolve(values[pos], blob_as_descriptor)
+            if converted is not values[pos]:
+                values[pos] = converted
+                changed = True
+    if not changed:
+        return row
+    new_tuple = (
+        row.row_tuple[:row.offset]
+        + tuple(values)
+        + row.row_tuple[row.offset + row.arity:]
+    )
+    row.replace(new_tuple)
+    return row
+
+
+class _ConvertedRow(InternalRow):
+    def __init__(
+            self,
+            inner: InternalRow,
+            file_io,
+            blob_field_indices: Set[int],
+            descriptor_field_indices: Set[int],
+            view_field_indices: Set[int],
+            blob_as_descriptor: bool,
+            view_resolver):
+        self._inner = inner
+        self._file_io = file_io
+        self._blob_field_indices = blob_field_indices
+        self._descriptor_field_indices = descriptor_field_indices
+        self._view_field_indices = view_field_indices
+        self._blob_as_descriptor = blob_as_descriptor
+        self._view_resolver = view_resolver
+
+    def get_field(self, pos: int):
+        value = self._inner.get_field(pos)
+        if pos in self._blob_field_indices and not self._blob_as_descriptor:
+            return _resolve_blob_payload(value, self._file_io)
+        if pos in self._descriptor_field_indices and not self._blob_as_descriptor:
+            return _resolve_descriptor_payload(value, self._file_io)
+        if pos in self._view_field_indices and self._view_resolver is not None:
+            self._view_resolver.preload_values([value])
+            return self._view_resolver.resolve(value, self._blob_as_descriptor)
+        return value
+
+    def get_blob(self, pos: int):
+        if not (pos in self._blob_field_indices
+                or pos in self._descriptor_field_indices
+                or pos in self._view_field_indices):
+            return self._inner.get_blob(pos)
+        value = self.get_field(pos)
+        if value is None:
+            return None
+        if self._blob_as_descriptor:
+            return Blob.from_descriptor_bytes(value, file_io=self._file_io)
+        return Blob.from_bytes(value, self._file_io)
+
+    def get_row_kind(self):
+        return self._inner.get_row_kind()
+
+    def get_vector(self, pos: int):
+        return self._inner.get_vector(pos)
+
+    def __len__(self) -> int:
+        return len(self._inner)
+
+
+class _BlobViewResolver:
+    """Caching facade over BlobViewLookup for the PK output path."""
+
+    def __init__(self, table):
+        if table is None:
+            raise ValueError("table is required to resolve blob-view-field values")
+        from pypaimon.utils.blob_view_lookup import BlobViewLookup
+
+        self._lookup = BlobViewLookup(table)
+        self._loaded = set()
+
+    def preload_batch(self, batch: pa.RecordBatch, field_names: Iterable[str]) -> None:
+        values = (
+            value
+            for field_name in field_names
+            if field_name in batch.schema.names
+            for value in batch.column(field_name).to_pylist()
+        )
+        self.preload_values(values)
+
+    def preload_values(self, values: Iterable[Any]) -> None:
+        structs = []
+        pending = set()
+        for value in values:
+            raw = _normalize_bytes(value)
+            if raw is None:
+                continue
+            if not BlobViewStruct.is_blob_view_struct(raw):
+                raise ValueError("Expected BlobViewStruct bytes in blob-view-field value.")
+            view_struct = BlobViewStruct.deserialize(raw)
+            if view_struct not in self._loaded and view_struct not in pending:
+                structs.append(view_struct)
+                pending.add(view_struct)
+        if structs:
+            self._lookup.preload(structs)
+            self._loaded.update(structs)
+
+    def resolve(self, value: Any, blob_as_descriptor: bool) -> Any:
+        raw = _normalize_bytes(value)
+        if raw is None:
+            return None
+        if not BlobViewStruct.is_blob_view_struct(raw):
+            raise ValueError("Expected BlobViewStruct bytes in blob-view-field value.")
+        view_struct = BlobViewStruct.deserialize(raw)
+        if view_struct not in self._loaded:
+            self.preload_values([raw])
+        if self._lookup.resolve_to_null(view_struct):
+            return None
+        if blob_as_descriptor:
+            return self._lookup.resolve_descriptor(view_struct).serialize()
+        return self._lookup.resolve_blob(view_struct).to_data()
+
+    def close(self) -> None:
+        self._lookup.close()
+
+
+def _normalize_bytes(value: Any) -> Optional[bytes]:
+    if value is None:
+        return None
+    if hasattr(value, "as_py"):
+        value = value.as_py()
+    if value is None:
+        return None
+    if isinstance(value, bytearray):
+        value = bytes(value)
+    if not isinstance(value, bytes):
+        raise TypeError("Expected bytes for BLOB reference, got %s" % type(value))
+    return value

--- a/paimon-python/pypaimon/read/split_read.py
+++ b/paimon-python/pypaimon/read/split_read.py
@@ -18,7 +18,7 @@
 import os
 from abc import ABC, abstractmethod
 from functools import partial
-from typing import Callable, Dict, List, Optional, Tuple
+from typing import Callable, Dict, List, Optional, Set, Tuple
 
 from pypaimon.common.merge_engine_dispatch import build_merge_function
 from pypaimon.common.options.core_options import CoreOptions, MergeEngine
@@ -215,6 +215,78 @@ class SplitRead(ABC):
             return pk_predicate
         else:
             return self.predicate
+
+    def _managed_blob_field_names(self) -> Set[str]:
+        from pypaimon.schema.data_types import field_names_in_blob_file
+
+        return field_names_in_blob_file(
+            self.value_fields,
+            CoreOptions.blob_inline_fields(self.table.options),
+        )
+
+    @staticmethod
+    def _blob_field_indices(field_names: Set[str], output_fields) -> Set[int]:
+        if not field_names:
+            return set()
+        name_to_idx = {field.name: idx for idx, field in enumerate(output_fields)}
+        return {
+            name_to_idx[name]
+            for name in field_names
+            if name in name_to_idx
+        }
+
+    def _wrap_managed_blob_reader(self, reader):
+        from pypaimon.read.reader.iface.record_batch_reader import RecordBatchReader
+        from pypaimon.read.reader.managed_blob_convert_record_reader import (
+            ManagedBlobConvertBatchReader,
+            ManagedBlobConvertRecordReader,
+        )
+
+        managed_blob_fields = self._managed_blob_field_names()
+        descriptor_fields = set()
+        view_fields = set()
+        if self.table.is_primary_key_table:
+            descriptor_fields = CoreOptions.blob_descriptor_fields(self.table.options)
+            if (CoreOptions.blob_view_resolve_enabled(self.table.options)
+                    and self.table.catalog_environment.catalog_loader is not None):
+                view_fields = CoreOptions.blob_view_fields(self.table.options)
+        blob_as_descriptor = CoreOptions.blob_as_descriptor(self.table.options)
+        needs_payload_resolution = not blob_as_descriptor and (
+            managed_blob_fields or descriptor_fields)
+        if not needs_payload_resolution and not view_fields:
+            return reader
+
+        if isinstance(reader, RecordBatchReader):
+            return ManagedBlobConvertBatchReader(
+                reader,
+                self.table.file_io,
+                managed_blob_fields,
+                descriptor_field_names=descriptor_fields,
+                view_field_names=view_fields,
+                table=self.table,
+                blob_as_descriptor=blob_as_descriptor,
+            )
+
+        output_fields = (
+            self.outer_flat_read_type
+            if self.outer_extract_name_paths and self.outer_flat_read_type is not None
+            else self.value_fields)
+        managed_indices = self._blob_field_indices(
+            managed_blob_fields, output_fields)
+        descriptor_indices = self._blob_field_indices(
+            descriptor_fields, output_fields)
+        view_indices = self._blob_field_indices(view_fields, output_fields)
+        if not (managed_indices or descriptor_indices or view_indices):
+            return reader
+        return ManagedBlobConvertRecordReader(
+            reader,
+            self.table.file_io,
+            managed_indices,
+            descriptor_field_indices=descriptor_indices,
+            view_field_indices=view_indices,
+            table=self.table,
+            blob_as_descriptor=blob_as_descriptor,
+        )
 
     @abstractmethod
     def create_reader(self) -> RecordReader:
@@ -880,7 +952,9 @@ class RawFileSplitRead(SplitRead):
                     reader = FilterRecordBatchReader(reader, trimmed)
         if self.limit is not None:
             reader = LimitedRecordBatchReader(reader, self.limit)
-        return reader
+        # PK descriptors are row references, not positional DataEvolution BLOB
+        # files. Resolve them only after filtering, projection and limiting.
+        return self._wrap_managed_blob_reader(reader)
 
     def _all_data_fields_from(self, fields):
         if self.row_tracking_enabled:
@@ -1044,6 +1118,8 @@ class MergeFileSplitRead(SplitRead):
                             trimmed, self.outer_flat_read_type))
         if self.limit is not None:
             reader = LimitedRecordReader(reader, self.limit)
+        # Keep descriptor/view resolution above merge and all output shaping.
+        reader = self._wrap_managed_blob_reader(reader)
         return reader
 
     def _all_data_fields_from(self, fields):

--- a/paimon-python/pypaimon/read/table_read.py
+++ b/paimon-python/pypaimon/read/table_read.py
@@ -36,10 +36,36 @@ from pypaimon.read.split import Split
 from pypaimon.read.split_read import (DataEvolutionSplitRead,
                                       MergeFileSplitRead, RawFileSplitRead,
                                       SplitRead, deferred_blob_field_names)
-from pypaimon.schema.data_types import DataField, PyarrowFieldParser
+from pypaimon.schema.data_types import (DataField, PyarrowFieldParser,
+                                        is_blob_file_type)
 from pypaimon.table.row.offset_row import OffsetRow
 
 ROW_KIND_COLUMN = "_row_kind"
+
+
+def validate_primary_key_blob_predicate(table, predicate: Optional[Predicate]) -> None:
+    """Reject unsupported value comparisons on primary-key BLOB fields."""
+    if not table.is_primary_key_table or predicate is None:
+        return
+
+    fields_by_name = {field.name: field for field in table.fields}
+
+    def validate(current: Predicate) -> None:
+        if current.method in ('and', 'or'):
+            for child in current.literals or []:
+                validate(child)
+            return
+        if current.method in ('isNull', 'isNotNull'):
+            return
+        field = fields_by_name.get(current.field)
+        if field is not None and is_blob_file_type(field.type):
+            raise ValueError(
+                "Primary-key BLOB, ARRAY<BLOB>, and MAP<X, BLOB> fields "
+                "only support isNull and isNotNull predicates, but got "
+                f"{current.method} for field '{current.field}'."
+            )
+
+    validate(predicate)
 
 
 class _RemainingRows:
@@ -97,6 +123,10 @@ class TableRead:
         from pypaimon.read.merge_engine_support import check_supported
         from pypaimon.table.file_store_table import FileStoreTable
 
+        self.table: FileStoreTable = table
+        self.predicate = predicate
+        validate_primary_key_blob_predicate(self.table, self.predicate)
+
         # Validate merge-engine support before any split-level dispatch.
         # Raw-convertible splits skip MergeFileSplitRead, so this guard
         # has to live at the read-builder level — otherwise unsupported
@@ -104,8 +134,6 @@ class TableRead:
         # silently ignored on fresh single-snapshot tables.
         check_supported(table)
 
-        self.table: FileStoreTable = table
-        self.predicate = predicate
         self.read_type = read_type
         # Split readers may need predicate-only columns that are absent from
         # the requested output. Read the widened schema internally, then use
@@ -762,7 +790,10 @@ class TableRead:
                     effective_read_type if outer_extract_name_paths else None),
                 limit=effective_limit,
             )
-        elif self.table.options.data_evolution_enabled():
+        # DataEvolutionSplitRead is an append-table reader. Primary-key
+        # tables always dispatch raw-convertible splits to RawFileSplitRead.
+        elif (not self.table.is_primary_key_table
+              and self.table.options.data_evolution_enabled()):
             if self.nested_name_paths and any(
                     len(p) > 1 for p in self.nested_name_paths):
                 raise NotImplementedError(

--- a/paimon-python/pypaimon/schema/data_types.py
+++ b/paimon-python/pypaimon/schema/data_types.py
@@ -20,7 +20,7 @@ import threading
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from enum import Enum
-from typing import Any, Dict, List, Optional, Union
+from typing import Any, Dict, List, Optional, Set, Union
 
 import pyarrow
 from pyarrow import types
@@ -300,6 +300,22 @@ def is_blob_file_type(data_type: DataType) -> bool:
 
 def is_blob_file_field(field: 'DataField') -> bool:
     return is_blob_file_type(field.type)
+
+
+def fields_in_blob_file(
+        fields: List['DataField'],
+        inline_fields: Optional[Set[str]] = None) -> List['DataField']:
+    inline = inline_fields or set()
+    return [
+        field for field in fields
+        if is_blob_file_field(field) and field.name not in inline
+    ]
+
+
+def field_names_in_blob_file(
+        fields: List['DataField'],
+        inline_fields: Optional[Set[str]] = None) -> Set[str]:
+    return {field.name for field in fields_in_blob_file(fields, inline_fields)}
 
 
 @dataclass

--- a/paimon-python/pypaimon/schema/schema_manager.py
+++ b/paimon-python/pypaimon/schema/schema_manager.py
@@ -29,6 +29,7 @@ from pypaimon.schema.column_directive_utils import (
 from pypaimon.casting.data_type_casts import can_execute_cast, supports_cast
 from pypaimon.schema.data_types import (ArrayType, AtomicInteger, DataField,
                                         DataType, MapType, MultisetType, RowType,
+                                        field_names_in_blob_file,
                                         is_array_blob_type, is_blob_file_field,
                                         is_blob_file_type, is_blob_type,
                                         is_map_blob_type, reassign_field_id)
@@ -422,34 +423,101 @@ def _validate_blob_fields(
         )
 
     if blob_field_names:
-        required_options = {
-            CoreOptions.ROW_TRACKING_ENABLED.key(): 'true',
-            CoreOptions.DATA_EVOLUTION_ENABLED.key(): 'true'
-        }
-
-        missing_options = []
-        for key, expected_value in required_options.items():
-            if key not in options or options[key] != expected_value:
-                missing_options.append(f"{key}='{expected_value}'")
-
-        if missing_options:
-            raise ValueError(
-                f"Schema contains BLOB, ARRAY<BLOB> or MAP<X, BLOB> type but is "
-                f"missing required options: "
-                f"{', '.join(missing_options)}. "
-                f"Please add these options to the schema."
-            )
-
         if primary_keys:
-            raise ValueError(
-                "BLOB, ARRAY<BLOB> or MAP<X, BLOB> type is not supported with primary key."
-            )
+            _validate_primary_key_blob_configuration(
+                fields, options, primary_keys, partition_keys)
+        else:
+            required_options = {
+                CoreOptions.ROW_TRACKING_ENABLED.key(): 'true',
+                CoreOptions.DATA_EVOLUTION_ENABLED.key(): 'true'
+            }
+
+            missing_options = []
+            for key, expected_value in required_options.items():
+                if key not in options or options[key] != expected_value:
+                    missing_options.append(f"{key}='{expected_value}'")
+
+            if missing_options:
+                raise ValueError(
+                    f"Schema contains BLOB, ARRAY<BLOB> or MAP<X, BLOB> type but is "
+                    f"missing required options: "
+                    f"{', '.join(missing_options)}. "
+                    f"Please add these options to the schema."
+                )
 
         if blob_field_names.intersection(partition_keys):
             raise ValueError(
                 "The BLOB, ARRAY<BLOB> or MAP<X, BLOB> type column can not be "
                 "part of partition keys."
             )
+
+
+def _validate_primary_key_blob_configuration(
+        fields: List[DataField],
+        options: dict,
+        primary_keys: List[str],
+        partition_keys: List[str]) -> None:
+    core_options = CoreOptions(Options(options))
+    managed_blob_fields = field_names_in_blob_file(
+        fields, core_options.blob_inline_fields())
+    if not managed_blob_fields:
+        return
+
+    from pypaimon.common.options.core_options import ChangelogProducer, MergeEngine
+    from pypaimon.schema.schema import Schema
+    from pypaimon.schema.table_schema import TableSchema
+
+    table_schema = TableSchema.from_schema(
+        schema_id=0,
+        schema=Schema(
+            fields=fields,
+            primary_keys=primary_keys,
+            partition_keys=partition_keys,
+            options=options,
+        ),
+    )
+    bucket_keys = table_schema.bucket_keys
+    sequence_fields = core_options.sequence_field()
+
+    pk_blob = sorted(managed_blob_fields.intersection(primary_keys))
+    if pk_blob:
+        raise ValueError(
+            "Managed BLOB fields cannot be primary keys: %s." % pk_blob)
+
+    bucket_blob = sorted(managed_blob_fields.intersection(bucket_keys))
+    if bucket_blob:
+        raise ValueError(
+            "Managed BLOB fields cannot be bucket keys: %s." % bucket_blob)
+
+    sequence_blob = sorted(
+        name for name in managed_blob_fields if name in sequence_fields)
+    if sequence_blob:
+        raise ValueError(
+            "Managed BLOB fields cannot be sequence fields: %s." % sequence_blob)
+
+    if core_options.merge_engine() != MergeEngine.DEDUPLICATE:
+        raise ValueError(
+            "Primary-key managed BLOB tables only support the deduplicate "
+            "merge engine.")
+
+    if core_options.changelog_producer() != ChangelogProducer.NONE:
+        raise ValueError(
+            "Primary-key managed BLOB tables only support changelog-producer "
+            "'none'.")
+
+    if core_options.data_file_external_paths() is not None:
+        raise ValueError(
+            "Primary-key managed BLOB tables do not support '%s'."
+            % CoreOptions.DATA_FILE_EXTERNAL_PATHS.key())
+
+    if core_options.options.contains_key("pk-clustering-override"):
+        from pypaimon.common.options.options_utils import OptionsUtils
+
+        override = core_options.options.data.get("pk-clustering-override")
+        if override is not None and OptionsUtils.convert_value(override, bool):
+            raise ValueError(
+                "Primary-key managed BLOB tables do not support "
+                "'pk-clustering-override'.")
 
 
 def _validate_options(options: dict):

--- a/paimon-python/pypaimon/table/blob_descriptor_reader_factory.py
+++ b/paimon-python/pypaimon/table/blob_descriptor_reader_factory.py
@@ -1,0 +1,129 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from pypaimon.common.identifier import Identifier
+from pypaimon.common.options import Options
+from pypaimon.common.options.core_options import CoreOptions
+from pypaimon.common.uri_reader import UriReader, UriReaderFactory
+
+
+class BlobDescriptorReaderFactory:
+    """Creates the URI reader factory used for descriptor-backed write input."""
+
+    @staticmethod
+    def create(table):
+        source_table = table.options.blob_descriptor_source_table()
+        if source_table is None:
+            descriptor_options = BlobDescriptorReaderFactory._descriptor_options(
+                table.options)
+            if descriptor_options is None:
+                return table.file_io.uri_reader_factory
+            factory = UriReaderFactory(descriptor_options)
+            # Static blob-descriptor.* options declare descriptor bytes as the
+            # write input contract, including v1 descriptors without magic.
+            factory.force_descriptor_bytes = True
+            factory._blob_descriptor_owned = True
+            return factory
+        return BlobDescriptorReaderFactory._from_source_table(table, source_table)
+
+    @staticmethod
+    def _descriptor_options(options):
+        """Return an isolated FileIO configuration for descriptor input.
+
+        This mirrors Java's ``BlobDescriptorUtils.getCatalogContext``: once any
+        ``blob-descriptor.*`` option is present, only options under that prefix
+        participate in descriptor reads and the prefix is removed before the
+        FileIO is created. ``source-table`` is handled before this method and
+        therefore always takes precedence.
+        """
+        prefix = "blob-descriptor."
+        raw_options = options.options.to_map()
+        descriptor_options = {
+            key[len(prefix):]: value
+            for key, value in raw_options.items()
+            if key is not None and key.startswith(prefix)
+        }
+        return Options(descriptor_options) if descriptor_options else None
+
+    @staticmethod
+    def _from_source_table(table, source_table: str):
+        catalog_environment = table.catalog_environment
+        catalog_loader = catalog_environment.catalog_loader
+        if catalog_loader is None:
+            raise ValueError(
+                "Option '%s' is not supported for tables without a catalog loader, "
+                "including external tables in REST catalogs."
+                % CoreOptions.BLOB_DESCRIPTOR_SOURCE_TABLE.key()
+            )
+
+        catalog_context = catalog_environment.catalog_context()
+        dependency_context = catalog_environment.dependency_read_context()
+        catalog = None
+        try:
+            if dependency_context is catalog_context or dependency_context is None:
+                catalog = catalog_loader.load()
+            else:
+                from pypaimon.catalog.catalog_factory import CatalogFactory
+                catalog = CatalogFactory.create_from_context(
+                    dependency_context, config_required=False)
+
+            source_identifier = Identifier.from_string(source_table)
+            source = catalog.get_table(source_identifier)
+            source_file_io = source.file_io
+            # Some credential-bearing FileIO implementations initialize their
+            # serializable token state lazily on the first capability check.
+            initialize = getattr(source_file_io, "is_object_store", None)
+            if callable(initialize):
+                initialize()
+            else:
+                # RESTTokenFileIO currently exposes token initialization
+                # directly rather than through is_object_store(). Materialize
+                # it while the source catalog/auth context is still available.
+                initialize = getattr(source_file_io, "valid_token", None)
+                if callable(initialize):
+                    initialize()
+            return _FileIOUriReaderFactory(source_file_io)
+        except Exception as e:
+            raise RuntimeError(
+                "Failed to load BLOB descriptor source table '%s'." % source_table
+            ) from e
+        finally:
+            close = getattr(catalog, "close", None)
+            if callable(close):
+                close()
+
+
+class _FileIOUriReaderFactory:
+    """A UriReaderFactory which always uses one table-scoped FileIO."""
+
+    # Configuring blob-descriptor.source-table makes serialized descriptor
+    # bytes the declared input contract. This lets the PK externalizer use the
+    # non-heuristic parser, which is required for v1 descriptors without a
+    # magic header.
+    force_descriptor_bytes = True
+    _blob_descriptor_owned = True
+
+    def __init__(self, file_io):
+        self._file_io = file_io
+
+    def create(self, _input_uri: str):
+        return UriReader.from_file(self._file_io)
+
+    def close(self):
+        close = getattr(self._file_io, "close", None)
+        if callable(close):
+            close()

--- a/paimon-python/pypaimon/table/row/blob.py
+++ b/paimon-python/pypaimon/table/row/blob.py
@@ -119,6 +119,65 @@ class BlobDescriptor:
         return descriptor
 
     @classmethod
+    def _try_parse_serialized(cls, data: bytes) -> Optional['BlobDescriptor']:
+        if not isinstance(data, (bytes, bytearray)):
+            return None
+        raw = bytes(data)
+        if len(raw) < 21:
+            return None
+        try:
+            offset = 0
+            version = raw[offset]
+            offset += 1
+            if version < 1 or version > cls.CURRENT_VERSION:
+                return None
+            if version > 1:
+                if offset + 8 > len(raw):
+                    return None
+                magic = struct.unpack('<Q', raw[offset:offset + 8])[0]
+                if magic != cls.MAGIC:
+                    return None
+                offset += 8
+            if offset + 4 > len(raw):
+                return None
+            uri_length = struct.unpack('<I', raw[offset:offset + 4])[0]
+            total = offset + 4 + uri_length + 16
+            if total != len(raw):
+                return None
+            return cls.deserialize(raw)
+        except (ValueError, struct.error, UnicodeDecodeError):
+            return None
+
+    @classmethod
+    def serialized_byte_length(cls, data: bytes) -> Optional[int]:
+        """Return the byte length when data is a complete serialized descriptor.
+
+        Public parsing utility only. The default managed-BLOB write path does
+        not call this; descriptor-byte input requires ``force_descriptor_bytes``
+        or v2 magic detection via :meth:`is_blob_descriptor`.
+        """
+        descriptor = cls._try_parse_serialized(data)
+        if descriptor is None:
+            return None
+        return len(bytes(data))
+
+    @classmethod
+    def parse_if_serialized(cls, data: bytes) -> Optional['BlobDescriptor']:
+        """Best-effort parse when data fully encodes a v1 or v2 descriptor.
+
+        Public parsing utility only. The default managed-BLOB write path does
+        not call this; descriptor-byte input requires ``force_descriptor_bytes``
+        (``blob-descriptor.*`` / ``source-table``) or v2 magic detection via
+        :meth:`is_blob_descriptor`.
+
+        Unlike :meth:`is_blob_descriptor` (v2 magic header only), this accepts
+        v1 descriptors without a magic prefix. Parsing is strict (exact byte
+        length match) but still heuristic: arbitrary inline blob bytes could
+        theoretically match.
+        """
+        return cls._try_parse_serialized(data)
+
+    @classmethod
     def is_blob_descriptor(cls, data: bytes) -> bool:
         if not isinstance(data, (bytes, bytearray)):
             return False
@@ -387,6 +446,32 @@ class Blob(ABC):
         return BlobRef(uri_reader, descriptor)
 
     @staticmethod
+    def from_descriptor_bytes(
+            data: Optional[bytes], file_io=None, uri_reader_factory=None,
+    ) -> Optional['Blob']:
+        """Build a Blob from bytes known to contain a descriptor.
+
+        Version 1 descriptors have no magic header, so they cannot be
+        distinguished safely from arbitrary payload bytes. Callers which know
+        from schema or storage context that a value is a descriptor must use
+        this method instead of the heuristic :meth:`from_bytes` entry point.
+        """
+        if data is None:
+            return None
+        if not isinstance(data, (bytes, bytearray)):
+            raise TypeError(
+                f"Blob.from_descriptor_bytes expects bytes, got {type(data)}")
+
+        descriptor = BlobDescriptor.deserialize(bytes(data))
+        if uri_reader_factory is None:
+            if file_io is None:
+                raise ValueError("file_io is required to resolve BlobDescriptor bytes")
+            uri_reader = UriReader.from_file(file_io)
+        else:
+            uri_reader = uri_reader_factory.create(descriptor.uri)
+        return BlobRef(uri_reader, descriptor)
+
+    @staticmethod
     def from_view(view_struct: BlobViewStruct) -> 'BlobView':
         return BlobView(view_struct)
 
@@ -401,20 +486,13 @@ class Blob(ABC):
         data = bytes(data)
         if BlobViewStruct.is_blob_view_struct(data):
             return Blob.from_view(BlobViewStruct.deserialize(data))
+        if not allow_blob_data:
+            return Blob.from_descriptor_bytes(
+                data, file_io=file_io, uri_reader_factory=uri_reader_factory)
         is_descriptor = BlobDescriptor.is_blob_descriptor(data)
-        if not allow_blob_data and not is_descriptor:
-            raise ValueError(
-                "Expected BlobDescriptor bytes, got raw bytes (allow_blob_data=False)"
-            )
         if is_descriptor:
-            descriptor = BlobDescriptor.deserialize(data)
-            if uri_reader_factory is None:
-                if file_io is None:
-                    raise ValueError("file_io is required to resolve BlobDescriptor bytes")
-                uri_reader = UriReader.from_file(file_io)
-            else:
-                uri_reader = uri_reader_factory.create(descriptor.uri)
-            return BlobRef(uri_reader, descriptor)
+            return Blob.from_descriptor_bytes(
+                data, file_io=file_io, uri_reader_factory=uri_reader_factory)
         return BlobData(data)
 
 

--- a/paimon-python/pypaimon/tests/blob_table_test.py
+++ b/paimon-python/pypaimon/tests/blob_table_test.py
@@ -5633,11 +5633,10 @@ class BlobConsumerTest(unittest.TestCase):
 
         self.assertGreater(len(received), 0)
 
-        # Capture data writers before close() clears them, then abort each one.
-        data_writers = list(writer.file_store_write.data_writers.values())
-        self.assertGreater(len(data_writers), 0)
-        for dw in data_writers:
-            dw.abort()
+        # Stage the whole parent/child writer tree so BLOB metadata crosses the
+        # child-to-parent boundary, then roll the transaction back.
+        prepared = writer.file_store_write.stage_commit(1)
+        prepared.abort()
 
         # Every descriptor returned to the consumer must still be readable.
         uri_reader = FileUriReader(table.file_io)
@@ -5645,6 +5644,51 @@ class BlobConsumerTest(unittest.TestCase):
             self.assertIsNotNone(desc)
             data = Blob.from_descriptor(uri_reader, desc).to_data()
             self.assertEqual(data, blob_bytes)
+
+    def test_blob_consumer_committer_abort_preserves_files(self):
+        """Committer abort must not delete blob files retained by the consumer."""
+        from pypaimon.table.row.blob import Blob
+        from pypaimon.common.uri_reader import FileUriReader
+
+        pa_schema = pa.schema([
+            ('id', pa.int32()),
+            ('blob_data', pa.large_binary()),
+        ])
+        schema = Schema.from_pyarrow_schema(pa_schema, options={
+            'row-tracking.enabled': 'true',
+            'data-evolution.enabled': 'true',
+            'blob.target-file-size': '1KB',
+        })
+        self.catalog.create_table('test_db.blob_consumer_committer_abort', schema, False)
+        table = self.catalog.get_table('test_db.blob_consumer_committer_abort')
+
+        blob_bytes = b'X' * 2048
+        received = []
+
+        def my_consumer(field_name, descriptor):
+            received.append(descriptor)
+            return False
+
+        write_builder = table.new_batch_write_builder()
+        writer = write_builder.new_write()
+        writer.with_blob_consumer(my_consumer)
+        committer = write_builder.new_commit()
+
+        writer.write_arrow(pa.Table.from_pydict({
+            'id': [1],
+            'blob_data': [blob_bytes],
+        }, schema=pa_schema))
+        messages = writer.prepare_commit()
+        committer.abort(messages)
+        writer.close()
+        committer.close()
+
+        self.assertEqual(1, len(received))
+        uri_reader = FileUriReader(table.file_io)
+        self.assertEqual(
+            blob_bytes,
+            Blob.from_descriptor(uri_reader, received[0]).to_data(),
+        )
 
     def test_blob_consumer_after_write_raises(self):
         """Setting consumer after data has been written must raise."""

--- a/paimon-python/pypaimon/tests/blob_test.py
+++ b/paimon-python/pypaimon/tests/blob_test.py
@@ -1323,6 +1323,16 @@ class BlobTest(unittest.TestCase):
         )
         random_bytes = b"not-a-descriptor"
         fake_v1_prefix = b"\x01not-a-descriptor"
+        # v1-shaped inline payload: passes len/version/uri-length checks but fails
+        # exact total-length match, so it must not be parsed as a descriptor.
+        v1_shaped_inline = (
+            bytes([1])
+            + struct.pack('<I', 5)
+            + b"hello"
+            + struct.pack('<q', 0)
+            + struct.pack('<q', 5)
+            + b"\xff"
+        )
         v2_magic_only = bytes([2]) + struct.pack('<Q', BlobDescriptor.MAGIC)
 
         self.assertTrue(BlobDescriptor.is_blob_descriptor(descriptor_v2.serialize()))
@@ -1332,6 +1342,13 @@ class BlobTest(unittest.TestCase):
         self.assertFalse(BlobDescriptor.is_blob_descriptor(random_bytes))
         self.assertFalse(BlobDescriptor.is_blob_descriptor(fake_v1_prefix))
         self.assertFalse(BlobDescriptor.is_blob_descriptor(b"tiny"))
+
+        self.assertIsNotNone(BlobDescriptor.parse_if_serialized(descriptor_v1_bytes))
+        self.assertIsNotNone(BlobDescriptor.parse_if_serialized(descriptor_v2.serialize()))
+        self.assertIsNone(BlobDescriptor.parse_if_serialized(random_bytes))
+        self.assertIsNone(BlobDescriptor.parse_if_serialized(fake_v1_prefix))
+        self.assertIsNone(BlobDescriptor.parse_if_serialized(v1_shaped_inline))
+        self.assertIsNone(BlobDescriptor.parse_if_serialized(b"tiny"))
 
 
 class BlobEndToEndTest(unittest.TestCase):

--- a/paimon-python/pypaimon/tests/catalog_environment_test.py
+++ b/paimon-python/pypaimon/tests/catalog_environment_test.py
@@ -158,6 +158,7 @@ class CatalogEnvironmentTest(unittest.TestCase):
         self.assertTrue(
             dependency_context.options.contains_key(self._READ_VIA_OPTION))
         dependency_catalog.get_table.assert_called_once_with(target)
+        dependency_catalog.close.assert_called_once_with()
         self.assertIs(result, dependency_table)
 
     def test_blob_view_lookup_preserves_custom_rest_catalog(self):
@@ -166,6 +167,7 @@ class CatalogEnvironmentTest(unittest.TestCase):
 
         class CustomRESTCatalog:
             context = None
+            closed = False
 
             def __init__(self, context):
                 CustomRESTCatalog.context = context
@@ -173,6 +175,9 @@ class CatalogEnvironmentTest(unittest.TestCase):
             def get_table(self, identifier):
                 self.identifier = identifier
                 return dependency_table
+
+            def close(self):
+                CustomRESTCatalog.closed = True
 
         context = CatalogContext.create_from_options(Options({
             CatalogOptions.METASTORE.key(): "custom-rest",
@@ -196,6 +201,52 @@ class CatalogEnvironmentTest(unittest.TestCase):
         self.assertTrue(
             dependency_context.options.contains_key(self._READ_VIA_OPTION))
         self.assertIs(result, dependency_table)
+        self.assertTrue(CustomRESTCatalog.closed)
+
+    def test_blob_view_uri_reader_catalog_lives_until_lookup_close(self):
+        target = Identifier.create("db", "target", branch="rt")
+        context = CatalogContext.create_from_options(Options({}))
+        catalogs = []
+
+        class TrackingCatalog:
+            def __init__(self):
+                self.closed = False
+                self.file_io = mock.Mock()
+
+            def get_table(self, identifier):
+                self.identifier = identifier
+                return SimpleNamespace(file_io=self.file_io)
+
+            def close(self):
+                self.closed = True
+
+        class TrackingLoader:
+            def context(self):
+                return context
+
+            def load(self):
+                catalog = TrackingCatalog()
+                catalogs.append(catalog)
+                return catalog
+
+        environment = CatalogEnvironment(
+            identifier=Identifier.create("db", "root"),
+            catalog_loader=TrackingLoader(),
+        )
+        lookup = BlobViewLookup(
+            SimpleNamespace(catalog_environment=environment))
+        view = mock.Mock(identifier=target)
+
+        uri_reader = lookup.resolve_uri_reader(view)
+
+        self.assertIs(uri_reader._file_io, catalogs[0].file_io)
+        self.assertEqual(target, catalogs[0].identifier)
+        self.assertFalse(catalogs[0].closed)
+
+        lookup.close()
+        self.assertTrue(catalogs[0].closed)
+        catalogs[0].file_io.close.assert_called_once_with()
+        lookup.close()
 
 
 if __name__ == "__main__":

--- a/paimon-python/pypaimon/tests/data_evolution_formats_test.py
+++ b/paimon-python/pypaimon/tests/data_evolution_formats_test.py
@@ -438,7 +438,9 @@ class DataEvolutionFormatsTest(unittest.TestCase):
         self.catalog.create_table('default.fmt_blob_abort_cleanup', schema, False)
         table = self.catalog.get_table('default.fmt_blob_abort_cleanup')
 
-        writer = table.new_batch_write_builder().new_write()
+        write_builder = table.new_batch_write_builder()
+        writer = write_builder.new_write()
+        committer = write_builder.new_commit()
         writer.write_arrow(pa.Table.from_pydict({
             'id': [1, 2, 3],
             'payload': [b'a', b'b', b'c'],
@@ -453,7 +455,8 @@ class DataEvolutionFormatsTest(unittest.TestCase):
         for file_meta in all_files:
             self.assertTrue(table.file_io.exists(self._file_path(file_meta)))
 
-        writer.abort()
+        committer.abort(commit_messages)
+        committer.close()
 
         for file_meta in all_files:
             self.assertFalse(
@@ -801,7 +804,9 @@ class DataEvolutionFormatsTest(unittest.TestCase):
         self.catalog.create_table('default.fmt_vector_abort_cleanup', schema, False)
         table = self.catalog.get_table('default.fmt_vector_abort_cleanup')
 
-        writer = table.new_batch_write_builder().new_write()
+        write_builder = table.new_batch_write_builder()
+        writer = write_builder.new_write()
+        committer = write_builder.new_commit()
         writer.write_arrow(pa.table({
             'id': pa.array([1, 2, 3], type=pa.int64()),
             'embed': pa.FixedSizeListArray.from_arrays(
@@ -819,7 +824,8 @@ class DataEvolutionFormatsTest(unittest.TestCase):
         for file_meta in all_files:
             self.assertTrue(table.file_io.exists(self._file_path(file_meta)))
 
-        writer.abort()
+        committer.abort(commit_messages)
+        committer.close()
 
         for file_meta in all_files:
             self.assertFalse(
@@ -842,7 +848,9 @@ class DataEvolutionFormatsTest(unittest.TestCase):
         self.catalog.create_table('default.fmt_vector_close_failure', schema, False)
         table = self.catalog.get_table('default.fmt_vector_close_failure')
 
-        writer = table.new_batch_write_builder().new_write()
+        write_builder = table.new_batch_write_builder()
+        writer = write_builder.new_write()
+        committer = write_builder.new_commit()
         writer.write_arrow(pa.table({
             'id': pa.array([1, 2, 3], type=pa.int64()),
             'embed': pa.FixedSizeListArray.from_arrays(
@@ -863,6 +871,13 @@ class DataEvolutionFormatsTest(unittest.TestCase):
             with self.assertRaisesRegex(RuntimeError, "Close error"):
                 writer.close()
 
+        # prepare_commit transferred ownership to the commit messages, so a
+        # writer close failure must not delete those files.
+        for file_meta in all_files:
+            self.assertTrue(table.file_io.exists(self._file_path(file_meta)))
+
+        committer.abort(commit_messages)
+        committer.close()
         for file_meta in all_files:
             self.assertFalse(
                 table.file_io.exists(self._file_path(file_meta)),

--- a/paimon-python/pypaimon/tests/deferred_blob_resolve_test.py
+++ b/paimon-python/pypaimon/tests/deferred_blob_resolve_test.py
@@ -24,6 +24,7 @@ from unittest.mock import patch
 
 import pyarrow as pa
 import pyarrow.compute as pc
+import pytest
 
 from pypaimon import CatalogFactory, Schema
 from pypaimon.catalog.table_query_auth import TableQueryAuthResult
@@ -270,6 +271,7 @@ class DeferredBlobResolveTest(unittest.TestCase):
         self.assertEqual(_ROW_COUNT, result.num_rows)
         self.assertEqual(_ROW_COUNT, counting_file_io.blobs_fetched)
 
+    @pytest.mark.python_plan
     def test_iterator_passes_remaining_limit_across_splits(self):
         table = self._create_table(
             "defer_iterator_limit_splits",
@@ -279,17 +281,19 @@ class DeferredBlobResolveTest(unittest.TestCase):
         )
         counting_file_io = _BlobCountingFileIO(table.file_io)
         table.file_io = counting_file_io
-        read_builder = table.new_read_builder().with_projection(
+        scan_builder = table.new_read_builder().with_projection(
             ["sample_id", "payload", "score"]
-        ).with_limit(2)
-        splits = read_builder.new_scan().plan().splits()
+        )
+        splits = scan_builder.new_scan().plan().splits()
+        table_read = scan_builder.with_limit(2).new_read()
 
-        rows = list(read_builder.new_read().to_iterator(splits))
+        rows = list(table_read.to_iterator(splits))
 
-        self.assertEqual(2, len(splits))
+        self.assertGreater(len(splits), 1)
         self.assertEqual(2, len(rows))
         self.assertEqual(2, counting_file_io.blobs_fetched)
 
+    @pytest.mark.python_plan
     def test_iterator_applies_limit_after_auth_filter(self):
         table = self._create_table(
             "defer_iterator_auth_limit_splits",
@@ -297,22 +301,28 @@ class DeferredBlobResolveTest(unittest.TestCase):
             partition_keys=["sample_id"],
             sample_ids=["a"] + ["b"] * (_ROW_COUNT - 1),
         )
-        read_builder = table.new_read_builder().with_projection(
+        scan_builder = table.new_read_builder().with_projection(
             ["sample_id", "payload", "score"]
-        ).with_limit(2)
+        )
         counting_file_io = _BlobCountingFileIO(table.file_io)
         table.file_io = counting_file_io
         auth_result = _RejectScoreOneAuthResult()
+        planned_splits = sorted(
+            scan_builder.new_scan().plan().splits(),
+            key=lambda split: tuple(split.partition.values),
+        )
         splits = [
             QueryAuthSplit(split, auth_result)
-            for split in read_builder.new_scan().plan().splits()
+            for split in planned_splits
         ]
+        table_read = scan_builder.with_limit(2).new_read()
 
         scores = [
             row.get_field(2)
-            for row in read_builder.new_read().to_iterator(splits)
+            for row in table_read.to_iterator(splits)
         ]
 
+        self.assertGreater(len(planned_splits), 1)
         self.assertEqual([0, 2], scores)
         self.assertEqual(2, counting_file_io.blobs_fetched)
 

--- a/paimon-python/pypaimon/tests/managed_blob_lifecycle_test.py
+++ b/paimon-python/pypaimon/tests/managed_blob_lifecycle_test.py
@@ -1,0 +1,56 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+import unittest
+from unittest.mock import Mock, call
+
+from pypaimon.write.file_store_commit import FileStoreCommit
+
+
+class ManagedBlobLifecycleTest(unittest.TestCase):
+
+    def test_commit_abort_deletes_files_but_not_shared_managed_packs(self):
+        file_io = Mock()
+        commit = FileStoreCommit.__new__(FileStoreCommit)
+        commit.table = Mock(file_io=file_io)
+
+        data_file = Mock(
+            external_path=None,
+            file_path="/warehouse/table/bucket-0/data.avro",
+            extra_files=["data.avro.blobref", "data.avro.row"],
+        )
+        message = Mock(
+            new_files=[data_file],
+            changelog_files=[],
+            index_adds=[],
+        )
+
+        commit.abort([message])
+
+        file_io.delete_quietly.assert_has_calls([
+            call("/warehouse/table/bucket-0/data.avro"),
+            call("/warehouse/table/bucket-0/data.avro.blobref"),
+            call("/warehouse/table/bucket-0/data.avro.row"),
+        ])
+        self.assertNotIn(
+            call("/warehouse/table/bucket-0/data.managed.blob"),
+            file_io.delete_quietly.call_args_list,
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/paimon-python/pypaimon/tests/managed_blob_reference_file_test.py
+++ b/paimon-python/pypaimon/tests/managed_blob_reference_file_test.py
@@ -1,0 +1,139 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+import io
+import struct
+import tempfile
+import unittest
+
+from pypaimon.blob.managed_blob_reference_file import (
+    ManagedBlobReferenceFile,
+    Reference,
+    _read_modified_utf,
+    _write_modified_utf,
+)
+from pypaimon.blob.managed_blob_reference_collector import (
+    ManagedBlobReferenceCollector,
+)
+from pypaimon.common.file_io import FileIO
+from pypaimon.common.options.options import Options
+
+
+class ManagedBlobReferenceFileTest(unittest.TestCase):
+
+    def setUp(self):
+        self.temp_dir = tempfile.mkdtemp()
+        self.file_io = FileIO.get(self.temp_dir, Options({}))
+
+    def test_round_trip_and_deduplicate_references(self):
+        path = f"{self.temp_dir}/data.avro.blobref"
+        first = Reference(f"{self.temp_dir}/bucket-0", "data-a.managed.blob")
+        second = Reference(f"{self.temp_dir}/bucket-0", "data-b.managed.blob")
+
+        ManagedBlobReferenceFile.write(self.file_io, path, [second, first, second])
+        self.assertEqual(
+            ManagedBlobReferenceFile.read(self.file_io, path),
+            [first, second],
+        )
+
+        empty_path = f"{self.temp_dir}/empty.avro.blobref"
+        ManagedBlobReferenceFile.write(self.file_io, empty_path, [])
+        self.assertEqual(ManagedBlobReferenceFile.read(self.file_io, empty_path), [])
+
+    def test_classify_managed_blob_path(self):
+        managed = f"{self.temp_dir}/bucket-0/data-b.managed.blob"
+        ordinary = f"{self.temp_dir}/bucket-0/data-d.blob"
+        reference = ManagedBlobReferenceFile.from_descriptor_uri(managed)
+        self.assertEqual(
+            reference,
+            Reference(f"{self.temp_dir}/bucket-0", "data-b.managed.blob"),
+        )
+        self.assertIsNone(ManagedBlobReferenceFile.from_descriptor_uri(ordinary))
+        self.assertEqual(
+            ManagedBlobReferenceFile.sidecar_name("data-a.avro"),
+            "data-a.avro.blobref",
+        )
+
+    def test_reference_collector_close_is_idempotent(self):
+        collector = ManagedBlobReferenceCollector(
+            self.file_io,
+            f"{self.temp_dir}/data.avro",
+            [],
+            set(),
+        )
+
+        first = collector.close()
+        second = collector.close()
+
+        self.assertEqual(first, "data.avro.blobref")
+        self.assertEqual(second, first)
+
+    def test_modified_utf8_round_trip(self):
+        payload = io.BytesIO()
+        value = "storage/root/测试"
+        _write_modified_utf(payload, value)
+        decoded, offset = _read_modified_utf(payload.getvalue(), 0)
+        self.assertEqual(decoded, value)
+        self.assertEqual(offset, len(payload.getvalue()))
+
+    def test_reference_file_matches_fixed_binary_fixture(self):
+        # Fixed bytes guard the on-disk layout independently of this module's
+        # writer/reader round trip. The fixture covers big-endian framing,
+        # modified UTF-8, and the CRC payload boundary.
+        fixture = bytes.fromhex(
+            "50424c520100000001001866696c653a2f2f2f77617265686f7573652f"
+            "eda0bdedb8800013646174612d612e6d616e616765642e626c6f62f2cb93c4"
+        )
+        expected = [Reference("file:///warehouse/😀", "data-a.managed.blob")]
+        fixture_path = f"{self.temp_dir}/fixture.blobref"
+        with self.file_io.new_output_stream(fixture_path) as out:
+            out.write(fixture)
+
+        self.assertEqual(ManagedBlobReferenceFile.read(
+            self.file_io, fixture_path), expected)
+
+        written_path = f"{self.temp_dir}/written.blobref"
+        ManagedBlobReferenceFile.write(self.file_io, written_path, expected)
+        with self.file_io.new_input_stream(written_path) as stream:
+            self.assertEqual(stream.read(), fixture)
+
+    def test_reject_unsupported_version(self):
+        path = f"{self.temp_dir}/unsupported.avro.blobref"
+        with self.file_io.new_output_stream(path) as out:
+            out.write(struct.pack(">i", ManagedBlobReferenceFile.MAGIC))
+            out.write(struct.pack(">B", 99))
+            out.write(struct.pack(">i", 0))
+            out.write(struct.pack(">i", 0))
+        with self.assertRaisesRegex(IOError, "Unsupported managed BLOB reference file version"):
+            ManagedBlobReferenceFile.read(self.file_io, path)
+
+    def test_reject_corrupt_checksum(self):
+        path = f"{self.temp_dir}/corrupt.avro.blobref"
+        payload = io.BytesIO()
+        payload.write(struct.pack(">B", ManagedBlobReferenceFile.VERSION))
+        payload.write(struct.pack(">i", 0))
+        payload_bytes = payload.getvalue()
+        with self.file_io.new_output_stream(path) as out:
+            out.write(struct.pack(">i", ManagedBlobReferenceFile.MAGIC))
+            out.write(payload_bytes)
+            out.write(struct.pack(">i", 12345))
+        with self.assertRaisesRegex(IOError, "Invalid managed BLOB reference file checksum"):
+            ManagedBlobReferenceFile.read(self.file_io, path)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/paimon-python/pypaimon/tests/managed_blob_write_ownership_test.py
+++ b/paimon-python/pypaimon/tests/managed_blob_write_ownership_test.py
@@ -1,0 +1,596 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+import glob
+import io
+import os
+import shutil
+import tempfile
+import unittest
+from types import SimpleNamespace
+from unittest.mock import Mock, patch
+
+import pyarrow as pa
+
+from pypaimon.blob.primary_key_blob_externalizer import PrimaryKeyBlobExternalizer
+from pypaimon.common.file_io import FileIO
+from pypaimon.common.identifier import Identifier
+from pypaimon.common.options.core_options import CoreOptions
+from pypaimon.common.options.options import Options
+from pypaimon.schema.data_types import AtomicType, DataField
+from pypaimon.table.blob_descriptor_reader_factory import BlobDescriptorReaderFactory
+from pypaimon.table.row.blob import Blob, BlobDescriptor
+from pypaimon.write.writer.data_writer import DataWriter
+from pypaimon.write.file_store_write import FileStoreWrite
+from pypaimon.write.table_write import TableWrite
+from pypaimon.write.writer.dedicated_format_writer import DedicatedFormatWriter
+
+
+class _ListOnlyDataWriter(DataWriter):
+
+    def __init__(self):
+        self.pending_data = None
+        self.committed_files = ["data"]
+        self.committed_changelog_files = ["changelog"]
+
+    def _process_data(self, data):
+        return data
+
+    def _merge_data(self, existing_data, new_data):
+        return new_data
+
+
+class _TransactionalListWriter(_ListOnlyDataWriter):
+
+    def __init__(self, name, fail_prepare=False):
+        super().__init__()
+        self.committed_files = [name]
+        self.committed_changelog_files = []
+        self.fail_prepare = fail_prepare
+        self.aborted = []
+
+    def _prepare_commit_data(self):
+        if self.fail_prepare:
+            raise RuntimeError("forced prepare failure")
+
+    def abort(self):
+        self.aborted.extend(self.committed_files)
+        self.aborted.extend(self.committed_changelog_files)
+        self.committed_files.clear()
+        self.committed_changelog_files.clear()
+        self._active_prepared_commit = None
+
+
+class DataWriterOwnershipTest(unittest.TestCase):
+
+    def test_prepare_drains_data_without_draining_changelog(self):
+        writer = _ListOnlyDataWriter()
+
+        self.assertEqual(writer.prepare_commit(), ["data"])
+        self.assertEqual(writer.committed_files, [])
+        self.assertEqual(writer.committed_changelog_files, ["changelog"])
+        self.assertEqual(writer.prepare_changelog_commit(), ["changelog"])
+        self.assertEqual(writer.committed_changelog_files, [])
+
+    def test_file_store_prepare_failure_aborts_all_staged_buckets(self):
+        first = _TransactionalListWriter("first")
+        second = _TransactionalListWriter("second", fail_prepare=True)
+        file_store = object.__new__(FileStoreWrite)
+        file_store.data_writers = {
+            (("p1",), 0): first,
+            (("p2",), 0): second,
+        }
+        file_store.commit_identifier = 0
+        file_store._active_prepared_commit = None
+
+        with self.assertRaisesRegex(RuntimeError, "forced prepare failure"):
+            file_store.prepare_commit(1)
+
+        self.assertEqual(first.aborted, ["first"])
+        self.assertEqual(second.aborted, ["second"])
+
+    def test_failed_next_round_does_not_abort_previous_handoff(self):
+        writer = _TransactionalListWriter("round-1")
+        first = writer.prepare_commit()
+        writer.committed_files.append("round-2")
+        writer.fail_prepare = True
+
+        with self.assertRaisesRegex(RuntimeError, "forced prepare failure"):
+            writer.prepare_commit()
+
+        self.assertEqual(first, ["round-1"])
+        self.assertEqual(writer.aborted, ["round-2"])
+
+    def test_dedicated_later_child_failure_aborts_earlier_stage(self):
+        first = _TransactionalListWriter("blob-1")
+        second = _TransactionalListWriter("blob-2", fail_prepare=True)
+        writer = object.__new__(DedicatedFormatWriter)
+        writer.pending_normal_data = None
+        writer.blob_file_column_names = ["blob_1", "blob_2"]
+        writer.blob_writers = {"blob_1": first, "blob_2": second}
+        writer.vector_writer = None
+        writer.committed_files = []
+
+        with self.assertRaisesRegex(RuntimeError, "forced prepare failure"):
+            writer._close_current_writers()
+
+        self.assertEqual(first.aborted, ["blob-1"])
+        self.assertEqual(second.aborted, ["blob-2"])
+
+    def test_dedicated_validation_failure_keeps_child_owned_for_abort(self):
+        child = _TransactionalListWriter("blob")
+        writer = object.__new__(DedicatedFormatWriter)
+        writer.pending_normal_data = SimpleNamespace(num_rows=1)
+        writer._write_normal_data_to_file = Mock(return_value="normal")
+        writer.blob_file_column_names = ["blob"]
+        writer.blob_writers = {"blob": child}
+        writer.vector_writer = None
+        writer.committed_files = []
+        writer._validate_consistency = Mock(
+            side_effect=RuntimeError("forced consistency failure"))
+
+        with self.assertRaisesRegex(RuntimeError, "forced consistency failure"):
+            writer._close_current_writers()
+
+        self.assertEqual(child.aborted, ["blob"])
+        self.assertEqual(writer.committed_files, ["normal"])
+
+    def test_index_prepare_failure_aborts_staged_data(self):
+        prepared = Mock()
+        prepared.messages = []
+        table_write = object.__new__(TableWrite)
+        table_write.file_store_write = Mock()
+        table_write.file_store_write.stage_commit.return_value = prepared
+        table_write.row_key_extractor = Mock()
+        table_write.row_key_extractor.prepare_commit.side_effect = RuntimeError(
+            "forced index failure")
+
+        with self.assertRaisesRegex(RuntimeError, "forced index failure"):
+            table_write._prepare_commit(1)
+
+        prepared.abort.assert_called_once_with()
+        table_write.row_key_extractor.abort.assert_called_once_with()
+
+    def test_bucket_stage_failure_rolls_back_index_assignment_state(self):
+        table_write = object.__new__(TableWrite)
+        table_write.file_store_write = Mock()
+        table_write.file_store_write.stage_commit.side_effect = RuntimeError(
+            "forced bucket failure")
+        table_write.row_key_extractor = Mock()
+
+        with self.assertRaisesRegex(RuntimeError, "forced bucket failure"):
+            table_write._prepare_commit(1)
+
+        table_write.row_key_extractor.abort.assert_called_once_with()
+
+
+class ManagedBlobWriteOwnershipTest(unittest.TestCase):
+
+    def setUp(self):
+        from pypaimon.catalog.catalog_factory import CatalogFactory
+
+        self.temp_dir = tempfile.mkdtemp()
+        self.addCleanup(shutil.rmtree, self.temp_dir, True)
+        self.warehouse = os.path.join(self.temp_dir, "warehouse")
+        self.catalog = CatalogFactory.create({"warehouse": self.warehouse})
+        self.catalog.create_database("default", True)
+        self.arrow_schema = pa.schema([
+            pa.field("id", pa.int32(), nullable=False),
+            pa.field("payload", pa.large_binary()),
+        ])
+
+    def _create_table(self, name):
+        from pypaimon.schema.schema import Schema
+
+        schema = Schema.from_pyarrow_schema(
+            self.arrow_schema,
+            primary_keys=["id"],
+            options={
+                "bucket": "1",
+                "merge-engine": "deduplicate",
+                "changelog-producer": "none",
+            },
+        )
+        identifier = "default.%s" % name
+        self.catalog.create_table(identifier, schema, False)
+        return self.catalog.get_table(identifier)
+
+    def _batch(self, row_id, payload):
+        return pa.Table.from_pydict(
+            {"id": [row_id], "payload": [payload]},
+            schema=self.arrow_schema,
+        )
+
+    @staticmethod
+    def _message_paths(messages):
+        return {
+            file.file_path
+            for message in messages
+            for file in message.new_files
+        }
+
+    def test_stream_prepare_transfers_only_current_round(self):
+        table = self._create_table("stream_drain")
+        builder = table.new_stream_write_builder()
+        writer = builder.new_write()
+        committer = builder.new_commit()
+        try:
+            writer.write_arrow(self._batch(1, b"one"))
+            first = writer.prepare_commit(1)
+            first_paths = self._message_paths(first)
+            self.assertTrue(first_paths)
+            committer.commit(first, 1)
+
+            writer.write_arrow(self._batch(2, b"two"))
+            second = writer.prepare_commit(2)
+            second_paths = self._message_paths(second)
+            self.assertTrue(second_paths)
+            self.assertTrue(first_paths.isdisjoint(second_paths))
+            committer.commit(second, 2)
+        finally:
+            writer.close()
+            committer.close()
+
+        for path in first_paths.union(second_paths):
+            self.assertTrue(table.file_io.exists(path))
+
+    def test_abort_after_prepare_does_not_delete_handed_off_files(self):
+        table = self._create_table("abort_after_prepare")
+        writer = table.new_stream_write_builder().new_write()
+        writer.write_arrow(self._batch(1, b"prepared"))
+        messages = writer.prepare_commit(1)
+        paths = self._message_paths(messages)
+        extra_paths = {
+            "%s/%s" % (file.file_path.rsplit("/", 1)[0], extra)
+            for message in messages
+            for file in message.new_files
+            for extra in file.extra_files
+        }
+
+        writer.abort()
+
+        for path in paths.union(extra_paths):
+            self.assertTrue(table.file_io.exists(path))
+
+    def test_committer_abort_preserves_potentially_shared_managed_blob_packs(self):
+        table = self._create_table("committer_abort_packs")
+        builder = table.new_stream_write_builder()
+        writer = builder.new_write()
+        committer = builder.new_commit()
+        writer.write_arrow(self._batch(1, b"prepared"))
+        messages = writer.prepare_commit(1)
+        packs = set(glob.glob(
+            os.path.join(table.table_path, "**", "*.managed.blob"), recursive=True))
+        self.assertTrue(packs)
+
+        committer.abort(messages)
+
+        for path in packs:
+            self.assertTrue(table.file_io.exists(path))
+        writer.close()
+        committer.close()
+
+    def test_close_without_prepare_removes_all_writer_owned_files(self):
+        table = self._create_table("close_cleanup")
+        writer = table.new_batch_write_builder().new_write()
+        writer.write_arrow(self._batch(1, b"uncommitted"))
+
+        writer.close()
+
+        patterns = ("*.parquet", "*.orc", "*.avro", "*.blobref", "*.managed.blob")
+        leftovers = []
+        for pattern in patterns:
+            leftovers.extend(glob.glob(
+                os.path.join(table.table_path, "**", pattern), recursive=True))
+        self.assertEqual(leftovers, [])
+
+    def test_metadata_failure_removes_main_sidecar_and_managed_pack(self):
+        table = self._create_table("metadata_failure_cleanup")
+        writer = table.new_batch_write_builder().new_write()
+        writer.write_arrow(self._batch(None, b"uncommitted"))
+
+        with self.assertRaisesRegex(
+                RuntimeError, r"(Primary key should not be null|contains nulls)"):
+            writer.prepare_commit()
+        writer.close()
+
+        leftovers = []
+        for pattern in ("*.parquet", "*.blobref", "*.managed.blob"):
+            leftovers.extend(glob.glob(
+                os.path.join(table.table_path, "**", pattern), recursive=True))
+        self.assertEqual(leftovers, [])
+
+    def test_failed_next_stream_prepare_keeps_previous_round_and_aborts_new_packs(self):
+        table = self._create_table("stream_failure_isolation")
+        writer = table.new_stream_write_builder().new_write()
+        writer.write_arrow(self._batch(1, b"first"))
+        first = writer.prepare_commit(1)
+        first_paths = self._message_paths(first)
+        first_extra_paths = {
+            "%s/%s" % (file.file_path.rsplit("/", 1)[0], extra)
+            for message in first
+            for file in message.new_files
+            for extra in file.extra_files
+        }
+        first_packs = set(glob.glob(
+            os.path.join(table.table_path, "**", "*.managed.blob"), recursive=True))
+        self.assertTrue(first_packs)
+
+        writer.write_arrow(self._batch(2, b"second"))
+        with patch.object(
+                writer.row_key_extractor,
+                "prepare_commit",
+                create=True,
+                side_effect=RuntimeError("forced index failure")):
+            with self.assertRaisesRegex(RuntimeError, "forced index failure"):
+                writer.prepare_commit(2)
+
+        for path in first_paths.union(first_extra_paths).union(first_packs):
+            self.assertTrue(table.file_io.exists(path))
+        self.assertEqual(
+            first_packs,
+            set(glob.glob(
+                os.path.join(table.table_path, "**", "*.managed.blob"), recursive=True)),
+        )
+        writer.close()
+
+
+class BlobDescriptorSourceTableTest(unittest.TestCase):
+
+    def setUp(self):
+        self.temp_dir = tempfile.mkdtemp()
+        self.addCleanup(shutil.rmtree, self.temp_dir, True)
+        self.target_file_io = FileIO.get(self.temp_dir, Options({}))
+
+    def test_source_table_reader_copies_descriptor_payload_to_new_pack(self):
+        payload = b"source-table-credential-payload"
+        source_file_io = _SourceFileIO(payload)
+        catalog = _SourceCatalog(source_file_io)
+        context = object()
+        environment = _SourceCatalogEnvironment(catalog, context)
+        table = SimpleNamespace(
+            file_io=self.target_file_io,
+            options=CoreOptions(Options({
+                "blob-descriptor.source-table": "default.source$branch_rt",
+                "blob-descriptor.fs.s3.endpoint": "must-be-ignored",
+            })),
+            catalog_environment=environment,
+        )
+        reader_factory = BlobDescriptorReaderFactory.create(table)
+        pack_path = os.path.join(self.temp_dir, "target.managed.blob")
+        externalizer = PrimaryKeyBlobExternalizer(
+            self.target_file_io,
+            [DataField(0, "payload", AtomicType("BLOB"))],
+            {"payload"},
+            lambda: pack_path,
+            1024 * 1024,
+            4096,
+            "data-",
+            reader_factory,
+        )
+        descriptor = BlobDescriptor(
+            "source://credential-scoped/object", 0, len(payload)).serialize()
+        batch = pa.RecordBatch.from_arrays(
+            [pa.array([descriptor], type=pa.large_binary())],
+            names=["payload"],
+        )
+
+        result = externalizer.externalize_record_batch(batch)
+        externalizer.prepare_commit()
+        copied = Blob.from_bytes(
+            result.column("payload")[0].as_py(), self.target_file_io).to_data()
+        externalizer.close()
+
+        self.assertEqual(copied, payload)
+        self.assertEqual(source_file_io.opened, ["source://credential-scoped/object"])
+        self.assertEqual(catalog.identifier.get_database_name(), "default")
+        self.assertEqual(catalog.identifier.get_table_name(), "source")
+        self.assertEqual(catalog.identifier.get_branch_name(), "rt")
+        self.assertTrue(source_file_io.token_initialized)
+        self.assertTrue(source_file_io.closed)
+        self.assertTrue(catalog.closed)
+
+    def test_static_descriptor_options_are_isolated_and_prefix_stripped(self):
+        target_factory = object()
+        table = SimpleNamespace(
+            file_io=SimpleNamespace(uri_reader_factory=target_factory),
+            options=CoreOptions(Options({
+                "fs.s3.endpoint": "target-endpoint",
+                "blob-descriptor.fs.s3.endpoint": "source-endpoint",
+                "blob-descriptor.fs.s3.accessKeyId": "source-key",
+                "blob-descriptor.fs.s3.accessKeySecret": "source-secret",
+            })),
+        )
+
+        reader_factory = BlobDescriptorReaderFactory.create(table)
+
+        self.assertIsNot(reader_factory, target_factory)
+        self.assertEqual(
+            {
+                "fs.s3.endpoint": "source-endpoint",
+                "fs.s3.accessKeyId": "source-key",
+                "fs.s3.accessKeySecret": "source-secret",
+            },
+            reader_factory.catalog_options.to_map(),
+        )
+
+    def test_without_descriptor_options_reuses_target_reader_factory(self):
+        target_factory = object()
+        table = SimpleNamespace(
+            file_io=SimpleNamespace(uri_reader_factory=target_factory),
+            options=CoreOptions(Options({"fs.s3.endpoint": "target-endpoint"})),
+        )
+
+        self.assertIs(
+            target_factory, BlobDescriptorReaderFactory.create(table))
+
+    def test_source_table_reader_copies_v1_descriptor_payload(self):
+        payload = b"legacy-source-descriptor"
+        source_file_io = _SourceFileIO(payload)
+        catalog = _SourceCatalog(source_file_io)
+        context = object()
+        table = SimpleNamespace(
+            file_io=self.target_file_io,
+            options=CoreOptions(Options({
+                "blob-descriptor.source-table": "default.source",
+            })),
+            catalog_environment=_SourceCatalogEnvironment(catalog, context),
+        )
+        reader_factory = BlobDescriptorReaderFactory.create(table)
+        pack_path = os.path.join(self.temp_dir, "target-v1.managed.blob")
+        externalizer = PrimaryKeyBlobExternalizer(
+            self.target_file_io,
+            [DataField(0, "payload", AtomicType("BLOB"))],
+            {"payload"},
+            lambda: pack_path,
+            1024 * 1024,
+            4096,
+            "data-",
+            reader_factory,
+        )
+        descriptor = BlobDescriptor(
+            "source://credential-scoped/v1", 0, len(payload))
+        descriptor._version = 1
+        batch = pa.RecordBatch.from_arrays(
+            [pa.array([descriptor.serialize()], type=pa.large_binary())],
+            names=["payload"],
+        )
+
+        result = externalizer.externalize_record_batch(batch)
+        externalizer.prepare_commit()
+
+        copied = Blob.from_descriptor_bytes(
+            result.column("payload")[0].as_py(), self.target_file_io).to_data()
+        self.assertEqual(copied, payload)
+        self.assertEqual(
+            source_file_io.opened, ["source://credential-scoped/v1"])
+
+    def test_static_descriptor_options_reader_copies_v1_descriptor_payload(self):
+        payload = b"legacy-static-descriptor"
+        source_file_io = _SourceFileIO(payload)
+        table = SimpleNamespace(
+            file_io=SimpleNamespace(uri_reader_factory=object()),
+            options=CoreOptions(Options({
+                "blob-descriptor.fs.default-scheme": "source",
+            })),
+            catalog_environment=SimpleNamespace(catalog_loader=None),
+        )
+        pack_path = os.path.join(self.temp_dir, "static-v1.managed.blob")
+        descriptor = BlobDescriptor(
+            "source://credential-scoped/v1", 0, len(payload))
+        descriptor._version = 1
+        batch = pa.RecordBatch.from_arrays(
+            [pa.array([descriptor.serialize()], type=pa.large_binary())],
+            names=["payload"],
+        )
+        with patch("pypaimon.common.file_io.FileIO.get", return_value=source_file_io):
+            reader_factory = BlobDescriptorReaderFactory.create(table)
+            self.assertTrue(reader_factory.force_descriptor_bytes)
+            externalizer = PrimaryKeyBlobExternalizer(
+                self.target_file_io,
+                [DataField(0, "payload", AtomicType("BLOB"))],
+                {"payload"},
+                lambda: pack_path,
+                1024 * 1024,
+                4096,
+                "data-",
+                reader_factory,
+            )
+            result = externalizer.externalize_record_batch(batch)
+            externalizer.prepare_commit()
+
+        copied = Blob.from_descriptor_bytes(
+            result.column("payload")[0].as_py(), self.target_file_io).to_data()
+        self.assertEqual(copied, payload)
+
+    def test_source_table_requires_catalog_loader(self):
+        table = SimpleNamespace(
+            file_io=self.target_file_io,
+            options=CoreOptions(Options({
+                "blob-descriptor.source-table": "default.source",
+            })),
+            catalog_environment=SimpleNamespace(catalog_loader=None),
+        )
+
+        with self.assertRaisesRegex(
+                ValueError, "tables without a catalog loader"):
+            BlobDescriptorReaderFactory.create(table)
+
+
+class _SourceFileIO:
+
+    def __init__(self, payload):
+        self.payload = payload
+        self.opened = []
+        self.token_initialized = False
+        self.closed = False
+
+    def valid_token(self):
+        self.token_initialized = True
+        return object()
+
+    def new_input_stream(self, uri):
+        self.opened.append(uri)
+        return io.BytesIO(self.payload)
+
+    def close(self):
+        self.closed = True
+
+
+class _SourceCatalog:
+
+    def __init__(self, file_io):
+        self.file_io = file_io
+        self.identifier = None
+        self.closed = False
+
+    def get_table(self, identifier: Identifier):
+        self.identifier = identifier
+        return SimpleNamespace(file_io=self.file_io)
+
+    def close(self):
+        self.closed = True
+
+
+class _SourceCatalogLoader:
+
+    def __init__(self, catalog, context):
+        self.catalog = catalog
+        self._context = context
+
+    def context(self):
+        return self._context
+
+    def load(self):
+        return self.catalog
+
+
+class _SourceCatalogEnvironment:
+
+    def __init__(self, catalog, context):
+        self.catalog_loader = _SourceCatalogLoader(catalog, context)
+        self._context = context
+
+    def catalog_context(self):
+        return self._context
+
+    def dependency_read_context(self):
+        return self._context
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/paimon-python/pypaimon/tests/primary_key_blob_e2e_test.py
+++ b/paimon-python/pypaimon/tests/primary_key_blob_e2e_test.py
@@ -1,0 +1,461 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+"""End-to-end tests for primary-key tables with managed BLOB columns."""
+
+import glob
+import io
+import os
+import shutil
+import tempfile
+import unittest
+from types import SimpleNamespace
+
+import pyarrow as pa
+import pyarrow.parquet as pq
+
+from pypaimon import CatalogFactory, Schema
+from pypaimon.blob.managed_blob_reference_file import ManagedBlobReferenceFile
+from pypaimon.table.row.blob import BlobDescriptor
+
+
+class PrimaryKeyBlobE2ETest(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        cls.tempdir = tempfile.mkdtemp()
+        cls.warehouse = os.path.join(cls.tempdir, 'warehouse')
+        cls.catalog = CatalogFactory.create({'warehouse': cls.warehouse})
+        cls.catalog.create_database('default', True)
+
+    @classmethod
+    def tearDownClass(cls):
+        shutil.rmtree(cls.tempdir, ignore_errors=True)
+
+    def _create_pk_blob_table(
+            self, table_name, pa_schema, primary_keys=None, extra_options=None):
+        options = {
+            'bucket': '1',
+            'merge-engine': 'deduplicate',
+            'changelog-producer': 'none',
+            'file.format': 'parquet',
+        }
+        options.update(extra_options or {})
+        schema = Schema.from_pyarrow_schema(
+            pa_schema,
+            primary_keys=primary_keys or ['id'],
+            options=options,
+        )
+        full_name = 'default.{}'.format(table_name)
+        self.catalog.create_table(full_name, schema, False)
+        return self.catalog.get_table(full_name), pa_schema
+
+    @staticmethod
+    def _write_arrow(table, pa_table):
+        write_builder = table.new_batch_write_builder()
+        writer = write_builder.new_write()
+        committer = write_builder.new_commit()
+        try:
+            writer.write_arrow(pa_table)
+            commit_messages = writer.prepare_commit()
+            committer.commit(commit_messages)
+            return commit_messages
+        finally:
+            writer.close()
+            committer.close()
+
+    @staticmethod
+    def _read_table(table):
+        read_builder = table.new_read_builder()
+        return read_builder.new_read().to_arrow(
+            read_builder.new_scan().plan().splits())
+
+    @staticmethod
+    def _table_data_path(table):
+        return table.table_path
+
+    def _assert_managed_collection_storage(
+            self, table, field_name, field_kind, expected_descriptor_count):
+        data_files = {
+            data_file.file_path: data_file
+            for split in table.new_read_builder().new_scan().plan().splits()
+            for data_file in split.files
+        }
+        self.assertTrue(data_files)
+
+        all_descriptor_uris = set()
+        descriptor_count = 0
+        for data_file_path, data_file in data_files.items():
+            physical_values = pq.read_table(
+                data_file_path, columns=[field_name]).column(field_name).to_pylist()
+            descriptor_values = []
+            for value in physical_values:
+                if value is None:
+                    continue
+                if field_kind == 'array':
+                    descriptor_values.extend(
+                        element for element in value if element is not None)
+                else:
+                    descriptor_values.extend(
+                        map_value
+                        for _, map_value in value
+                        if map_value is not None)
+
+            descriptor_uris = set()
+            for raw in descriptor_values:
+                self.assertTrue(
+                    BlobDescriptor.is_blob_descriptor(raw),
+                    'Managed collection value was stored inline instead of as a descriptor.',
+                )
+                descriptor = BlobDescriptor.deserialize(raw)
+                self.assertTrue(descriptor.uri.endswith('.managed.blob'))
+                self.assertGreaterEqual(descriptor.offset, 0)
+                self.assertGreaterEqual(descriptor.length, 0)
+                descriptor_uris.add(descriptor.uri)
+
+            descriptor_count += len(descriptor_values)
+            all_descriptor_uris.update(descriptor_uris)
+
+            sidecar_names = [
+                extra_file for extra_file in data_file.extra_files
+                if extra_file.endswith('.blobref')
+            ]
+            self.assertEqual(len(sidecar_names), 1)
+            sidecar_path = os.path.join(
+                os.path.dirname(data_file_path), sidecar_names[0])
+            references = ManagedBlobReferenceFile.read(table.file_io, sidecar_path)
+            referenced_uris = {
+                os.path.join(ref.storage_root_id, ref.relative_path)
+                for ref in references
+            }
+            self.assertEqual(referenced_uris, descriptor_uris)
+
+        managed_paths = set(glob.glob(
+            os.path.join(
+                self._table_data_path(table), '**', '*.managed.blob'),
+            recursive=True,
+        ))
+        self.assertEqual(descriptor_count, expected_descriptor_count)
+        self.assertEqual(all_descriptor_uris, managed_paths)
+
+    def test_scalar_blob_write_read_round_trip(self):
+        pa_schema = pa.schema([
+            pa.field('id', pa.int32(), nullable=False),
+            pa.field('payload', pa.large_binary()),
+        ])
+        table, schema = self._create_pk_blob_table('pk_scalar_blob', pa_schema)
+
+        self._write_arrow(table, pa.Table.from_pydict({
+            'id': [1, 2, 3],
+            'payload': [b'alpha', b'beta', b'gamma'],
+        }, schema=schema))
+
+        result = self._read_table(table).sort_by('id')
+        self.assertEqual(
+            {row['id']: row['payload'] for row in result.to_pylist()},
+            {1: b'alpha', 2: b'beta', 3: b'gamma'},
+        )
+
+        data_path = self._table_data_path(table)
+        self.assertTrue(glob.glob(
+            os.path.join(data_path, '**', '*.managed.blob'), recursive=True))
+        self.assertTrue(glob.glob(
+            os.path.join(data_path, '**', '*.blobref'), recursive=True))
+
+    def test_scalar_blob_deduplicate_last_write_wins(self):
+        pa_schema = pa.schema([
+            pa.field('id', pa.int32(), nullable=False),
+            pa.field('payload', pa.large_binary()),
+        ])
+        table, schema = self._create_pk_blob_table('pk_scalar_blob_dedup', pa_schema)
+
+        self._write_arrow(table, pa.Table.from_pydict({
+            'id': [1, 2],
+            'payload': [b'first-1', b'first-2'],
+        }, schema=schema))
+        self._write_arrow(table, pa.Table.from_pydict({
+            'id': [1],
+            'payload': [b'second-1'],
+        }, schema=schema))
+
+        result = self._read_table(table).sort_by('id')
+        self.assertEqual(
+            {row['id']: row['payload'] for row in result.to_pylist()},
+            {1: b'second-1', 2: b'first-2'},
+        )
+
+    def test_close_without_prepare_aborts_managed_blob_packs(self):
+        pa_schema = pa.schema([
+            pa.field('id', pa.int32(), nullable=False),
+            pa.field('payload', pa.large_binary()),
+        ])
+        table, schema = self._create_pk_blob_table('pk_blob_close_abort', pa_schema)
+        writer = table.new_batch_write_builder().new_write()
+        data_path = self._table_data_path(table)
+        try:
+            writer.write_arrow(pa.Table.from_pydict({
+                'id': [1],
+                'payload': [b'uncommitted'],
+            }, schema=schema))
+            self.assertTrue(glob.glob(
+                os.path.join(data_path, '**', '*.managed.blob'), recursive=True))
+        finally:
+            writer.close()
+
+        self.assertFalse(glob.glob(
+            os.path.join(data_path, '**', '*.managed.blob'), recursive=True))
+
+    def test_close_after_prepare_keeps_managed_blob_packs(self):
+        pa_schema = pa.schema([
+            pa.field('id', pa.int32(), nullable=False),
+            pa.field('payload', pa.large_binary()),
+        ])
+        table, schema = self._create_pk_blob_table('pk_blob_close_prepared', pa_schema)
+        writer = table.new_batch_write_builder().new_write()
+        data_path = self._table_data_path(table)
+        writer.write_arrow(pa.Table.from_pydict({
+            'id': [1],
+            'payload': [b'prepared'],
+        }, schema=schema))
+        writer.prepare_commit()
+        packs_before_close = set(glob.glob(
+            os.path.join(data_path, '**', '*.managed.blob'), recursive=True))
+        self.assertTrue(packs_before_close)
+
+        writer.close()
+
+        self.assertEqual(
+            set(glob.glob(
+                os.path.join(data_path, '**', '*.managed.blob'), recursive=True)),
+            packs_before_close,
+        )
+
+    def test_array_blob_write_read_round_trip(self):
+        array_type = pa.list_(pa.large_binary())
+        pa_schema = pa.schema([
+            pa.field('id', pa.int32(), nullable=False),
+            pa.field('payloads', array_type),
+        ])
+        table, schema = self._create_pk_blob_table('pk_array_blob', pa_schema)
+
+        expected = {
+            1: [b'a1', None, b'a3'],
+            2: None,
+            3: [b'c1'],
+            4: [],
+        }
+        self._write_arrow(table, pa.Table.from_pydict({
+            'id': [1, 2, 3, 4],
+            'payloads': pa.array(
+                [expected[1], expected[2], expected[3], expected[4]],
+                type=array_type,
+            ),
+        }, schema=schema))
+
+        result = self._read_table(table).sort_by('id')
+        actual = {
+            row['id']: row['payloads']
+            for row in result.to_pylist()
+        }
+        self.assertEqual(actual, expected)
+        self._assert_managed_collection_storage(
+            table, 'payloads', 'array', expected_descriptor_count=3)
+
+    def test_map_blob_write_read_round_trip(self):
+        map_type = pa.map_(pa.string(), pa.large_binary())
+        pa_schema = pa.schema([
+            pa.field('id', pa.int32(), nullable=False),
+            pa.field('payload', map_type),
+        ])
+        table, schema = self._create_pk_blob_table('pk_map_blob', pa_schema)
+
+        expected = {
+            1: [('k1', b'v1'), ('k2', b'v2')],
+            2: None,
+            3: [],
+            4: [('null-value', None)],
+        }
+        self._write_arrow(table, pa.Table.from_pydict({
+            'id': [1, 2, 3, 4],
+            'payload': pa.array(
+                [dict(expected[1]), expected[2], dict(expected[3]), dict(expected[4])],
+                type=map_type,
+            ),
+        }, schema=schema))
+
+        result = self._read_table(table).sort_by('id')
+        actual = {}
+        for row in result.to_pylist():
+            value = row['payload']
+            if value is None:
+                actual[row['id']] = None
+            elif isinstance(value, dict):
+                actual[row['id']] = sorted(value.items())
+            else:
+                actual[row['id']] = sorted(value)
+        self.assertEqual(actual, {
+            1: sorted(expected[1]),
+            2: None,
+            3: [],
+            4: expected[4],
+        })
+        self._assert_managed_collection_storage(
+            table, 'payload', 'map', expected_descriptor_count=2)
+
+    def test_blobref_sidecar_lists_managed_blob_packs(self):
+        pa_schema = pa.schema([
+            pa.field('id', pa.int32(), nullable=False),
+            pa.field('payload', pa.large_binary()),
+        ])
+        table, schema = self._create_pk_blob_table('pk_blob_sidecar', pa_schema)
+
+        self._write_arrow(table, pa.Table.from_pydict({
+            'id': [1, 2],
+            'payload': [b'one', b'two'],
+        }, schema=schema))
+
+        data_path = self._table_data_path(table)
+        sidecar_paths = glob.glob(
+            os.path.join(data_path, '**', '*.blobref'), recursive=True)
+        managed_paths = glob.glob(
+            os.path.join(data_path, '**', '*.managed.blob'), recursive=True)
+        self.assertEqual(len(sidecar_paths), 1)
+        self.assertGreaterEqual(len(managed_paths), 1)
+
+        references = ManagedBlobReferenceFile.read(table.file_io, sidecar_paths[0])
+        referenced = {
+            os.path.join(ref.storage_root_id, ref.relative_path)
+            for ref in references
+        }
+        self.assertTrue(referenced)
+        self.assertEqual(referenced, set(managed_paths))
+
+    def test_source_table_descriptor_uses_production_writer_chain(self):
+        pa_schema = pa.schema([
+            pa.field('id', pa.int32(), nullable=False),
+            pa.field('payload', pa.large_binary()),
+        ])
+        source_identifier = 'default.credential_source$branch_cred'
+        table, schema = self._create_pk_blob_table(
+            'pk_source_table_descriptor',
+            pa_schema,
+            extra_options={'blob-descriptor.source-table': source_identifier},
+        )
+
+        payload = b'payload-readable-only-with-source-credentials'
+        source_file_io = _CredentialScopedFileIO(payload)
+        source_catalog = _RoutingSourceCatalog(self.catalog, source_file_io)
+        original_loader = table.catalog_environment.catalog_loader
+        table.catalog_environment.catalog_loader = _RoutingCatalogLoader(
+            source_catalog, original_loader.context())
+
+        source_uri = 'credential://isolated-bucket/object'
+        source_descriptor = BlobDescriptor(
+            source_uri, 0, len(payload)).serialize()
+        commit_messages = self._write_arrow(
+            table,
+            pa.Table.from_pydict({
+                'id': [1],
+                'payload': [source_descriptor],
+            }, schema=schema),
+        )
+
+        self.assertEqual(source_file_io.opened, [source_uri])
+        self.assertIsNotNone(source_catalog.source_identifier)
+        self.assertEqual(
+            source_catalog.source_identifier.get_branch_name(), 'cred')
+
+        data_files = [
+            data_file
+            for message in commit_messages
+            for data_file in message.new_files
+        ]
+        self.assertEqual(len(data_files), 1)
+        data_file = data_files[0]
+        physical = pq.read_table(
+            data_file.file_path, columns=['payload']).column('payload')[0].as_py()
+        target_descriptor = BlobDescriptor.deserialize(physical)
+        self.assertNotEqual(target_descriptor.uri, source_uri)
+        self.assertTrue(target_descriptor.uri.endswith('.managed.blob'))
+        self.assertTrue(table.file_io.exists(target_descriptor.uri))
+
+        sidecars = [
+            extra for extra in data_file.extra_files if extra.endswith('.blobref')
+        ]
+        self.assertEqual(len(sidecars), 1)
+        references = ManagedBlobReferenceFile.read(
+            table.file_io,
+            os.path.join(os.path.dirname(data_file.file_path), sidecars[0]),
+        )
+        self.assertEqual(len(references), 1)
+        self.assertEqual(
+            os.path.join(
+                references[0].storage_root_id,
+                references[0].relative_path,
+            ),
+            target_descriptor.uri,
+        )
+        self.assertEqual(
+            self._read_table(table).column('payload').to_pylist(), [payload])
+
+
+class _CredentialScopedFileIO:
+
+    def __init__(self, payload):
+        self.payload = payload
+        self.opened = []
+
+    def new_input_stream(self, uri):
+        self.opened.append(uri)
+        return io.BytesIO(self.payload)
+
+
+class _RoutingSourceCatalog:
+
+    def __init__(self, delegate, source_file_io):
+        self.delegate = delegate
+        self.source_file_io = source_file_io
+        self.source_identifier = None
+
+    def get_table(self, identifier):
+        if identifier.get_table_name() == 'credential_source':
+            self.source_identifier = identifier
+            return SimpleNamespace(file_io=self.source_file_io)
+        return self.delegate.get_table(identifier)
+
+    def __getattr__(self, name):
+        return getattr(self.delegate, name)
+
+    def close(self):
+        pass
+
+
+class _RoutingCatalogLoader:
+
+    def __init__(self, catalog, context):
+        self.catalog = catalog
+        self._context = context
+
+    def context(self):
+        return self._context
+
+    def load(self):
+        return self.catalog
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/paimon-python/pypaimon/tests/primary_key_blob_externalizer_test.py
+++ b/paimon-python/pypaimon/tests/primary_key_blob_externalizer_test.py
@@ -1,0 +1,230 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+import shutil
+import struct
+import tempfile
+import unittest
+
+import pyarrow as pa
+
+from pypaimon.blob.primary_key_blob_externalizer import PrimaryKeyBlobExternalizer
+from pypaimon.common.file_io import FileIO
+from pypaimon.common.options.options import Options
+from pypaimon.schema.data_types import ArrayType, AtomicType, DataField, MapType
+from pypaimon.table.row.blob import Blob, BlobDescriptor
+
+
+class PrimaryKeyBlobExternalizerTest(unittest.TestCase):
+
+    def setUp(self):
+        self.temp_dir = tempfile.mkdtemp()
+        self.addCleanup(shutil.rmtree, self.temp_dir, True)
+        self.file_io = FileIO.get(self.temp_dir, Options({}))
+
+    def _externalizer(self, field, pack_name, descriptor_reader_factory=None):
+        return PrimaryKeyBlobExternalizer(
+            self.file_io,
+            [field],
+            {field.name},
+            lambda: "%s/%s.managed.blob" % (self.temp_dir, pack_name),
+            1024 * 1024,
+            4096,
+            "data-",
+            descriptor_reader_factory=descriptor_reader_factory,
+        )
+
+    def test_map_blob_preserves_integer_key_type_and_value_field(self):
+        value_field = pa.field(
+            "value",
+            pa.large_binary(),
+            nullable=False,
+        )
+        map_type = pa.map_(
+            pa.field("key", pa.int32(), nullable=False),
+            value_field,
+        )
+        batch_field = pa.field(
+            "payload",
+            map_type,
+            metadata={b"field-meta": b"preserved"},
+        )
+        batch = pa.RecordBatch.from_arrays(
+            [pa.array([[(7, b"payload")]], type=map_type)],
+            schema=pa.schema([batch_field]),
+        )
+        externalizer = self._externalizer(
+            DataField(
+                0,
+                "payload",
+                MapType(
+                    True,
+                    AtomicType("INT", False),
+                    AtomicType("BLOB", False),
+                ),
+            ),
+            "map",
+        )
+
+        try:
+            result = externalizer.externalize_record_batch(batch)
+            result_field = result.schema.field("payload")
+            self.assertEqual(result_field.type.key_type, pa.int32())
+            self.assertFalse(result_field.type.item_field.nullable)
+            self.assertEqual(result_field.metadata, batch_field.metadata)
+            self.assertEqual(result.column("payload").to_pylist()[0][0][0], 7)
+        finally:
+            externalizer.abort()
+
+    def test_array_blob_empty_then_nonempty_batches_keep_schema(self):
+        item_field = pa.field(
+            "item",
+            pa.large_binary(),
+            nullable=False,
+            metadata={b"item-meta": b"preserved"},
+        )
+        array_type = pa.list_(item_field)
+        batch_field = pa.field(
+            "payload",
+            array_type,
+            metadata={b"field-meta": b"preserved"},
+        )
+        schema = pa.schema([batch_field])
+        empty_batch = pa.RecordBatch.from_arrays(
+            [pa.array([[]], type=array_type)],
+            schema=schema,
+        )
+        nonempty_batch = pa.RecordBatch.from_arrays(
+            [pa.array([[b"payload"]], type=array_type)],
+            schema=schema,
+        )
+        externalizer = self._externalizer(
+            DataField(
+                0,
+                "payload",
+                ArrayType(True, AtomicType("BLOB", False)),
+            ),
+            "array",
+        )
+
+        try:
+            empty_result = externalizer.externalize_record_batch(empty_batch)
+            nonempty_result = externalizer.externalize_record_batch(nonempty_batch)
+            combined = pa.concat_tables([
+                pa.Table.from_batches([empty_result]),
+                pa.Table.from_batches([nonempty_result]),
+            ])
+            result_field = nonempty_result.schema.field("payload")
+            self.assertEqual(result_field.type, array_type)
+            self.assertFalse(result_field.type.value_field.nullable)
+            self.assertEqual(
+                result_field.type.value_field.metadata,
+                item_field.metadata,
+            )
+            self.assertEqual(result_field.metadata, batch_field.metadata)
+            self.assertEqual(combined.num_rows, 2)
+        finally:
+            externalizer.abort()
+
+    def test_v1_descriptor_bytes_with_force_descriptor_contract(self):
+        payload = b"legacy-v1-payload"
+        pack_bytes = b"prefix" + payload + b"suffix"
+        source_path = "%s/source-v1.managed.blob" % self.temp_dir
+        with self.file_io.new_output_stream(source_path) as out:
+            out.write(pack_bytes)
+        uri_bytes = source_path.encode("utf-8")
+        v1_descriptor = (
+            b"\x01"
+            + struct.pack("<I", len(uri_bytes))
+            + uri_bytes
+            + struct.pack("<q", len(b"prefix"))
+            + struct.pack("<q", len(payload))
+        )
+        descriptor_factory = self.file_io.uri_reader_factory
+        descriptor_factory.force_descriptor_bytes = True
+        batch = pa.RecordBatch.from_arrays(
+            [pa.array([v1_descriptor], type=pa.large_binary())],
+            names=["payload"],
+        )
+        externalizer = self._externalizer(
+            DataField(0, "payload", AtomicType("BLOB")),
+            "v1-force-descriptor",
+            descriptor_reader_factory=descriptor_factory,
+        )
+        try:
+            result = externalizer.externalize_record_batch(batch)
+            externalizer.prepare_commit()
+            copied = Blob.from_descriptor_bytes(
+                result.column("payload")[0].as_py(), self.file_io).to_data()
+            self.assertEqual(payload, copied)
+        finally:
+            externalizer.abort()
+
+    def test_inline_payload_bytes_are_not_treated_as_v1_descriptor(self):
+        from pypaimon.blob.primary_key_blob_externalizer import _to_blob_value
+        from pypaimon.table.row.blob import BlobData
+
+        # Exact-length v1-shaped collision: heuristic may accept it, but the
+        # default write path must still treat it as inline payload.
+        collision_payload = (
+            b"\x01"
+            + struct.pack("<I", 0)
+            + struct.pack("<q", 0)
+            + struct.pack("<q", 0)
+        )
+        self.assertEqual(len(collision_payload), 21)
+        self.assertIsNotNone(BlobDescriptor.parse_if_serialized(collision_payload))
+        blob_value = _to_blob_value(collision_payload, self.file_io)
+        self.assertIsInstance(blob_value, BlobData)
+        self.assertEqual(blob_value.to_data(), collision_payload)
+
+        # Near-miss v1 shape: enters heuristic checks but fails exact length.
+        uri_body = b"inline-payload-body"
+        inline_payload = (
+            b"\x01"
+            + struct.pack("<I", len(uri_body))
+            + uri_body
+            + struct.pack("<q", 0)
+            + struct.pack("<q", len(uri_body))
+            + b"\xff"
+        )
+        self.assertGreaterEqual(len(inline_payload), 21)
+        self.assertIsNone(BlobDescriptor.parse_if_serialized(inline_payload))
+        blob_value = _to_blob_value(inline_payload, self.file_io)
+        self.assertIsInstance(blob_value, BlobData)
+        self.assertEqual(blob_value.to_data(), inline_payload)
+
+        batch = pa.RecordBatch.from_arrays(
+            [pa.array([collision_payload], type=pa.large_binary())],
+            names=["payload"],
+        )
+        externalizer = self._externalizer(
+            DataField(0, "payload", AtomicType("BLOB")),
+            "inline",
+        )
+        try:
+            result = externalizer.externalize_record_batch(batch)
+            externalizer.prepare_commit()
+            copied = Blob.from_descriptor_bytes(
+                result.column("payload")[0].as_py(), self.file_io).to_data()
+            self.assertEqual(collision_payload, copied)
+        finally:
+            externalizer.abort()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/paimon-python/pypaimon/tests/primary_key_blob_inline_compat_test.py
+++ b/paimon-python/pypaimon/tests/primary_key_blob_inline_compat_test.py
@@ -1,0 +1,527 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import io
+import os
+import shutil
+import struct
+import tempfile
+import unittest
+from unittest.mock import Mock, patch
+
+import pyarrow as pa
+
+from pypaimon.common.options.core_options import CoreOptions
+from pypaimon.common.options.options import Options
+from pypaimon.read.reader.iface.record_batch_reader import RecordBatchReader
+from pypaimon.read.reader.iface.record_iterator import RecordIterator
+from pypaimon.read.reader.iface.record_reader import RecordReader
+from pypaimon.read.reader.managed_blob_convert_record_reader import (
+    convert_managed_blob_batch,
+)
+from pypaimon.read.split_read import MergeFileSplitRead, RawFileSplitRead
+from pypaimon.schema.data_types import ArrayType, AtomicType, DataField, MapType
+from pypaimon.table.row.blob import Blob, BlobDescriptor, BlobViewStruct
+from pypaimon.table.row.offset_row import OffsetRow
+
+
+class _OneBatchReader(RecordBatchReader):
+
+    def __init__(self, batch):
+        self._batch = batch
+
+    def read_arrow_batch(self):
+        batch = self._batch
+        self._batch = None
+        return batch
+
+    def close(self):
+        pass
+
+
+class _OneRowIterator(RecordIterator):
+
+    def __init__(self, row):
+        self._row = row
+
+    def next(self):
+        row = self._row
+        self._row = None
+        return row
+
+
+class _OneRowReader(RecordReader):
+
+    def __init__(self, row):
+        self._row = row
+
+    def read_batch(self):
+        if self._row is None:
+            return None
+        row = self._row
+        self._row = None
+        return _OneRowIterator(row)
+
+    def close(self):
+        pass
+
+
+class _FakeBlobViewLookup:
+
+    preload_calls = []
+    close_calls = 0
+
+    def __init__(self, table):
+        self._table = table
+
+    def preload(self, structs):
+        self.preload_calls.append(list(structs))
+
+    def resolve_to_null(self, _view_struct):
+        return False
+
+    def resolve_descriptor(self, _view_struct):
+        return self._table.view_descriptor
+
+    def resolve_blob(self, _view_struct):
+        return Blob.from_data(self._table.view_payload)
+
+    def close(self):
+        type(self).close_calls += 1
+
+
+def _v1_descriptor(uri, offset, length):
+    uri_bytes = uri.encode("utf-8")
+    return (
+        b"\x01"
+        + struct.pack("<I", len(uri_bytes))
+        + uri_bytes
+        + struct.pack("<q", offset)
+        + struct.pack("<q", length)
+    )
+
+
+class PrimaryKeyInlineBlobCompatibilityTest(unittest.TestCase):
+
+    def setUp(self):
+        _FakeBlobViewLookup.preload_calls = []
+        _FakeBlobViewLookup.close_calls = 0
+        self.descriptor_payload = b"descriptor-payload"
+        self.view_payload = b"view-payload"
+        self.pack = b"prefix" + self.descriptor_payload + b"suffix"
+        self.descriptor = _v1_descriptor(
+            "file:///managed-v1.blob",
+            len(b"prefix"),
+            len(self.descriptor_payload),
+        )
+        self.view_struct = BlobViewStruct("db.source", 7, 42).serialize()
+        self.view_descriptor = BlobDescriptor(
+            "file:///view.blob", 0, len(self.view_payload))
+        self.fields = [
+            DataField(0, "id", AtomicType("INT")),
+            DataField(1, "inline_descriptor", AtomicType("BLOB")),
+            DataField(2, "inline_view", AtomicType("BLOB")),
+        ]
+
+    def _table(self, **options):
+        values = {
+            "blob-descriptor-field": "inline_descriptor",
+            "blob-view-field": "inline_view",
+        }
+        values.update(options)
+        table = Mock()
+        table.is_primary_key_table = True
+        table.options = CoreOptions(Options(values))
+        table.file_io.new_input_stream.side_effect = lambda _: io.BytesIO(self.pack)
+        table.catalog_environment.catalog_loader = object()
+        table.view_descriptor = self.view_descriptor
+        table.view_payload = self.view_payload
+        return table
+
+    def _create_real_pk_inline_table(self, table_name, versions):
+        from pypaimon import CatalogFactory, Schema
+
+        temp_dir = tempfile.mkdtemp()
+        self.addCleanup(shutil.rmtree, temp_dir, True)
+        catalog = CatalogFactory.create({
+            "warehouse": os.path.join(temp_dir, "warehouse"),
+        })
+        catalog.create_database("default", True)
+        arrow_schema = pa.schema([
+            pa.field("id", pa.int32(), nullable=False),
+            pa.field("inline_descriptor", pa.large_binary()),
+            pa.field("inline_view", pa.large_binary()),
+        ])
+        schema = Schema.from_pyarrow_schema(
+            arrow_schema,
+            primary_keys=["id"],
+            options={
+                "bucket": "1",
+                "file.format": "parquet",
+                "merge-engine": "deduplicate",
+                "changelog-producer": "none",
+                "blob-descriptor-field": "inline_descriptor",
+                "blob-view-field": "inline_view",
+            },
+        )
+        identifier = "default.%s" % table_name
+        catalog.create_table(identifier, schema, False)
+        table = catalog.get_table(identifier)
+
+        for version, (descriptor_payload, view_payload) in enumerate(versions):
+            external_path = os.path.join(
+                temp_dir, "descriptor-payload-%s" % version)
+            prefix = b"prefix-"
+            with open(external_path, "wb") as out:
+                out.write(prefix + descriptor_payload)
+            descriptor = BlobDescriptor(
+                external_path, len(prefix), len(descriptor_payload)).serialize()
+            view = BlobViewStruct(
+                "default.controlled_source", 7, version).serialize()
+            write_builder = table.new_batch_write_builder()
+            writer = write_builder.new_write()
+            committer = write_builder.new_commit()
+            try:
+                writer.write_arrow(pa.Table.from_pydict({
+                    "id": [1],
+                    "inline_descriptor": [descriptor],
+                    "inline_view": [view],
+                }, schema=arrow_schema))
+                committer.commit(writer.prepare_commit())
+            finally:
+                writer.close()
+                committer.close()
+
+        table.view_payload = versions[-1][1]
+        table.view_descriptor = BlobDescriptor(
+            "file:///controlled-view.blob", 0, len(table.view_payload))
+        return table
+
+    def _read_real_table_with_reader_tracking(self, table, projection):
+        raw_calls = []
+        merge_calls = []
+        raw_create = RawFileSplitRead.create_reader
+        merge_create = MergeFileSplitRead.create_reader
+
+        def track_raw(split_read):
+            raw_calls.append(split_read)
+            return raw_create(split_read)
+
+        def track_merge(split_read):
+            merge_calls.append(split_read)
+            return merge_create(split_read)
+
+        with patch.object(RawFileSplitRead, "create_reader", new=track_raw), \
+                patch.object(
+                    MergeFileSplitRead, "create_reader", new=track_merge):
+            read_builder = table.new_read_builder().with_projection(projection)
+            result = read_builder.new_read().to_arrow(
+                read_builder.new_scan().plan().splits())
+        return result, raw_calls, merge_calls
+
+    @patch(
+        "pypaimon.utils.blob_view_lookup.BlobViewLookup",
+        _FakeBlobViewLookup,
+    )
+    def test_raw_reader_resolves_inline_descriptor_and_view_after_output_stage(self):
+        schema = pa.schema([
+            pa.field("id", pa.int32(), nullable=False),
+            pa.field("inline_descriptor", pa.large_binary()),
+            pa.field("inline_view", pa.large_binary()),
+        ])
+        batch = pa.RecordBatch.from_arrays([
+            pa.array([1], type=pa.int32()),
+            pa.array([self.descriptor], type=pa.large_binary()),
+            pa.array([self.view_struct], type=pa.large_binary()),
+        ], schema=schema)
+        split_read = RawFileSplitRead.__new__(RawFileSplitRead)
+        split_read.table = self._table()
+        split_read.value_fields = self.fields
+        split_read.outer_extract_name_paths = None
+        split_read.outer_flat_read_type = None
+
+        wrapped = split_read._wrap_managed_blob_reader(_OneBatchReader(batch))
+        result = wrapped.read_arrow_batch()
+
+        self.assertEqual(schema, result.schema)
+        self.assertEqual(
+            [{
+                "id": 1,
+                "inline_descriptor": self.descriptor_payload,
+                "inline_view": self.view_payload,
+            }],
+            result.to_pylist(),
+        )
+        self.assertEqual(1, len(_FakeBlobViewLookup.preload_calls))
+
+    @patch(
+        "pypaimon.utils.blob_view_lookup.BlobViewLookup",
+        _FakeBlobViewLookup,
+    )
+    def test_wrapped_reader_close_releases_view_lookup(self):
+        batch = pa.record_batch(
+            [pa.array([self.view_struct], type=pa.large_binary())],
+            names=["inline_view"],
+        )
+        split_read = RawFileSplitRead.__new__(RawFileSplitRead)
+        split_read.table = self._table()
+        split_read.value_fields = [self.fields[2]]
+        split_read.outer_extract_name_paths = None
+        split_read.outer_flat_read_type = None
+        wrapped = split_read._wrap_managed_blob_reader(_OneBatchReader(batch))
+
+        wrapped.close()
+
+        self.assertEqual(1, _FakeBlobViewLookup.close_calls)
+
+    @patch(
+        "pypaimon.utils.blob_view_lookup.BlobViewLookup",
+        _FakeBlobViewLookup,
+    )
+    def test_merge_reader_resolves_projected_inline_fields_by_output_index(self):
+        projected_fields = [self.fields[2], self.fields[1]]
+        row = OffsetRow((self.view_struct, self.descriptor), 0, 2)
+        split_read = MergeFileSplitRead.__new__(MergeFileSplitRead)
+        split_read.table = self._table()
+        split_read.value_fields = self.fields
+        split_read.outer_extract_name_paths = [
+            ["inline_view"], ["inline_descriptor"]]
+        split_read.outer_flat_read_type = projected_fields
+
+        wrapped = split_read._wrap_managed_blob_reader(_OneRowReader(row))
+        result = wrapped.read_batch().next()
+
+        self.assertIsInstance(result, OffsetRow)
+        self.assertEqual(
+            (self.view_payload, self.descriptor_payload), result.row_tuple)
+
+    @patch(
+        "pypaimon.utils.blob_view_lookup.BlobViewLookup",
+        _FakeBlobViewLookup,
+    )
+    def test_merge_descriptor_mode_keeps_descriptor_and_resolves_view_reference(self):
+        projected_fields = [self.fields[2], self.fields[1]]
+        row = OffsetRow((self.view_struct, self.descriptor), 0, 2)
+        split_read = MergeFileSplitRead.__new__(MergeFileSplitRead)
+        split_read.table = self._table(**{"blob-as-descriptor": "true"})
+        split_read.value_fields = self.fields
+        split_read.outer_extract_name_paths = [
+            ["inline_view"], ["inline_descriptor"]]
+        split_read.outer_flat_read_type = projected_fields
+
+        result = split_read._wrap_managed_blob_reader(
+            _OneRowReader(row)).read_batch().next()
+
+        self.assertEqual(
+            (self.view_descriptor.serialize(), self.descriptor),
+            result.row_tuple,
+        )
+
+    @patch(
+        "pypaimon.utils.blob_view_lookup.BlobViewLookup",
+        _FakeBlobViewLookup,
+    )
+    def test_descriptor_mode_resolves_view_to_descriptor_but_keeps_inline_descriptor(self):
+        batch = pa.record_batch(
+            [
+                pa.array([self.descriptor], type=pa.large_binary()),
+                pa.array([self.view_struct], type=pa.large_binary()),
+            ],
+            names=["inline_descriptor", "inline_view"],
+        )
+        split_read = RawFileSplitRead.__new__(RawFileSplitRead)
+        split_read.table = self._table(**{"blob-as-descriptor": "true"})
+        split_read.value_fields = self.fields[1:]
+        split_read.outer_extract_name_paths = None
+        split_read.outer_flat_read_type = None
+
+        result = split_read._wrap_managed_blob_reader(
+            _OneBatchReader(batch)).read_arrow_batch()
+
+        self.assertEqual(self.descriptor, result.column(0)[0].as_py())
+        self.assertEqual(
+            self.view_descriptor.serialize(), result.column(1)[0].as_py())
+
+    def test_disabled_view_resolution_preserves_view_metadata(self):
+        batch = pa.record_batch(
+            [
+                pa.array([self.descriptor], type=pa.large_binary()),
+                pa.array([self.view_struct], type=pa.large_binary()),
+            ],
+            names=["inline_descriptor", "inline_view"],
+        )
+        split_read = RawFileSplitRead.__new__(RawFileSplitRead)
+        split_read.table = self._table(**{"blob-view.resolve.enabled": "false"})
+        split_read.value_fields = self.fields[1:]
+        split_read.outer_extract_name_paths = None
+        split_read.outer_flat_read_type = None
+
+        result = split_read._wrap_managed_blob_reader(
+            _OneBatchReader(batch)).read_arrow_batch()
+
+        self.assertEqual(self.descriptor_payload, result.column(0)[0].as_py())
+        self.assertEqual(self.view_struct, result.column(1)[0].as_py())
+
+    @patch(
+        "pypaimon.utils.blob_view_lookup.BlobViewLookup",
+        _FakeBlobViewLookup,
+    )
+    def test_real_raw_scan_installs_inline_descriptor_and_view_wrapper(self):
+        table = self._create_real_pk_inline_table(
+            "pk_inline_raw",
+            [(b"raw-descriptor", b"raw-view")],
+        )
+
+        result, raw_calls, merge_calls = self._read_real_table_with_reader_tracking(
+            table, ["id", "inline_descriptor", "inline_view"])
+
+        self.assertTrue(raw_calls)
+        self.assertFalse(merge_calls)
+        self.assertEqual(result.to_pylist(), [{
+            "id": 1,
+            "inline_descriptor": b"raw-descriptor",
+            "inline_view": b"raw-view",
+        }])
+        self.assertTrue(_FakeBlobViewLookup.preload_calls)
+
+    @patch(
+        "pypaimon.utils.blob_view_lookup.BlobViewLookup",
+        _FakeBlobViewLookup,
+    )
+    def test_real_merge_scan_installs_projected_inline_wrapper(self):
+        table = self._create_real_pk_inline_table(
+            "pk_inline_merge",
+            [
+                (b"old-descriptor", b"old-view"),
+                (b"new-descriptor", b"new-view"),
+            ],
+        )
+
+        result, raw_calls, merge_calls = self._read_real_table_with_reader_tracking(
+            table, ["inline_view", "inline_descriptor"])
+
+        self.assertFalse(raw_calls)
+        self.assertTrue(merge_calls)
+        self.assertEqual(result.to_pylist(), [{
+            "inline_view": b"new-view",
+            "inline_descriptor": b"new-descriptor",
+        }])
+        self.assertTrue(_FakeBlobViewLookup.preload_calls)
+
+
+class LegacyManagedBlobDescriptorTest(unittest.TestCase):
+
+    def test_known_descriptor_context_supports_v1_without_changing_heuristic_mode(self):
+        payload = b"legacy"
+        descriptor = _v1_descriptor("file:///legacy.blob", 2, len(payload))
+        file_io = Mock()
+        file_io.new_input_stream.side_effect = lambda _: io.BytesIO(b"xx" + payload)
+
+        self.assertEqual(
+            payload, Blob.from_descriptor_bytes(descriptor, file_io).to_data())
+        self.assertEqual(
+            payload,
+            Blob.from_bytes(
+                descriptor, file_io, allow_blob_data=False).to_data(),
+        )
+        self.assertEqual(descriptor, Blob.from_bytes(descriptor, file_io).to_data())
+
+    def test_managed_v1_scalar_array_and_map_are_resolved_recursively(self):
+        first = b"first"
+        second = b"second"
+        pack = first + b"/" + second
+        first_descriptor = _v1_descriptor(
+            "file:///legacy.pack", 0, len(first))
+        second_descriptor = _v1_descriptor(
+            "file:///legacy.pack", len(first) + 1, len(second))
+        map_type = pa.map_(pa.field("key", pa.string(), nullable=False),
+                           pa.field("value", pa.large_binary(), nullable=True))
+        schema = pa.schema([
+            pa.field("scalar", pa.large_binary()),
+            pa.field("array", pa.list_(pa.field("item", pa.large_binary()))),
+            pa.field("map", map_type),
+        ])
+        batch = pa.RecordBatch.from_arrays([
+            pa.array([first_descriptor], type=schema.field("scalar").type),
+            pa.array(
+                [[first_descriptor, None, second_descriptor]],
+                type=schema.field("array").type,
+            ),
+            pa.array(
+                [[("a", first_descriptor), ("b", None),
+                  ("c", second_descriptor)]],
+                type=map_type,
+            ),
+        ], schema=schema)
+        file_io = Mock()
+        file_io.new_input_stream.side_effect = lambda _: io.BytesIO(pack)
+
+        result = convert_managed_blob_batch(
+            batch, file_io, {"scalar", "array", "map"})
+
+        self.assertEqual(schema, result.schema)
+        self.assertEqual(first, result.column("scalar")[0].as_py())
+        self.assertEqual(
+            [first, None, second], result.column("array")[0].as_py())
+        self.assertEqual(
+            [("a", first), ("b", None), ("c", second)],
+            result.column("map")[0].as_py(),
+        )
+
+    def test_merge_managed_array_map_use_projected_output_indices(self):
+        first = b"first"
+        second = b"second"
+        pack = first + b"/" + second
+        first_descriptor = _v1_descriptor(
+            "file:///legacy.pack", 0, len(first))
+        second_descriptor = _v1_descriptor(
+            "file:///legacy.pack", len(first) + 1, len(second))
+        array_field = DataField(
+            1, "managed_array", ArrayType(True, AtomicType("BLOB")))
+        map_field = DataField(
+            2,
+            "managed_map",
+            MapType(True, AtomicType("STRING", False), AtomicType("BLOB")),
+        )
+        table = Mock()
+        table.is_primary_key_table = True
+        table.options = CoreOptions(Options({
+            "blob-field": "managed_array,managed_map",
+        }))
+        table.file_io.new_input_stream.side_effect = lambda _: io.BytesIO(pack)
+        split_read = MergeFileSplitRead.__new__(MergeFileSplitRead)
+        split_read.table = table
+        split_read.value_fields = [
+            DataField(0, "id", AtomicType("INT")), array_field, map_field]
+        split_read.outer_extract_name_paths = [
+            ["managed_map"], ["managed_array"]]
+        split_read.outer_flat_read_type = [map_field, array_field]
+        row = OffsetRow((
+            [("a", first_descriptor), ("b", second_descriptor)],
+            [second_descriptor, None, first_descriptor],
+        ), 0, 2)
+
+        result = split_read._wrap_managed_blob_reader(
+            _OneRowReader(row)).read_batch().next()
+
+        self.assertEqual(
+            [("a", first), ("b", second)], result.get_field(0))
+        self.assertEqual(
+            [second, None, first], result.get_field(1))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/paimon-python/pypaimon/tests/py36/ao_simple_test.py
+++ b/paimon-python/pypaimon/tests/py36/ao_simple_test.py
@@ -440,7 +440,7 @@ class AOSimpleTest(RESTBaseTest):
         }
         pa_table = pa.Table.from_pydict(data1, schema=self.pa_schema)
         table_write.write_arrow(pa_table)
-        table_write.prepare_commit(0)
+        table_commit.commit(table_write.prepare_commit(0), 0)
         # write 2
         data2 = {
             'user_id': [5, 6, 7, 8],
@@ -450,7 +450,7 @@ class AOSimpleTest(RESTBaseTest):
         }
         pa_table = pa.Table.from_pydict(data2, schema=self.pa_schema)
         table_write.write_arrow(pa_table)
-        table_write.prepare_commit(1)
+        table_commit.commit(table_write.prepare_commit(1), 1)
         # write 3
         data3 = {
             'user_id': [9, 10],

--- a/paimon-python/pypaimon/tests/schema_manager_test.py
+++ b/paimon-python/pypaimon/tests/schema_manager_test.py
@@ -212,7 +212,7 @@ class TestBlobPartitionValidation(unittest.TestCase):
                 ):
                     manager.create_table(schema)
 
-    def test_create_table_still_rejects_primary_key_map_blob(self):
+    def test_create_table_allows_primary_key_map_blob(self):
         manager = SchemaManager(
             self.file_io,
             f"{self.temp_dir}/test_db.db/pk_map_blob",
@@ -220,8 +220,9 @@ class TestBlobPartitionValidation(unittest.TestCase):
         schema = Schema(
             fields=[
                 DataField(0, "id", AtomicType("INT", False)),
+                DataField(1, "name", AtomicType("STRING")),
                 DataField(
-                    1,
+                    2,
                     "payload",
                     MapType(
                         True,
@@ -231,17 +232,10 @@ class TestBlobPartitionValidation(unittest.TestCase):
                 ),
             ],
             primary_keys=["id"],
-            options={
-                "row-tracking.enabled": "true",
-                "data-evolution.enabled": "true",
-            },
+            options={},
         )
 
-        with self.assertRaisesRegex(
-            ValueError,
-            "MAP<X, BLOB> type is not supported with primary key",
-        ):
-            manager.create_table(schema)
+        manager.create_table(schema)
 
 
 class TestOptionValidation(unittest.TestCase):

--- a/paimon-python/pypaimon/tests/test_file_store_write.py
+++ b/paimon-python/pypaimon/tests/test_file_store_write.py
@@ -1,0 +1,132 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+import sys
+import types
+import unittest
+from unittest.mock import Mock, patch
+
+# Skip pypaimon/__init__.py (pulls catalog -> polars) when collecting this module.
+if "pypaimon" not in sys.modules:
+    _pypaimon = types.ModuleType("pypaimon")
+    _pypaimon.__path__ = [
+        __file__.rsplit("/tests/", 1)[0],
+    ]
+    sys.modules["pypaimon"] = _pypaimon
+
+from pypaimon.common.options.core_options import ChangelogProducer, CoreOptions
+from pypaimon.common.options.options import Options
+from pypaimon.schema.data_types import (ArrayType, AtomicType, DataField,
+                                        MapType)
+from pypaimon.write.file_store_write import FileStoreWrite
+
+
+class TestFileStoreWritePrimaryKeyBlobRouting(unittest.TestCase):
+    """Writer routing for primary-key managed BLOB tables."""
+
+    def _write(self, fields, is_primary_key_table):
+        table = Mock()
+        table.is_primary_key_table = is_primary_key_table
+        table.table_schema.fields = fields
+        table.options = CoreOptions(Options({}))
+        table.bucket_mode = Mock(return_value=0)
+        table.trimmed_primary_keys = ["id"]
+        table.primary_keys = ["id"]
+
+        write = FileStoreWrite.__new__(FileStoreWrite)
+        write.table = table
+        write.write_cols = None
+        write.blob_consumer = None
+        write.changelog_producer = ChangelogProducer.NONE
+        write.options = CoreOptions.copy(table.options)
+        return write
+
+    @patch("pypaimon.write.file_store_write.KeyValueDataWriter")
+    def test_primary_key_scalar_blob_uses_key_value_writer(self, kv_writer):
+        fields = [
+            DataField(0, "id", AtomicType("INT", False)),
+            DataField(1, "name", AtomicType("STRING")),
+            DataField(2, "payload", AtomicType("BLOB")),
+        ]
+        write = self._write(fields, True)
+        write._seq_number_stats = Mock(return_value={0: 1})
+
+        write._create_data_writer((), 0, write.options)
+        kwargs = kv_writer.call_args.kwargs
+        self.assertEqual(kwargs["managed_blob_fields"], {"payload"})
+
+    @patch("pypaimon.write.file_store_write.KeyValueDataWriter")
+    def test_primary_key_inline_blob_skips_managed_fields(self, kv_writer):
+        fields = [
+            DataField(0, "id", AtomicType("INT", False)),
+            DataField(1, "payload", AtomicType("BLOB")),
+        ]
+        write = self._write(fields, True)
+        write.options = CoreOptions.copy(CoreOptions(Options({
+            "blob-descriptor-field": "payload",
+        })))
+        write.table.options = write.options
+        write._seq_number_stats = Mock(return_value={0: 1})
+
+        write._create_data_writer((), 0, write.options)
+        kwargs = kv_writer.call_args.kwargs
+        self.assertEqual(kwargs["managed_blob_fields"], set())
+
+    @patch("pypaimon.write.file_store_write.DedicatedFormatWriter")
+    def test_append_blob_table_uses_dedicated_format_writer(self, blob_writer):
+        fields = [
+            DataField(0, "payload", AtomicType("BLOB")),
+            DataField(1, "tag", AtomicType("STRING")),
+        ]
+        write = self._write(fields, False)
+
+        write._create_data_writer((), 0, write.options)
+        blob_writer.assert_called_once()
+
+    @patch("pypaimon.write.file_store_write.KeyValueDataWriter")
+    def test_primary_key_array_blob_managed_fields(self, kv_writer):
+        fields = [
+            DataField(0, "id", AtomicType("INT", False)),
+            DataField(1, "name", AtomicType("STRING")),
+            DataField(2, "pictures", ArrayType(True, AtomicType("BLOB"))),
+        ]
+        write = self._write(fields, True)
+        write._seq_number_stats = Mock(return_value={0: 1})
+        write._create_data_writer((), 0, write.options)
+        kwargs = kv_writer.call_args.kwargs
+        self.assertEqual(kwargs["managed_blob_fields"], {"pictures"})
+
+    @patch("pypaimon.write.file_store_write.KeyValueDataWriter")
+    def test_primary_key_map_blob_managed_fields(self, kv_writer):
+        fields = [
+            DataField(0, "id", AtomicType("INT", False)),
+            DataField(1, "name", AtomicType("STRING")),
+            DataField(
+                2,
+                "payload",
+                MapType(True, AtomicType("STRING", False), AtomicType("BLOB")),
+            ),
+        ]
+        write = self._write(fields, True)
+        write._seq_number_stats = Mock(return_value={0: 1})
+        write._create_data_writer((), 0, write.options)
+        kwargs = kv_writer.call_args.kwargs
+        self.assertEqual(kwargs["managed_blob_fields"], {"payload"})
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/paimon-python/pypaimon/tests/test_primary_key_blob_read_contract.py
+++ b/paimon-python/pypaimon/tests/test_primary_key_blob_read_contract.py
@@ -1,0 +1,298 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import io
+import unittest
+from unittest.mock import Mock, patch
+
+import pyarrow as pa
+
+from pypaimon.common.options.core_options import CoreOptions
+from pypaimon.common.options.options import Options
+from pypaimon.common.predicate_builder import PredicateBuilder
+from pypaimon.read.read_builder import ReadBuilder
+from pypaimon.read.reader.iface.record_batch_reader import RecordBatchReader
+from pypaimon.read.reader.managed_blob_convert_record_reader import (
+    ManagedBlobConvertBatchReader,
+    _ConvertedRow,
+)
+from pypaimon.read.split_read import RawFileSplitRead
+from pypaimon.read.table_read import (TableRead,
+                                      validate_primary_key_blob_predicate)
+from pypaimon.schema.data_types import ArrayType, AtomicType, DataField, MapType
+from pypaimon.table.row.blob import BlobData, BlobDescriptor
+
+
+class _OneBatchReader(RecordBatchReader):
+
+    def __init__(self, batch):
+        self._batch = batch
+
+    def read_arrow_batch(self):
+        batch = self._batch
+        self._batch = None
+        return batch
+
+    def close(self):
+        pass
+
+
+class PrimaryKeyBlobReadContractTest(unittest.TestCase):
+
+    @staticmethod
+    def _table_read(primary_key, data_evolution):
+        read = TableRead.__new__(TableRead)
+        read.table = Mock()
+        read.table.is_primary_key_table = primary_key
+        read.table.options.data_evolution_enabled.return_value = data_evolution
+        read.table.options.row_tracking_enabled.return_value = data_evolution
+        read.table.options.sequence_field.return_value = []
+        read.predicate = None
+        read.read_type = [DataField(0, "id", AtomicType("INT"))]
+        read._scan_read_type = read.read_type
+        read._predicate_extra_fields = []
+        read.nested_name_paths = None
+        read.limit = None
+        return read
+
+    @patch("pypaimon.read.table_read.DataEvolutionSplitRead")
+    @patch("pypaimon.read.table_read.RawFileSplitRead")
+    def test_primary_key_data_evolution_raw_split_uses_raw_reader(
+            self, raw_read, data_evolution_read):
+        read = self._table_read(primary_key=True, data_evolution=True)
+        split = Mock(raw_convertible=True)
+
+        result = read._build_split_read(split)
+
+        self.assertIs(result, raw_read.return_value)
+        raw_read.assert_called_once()
+        data_evolution_read.assert_not_called()
+
+    @patch("pypaimon.read.table_read.DataEvolutionSplitRead")
+    @patch("pypaimon.read.table_read.MergeFileSplitRead")
+    def test_primary_key_data_evolution_non_raw_split_uses_merge_reader(
+            self, merge_read, data_evolution_read):
+        read = self._table_read(primary_key=True, data_evolution=True)
+        split = Mock(raw_convertible=False)
+
+        result = read._build_split_read(split)
+
+        self.assertIs(result, merge_read.return_value)
+        merge_read.assert_called_once()
+        data_evolution_read.assert_not_called()
+
+    @patch("pypaimon.read.table_read.DataEvolutionSplitRead")
+    def test_append_data_evolution_split_keeps_data_evolution_reader(
+            self, data_evolution_read):
+        read = self._table_read(primary_key=False, data_evolution=True)
+        split = Mock(raw_convertible=True)
+
+        result = read._build_split_read(split)
+
+        self.assertIs(result, data_evolution_read.return_value)
+        data_evolution_read.assert_called_once()
+
+    def test_managed_blob_default_resolves_payload_and_descriptor_mode_bypasses(self):
+        payload = b"managed payload"
+        pack_bytes = b"prefix" + payload + b"suffix"
+        descriptor = BlobDescriptor(
+            "file:///managed.pack", len(b"prefix"), len(payload)).serialize()
+        batch = pa.record_batch(
+            [pa.array([descriptor], type=pa.binary())], names=["payload"])
+        field = DataField(0, "payload", AtomicType("BLOB"))
+        file_io = Mock()
+        file_io.new_input_stream.side_effect = lambda _: io.BytesIO(pack_bytes)
+
+        split_read = RawFileSplitRead.__new__(RawFileSplitRead)
+        split_read.value_fields = [field]
+        split_read.outer_extract_name_paths = None
+        split_read.outer_flat_read_type = None
+        split_read.table = Mock()
+        split_read.table.file_io = file_io
+        split_read.table.options = CoreOptions(Options({"blob-field": "payload"}))
+
+        wrapped = split_read._wrap_managed_blob_reader(_OneBatchReader(batch))
+        self.assertIsInstance(wrapped, ManagedBlobConvertBatchReader)
+        self.assertEqual(
+            [payload], wrapped.read_arrow_batch().column("payload").to_pylist())
+
+        split_read.table.options = CoreOptions(Options({
+            "blob-field": "payload",
+            "blob-as-descriptor": "true",
+        }))
+        descriptor_reader = _OneBatchReader(batch)
+        self.assertIs(
+            descriptor_reader,
+            split_read._wrap_managed_blob_reader(descriptor_reader),
+        )
+        self.assertEqual(
+            [descriptor],
+            descriptor_reader.read_arrow_batch().column("payload").to_pylist(),
+        )
+
+    def test_converted_row_get_blob_returns_blob_object(self):
+        payload = b"managed payload"
+        pack_bytes = b"prefix" + payload + b"suffix"
+        descriptor = BlobDescriptor(
+            "file:///managed.pack", len(b"prefix"), len(payload)).serialize()
+        file_io = Mock()
+        file_io.new_input_stream.side_effect = lambda _: io.BytesIO(pack_bytes)
+
+        class _InnerRow:
+            def get_field(self, pos):
+                return descriptor
+
+            def get_blob(self, pos):
+                raise AssertionError("should delegate to converted row")
+
+            def get_row_kind(self):
+                return 0
+
+            def get_vector(self, pos):
+                raise NotImplementedError
+
+            def __len__(self):
+                return 1
+
+        reader = _ConvertedRow(
+            _InnerRow(),
+            file_io,
+            blob_field_indices={0},
+            descriptor_field_indices=set(),
+            view_field_indices=set(),
+            blob_as_descriptor=False,
+            view_resolver=None,
+        )
+        blob = reader.get_blob(0)
+        self.assertIsInstance(blob, BlobData)
+        self.assertEqual(payload, blob.to_data())
+
+
+class BlobDescriptorConvertReaderTest(unittest.TestCase):
+
+    def test_descriptor_field_resolves_v1_descriptor_bytes(self):
+        from pypaimon.read.reader.blob_descriptor_convert_reader import (
+            BlobInlineConvertReader,
+        )
+
+        payload = b"v1-inline-payload"
+        pack_bytes = b"xx" + payload + b"yy"
+        descriptor = BlobDescriptor("file:///pack.blob", 2, len(payload))
+        descriptor._version = 1
+        batch = pa.record_batch(
+            [pa.array([descriptor.serialize()], type=pa.large_binary())],
+            names=["payload"],
+        )
+        table = Mock()
+        table.file_io = Mock()
+        table.file_io.new_input_stream.side_effect = lambda _: io.BytesIO(pack_bytes)
+        table.options = CoreOptions(Options({
+            "blob-descriptor-field": "payload",
+        }))
+        table.catalog_environment = Mock(catalog_loader=None)
+
+        reader = BlobInlineConvertReader(_OneBatchReader(batch), table)
+        result = reader.read_arrow_batch()
+        self.assertEqual([payload], result.column("payload").to_pylist())
+
+
+class BlobPredicateBuilderContractTest(unittest.TestCase):
+
+    @staticmethod
+    def _validate(fields, predicate, primary_key=True):
+        table = Mock()
+        table.is_primary_key_table = primary_key
+        table.fields = fields
+        validate_primary_key_blob_predicate(table, predicate)
+
+    def test_blob_shapes_reject_value_comparison_and_allow_null_checks(self):
+        fields = [
+            DataField(0, "scalar", AtomicType("BLOB")),
+            DataField(1, "array", ArrayType(True, AtomicType("BLOB"))),
+            DataField(
+                2,
+                "map",
+                MapType(True, AtomicType("STRING", False), AtomicType("BLOB")),
+            ),
+        ]
+        builder = PredicateBuilder(fields)
+
+        for field in fields:
+            with self.subTest(field=field.name):
+                with self.assertRaisesRegex(ValueError, "only support isNull and isNotNull"):
+                    self._validate(fields, builder.equal(field.name, b"payload"))
+                self._validate(fields, builder.is_null(field.name))
+                self._validate(fields, builder.is_not_null(field.name))
+
+    def test_append_blob_predicate_builder_api_is_unchanged(self):
+        fields = [DataField(0, "payload", AtomicType("BLOB"))]
+        predicate = PredicateBuilder(fields).equal("payload", b"value")
+
+        self.assertEqual("equal", predicate.method)
+        self._validate(fields, predicate, primary_key=False)
+
+    def test_compound_predicate_validates_blob_leaf(self):
+        fields = [
+            DataField(0, "id", AtomicType("INT")),
+            DataField(1, "payload", AtomicType("BLOB")),
+        ]
+        builder = PredicateBuilder(fields)
+        predicate = PredicateBuilder.and_predicates([
+            builder.equal("id", 1),
+            builder.equal("payload", b"value"),
+        ])
+
+        with self.assertRaisesRegex(ValueError, "field 'payload'"):
+            self._validate(fields, predicate)
+
+    def test_read_builder_scan_read_and_explain_share_blob_validation(self):
+        fields = [
+            DataField(0, "id", AtomicType("INT")),
+            DataField(1, "payload", AtomicType("BLOB")),
+        ]
+        table = Mock()
+        table.is_primary_key_table = True
+        table.fields = fields
+        predicate = PredicateBuilder(fields).equal("payload", b"value")
+        builder = ReadBuilder(table).with_filter(predicate)
+
+        for boundary in (builder.new_scan, builder.new_read, builder.explain):
+            with self.subTest(boundary=boundary.__name__):
+                with self.assertRaisesRegex(
+                        ValueError, "only support isNull and isNotNull"):
+                    boundary()
+
+    @patch("pypaimon.read.read_builder._build_explain_result")
+    @patch("pypaimon.read.read_builder.TableRead")
+    @patch("pypaimon.read.read_builder.TableScan")
+    def test_read_builder_keeps_append_blob_predicates_unchanged(
+            self, table_scan, table_read, build_explain_result):
+        fields = [DataField(0, "payload", AtomicType("BLOB"))]
+        table = Mock()
+        table.is_primary_key_table = False
+        table.fields = fields
+        table.options.row_tracking_enabled.return_value = False
+        predicate = PredicateBuilder(fields).equal("payload", b"value")
+        builder = ReadBuilder(table).with_filter(predicate)
+        table_scan.return_value.scan_with_stats.return_value = (Mock(), Mock())
+
+        self.assertIs(table_scan.return_value, builder.new_scan())
+        self.assertIs(table_read.return_value, builder.new_read())
+        self.assertIs(build_explain_result.return_value, builder.explain())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/paimon-python/pypaimon/tests/test_write_merge_buffer.py
+++ b/paimon-python/pypaimon/tests/test_write_merge_buffer.py
@@ -90,6 +90,7 @@ class _Harness(KeyValueDataWriter):
         self.pending_data = None
         self.committed_files = []
         self.written_chunks = []
+        self._blob_externalizer = None
 
     def _write_data_to_file(self, data):
         # Record each chunk instead of writing to disk; mirrors the

--- a/paimon-python/pypaimon/tests/write/dynamic_bucket_test.py
+++ b/paimon-python/pypaimon/tests/write/dynamic_bucket_test.py
@@ -17,6 +17,7 @@
 ################################################################################
 
 import datetime
+import os
 import tempfile
 import unittest
 from decimal import Decimal
@@ -345,10 +346,12 @@ class DynamicBucketTest(unittest.TestCase):
             ):
                 table.new_batch_write_builder().new_write()
 
-    def test_batch_writer_abort_after_prepare_deletes_hash_index(self):
+    def test_batch_writer_abort_after_prepare_keeps_handed_off_hash_index(self):
         with tempfile.TemporaryDirectory() as root:
             table = self._create_table(root, 'abort_prepared')
-            writer = table.new_batch_write_builder().new_write()
+            builder = table.new_batch_write_builder()
+            writer = builder.new_write()
+            committer = builder.new_commit()
             writer.write_arrow(pa.table({'id': [1], 'value': ['v-1']}))
             messages = writer.prepare_commit()
             index_path = messages[0].index_adds[0].index_file.external_path
@@ -361,7 +364,136 @@ class DynamicBucketTest(unittest.TestCase):
 
             writer.abort()
 
+            self.assertTrue(table.file_io.exists(index_path))
+            committer.abort(messages)
             self.assertFalse(table.file_io.exists(index_path))
+            committer.close()
+
+    def test_hash_index_prepare_failure_aborts_staged_data_files(self):
+        with tempfile.TemporaryDirectory() as root:
+            table = self._create_table(root, 'index_prepare_failure')
+            writer = (
+                table.new_batch_write_builder()
+                .new_write()
+                .with_dynamic_bucket_index()
+            )
+            before_files = {
+                os.path.relpath(os.path.join(path, name), table.table_path)
+                for path, _dirs, files in os.walk(table.table_path)
+                for name in files
+            }
+            writer.write_arrow(pa.table({'id': [1], 'value': ['v-1']}))
+            maintainer = writer.row_key_extractor._index_maintainer
+
+            original_write_index = maintainer._write_index
+
+            def fail_after_index_write(*args, **kwargs):
+                original_write_index(*args, **kwargs)
+                raise RuntimeError('forced HASH index failure')
+
+            with patch.object(
+                    maintainer,
+                    '_write_index',
+                    side_effect=fail_after_index_write):
+                with self.assertRaisesRegex(RuntimeError, 'forced HASH index failure'):
+                    writer.prepare_commit()
+
+            after_files = {
+                os.path.relpath(os.path.join(path, name), table.table_path)
+                for path, _dirs, files in os.walk(table.table_path)
+                for name in files
+            }
+            self.assertEqual(before_files, after_files)
+            writer.close()
+
+    def test_failed_stream_round_restores_previous_hash_index_state(self):
+        with tempfile.TemporaryDirectory() as root:
+            table = self._create_table(root, 'stream_index_prepare_failure')
+            builder = table.new_stream_write_builder()
+            writer = builder.new_write().with_dynamic_bucket_index()
+            committer = builder.new_commit()
+
+            writer.write_arrow(pa.table({'id': [1], 'value': ['v-1']}))
+            first = writer.prepare_commit(1)
+            committer.commit(first, 1)
+            maintainer = writer.row_key_extractor._index_maintainer
+            baseline = {
+                key: (set(state[0]), state[1], state[2])
+                for key, state in maintainer._states.items()
+            }
+
+            writer.write_arrow(pa.table({'id': [2], 'value': ['v-2']}))
+            original_write_index = maintainer._write_index
+
+            def fail_after_index_write(*args, **kwargs):
+                original_write_index(*args, **kwargs)
+                raise RuntimeError('forced HASH index failure')
+
+            with patch.object(
+                    maintainer,
+                    '_write_index',
+                    side_effect=fail_after_index_write):
+                with self.assertRaisesRegex(RuntimeError, 'forced HASH index failure'):
+                    writer.prepare_commit(2)
+
+            self.assertEqual(baseline, maintainer._states)
+
+            writer.write_arrow(pa.table({'id': [2], 'value': ['v-2-retry']}))
+            retried = writer.prepare_commit(3)
+            self.assertTrue(any(message.index_adds for message in retried))
+            committer.abort(retried)
+            writer.close()
+            committer.close()
+
+    def test_stream_writer_commit_before_write_links_hash_callbacks(self):
+        with tempfile.TemporaryDirectory() as root:
+            table = self._create_table(root, 'stream_commit_first')
+            builder = table.new_stream_write_builder()
+            committer = builder.new_commit()
+            writer = builder.new_write().with_dynamic_bucket_index()
+
+            writer.write_arrow(pa.table({'id': [1], 'value': ['v-1']}))
+            committer.commit(writer.prepare_commit(1), 1)
+
+            writer.write_arrow(pa.table({'id': [2], 'value': ['v-2']}))
+            second = writer.prepare_commit(2)
+            self.assertEqual(
+                table.snapshot_manager().get_latest_snapshot().id,
+                second[0].hash_index_base_snapshot,
+            )
+            committer.commit(second, 2)
+
+            self.assertEqual(
+                {'id': [1, 2], 'value': ['v-1', 'v-2']},
+                self._read_arrow(table).to_pydict(),
+            )
+            writer.close()
+            committer.close()
+
+    def test_stream_writer_supports_two_successful_commits(self):
+        with tempfile.TemporaryDirectory() as root:
+            table = self._create_table(root, 'stream_two_commits')
+            builder = table.new_stream_write_builder()
+            writer = builder.new_write().with_dynamic_bucket_index()
+            committer = builder.new_commit()
+
+            writer.write_arrow(pa.table({'id': [1], 'value': ['v-1']}))
+            committer.commit(writer.prepare_commit(1), 1)
+
+            writer.write_arrow(pa.table({'id': [2], 'value': ['v-2']}))
+            second = writer.prepare_commit(2)
+            self.assertEqual(
+                table.snapshot_manager().get_latest_snapshot().id,
+                second[0].hash_index_base_snapshot,
+            )
+            committer.commit(second, 2)
+
+            self.assertEqual(
+                {'id': [1, 2], 'value': ['v-1', 'v-2']},
+                self._read_arrow(table).to_pydict(),
+            )
+            writer.close()
+            committer.close()
 
     def test_stream_writer_releases_prepared_hash_index_ownership(self):
         with tempfile.TemporaryDirectory() as root:

--- a/paimon-python/pypaimon/tests/write/table_write_test.py
+++ b/paimon-python/pypaimon/tests/write/table_write_test.py
@@ -538,7 +538,7 @@ class TableWriteTest(unittest.TestCase):
         }
         pa_table = pa.Table.from_pydict(data1, schema=self.pa_schema)
         table_write.write_arrow(pa_table)
-        table_write.prepare_commit(0)
+        table_commit.commit(table_write.prepare_commit(0), 0)
         # write 2
         data2 = {
             'user_id': [5, 6, 7, 8],
@@ -548,7 +548,7 @@ class TableWriteTest(unittest.TestCase):
         }
         pa_table = pa.Table.from_pydict(data2, schema=self.pa_schema)
         table_write.write_arrow(pa_table)
-        table_write.prepare_commit(1)
+        table_commit.commit(table_write.prepare_commit(1), 1)
         # write 3
         data3 = {
             'user_id': [9, 10],
@@ -639,7 +639,7 @@ class TableWriteTest(unittest.TestCase):
         }
         pa_table = pa.Table.from_pydict(data1, schema=self.pk_pa_schema)
         table_write.write_arrow(pa_table)
-        table_write.prepare_commit(0)
+        table_commit.commit(table_write.prepare_commit(0), 0)
         # write 2
         data2 = {
             'user_id': [5, 6, 7, 8],
@@ -649,7 +649,7 @@ class TableWriteTest(unittest.TestCase):
         }
         pa_table = pa.Table.from_pydict(data2, schema=self.pk_pa_schema)
         table_write.write_arrow(pa_table)
-        table_write.prepare_commit(1)
+        table_commit.commit(table_write.prepare_commit(1), 1)
         # write 3
         data3 = {
             'user_id': [9, 10],

--- a/paimon-python/pypaimon/utils/blob_view_lookup.py
+++ b/paimon-python/pypaimon/utils/blob_view_lookup.py
@@ -16,7 +16,8 @@
 # under the License.
 
 from concurrent.futures import ThreadPoolExecutor, as_completed
-from typing import Dict, List, Tuple, Set
+from contextlib import contextmanager
+from typing import TYPE_CHECKING, Dict, List, Set, Tuple
 
 from pypaimon.common.identifier import Identifier
 from pypaimon.common.uri_reader import FileUriReader, UriReader
@@ -24,6 +25,9 @@ from pypaimon.common.options.core_options import CoreOptions
 from pypaimon.table.row.blob import Blob, BlobDescriptor, BlobViewStruct
 from pypaimon.table.special_fields import SpecialFields
 from pypaimon.utils.range import Range
+
+if TYPE_CHECKING:
+    from pypaimon.schema.data_types import DataField
 
 _PRELOAD_THREAD_NUM = 100
 _MIN_ROWS_PER_TASK = 100
@@ -45,10 +49,9 @@ class TableReferences:
 class TableReadPlan:
     """A plan for reading blob descriptors from one upstream table."""
 
-    def __init__(self, identifier: Identifier, upstream_table,
+    def __init__(self, identifier: Identifier,
                  read_fields: List, row_ranges: List[Range]):
         self.identifier: Identifier = identifier
-        self.upstream_table = upstream_table
         self.read_fields: List = read_fields
         self.row_ranges: List[Range] = row_ranges
 
@@ -60,9 +63,16 @@ class BlobViewLookup:
         self._table = table
         self._descriptor_cache: Dict[BlobViewStruct, BlobDescriptor] = {}
         self._uri_reader_cache: Dict[str, UriReader] = {}
+        self._uri_reader_file_ios: Dict[str, object] = {}
+        # A cached UriReader may depend on a table-scoped FileIO owned by the
+        # catalog which produced it. Keep that catalog alive until close() so
+        # the FileIO is never invalidated while the reader is still in use.
+        self._uri_reader_catalogs: Dict[str, object] = {}
         self._null_value_cache: Set[BlobViewStruct] = set()
+        self._closed = False
 
     def preload(self, view_structs: List[BlobViewStruct]):
+        self._check_open()
         if not view_structs:
             return
 
@@ -102,6 +112,7 @@ class BlobViewLookup:
                     raise RuntimeError("Failed to preload blob descriptors.") from exc
 
     def resolve_descriptor(self, view_struct: BlobViewStruct) -> BlobDescriptor:
+        self._check_open()
         descriptor: BlobDescriptor = self._descriptor_cache.get(view_struct)
         if descriptor is None:
             if view_struct in self._null_value_cache:
@@ -130,16 +141,64 @@ class BlobViewLookup:
         return uri_reader._file_io
 
     def resolve_uri_reader(self, view_struct: BlobViewStruct) -> UriReader:
+        self._check_open()
         table_key = view_struct.identifier.get_full_name()
         uri_reader = self._uri_reader_cache.get(table_key)
         if uri_reader is None:
-            raise ValueError(
-                "Cannot resolve BlobViewStruct {} because upstream table {} "
-                "was not loaded.".format(view_struct, table_key)
-            )
+            catalog = self._create_catalog()
+            try:
+                upstream_table = catalog.get_table(view_struct.identifier)
+                uri_reader = UriReader.from_file(upstream_table.file_io)
+            except Exception:
+                self._close_catalog(catalog)
+                raise
+            self._uri_reader_cache[table_key] = uri_reader
+            self._uri_reader_file_ios[table_key] = upstream_table.file_io
+            self._uri_reader_catalogs[table_key] = catalog
         return uri_reader
 
+    def close(self) -> None:
+        if self._closed:
+            return
+        self._closed = True
+        catalogs = list(self._uri_reader_catalogs.values())
+        file_ios = list(self._uri_reader_file_ios.values())
+        self._uri_reader_catalogs.clear()
+        self._uri_reader_file_ios.clear()
+        self._uri_reader_cache.clear()
+        self._descriptor_cache.clear()
+        self._null_value_cache.clear()
+        first_error = None
+        catalog_file_io_ids = {
+            id(file_io)
+            for file_io in (getattr(catalog, "file_io", None) for catalog in catalogs)
+            if file_io is not None
+        }
+        for catalog in catalogs:
+            try:
+                self._close_catalog(catalog)
+            except Exception as error:
+                if first_error is None:
+                    first_error = error
+        closed_file_ios = set(catalog_file_io_ids)
+        for file_io in file_ios:
+            if id(file_io) in closed_file_ios:
+                continue
+            closed_file_ios.add(id(file_io))
+            try:
+                self._close_file_io(file_io)
+            except Exception as error:
+                if first_error is None:
+                    first_error = error
+        if first_error is not None:
+            raise first_error
+
+    def _check_open(self) -> None:
+        if self._closed:
+            raise RuntimeError("BlobViewLookup is already closed.")
+
     def resolve_to_null(self, view_struct: BlobViewStruct) -> bool:
+        self._check_open()
         if view_struct in self._null_value_cache:
             return True
         if view_struct not in self._descriptor_cache:
@@ -161,55 +220,63 @@ class BlobViewLookup:
         return grouped
 
     def _create_table_read_plan(self, table_refs: TableReferences) -> TableReadPlan:
-        upstream_table = self._load_table(table_refs.identifier)
-        self._uri_reader_cache[table_refs.identifier.get_full_name()] = (
-            UriReader.from_file(upstream_table.file_io)
-        )
-
-        fields: List = []
-        for field_id in table_refs.references_by_field:
-            fields.append(self._field_by_id(upstream_table, field_id))
+        with self._catalog_scope() as catalog:
+            upstream_table = catalog.get_table(table_refs.identifier)
+            try:
+                fields: List = []
+                for field_id in table_refs.references_by_field:
+                    fields.append(self._field_by_id(upstream_table, field_id))
+            finally:
+                self._close_distinct_table_file_io(upstream_table, catalog)
 
         read_fields = SpecialFields.row_type_with_row_id(fields)
         return TableReadPlan(
-            table_refs.identifier, upstream_table, read_fields,
+            table_refs.identifier, read_fields,
             Range.to_ranges(table_refs.row_ids))
 
     def _load_descriptor_chunk(
         self, plan: TableReadPlan, row_ranges: List[Range]
     ) -> Tuple[Dict[BlobViewStruct, BlobDescriptor], set]:
         identifier: Identifier = plan.identifier
-        upstream_table = plan.upstream_table
         read_fields = plan.read_fields
 
         projection_field_names: List[str] = [f.name for f in read_fields]
 
-        descriptor_table = upstream_table.copy({CoreOptions.BLOB_AS_DESCRIPTOR.key(): "true"})
-        read_builder = descriptor_table.new_read_builder().with_projection(projection_field_names)
+        with self._catalog_scope() as catalog:
+            upstream_table = catalog.get_table(identifier)
+            try:
+                descriptor_table = upstream_table.copy(
+                    {CoreOptions.BLOB_AS_DESCRIPTOR.key(): "true"})
+                read_builder = descriptor_table.new_read_builder().with_projection(
+                    projection_field_names)
 
-        if SpecialFields.ROW_ID.name not in [
-            data_field.name for data_field in read_builder.read_type()
-        ]:
-            raise ValueError(
-                "Cannot resolve blob view for table {} because row tracking is not readable."
-                .format(identifier.get_full_name())
-            )
+                if SpecialFields.ROW_ID.name not in [
+                    data_field.name for data_field in read_builder.read_type()
+                ]:
+                    raise ValueError(
+                        "Cannot resolve blob view for table {} because row tracking is not readable."
+                        .format(identifier.get_full_name())
+                    )
 
-        predicate_builder = read_builder.new_predicate_builder()
-        range_predicates: List = []
-        for r in row_ranges:
-            if r.from_ == r.to:
-                range_predicates.append(
-                    predicate_builder.equal(SpecialFields.ROW_ID.name, r.from_))
-            else:
-                range_predicates.append(
-                    predicate_builder.between(SpecialFields.ROW_ID.name, r.from_, r.to))
-        if len(range_predicates) == 1:
-            predicate = range_predicates[0]
-        else:
-            predicate = predicate_builder.or_predicates(range_predicates)
-        read_builder.with_filter(predicate)
-        result = read_builder.new_read().to_arrow(read_builder.new_scan().plan().splits())
+                predicate_builder = read_builder.new_predicate_builder()
+                range_predicates: List = []
+                for r in row_ranges:
+                    if r.from_ == r.to:
+                        range_predicates.append(
+                            predicate_builder.equal(SpecialFields.ROW_ID.name, r.from_))
+                    else:
+                        range_predicates.append(
+                            predicate_builder.between(
+                                SpecialFields.ROW_ID.name, r.from_, r.to))
+                if len(range_predicates) == 1:
+                    predicate = range_predicates[0]
+                else:
+                    predicate = predicate_builder.or_predicates(range_predicates)
+                read_builder.with_filter(predicate)
+                result = read_builder.new_read().to_arrow(
+                    read_builder.new_scan().plan().splits())
+            finally:
+                self._close_distinct_table_file_io(upstream_table, catalog)
 
         if SpecialFields.ROW_ID.name not in result.schema.names:
             raise ValueError(
@@ -290,16 +357,51 @@ class BlobViewLookup:
         return max(_MIN_ROWS_PER_TASK, (total_rows + _PRELOAD_THREAD_NUM - 1) // _PRELOAD_THREAD_NUM)
 
     def _load_table(self, identifier: Identifier):
+        # Kept as a small compatibility helper for callers/tests which only
+        # need table metadata. Internal read paths use _catalog_scope directly
+        # so a catalog stays alive for the entire table operation.
+        with self._catalog_scope() as catalog:
+            return catalog.get_table(identifier)
+
+    def _create_catalog(self):
         catalog_environment = self._table.catalog_environment
         catalog_loader = catalog_environment.catalog_loader
         dependency_context = catalog_environment.dependency_read_context()
         if dependency_context is catalog_environment.catalog_context():
-            catalog = catalog_loader.load()
-        else:
-            from pypaimon.catalog.catalog_factory import CatalogFactory
-            catalog = CatalogFactory.create_from_context(
-                dependency_context, config_required=False)
-        return catalog.get_table(identifier)
+            return catalog_loader.load()
+        from pypaimon.catalog.catalog_factory import CatalogFactory
+        return CatalogFactory.create_from_context(
+            dependency_context, config_required=False)
+
+    @contextmanager
+    def _catalog_scope(self):
+        catalog = self._create_catalog()
+        try:
+            yield catalog
+        finally:
+            self._close_catalog(catalog)
+
+    @staticmethod
+    def _close_catalog(catalog) -> None:
+        file_io = getattr(catalog, "file_io", None)
+        try:
+            close = getattr(catalog, "close", None)
+            if callable(close):
+                close()
+        finally:
+            BlobViewLookup._close_file_io(file_io)
+
+    @staticmethod
+    def _close_distinct_table_file_io(table, catalog) -> None:
+        table_file_io = getattr(table, "file_io", None)
+        if table_file_io is not getattr(catalog, "file_io", None):
+            BlobViewLookup._close_file_io(table_file_io)
+
+    @staticmethod
+    def _close_file_io(file_io) -> None:
+        close = getattr(file_io, "close", None)
+        if callable(close):
+            close()
 
     @staticmethod
     def _field_by_id(table, field_id: int) -> 'DataField':

--- a/paimon-python/pypaimon/write/commit_message.py
+++ b/paimon-python/pypaimon/write/commit_message.py
@@ -36,6 +36,7 @@ class CommitMessage:
     changelog_files: List[DataFileMeta] = field(default_factory=list)
     hash_index_base_snapshot: Optional[int] = None
     total_buckets: Optional[int] = None
+    preserve_blob_files_on_abort: bool = False
 
     def is_empty(self):
         return (

--- a/paimon-python/pypaimon/write/file_store_commit.py
+++ b/paimon-python/pypaimon/write/file_store_commit.py
@@ -1041,16 +1041,29 @@ class FileStoreCommit:
 
     def abort(self, commit_messages: List[CommitMessage]):
         """Abort commit and delete files. Uses external_path if available to ensure proper scheme handling."""
+        blob_suffix = ".%s" % CoreOptions.FILE_FORMAT_BLOB
         for message in commit_messages:
+            preserve_blob_files = message.preserve_blob_files_on_abort
             for file in list(message.new_files) + list(message.changelog_files):
-                try:
-                    path_to_delete = file.external_path if file.external_path else file.file_path
-                    if path_to_delete:
-                        path_str = str(path_to_delete)
-                        self.table.file_io.delete_quietly(path_str)
-                except Exception as e:
-                    path_to_delete = file.external_path if file.external_path else file.file_path
-                    logger.warning(f"Failed to clean up file {path_to_delete} during abort: {e}")
+                file_path = file.external_path if file.external_path else file.file_path
+                paths_to_delete = []
+                if file_path:
+                    if not (
+                            preserve_blob_files
+                            and str(file_path).endswith(blob_suffix)
+                    ):
+                        paths_to_delete.append(file_path)
+                for extra_file in (file.extra_files or []):
+                    extra_path = self._aligned_extra_file_path(file, extra_file)
+                    if preserve_blob_files and extra_path.endswith(blob_suffix):
+                        continue
+                    paths_to_delete.append(extra_path)
+                for path_to_delete in paths_to_delete:
+                    try:
+                        self.table.file_io.delete_quietly(str(path_to_delete))
+                    except Exception as e:
+                        logger.warning(
+                            f"Failed to clean up file {path_to_delete} during abort: {e}")
             for entry in message.index_adds:
                 try:
                     file_name = entry.index_file.file_name
@@ -1064,6 +1077,15 @@ class FileStoreCommit:
                 except Exception as e:
                     logger.warning(
                         f"Failed to clean up index file {entry.index_file.file_name} during abort: {e}")
+
+    @staticmethod
+    def _aligned_extra_file_path(file: DataFileMeta, extra_file: str) -> str:
+        if "://" in extra_file or extra_file.startswith("/"):
+            return extra_file
+        file_path = file.external_path if file.external_path else file.file_path
+        if not file_path or "/" not in file_path:
+            return extra_file
+        return f"{str(file_path).rsplit('/', 1)[0]}/{extra_file}"
 
     def close(self):
         """Close the FileStoreCommit and release resources."""

--- a/paimon-python/pypaimon/write/file_store_write.py
+++ b/paimon-python/pypaimon/write/file_store_write.py
@@ -17,23 +17,59 @@
 
 import logging
 import random
-from typing import Dict, List, Tuple
+from typing import Dict, List, Optional, Tuple
 
 import pyarrow as pa
 
-
-logger = logging.getLogger(__name__)
-
 from pypaimon.common.options.core_options import CoreOptions
-from pypaimon.schema.data_types import is_blob_file_field
+from pypaimon.schema.data_types import field_names_in_blob_file, is_blob_file_field
 from pypaimon.write.commit_message import CommitMessage
 from pypaimon.write.row_utils import row_values_to_arrow_table
 from pypaimon.write.writer.append_only_data_writer import AppendOnlyDataWriter
 from pypaimon.write.writer.dedicated_format_writer import DedicatedFormatWriter
 from pypaimon.write.writer.data_vector_writer import DataVectorWriter
-from pypaimon.write.writer.data_writer import DataWriter
+from pypaimon.write.writer.data_writer import DataWriter, DataWriterPrepareTransaction
 from pypaimon.write.writer.key_value_data_writer import KeyValueDataWriter
 from pypaimon.table.bucket_mode import BucketMode
+
+
+logger = logging.getLogger(__name__)
+
+
+class PreparedFileStoreCommit:
+    """All bucket writers staged successfully, but still own their files."""
+
+    def __init__(
+            self,
+            owner: "FileStoreWrite",
+            messages: List[CommitMessage],
+            transaction: DataWriterPrepareTransaction):
+        self.owner = owner
+        self.messages = messages
+        self.transaction = transaction
+        self._finished = False
+
+    def complete(self) -> List[CommitMessage]:
+        if self._finished:
+            raise RuntimeError("Prepared file-store commit is already finished.")
+        self.transaction.complete()
+        self._finished = True
+        self.owner._active_prepared_commit = None
+        return self.messages
+
+    def validate(self) -> None:
+        if self._finished:
+            raise RuntimeError("Prepared file-store commit is already finished.")
+        self.transaction.validate()
+
+    def abort(self) -> None:
+        if self._finished:
+            return
+        self._finished = True
+        try:
+            self.transaction.abort()
+        finally:
+            self.owner._active_prepared_commit = None
 
 
 class FileStoreWrite:
@@ -51,6 +87,7 @@ class FileStoreWrite:
         self.commit_identifier = 0
         self.options = CoreOptions.copy(table.options)
         self.changelog_producer = self.options.changelog_producer()
+        self._active_prepared_commit: Optional[PreparedFileStoreCommit] = None
         self._configure_data_file_prefix(commit_user)
 
     def _configure_data_file_prefix(self, commit_user):
@@ -163,8 +200,13 @@ class FileStoreWrite:
         def max_seq_number():
             return self._seq_number_stats(partition).get(bucket, 1)
 
+        managed_blob_fields = field_names_in_blob_file(
+            self.table.table_schema.fields,
+            self.options.blob_inline_fields(),
+        )
+
         # Check if table has blob columns
-        if self._has_blob_columns():
+        if self._has_blob_columns() and not self.table.is_primary_key_table:
             return DedicatedFormatWriter(
                 table=self.table,
                 partition=partition,
@@ -192,7 +234,8 @@ class FileStoreWrite:
                 max_seq_number=max_seq_number(),
                 options=options,
                 merge_function=self._build_pk_merge_function(),
-                changelog_producer=self.changelog_producer)
+                changelog_producer=self.changelog_producer,
+                managed_blob_fields=managed_blob_fields)
         else:
             seq_number = 0 if self.table.bucket_mode() == BucketMode.BUCKET_UNAWARE else max_seq_number()
             return AppendOnlyDataWriter(
@@ -318,25 +361,45 @@ class FileStoreWrite:
         from pypaimon.schema.data_types import VectorType
         return any(isinstance(f.type, VectorType) for f in self.table.table_schema.fields)
 
-    def prepare_commit(self, commit_identifier) -> List[CommitMessage]:
+    def stage_commit(self, commit_identifier) -> PreparedFileStoreCommit:
+        if self._active_prepared_commit is not None:
+            raise RuntimeError("A file-store commit is already staged.")
         self.commit_identifier = commit_identifier
         commit_messages = []
-        for (partition, bucket), writer in self.data_writers.items():
-            committed_files = writer.prepare_commit()
-            changelog_files = writer.prepare_changelog_commit()
-            if committed_files or changelog_files:
-                commit_message = CommitMessage(
-                    partition=partition,
-                    bucket=bucket,
-                    new_files=committed_files,
-                    changelog_files=changelog_files,
-                    total_buckets=self._runtime_total_buckets.get(partition),
-                )
-                commit_messages.append(commit_message)
-        return commit_messages
+        transaction = DataWriterPrepareTransaction()
+        preserve_blob_files = getattr(self, "blob_consumer", None) is not None
+        try:
+            for (partition, bucket), writer in self.data_writers.items():
+                stage = transaction.stage(writer)
+                if stage.data_files or stage.changelog_files:
+                    commit_messages.append(CommitMessage(
+                        partition=partition,
+                        bucket=bucket,
+                        new_files=stage.data_files,
+                        changelog_files=stage.changelog_files,
+                        total_buckets=getattr(
+                            self, "_runtime_total_buckets", {}).get(partition),
+                        preserve_blob_files_on_abort=preserve_blob_files,
+                    ))
+        except Exception:
+            transaction.abort()
+            raise
+        prepared = PreparedFileStoreCommit(self, commit_messages, transaction)
+        self._active_prepared_commit = prepared
+        return prepared
+
+    def prepare_commit(self, commit_identifier) -> List[CommitMessage]:
+        prepared = self.stage_commit(commit_identifier)
+        try:
+            return prepared.complete()
+        except Exception:
+            prepared.abort()
+            raise
 
     def close(self):
         """Close all data writers and clean up resources."""
+        if self._active_prepared_commit is not None:
+            self._active_prepared_commit.abort()
         for writer in self.data_writers.values():
             writer.close()
         self.data_writers.clear()
@@ -344,6 +407,8 @@ class FileStoreWrite:
 
     def abort(self):
         """Abort all data writers and clean up files produced by this write."""
+        if self._active_prepared_commit is not None:
+            self._active_prepared_commit.abort()
         for writer in self.data_writers.values():
             try:
                 writer.abort()

--- a/paimon-python/pypaimon/write/hash_index_commit_callback.py
+++ b/paimon-python/pypaimon/write/hash_index_commit_callback.py
@@ -1,0 +1,33 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from typing import TYPE_CHECKING
+
+from pypaimon.write.commit_callback import CommitCallback, CommitCallbackContext
+
+if TYPE_CHECKING:
+    from pypaimon.write.row_key_extractor import DynamicBucketRowKeyExtractor
+
+
+class HashIndexSnapshotRefreshCallback(CommitCallback):
+    """Advance HASH-index snapshot baseline after each successful commit."""
+
+    def __init__(self, extractor: "DynamicBucketRowKeyExtractor") -> None:
+        self._extractor = extractor
+
+    def call(self, context: CommitCallbackContext) -> None:
+        self._extractor.refresh_hash_index_snapshot(context.snapshot)

--- a/paimon-python/pypaimon/write/ray_datasink.py
+++ b/paimon-python/pypaimon/write/ray_datasink.py
@@ -117,6 +117,9 @@ class PaimonDatasink(_DatasinkBase):
     ) -> List["CommitMessage"]:
         commit_messages_list: List["CommitMessage"] = []
         table_write = None
+        writer_builder = None
+        table_commit = None
+        commit_messages = None
 
         try:
             writer_builder = (
@@ -154,12 +157,24 @@ class PaimonDatasink(_DatasinkBase):
         except Exception:
             if table_write is not None:
                 try:
+                    if commit_messages is not None and writer_builder is not None:
+                        table_commit = writer_builder.new_commit()
+                        table_commit.abort(commit_messages)
                     table_write.abort()
                 except Exception as abort_error:
                     logger.warning(
                         f"Error aborting worker-side table_write: {abort_error}",
                         exc_info=abort_error
                     )
+                finally:
+                    if table_commit is not None:
+                        try:
+                            table_commit.close()
+                        except Exception as close_error:
+                            logger.warning(
+                                f"Error closing worker-side table_commit: {close_error}",
+                                exc_info=close_error,
+                            )
             raise
 
     @staticmethod

--- a/paimon-python/pypaimon/write/row_key_extractor.py
+++ b/paimon-python/pypaimon/write/row_key_extractor.py
@@ -698,12 +698,39 @@ class DynamicBucketRowKeyExtractor(RowKeyExtractor):
         return partition
 
     def release_prepared(self) -> None:
+        release_assigner = getattr(self._assigner, "release_prepared", None)
+        if release_assigner is not None:
+            release_assigner()
         if self._index_maintainer is not None:
             self._index_maintainer.release_prepared()
+
+    def refresh_hash_index_snapshot(self, snapshot=None) -> None:
+        if self._table is None:
+            return
+        if snapshot is None:
+            snapshot = self._table.snapshot_manager().get_latest_snapshot()
+        self.base_snapshot_id = snapshot.id if snapshot is not None else 0
+        refresh_assigner = getattr(self._assigner, "refresh_snapshot", None)
+        if refresh_assigner is not None:
+            refresh_assigner(snapshot)
+        if self._index_maintainer is not None:
+            self._index_maintainer.refresh_snapshot(snapshot)
+
+    def create_hash_index_refresh_callback(self):
+        if self._table is None or self._index_maintainer is None:
+            return None
+        from pypaimon.write.hash_index_commit_callback import (
+            HashIndexSnapshotRefreshCallback,
+        )
+
+        return HashIndexSnapshotRefreshCallback(self)
 
     def abort(self) -> None:
         if self._index_maintainer is not None:
             self._index_maintainer.abort()
+        abort_assigner = getattr(self._assigner, "abort", None)
+        if abort_assigner is not None:
+            abort_assigner()
 
 
 class PostponeBucketRowKeyExtractor(RowKeyExtractor):

--- a/paimon-python/pypaimon/write/table_commit.py
+++ b/paimon-python/pypaimon/write/table_commit.py
@@ -61,6 +61,13 @@ class TableCommit:
         """Register a callback to be invoked after each successful commit."""
         self._commit_callbacks.append(callback)
 
+    def remove_commit_callback(self, callback: CommitCallback) -> None:
+        """Remove a previously registered commit callback."""
+        try:
+            self._commit_callbacks.remove(callback)
+        except ValueError:
+            pass
+
     def _commit(self, commit_messages: List[CommitMessage], commit_identifier: int = BATCH_COMMIT_IDENTIFIER):
         non_empty_messages = [msg for msg in commit_messages if not msg.is_empty()]
 
@@ -107,6 +114,10 @@ class TableCommit:
 
     def close(self):
         self.file_store_commit.close()
+        builder = getattr(self, "_stream_write_builder", None)
+        if builder is not None:
+            builder._detach_commit(self)
+            self._stream_write_builder = None
 
 
 class BatchTableCommit(TableCommit):

--- a/paimon-python/pypaimon/write/table_update_by_row_id.py
+++ b/paimon-python/pypaimon/write/table_update_by_row_id.py
@@ -49,6 +49,7 @@ from pypaimon.write.row_utils import (
     value_for_arrow,
 )
 from pypaimon.write.writer.blob_writer import BlobWriter
+from pypaimon.write.writer.data_writer import DataWriterPrepareTransaction
 
 
 @dataclass(frozen=True)
@@ -587,7 +588,9 @@ class TableUpdateByRowId:
         partition_tuple = tuple(partition.values)
         new_files = []
         file_store_write = None
+        prepared_file_store = None
         blob_writers = []
+        blob_transaction = DataWriterPrepareTransaction()
         success = False
         try:
             if merged_data is not None:
@@ -596,8 +599,8 @@ class TableUpdateByRowId:
                 file_store_write.write_cols = list(merged_data.column_names)
                 for batch in merged_data.to_batches():
                     file_store_write.write(partition_tuple, 0, batch)
-                new_messages = file_store_write.prepare_commit(self.commit_identifier)
-                for msg in new_messages:
+                prepared_file_store = file_store_write.stage_commit(self.commit_identifier)
+                for msg in prepared_file_store.messages:
                     new_files.extend(msg.new_files)
 
             for column_name, values in blob_columns.items():
@@ -613,19 +616,29 @@ class TableUpdateByRowId:
                 arrow_type = original_data.schema.field(column_name).type
                 for value in values:
                     blob_writer.write_blob(value, arrow_type)
-                new_files.extend(blob_writer.prepare_commit())
+                new_files.extend(blob_transaction.stage(blob_writer).data_files)
 
+            commit_message = None
             if new_files:
                 self._assign_update_file_metadata(
                     new_files, first_row_id, column_names, blob_columns)
-                self.commit_messages.append(
-                    CommitMessage(
-                        partition=partition_tuple,
-                        bucket=0,
-                        new_files=new_files,
-                        check_from_snapshot=self.snapshot_id,
-                    )
+                commit_message = CommitMessage(
+                    partition=partition_tuple,
+                    bucket=0,
+                    new_files=new_files,
+                    check_from_snapshot=self.snapshot_id,
                 )
+
+            # No fallible work follows these acknowledgements. Ownership moves
+            # from every staged writer to the single update commit message.
+            if prepared_file_store is not None:
+                prepared_file_store.validate()
+            blob_transaction.validate()
+            if prepared_file_store is not None:
+                prepared_file_store.complete()
+            blob_transaction.complete()
+            if commit_message is not None:
+                self.commit_messages.append(commit_message)
             success = True
         finally:
             if success:
@@ -634,6 +647,9 @@ class TableUpdateByRowId:
                 for blob_writer in blob_writers:
                     blob_writer.close()
             else:
+                if prepared_file_store is not None:
+                    prepared_file_store.abort()
+                blob_transaction.abort()
                 if file_store_write is not None:
                     file_store_write.abort()
                 for blob_writer in blob_writers:

--- a/paimon-python/pypaimon/write/table_write.py
+++ b/paimon-python/pypaimon/write/table_write.py
@@ -112,6 +112,11 @@ class TableWrite:
             ignore_existing=ignore_existing,
             base_snapshot_id=base_snapshot_id,
         )
+        self._hash_index_stream_maintenance = True
+        builder = getattr(self, "_stream_write_builder", None)
+        if builder is not None:
+            for commit in builder._stream_commits:
+                self.register_hash_index_commit_callbacks(commit)
         return self
 
     def write_arrow_batch_to_bucket(
@@ -226,6 +231,33 @@ class TableWrite:
         self.file_store_write.blob_consumer = blob_consumer
         return self
 
+    def register_hash_index_commit_callbacks(self, commit) -> None:
+        if not getattr(self, "_hash_index_stream_maintenance", False):
+            return
+        create_callback = getattr(
+            self.row_key_extractor, "create_hash_index_refresh_callback", None
+        )
+        if create_callback is None:
+            return
+        registered = getattr(self, "_hash_index_commit_callbacks", None)
+        if registered is None:
+            registered = {}
+            self._hash_index_commit_callbacks = registered
+        commit_id = id(commit)
+        previous = registered.get(commit_id)
+        if previous is not None:
+            commit.remove_commit_callback(previous)
+        callback = create_callback()
+        if callback is not None:
+            commit.add_commit_callback(callback)
+            registered[commit_id] = callback
+
+    def _unregister_hash_index_commit_callback(self, commit) -> None:
+        registered = getattr(self, "_hash_index_commit_callbacks", None)
+        if registered is None:
+            return
+        registered.pop(id(commit), None)
+
     def write_ray(
         self,
         dataset: "Dataset",
@@ -280,6 +312,13 @@ class TableWrite:
             self.file_store_write.close()
         finally:
             self._release_prepared_indexes()
+            registered = getattr(self, "_hash_index_commit_callbacks", None)
+            if registered is not None:
+                registered.clear()
+            builder = getattr(self, "_stream_write_builder", None)
+            if builder is not None:
+                builder._detach_writer(self)
+                self._stream_write_builder = None
 
     def abort(self):
         try:
@@ -290,38 +329,49 @@ class TableWrite:
                 abort()
 
     def _prepare_commit(self, commit_identifier) -> List[CommitMessage]:
-        commit_messages = self.file_store_write.prepare_commit(commit_identifier)
-        prepare_indexes = getattr(self.row_key_extractor, "prepare_commit", None)
-        if prepare_indexes is None:
-            return commit_messages
-
-        index_changes = prepare_indexes()
-        base_snapshot_id = getattr(
-            self.row_key_extractor, "base_snapshot_id", None
-        )
-        messages_by_bucket = {
-            (tuple(message.partition), message.bucket): message
-            for message in commit_messages
-        }
-        for (partition, bucket), changes in index_changes.items():
-            message = messages_by_bucket.get((partition, bucket))
-            if message is None:
-                message = CommitMessage(
-                    partition=partition,
-                    bucket=bucket,
-                    new_files=[],
+        prepared = None
+        try:
+            prepared = self.file_store_write.stage_commit(commit_identifier)
+            commit_messages = prepared.messages
+            prepare_indexes = getattr(self.row_key_extractor, "prepare_commit", None)
+            if prepare_indexes is not None:
+                index_changes = prepare_indexes()
+                base_snapshot_id = getattr(
+                    self.row_key_extractor, "base_snapshot_id", None
                 )
-                commit_messages.append(message)
-                messages_by_bucket[(partition, bucket)] = message
-            message.index_adds.extend(changes.additions)
-            message.index_deletes.extend(changes.deletions)
-        if base_snapshot_id is not None:
-            # Data-only upserts must participate too. A concurrent overwrite
-            # can rebuild the HASH index and move an existing key, making a
-            # stale data file unsafe even when this writer added no mapping.
-            for message in commit_messages:
-                message.hash_index_base_snapshot = base_snapshot_id
-        return commit_messages
+                messages_by_bucket = {
+                    (tuple(message.partition), message.bucket): message
+                    for message in commit_messages
+                }
+                for (partition, bucket), changes in index_changes.items():
+                    message = messages_by_bucket.get((partition, bucket))
+                    if message is None:
+                        message = CommitMessage(
+                            partition=partition,
+                            bucket=bucket,
+                            new_files=[],
+                        )
+                        commit_messages.append(message)
+                        messages_by_bucket[(partition, bucket)] = message
+                    message.index_adds.extend(changes.additions)
+                    message.index_deletes.extend(changes.deletions)
+                if base_snapshot_id is not None:
+                    # Data-only upserts must participate too. A concurrent overwrite
+                    # can rebuild the HASH index and move an existing key, making a
+                    # stale data file unsafe even when this writer added no mapping.
+                    for message in commit_messages:
+                        message.hash_index_base_snapshot = base_snapshot_id
+
+            messages = prepared.complete()
+            self._release_prepared_indexes()
+            return messages
+        except Exception:
+            if prepared is not None:
+                prepared.abort()
+            abort_indexes = getattr(self.row_key_extractor, "abort", None)
+            if abort_indexes is not None:
+                abort_indexes()
+            raise
 
     def _release_prepared_indexes(self) -> None:
         release = getattr(self.row_key_extractor, "release_prepared", None)
@@ -387,6 +437,4 @@ class BatchTableWrite(TableWrite):
 class StreamTableWrite(TableWrite):
 
     def prepare_commit(self, commit_identifier) -> List[CommitMessage]:
-        messages = self._prepare_commit(commit_identifier)
-        self._release_prepared_indexes()
-        return messages
+        return self._prepare_commit(commit_identifier)

--- a/paimon-python/pypaimon/write/write_builder.py
+++ b/paimon-python/pypaimon/write/write_builder.py
@@ -70,13 +70,51 @@ class BatchWriteBuilder(WriteBuilder):
 
 
 class StreamWriteBuilder(WriteBuilder):
+    """Streaming write/commit factory for coordinated multi-commit workflows.
+
+    Writers and commits created from the same builder are linked automatically
+    once :meth:`~pypaimon.write.table_write.TableWrite.with_dynamic_bucket_index`
+    is enabled, so HASH-index snapshot refresh callbacks stay registered
+    regardless of whether ``new_write()`` or ``new_commit()`` is called first.  Creating
+    writers or commits from separate builders (or constructing
+    ``StreamTableCommit`` directly) skips this wiring and can break dynamic
+    bucket index maintenance across successive commits.
+    """
+
+    def __init__(self, table):
+        super().__init__(table)
+        self._stream_writers = []
+        self._stream_commits = []
 
     def new_write(self) -> StreamTableWrite:
-        return StreamTableWrite(self.table, self.commit_user, self.static_partition)
+        writer = StreamTableWrite(self.table, self.commit_user, self.static_partition)
+        writer._stream_write_builder = self
+        self._stream_writers.append(writer)
+        for commit in self._stream_commits:
+            writer.register_hash_index_commit_callbacks(commit)
+        return writer
 
     def new_update(self) -> StreamTableUpdate:
         return StreamTableUpdate(self.table, self.commit_user)
 
     def new_commit(self) -> StreamTableCommit:
         commit = StreamTableCommit(self.table, self.commit_user, self.static_partition)
+        commit._stream_write_builder = self
+        self._stream_commits.append(commit)
+        for writer in self._stream_writers:
+            writer.register_hash_index_commit_callbacks(commit)
         return commit
+
+    def _detach_writer(self, writer: StreamTableWrite) -> None:
+        try:
+            self._stream_writers.remove(writer)
+        except ValueError:
+            pass
+
+    def _detach_commit(self, commit: StreamTableCommit) -> None:
+        try:
+            self._stream_commits.remove(commit)
+        except ValueError:
+            pass
+        for writer in self._stream_writers:
+            writer._unregister_hash_index_commit_callback(commit)

--- a/paimon-python/pypaimon/write/writer/blob_writer.py
+++ b/paimon-python/pypaimon/write/writer/blob_writer.py
@@ -219,14 +219,14 @@ class BlobWriter(AppendOnlyDataWriter):
             file_path=file_path,
         ))
 
-    def prepare_commit(self):
-        """Prepare commit, preserving blob files in write/rolling order."""
+    def _prepare_commit_data(self):
+        """Stage commit, preserving blob files in write/rolling order."""
         # Close current file if open.
         if self.current_writer is not None:
             self.close_current_writer()
 
-        # Call parent to handle pending_data fallback.
-        return super().prepare_commit()
+        # Call parent to handle pending_data fallback without transferring ownership.
+        return super()._prepare_commit_data()
 
     def close(self):
         """Close current writer if open."""
@@ -248,6 +248,8 @@ class BlobWriter(AppendOnlyDataWriter):
         if self._blob_consumer is not None:
             self.pending_data = None
             self.committed_files.clear()
+            self.committed_changelog_files.clear()
+            self._active_prepared_commit = None
         else:
             super().abort()
 

--- a/paimon-python/pypaimon/write/writer/data_vector_writer.py
+++ b/paimon-python/pypaimon/write/writer/data_vector_writer.py
@@ -27,7 +27,7 @@ from pypaimon.manifest.schema.data_file_meta import DataFileMeta
 from pypaimon.manifest.schema.simple_stats import SimpleStats
 from pypaimon.schema.data_types import VectorType
 from pypaimon.table.row.generic_row import GenericRow
-from pypaimon.write.writer.data_writer import DataWriter
+from pypaimon.write.writer.data_writer import DataWriter, DataWriterPrepareTransaction
 
 logger = logging.getLogger(__name__)
 
@@ -131,9 +131,8 @@ class DataVectorWriter(DataWriter):
             self.abort()
             raise e
 
-    def prepare_commit(self) -> List[DataFileMeta]:
+    def _prepare_commit_data(self):
         self._close_current_writers()
-        return self.committed_files.copy()
 
     def close(self):
         if self.closed:
@@ -147,6 +146,7 @@ class DataVectorWriter(DataWriter):
         finally:
             self.closed = True
             self.pending_normal_data = None
+        self.abort()
 
     def abort(self):
         if self.vector_writer is not None:
@@ -187,12 +187,17 @@ class DataVectorWriter(DataWriter):
             self.committed_files.append(normal_meta)
 
         if self.vector_writer is not None:
-            vector_metas = self.vector_writer.prepare_commit()
-            if vector_metas:
-                if normal_meta is not None:
-                    self._validate_consistency(normal_meta, vector_metas)
-                self.committed_files.extend(vector_metas)
-            self.vector_writer.committed_files.clear()
+            transaction = DataWriterPrepareTransaction()
+            try:
+                vector_metas = transaction.stage(self.vector_writer).data_files
+                if vector_metas:
+                    if normal_meta is not None:
+                        self._validate_consistency(normal_meta, vector_metas)
+                    self.committed_files.extend(vector_metas)
+                transaction.complete()
+            except Exception:
+                transaction.abort()
+                raise
 
         self.pending_normal_data = None
 

--- a/paimon-python/pypaimon/write/writer/data_writer.py
+++ b/paimon-python/pypaimon/write/writer/data_writer.py
@@ -15,11 +15,13 @@
 # specific language governing permissions and limitations
 # under the License.
 
-import pyarrow as pa
-import pyarrow.compute as pc
+import logging
 import uuid
 from abc import ABC, abstractmethod
-from typing import Dict, List, Optional, Tuple
+from typing import Any, Dict, List, Optional, Tuple
+
+import pyarrow as pa
+import pyarrow.compute as pc
 
 from pypaimon.common.options.core_options import CoreOptions, ChangelogProducer
 from pypaimon.common.external_path_provider import ExternalPathProvider
@@ -30,6 +32,83 @@ from pypaimon.schema.data_types import PyarrowFieldParser
 from pypaimon.table.bucket_mode import BucketMode
 from pypaimon.table.row.generic_row import GenericRow
 from pypaimon.write.writer.mosaic_writer_options import create_mosaic_writer_options
+
+logger = logging.getLogger(__name__)
+
+
+class PreparedDataWriterCommit:
+    """A writer-owned commit stage which has not crossed the ownership boundary yet."""
+
+    def __init__(
+            self,
+            writer: "DataWriter",
+            data_files: List[DataFileMeta],
+            changelog_files: List[DataFileMeta],
+            extra: Any = None):
+        self.writer = writer
+        self.data_files = data_files
+        self.changelog_files = changelog_files
+        self.extra = extra
+        self._finished = False
+
+    def complete(self, include_changelog: bool = True) -> Tuple[
+            List[DataFileMeta], List[DataFileMeta]]:
+        if self._finished:
+            raise RuntimeError("Prepared writer commit is already finished.")
+        result = self.writer._complete_prepared_commit(self, include_changelog)
+        self._finished = True
+        return result
+
+    def abort(self) -> None:
+        if self._finished:
+            return
+        self._finished = True
+        self.writer._abort_prepared_commit(self)
+
+
+class DataWriterPrepareTransaction:
+    """Stages several writers and atomically completes or aborts the whole group."""
+
+    def __init__(self):
+        self._stages: List[PreparedDataWriterCommit] = []
+        self._finished = False
+
+    def stage(self, writer: "DataWriter") -> PreparedDataWriterCommit:
+        if self._finished:
+            raise RuntimeError("Writer prepare transaction is already finished.")
+        try:
+            stage = writer.stage_commit()
+        except Exception:
+            self.abort()
+            raise
+        self._stages.append(stage)
+        return stage
+
+    def complete(self) -> None:
+        if self._finished:
+            raise RuntimeError("Writer prepare transaction is already finished.")
+        # Completion only clears already validated in-memory ownership and invokes
+        # non-throwing acknowledgement hooks. All fallible work belongs in stage().
+        self.validate()
+        for stage in self._stages:
+            stage.complete()
+        self._finished = True
+
+    def validate(self) -> None:
+        if self._finished:
+            raise RuntimeError("Writer prepare transaction is already finished.")
+        for stage in self._stages:
+            stage.writer._validate_prepared_commit(stage, True)
+
+    def abort(self) -> None:
+        if self._finished:
+            return
+        self._finished = True
+        for stage in reversed(self._stages):
+            try:
+                stage.abort()
+            except Exception:
+                logger.warning("Failed to abort staged data writer.", exc_info=True)
 
 
 class DataWriter(ABC):
@@ -75,6 +154,7 @@ class DataWriter(ABC):
         self.pending_data: Optional[pa.Table] = None
         self.committed_files: List[DataFileMeta] = []
         self.committed_changelog_files: List[DataFileMeta] = []
+        self._active_prepared_commit: Optional[PreparedDataWriterCommit] = None
         self.changelog_producer = changelog_producer
         self.changelog_file_format = (
             self.options.changelog_file_format()
@@ -121,15 +201,42 @@ class DataWriter(ABC):
             self.abort()
             raise e
 
-    def prepare_commit(self) -> List[DataFileMeta]:
+    def _prepare_commit_data(self) -> Any:
         if self.pending_data is not None and self.pending_data.num_rows > 0:
             self._write_data_to_file(self.pending_data)
             self.pending_data = None
 
-        return self.committed_files.copy()
+        return None
+
+    def stage_commit(self) -> PreparedDataWriterCommit:
+        """Flush fallible work while retaining ownership of every produced file."""
+        if getattr(self, "_active_prepared_commit", None) is not None:
+            raise RuntimeError("A writer commit is already staged.")
+        try:
+            extra = self._prepare_commit_data()
+            stage = PreparedDataWriterCommit(
+                self,
+                self.committed_files.copy(),
+                self.committed_changelog_files.copy(),
+                extra,
+            )
+            self._active_prepared_commit = stage
+            return stage
+        except Exception:
+            self.abort()
+            raise
+
+    def prepare_commit(self) -> List[DataFileMeta]:
+        stage = self.stage_commit()
+        try:
+            data_files, _ = stage.complete(include_changelog=False)
+            return data_files
+        except Exception:
+            stage.abort()
+            raise
 
     def prepare_changelog_commit(self) -> List[DataFileMeta]:
-        return self.committed_changelog_files.copy()
+        return self._drain_committed_files(self.committed_changelog_files)
 
     def close(self):
         try:
@@ -143,7 +250,10 @@ class DataWriter(ABC):
             raise e
         finally:
             self.pending_data = None
-            # Note: Don't clear committed_files in close() - they should be returned by prepare_commit()
+        # Files which have not been drained by prepare_commit are still owned
+        # by this writer. Closing without handing them to a committer must not
+        # leave unreachable data or aligned extra files behind.
+        self.abort()
 
     def abort(self):
         """
@@ -156,6 +266,45 @@ class DataWriter(ABC):
         self.pending_data = None
         self.committed_files.clear()
         self.committed_changelog_files.clear()
+        self._active_prepared_commit = None
+
+    def _complete_prepared_commit(
+            self,
+            stage: PreparedDataWriterCommit,
+            include_changelog: bool) -> Tuple[List[DataFileMeta], List[DataFileMeta]]:
+        self._validate_prepared_commit(stage, include_changelog)
+
+        self.committed_files.clear()
+        changelog_files = []
+        if include_changelog:
+            self.committed_changelog_files.clear()
+            changelog_files = stage.changelog_files
+        self._complete_prepared_commit_extra(stage.extra)
+        self._active_prepared_commit = None
+        return stage.data_files, changelog_files
+
+    def _validate_prepared_commit(
+            self,
+            stage: PreparedDataWriterCommit,
+            include_changelog: bool) -> None:
+        if getattr(self, "_active_prepared_commit", None) is not stage:
+            raise RuntimeError("Prepared writer commit is not active.")
+        if self.committed_files != stage.data_files:
+            raise RuntimeError("Writer data files changed while commit was staged.")
+        if include_changelog and self.committed_changelog_files != stage.changelog_files:
+            raise RuntimeError("Writer changelog files changed while commit was staged.")
+        self._validate_prepared_commit_extra(stage.extra)
+
+    def _validate_prepared_commit_extra(self, extra: Any) -> None:
+        """Validate non-file resources without changing their ownership."""
+
+    def _complete_prepared_commit_extra(self, extra: Any) -> None:
+        """Acknowledge non-file resources captured by ``_prepare_commit_data``."""
+
+    def _abort_prepared_commit(self, stage: PreparedDataWriterCommit) -> None:
+        if getattr(self, "_active_prepared_commit", None) is not stage:
+            return
+        self.abort()
 
     def _delete_committed_files(self, file_metas: List[DataFileMeta]):
         for file_meta in file_metas:
@@ -171,6 +320,13 @@ class DataWriter(ABC):
                 logger = logging.getLogger(__name__)
                 path_to_delete = file_meta.external_path if file_meta.external_path else file_meta.file_path
                 logger.warning(f"Failed to delete file {path_to_delete} during abort: {e}")
+
+    @staticmethod
+    def _drain_committed_files(file_metas: List[DataFileMeta]) -> List[DataFileMeta]:
+        """Transfer ownership of all current files to the commit caller."""
+        drained = file_metas.copy()
+        file_metas.clear()
+        return drained
 
     @abstractmethod
     def _process_data(self, data: pa.RecordBatch) -> pa.RecordBatch:
@@ -255,67 +411,75 @@ class DataWriter(ABC):
                     fields=self._row_sidecar_fields(logical_data),
                     zstd_level=self.zstd_level)
                 extra_files.append(row_sidecar_name)
+            extra_files.extend(self._write_managed_blob_extra_files(
+                logical_data, file_name, file_path))
         except Exception:
             self.file_io.delete_quietly(file_path)
             if row_sidecar_path is not None:
                 self.file_io.delete_quietly(row_sidecar_path)
             raise
 
-        # min key & max key
+        try:
+            selected_table = data.select(self.trimmed_primary_keys)
+            key_columns_batch = selected_table.to_batches()[0]
+            min_key_row_batch = key_columns_batch.slice(0, 1)
+            max_key_row_batch = key_columns_batch.slice(key_columns_batch.num_rows - 1, 1)
+            min_key = [col.to_pylist()[0] for col in min_key_row_batch.columns]
+            max_key = [col.to_pylist()[0] for col in max_key_row_batch.columns]
 
-        selected_table = data.select(self.trimmed_primary_keys)
-        key_columns_batch = selected_table.to_batches()[0]
-        min_key_row_batch = key_columns_batch.slice(0, 1)
-        max_key_row_batch = key_columns_batch.slice(key_columns_batch.num_rows - 1, 1)
-        min_key = [col.to_pylist()[0] for col in min_key_row_batch.columns]
-        max_key = [col.to_pylist()[0] for col in max_key_row_batch.columns]
+            value_stats_enabled = self.options.metadata_stats_enabled()
+            if value_stats_enabled:
+                stats_fields = self.table.fields if self.table.is_primary_key_table \
+                    else PyarrowFieldParser.to_paimon_schema(data.schema)
+            else:
+                stats_fields = self.table.trimmed_primary_keys_fields
+            column_stats = {
+                field.name: self._get_column_stats(data, field.name)
+                for field in stats_fields
+            }
+            key_fields = self.trimmed_primary_keys_fields
+            key_stats = self._collect_value_stats(data, key_fields, column_stats)
+            if not self.options.primary_key_nullable() and not all(
+                    count == 0 for count in key_stats.null_counts):
+                raise RuntimeError("Primary key should not be null")
 
-        # key stats & value stats
-        value_stats_enabled = self.options.metadata_stats_enabled()
-        if value_stats_enabled:
-            stats_fields = self.table.fields if self.table.is_primary_key_table \
-                else PyarrowFieldParser.to_paimon_schema(data.schema)
-        else:
-            stats_fields = self.table.trimmed_primary_keys_fields
-        column_stats = {
-            field.name: self._get_column_stats(data, field.name)
-            for field in stats_fields
-        }
-        key_fields = self.trimmed_primary_keys_fields
-        key_stats = self._collect_value_stats(data, key_fields, column_stats)
-        if not self.options.primary_key_nullable() and not all(
-                count == 0 for count in key_stats.null_counts):
-            raise RuntimeError("Primary key should not be null")
+            value_fields = stats_fields if value_stats_enabled else []
+            value_stats = self._collect_value_stats(data, value_fields, column_stats)
 
-        value_fields = stats_fields if value_stats_enabled else []
-        value_stats = self._collect_value_stats(data, value_fields, column_stats)
+            min_seq = self.sequence_generator.start
+            max_seq = self.sequence_generator.current
+            creation_time = Timestamp.now()
+            file_meta = DataFileMeta.create(
+                file_name=file_name,
+                file_size=self.file_io.get_file_size(file_path),
+                row_count=data.num_rows,
+                min_key=GenericRow(min_key, self.trimmed_primary_keys_fields),
+                max_key=GenericRow(max_key, self.trimmed_primary_keys_fields),
+                key_stats=key_stats,
+                value_stats=value_stats,
+                min_sequence_number=min_seq,
+                max_sequence_number=max_seq,
+                schema_id=self.table.table_schema.id,
+                level=0,
+                extra_files=extra_files,
+                creation_time=creation_time,
+                delete_row_count=0,
+                file_source=0,
+                value_stats_cols=None if value_stats_enabled else [],
+                external_path=external_path_str,
+                first_row_id=None,
+                write_cols=self.write_cols,
+                file_path=file_path,
+            )
+        except Exception:
+            self.file_io.delete_quietly(file_path)
+            for extra_file in extra_files:
+                self.file_io.delete_quietly(
+                    self._aligned_extra_file_path_from_path(file_path, extra_file))
+            raise
 
-        min_seq = self.sequence_generator.start
-        max_seq = self.sequence_generator.current
+        self.committed_files.append(file_meta)
         self.sequence_generator.start = self.sequence_generator.current
-        creation_time = Timestamp.now()
-        self.committed_files.append(DataFileMeta.create(
-            file_name=file_name,
-            file_size=self.file_io.get_file_size(file_path),
-            row_count=data.num_rows,
-            min_key=GenericRow(min_key, self.trimmed_primary_keys_fields),
-            max_key=GenericRow(max_key, self.trimmed_primary_keys_fields),
-            key_stats=key_stats,
-            value_stats=value_stats,
-            min_sequence_number=min_seq,
-            max_sequence_number=max_seq,
-            schema_id=self.table.table_schema.id,
-            level=0,
-            extra_files=extra_files,
-            creation_time=creation_time,
-            delete_row_count=0,
-            file_source=0,
-            value_stats_cols=None if value_stats_enabled else [],
-            external_path=external_path_str,
-            first_row_id=None,
-            write_cols=self.write_cols,
-            file_path=file_path,
-        ))
 
         if self.changelog_producer == ChangelogProducer.INPUT:
             self._write_changelog_file(
@@ -401,6 +565,10 @@ class DataWriter(ABC):
         bucket_path = self.path_factory.bucket_path(self.partition, self.bucket)
         return f"{bucket_path.rstrip('/')}/{file_name}"
 
+    def _write_managed_blob_extra_files(
+            self, data: pa.Table, file_name: str, file_path: str) -> List[str]:
+        return []
+
     def _should_write_row_sidecar(self) -> bool:
         return (
             self.options.data_evolution_enabled(False)
@@ -415,9 +583,13 @@ class DataWriter(ABC):
 
     @staticmethod
     def _aligned_extra_file_path(file_meta: DataFileMeta, extra_file: str) -> str:
+        file_path = file_meta.external_path if file_meta.external_path else file_meta.file_path
+        return DataWriter._aligned_extra_file_path_from_path(file_path, extra_file)
+
+    @staticmethod
+    def _aligned_extra_file_path_from_path(file_path: str, extra_file: str) -> str:
         if "://" in extra_file or extra_file.startswith("/"):
             return extra_file
-        file_path = file_meta.external_path if file_meta.external_path else file_meta.file_path
         if not file_path or "/" not in file_path:
             return extra_file
         return f"{file_path.rsplit('/', 1)[0]}/{extra_file}"

--- a/paimon-python/pypaimon/write/writer/dedicated_format_writer.py
+++ b/paimon-python/pypaimon/write/writer/dedicated_format_writer.py
@@ -38,7 +38,7 @@ from pypaimon.write.row_utils import (
     row_to_named_values,
     row_values_to_arrow_table,
 )
-from pypaimon.write.writer.data_writer import DataWriter
+from pypaimon.write.writer.data_writer import DataWriter, DataWriterPrepareTransaction
 
 logger = logging.getLogger(__name__)
 
@@ -133,6 +133,7 @@ class DedicatedFormatWriter(DataWriter):
         # State management for blob writer
         self.record_count = 0
         self.closed = False
+        self.blob_consumer = blob_consumer
 
         # Track pending data for normal data only
         self.pending_normal_data: Optional[pa.Table] = None
@@ -309,11 +310,9 @@ class DedicatedFormatWriter(DataWriter):
 
         return value
 
-    def prepare_commit(self) -> List[DataFileMeta]:
+    def _prepare_commit_data(self):
         # Close any remaining data
         self._close_current_writers()
-
-        return self.committed_files.copy()
 
     def close(self):
         if self.closed:
@@ -328,6 +327,9 @@ class DedicatedFormatWriter(DataWriter):
         finally:
             self.closed = True
             self.pending_normal_data = None
+        # Anything not drained by prepare_commit is still owned by this
+        # writer and must not survive close as an unreachable file set.
+        self.abort()
 
     def abort(self):
         """Abort all writers and clean up resources."""
@@ -335,14 +337,23 @@ class DedicatedFormatWriter(DataWriter):
             blob_writer.abort()
         if self.vector_writer is not None:
             self.vector_writer.abort()
-        committed_non_blob_files = [
-            file_meta for file_meta in self.committed_files
-            if not DataFileMeta.is_blob_file(file_meta.file_name)
-        ]
-        self._delete_committed_files(committed_non_blob_files)
+        # A BlobConsumer receives descriptors as bytes are written and may retain
+        # them independently of this table commit. Preserve those BLOB files on
+        # abort, matching BlobWriter.abort(); normal and vector files are still
+        # exclusively owned by this writer and must be removed.
+        files_to_delete = self.committed_files
+        if self.blob_consumer is not None:
+            files_to_delete = [
+                file_meta for file_meta in self.committed_files
+                if not file_meta.file_name.endswith(
+                    ".%s" % CoreOptions.FILE_FORMAT_BLOB)
+            ]
+        self._delete_committed_files(files_to_delete)
         self.pending_normal_data = None
         self.pending_data = None
         self.committed_files.clear()
+        self.committed_changelog_files.clear()
+        self._active_prepared_commit = None
 
     def _split_data(self, data: pa.RecordBatch) -> Tuple[
             Optional[pa.RecordBatch], Dict[str, pa.RecordBatch], Optional[pa.RecordBatch]]:
@@ -469,21 +480,32 @@ class DedicatedFormatWriter(DataWriter):
             normal_meta = self._write_normal_data_to_file(self.pending_normal_data)
             self.committed_files.append(normal_meta)
 
-        blob_metas = []
-        for blob_column in self.blob_file_column_names:
-            writer_metas = self.blob_writers[blob_column].prepare_commit()
-            if normal_meta is not None:
-                self._validate_consistency(normal_meta, writer_metas, blob_column)
-            blob_metas.extend(writer_metas)
-        self.committed_files.extend(blob_metas)
+        transaction = DataWriterPrepareTransaction()
+        try:
+            blob_metas = []
+            for blob_column in self.blob_file_column_names:
+                stage = transaction.stage(self.blob_writers[blob_column])
+                writer_metas = stage.data_files
+                if normal_meta is not None:
+                    self._validate_consistency(normal_meta, writer_metas, blob_column)
+                blob_metas.extend(writer_metas)
 
-        vector_metas = []
-        if self.vector_writer is not None:
-            vector_metas = self.vector_writer.prepare_commit()
-            if vector_metas and normal_meta is not None:
-                self._validate_consistency(normal_meta, vector_metas, 'vector')
+            vector_metas = []
+            if self.vector_writer is not None:
+                stage = transaction.stage(self.vector_writer)
+                vector_metas = stage.data_files
+                if vector_metas and normal_meta is not None:
+                    self._validate_consistency(normal_meta, vector_metas, 'vector')
+
+            # Parent ownership is established before child ownership is acknowledged.
+            # If acknowledgement unexpectedly fails, the parent's outer abort still
+            # has every file needed for cleanup.
+            self.committed_files.extend(blob_metas)
             self.committed_files.extend(vector_metas)
-            self.vector_writer.committed_files.clear()
+            transaction.complete()
+        except Exception:
+            transaction.abort()
+            raise
 
         self.pending_normal_data = None
 

--- a/paimon-python/pypaimon/write/writer/key_value_data_writer.py
+++ b/paimon-python/pypaimon/write/writer/key_value_data_writer.py
@@ -15,15 +15,19 @@
 # specific language governing permissions and limitations
 # under the License.
 
-from typing import List, Union
+from typing import Any, List, Optional, Set, Union
 
 import pyarrow as pa
 import pyarrow.compute as pc
 
-from pypaimon.manifest.schema.data_file_meta import DataFileMeta
+from pypaimon.blob.managed_blob_reference_collector import ManagedBlobReferenceCollector
+from pypaimon.blob.primary_key_blob_externalizer import (
+    PrimaryKeyBlobExternalizer,
+    new_managed_blob_path,
+)
+from pypaimon.common.options.core_options import ChangelogProducer, CoreOptions
 from pypaimon.read.reader.deduplicate_merge_function import \
     DeduplicateMergeFunction
-from pypaimon.common.options.core_options import ChangelogProducer
 from pypaimon.table.row.key_value import KeyValue
 from pypaimon.write.writer.data_writer import DataWriter
 
@@ -42,15 +46,42 @@ class KeyValueDataWriter(DataWriter):
 
     def __init__(self, table, partition, bucket, max_seq_number,
                  options=None, write_cols=None, merge_function=None,
-                 changelog_producer=ChangelogProducer.NONE):
+                 changelog_producer=ChangelogProducer.NONE,
+                 managed_blob_fields: Optional[Set[str]] = None):
         super().__init__(table, partition, bucket, max_seq_number,
                          options, write_cols, changelog_producer)
         # Defaults to deduplicate so direct callers (tests / future code
         # paths that don't go through FileStoreWrite) don't accidentally
         # skip the merge step entirely.
         self._merge_function = merge_function or DeduplicateMergeFunction()
+        self._managed_blob_fields = managed_blob_fields or set()
+        self._blob_externalizer = None
+        if self._managed_blob_fields:
+            from pypaimon.table.blob_descriptor_reader_factory import \
+                BlobDescriptorReaderFactory
+
+            def _new_pack_path():
+                return new_managed_blob_path(
+                    self.path_factory,
+                    self.partition,
+                    self.bucket,
+                    self.options,
+                )
+
+            self._blob_externalizer = PrimaryKeyBlobExternalizer(
+                self.file_io,
+                self.table.table_schema.fields,
+                self._managed_blob_fields,
+                _new_pack_path,
+                self.options.blob_target_file_size(),
+                self.options.blob_copy_buffer_size(),
+                CoreOptions.data_file_prefix(self.options),
+                BlobDescriptorReaderFactory.create(self.table),
+            )
 
     def _process_data(self, data: pa.RecordBatch) -> pa.Table:
+        if self._blob_externalizer is not None and self._blob_externalizer.enabled:
+            data = self._blob_externalizer.externalize_record_batch(data)
         # No sort here: sorting once at flush is strictly cheaper than
         # per-batch sort + a final global sort. ``pending_data`` ends
         # up as a concat of unsorted batches; ``_flush_all`` sorts it
@@ -63,12 +94,38 @@ class KeyValueDataWriter(DataWriter):
         # N writes incur 1 sort instead of N sorts.
         return pa.concat_tables([existing_data, new_data])
 
-    def prepare_commit(self) -> List[DataFileMeta]:
+    def _prepare_commit_data(self) -> Any:
         if self.pending_data is not None and self.pending_data.num_rows > 0:
             self._flush_all()
-        # ``_flush_all`` leaves ``pending_data = None``, so super's
-        # prepare_commit just returns ``committed_files``.
-        return super().prepare_commit()
+        if self._blob_externalizer is not None and self._blob_externalizer.enabled:
+            return self._blob_externalizer.stage_commit()
+        return None
+
+    def _complete_prepared_commit_extra(self, extra: Any) -> None:
+        if self._blob_externalizer is not None and self._blob_externalizer.enabled:
+            self._blob_externalizer.complete_commit(extra)
+
+    def _validate_prepared_commit_extra(self, extra: Any) -> None:
+        if self._blob_externalizer is not None and self._blob_externalizer.enabled:
+            self._blob_externalizer.validate_commit(extra)
+
+    def abort(self):
+        if self._blob_externalizer is not None and self._blob_externalizer.enabled:
+            self._blob_externalizer.abort()
+        super().abort()
+
+    def _write_managed_blob_extra_files(
+            self, data: pa.Table, file_name: str, file_path: str) -> List[str]:
+        if not self._managed_blob_fields:
+            return []
+        collector = ManagedBlobReferenceCollector(
+            self.file_io,
+            file_path,
+            self.table.table_schema.fields,
+            self._managed_blob_fields,
+        )
+        collector.collect_table(data)
+        return [collector.close()]
 
     def _check_and_roll_if_needed(self):
         # Buffer overflowed target_file_size: sort + fold + roll-write
@@ -88,18 +145,26 @@ class KeyValueDataWriter(DataWriter):
         # ``_flush_all`` so the contract holds even on the
         # close-without-prepare_commit path.
         try:
-            if self.pending_data is not None and self.pending_data.num_rows > 0:
-                self._flush_all()
-        except Exception as e:
-            import logging
-            logger = logging.getLogger(__name__)
-            logger.warning(
-                "Exception occurs when closing writer. Cleaning up.",
-                exc_info=e)
+            try:
+                if self.pending_data is not None and self.pending_data.num_rows > 0:
+                    self._flush_all()
+            except Exception as e:
+                import logging
+                logger = logging.getLogger(__name__)
+                logger.warning(
+                    "Exception occurs when closing writer. Cleaning up.",
+                    exc_info=e)
+                self.abort()
+                raise e
+            finally:
+                self.pending_data = None
+            # prepare_commit drains handed-off files and marks their packs as
+            # committed. Everything still owned by the writer is unprepared and
+            # must be removed on close.
             self.abort()
-            raise e
         finally:
-            self.pending_data = None
+            if self._blob_externalizer is not None:
+                self._blob_externalizer.close()
 
     def _flush_all(self) -> None:
         """Sort + fold the entire buffer, then roll-write as files.


### PR DESCRIPTION
### Purpose
Add PyPaimon support for BLOB storage on **primary-key tables**, aligned with Java managed-BLOB semantics.
**Write path**
- Externalize `blob-field` payloads (`BLOB`, `ARRAY<BLOB>`, `MAP<K,BLOB>`) into immutable `.managed.blob` packs before they enter the MergeTree sort buffer, via `PrimaryKeyBlobExternalizer`.
- Emit per-data-file `.blobref` sidecars that reference the managed packs used by that file (`ManagedBlobReferenceFile` / collector).
- Keep `blob-descriptor-field` and `blob-view-field` **inline** in the normal data file (scalar only); integrate with `DedicatedFormatWriter` and descriptor/source-table input via `BlobDescriptorReaderFactory` (`blob-descriptor.*`, `blob-descriptor.source-table`).
- Enforce PK BLOB schema constraints (`merge-engine=deduplicate`, `changelog-producer=none`, key usage, inline vs managed field rules) in `schema_manager`.
- Harden write lifecycle: staged-commit ownership/abort, `preserve_blob_files_on_abort` when a `BlobConsumer` retains packs, and stream dynamic-bucket HASH-index refresh across multiple checkpoints (`StreamWriteBuilder` ↔ `with_dynamic_bucket_index()` callback wiring).
**Read path**
- Resolve managed BLOB columns through `managed_blob_convert_record_reader` on raw/merge PK scans; support `blob-as-descriptor` and projected fields.
- Fix v1 `BlobDescriptor` read paths (`from_descriptor_bytes`, descriptor/view inline resolution).
- Extend `BlobViewLookup` for PK `blob-view-field` resolution and resource lifecycle.
**Safety**
- Default managed-BLOB write treats input as **inline bytes** unless `force_descriptor_bytes` (v2 magic or explicit descriptor contract); avoids v1 heuristic false positives on the hot path.
### Test
**New / extended test modules**
- `primary_key_blob_e2e_test.py` — PK managed BLOB E2E: scalar/array/map round-trip, dedup, `.blobref`, source-table copy, close/abort lifecycle
- `primary_key_blob_inline_compat_test.py` — inline `blob-descriptor-field` / `blob-view-field` on PK raw & merge reads, projection, `blob-as-descriptor`, v1 managed resolution
- `primary_key_blob_externalizer_test.py` — externalizer schema preservation, v1 descriptor with `force_descriptor_bytes`, inline collision guard
- `managed_blob_write_ownership_test.py` — staged-commit ownership, abort/close, committer abort preserving shared packs, descriptor reader factory (static / source-table / v1)
- `managed_blob_reference_file_test.py`, `managed_blob_lifecycle_test.py`
- `test_primary_key_blob_read_contract.py` — read routing, `_ConvertedRow.get_blob`, v1 descriptor field, predicate validation
- `test_file_store_write.py` — managed vs inline field routing into writers
- `dynamic_bucket_test.py` — stream writer multi-commit HASH-index refresh (write-before-commit & commit-before-write)
- `blob_test.py`, `blob_table_test.py`, `schema_manager_test.py`, `data_evolution_formats_test.py` — regressions