### PR TITLE
[mosaic] Reject TIMESTAMP with precision 0 in schema validation

### DIFF
--- a/paimon-mosaic/src/main/java/org/apache/paimon/format/mosaic/MosaicFileFormat.java
+++ b/paimon-mosaic/src/main/java/org/apache/paimon/format/mosaic/MosaicFileFormat.java
@@ -187,12 +187,29 @@ public class MosaicFileFormat extends FileFormat {
 
         @Override
         public Void visit(TimestampType timestampType) {
+            checkTimestampPrecision(timestampType.getPrecision(), "TIMESTAMP");
             return null;
         }
 
         @Override
         public Void visit(LocalZonedTimestampType localZonedTimestampType) {
+            checkTimestampPrecision(localZonedTimestampType.getPrecision(), "TIMESTAMP_LTZ");
             return null;
+        }
+
+        /**
+         * Precision 0 maps to Arrow {@code TimeUnit.SECOND}, which the mosaic native writer rejects
+         * with "unsupported Timestamp unit: Second". Reject it here so the failure surfaces at
+         * schema validation instead of at write time.
+         */
+        private void checkTimestampPrecision(int precision, String typeName) {
+            if (precision == 0) {
+                throw new UnsupportedOperationException(
+                        String.format(
+                                "Mosaic file format does not support type %s with precision 0, "
+                                        + "please use a precision between 1 and 9.",
+                                typeName));
+            }
         }
 
         @Override

--- a/paimon-mosaic/src/test/java/org/apache/paimon/format/mosaic/MosaicFileFormatTest.java
+++ b/paimon-mosaic/src/test/java/org/apache/paimon/format/mosaic/MosaicFileFormatTest.java
@@ -99,6 +99,35 @@ class MosaicFileFormatTest {
     }
 
     @Test
+    void testValidateDataFieldsTimestampPrecisionZeroUnsupported() {
+        MosaicFileFormat format = createFormat();
+        assertThatThrownBy(() -> format.validateDataFields(DataTypes.ROW(DataTypes.TIMESTAMP(0))))
+                .isInstanceOf(UnsupportedOperationException.class)
+                .hasMessageContaining("TIMESTAMP with precision 0");
+    }
+
+    @Test
+    void testValidateDataFieldsLocalZonedTimestampPrecisionZeroUnsupported() {
+        MosaicFileFormat format = createFormat();
+        assertThatThrownBy(
+                        () ->
+                                format.validateDataFields(
+                                        DataTypes.ROW(DataTypes.TIMESTAMP_WITH_LOCAL_TIME_ZONE(0))))
+                .isInstanceOf(UnsupportedOperationException.class)
+                .hasMessageContaining("TIMESTAMP_LTZ with precision 0");
+    }
+
+    @Test
+    void testValidateDataFieldsTimestampPrecisionSupported() {
+        MosaicFileFormat format = createFormat();
+        for (int precision = 1; precision <= 9; precision++) {
+            format.validateDataFields(DataTypes.ROW(DataTypes.TIMESTAMP(precision)));
+            format.validateDataFields(
+                    DataTypes.ROW(DataTypes.TIMESTAMP_WITH_LOCAL_TIME_ZONE(precision)));
+        }
+    }
+
+    @Test
     void testValidateDataFieldsMultisetUnsupported() {
         MosaicFileFormat format = createFormat();
         RowType rowType = DataTypes.ROW(DataTypes.MULTISET(DataTypes.STRING()));


### PR DESCRIPTION
### Purpose

`MosaicRowTypeVisitor` accepted every timestamp precision, but precision 0 maps to Arrow
`TimeUnit.SECOND` (`ArrowFieldTypeConversion#getTimeUnit`), which the mosaic native writer
rejects. `CREATE TABLE t (ts TIMESTAMP(0)) WITH ('file.format' = 'mosaic')` succeeded and the
first `INSERT` failed with `RuntimeException: failed to open writer` and a null cause — the
real reason ("unsupported Timestamp unit: Second") only reached stderr from native code.

MySQL `DATETIME`/`TIMESTAMP` without an explicit length maps to `TIMESTAMP(0)`
(`MySqlTypeUtils`), so a CDC-synced table hits this by default.

Reject precision 0 at schema validation, as `LanceFileFormat` does for
`LOCAL_ZONED_TIMESTAMP`.

### Tests

`MosaicFileFormatTest` — added rejecting cases for `TIMESTAMP(0)` and `TIMESTAMP_LTZ(0)`, plus
a positive case over precisions 1-9. 12/12 pass; both negatives fail without the fix.
