### PR TITLE
[lance] Reject unsupported element types nested in ARRAY

### DIFF
--- a/paimon-lance/src/main/java/org/apache/paimon/format/lance/LanceFileFormat.java
+++ b/paimon-lance/src/main/java/org/apache/paimon/format/lance/LanceFileFormat.java
@@ -190,7 +190,7 @@ public class LanceFileFormat extends FileFormat {
 
         @Override
         public Void visit(ArrayType arrayType) {
-            return null;
+            return arrayType.getElementType().accept(this);
         }
 
         @Override

--- a/paimon-lance/src/test/java/org/apache/paimon/format/lance/LanceFileFormatTest.java
+++ b/paimon-lance/src/test/java/org/apache/paimon/format/lance/LanceFileFormatTest.java
@@ -64,6 +64,22 @@ public class LanceFileFormatTest {
     }
 
     @Test
+    public void testValidateDataFields_UnsupportedTypeNestedInArray() {
+        LanceFileFormat format =
+                new LanceFileFormat(new FileFormatFactory.FormatContext(new Options(), 1024, 1024));
+        RowType rowType = RowType.of(DataTypes.ARRAY(DataTypes.MULTISET(DataTypes.STRING())));
+        assertThrows(UnsupportedOperationException.class, () -> format.validateDataFields(rowType));
+    }
+
+    @Test
+    public void testValidateDataFields_SupportedTypeNestedInArray() {
+        LanceFileFormat format =
+                new LanceFileFormat(new FileFormatFactory.FormatContext(new Options(), 1024, 1024));
+        RowType rowType = RowType.of(DataTypes.ARRAY(DataTypes.ARRAY(DataTypes.INT())));
+        assertDoesNotThrow(() -> format.validateDataFields(rowType));
+    }
+
+    @Test
     public void testValidateDataFields_SupportedTypes() {
         LanceFileFormat format =
                 new LanceFileFormat(new FileFormatFactory.FormatContext(new Options(), 1024, 1024));


### PR DESCRIPTION
### Purpose

`LanceRowTypeVisitor.visit(ArrayType)` returned without checking the element type, so
`MULTISET` / `MAP` / `LOCAL_ZONED_TIMESTAMP` passed `validateDataFields` when nested in an
`ARRAY`, even though the visitor rejects them at the top level and recurses through `ROW`.
`ARRAY<MULTISET<...>>` then failed at write time in
`ArrowFieldTypeConversion.visit(MultisetType)` instead of at `CREATE TABLE`.

Recurse into the element type, same as `VortexFileFormat` (#8690) and `MosaicFileFormat`.

### Tests

`LanceFileFormatTest` — added a rejecting case for `ARRAY<MULTISET<STRING>>` and kept
`ARRAY<ARRAY<INT>>` passing. 7/7 pass; both fail without the fix.
