### PR TITLE
[core] Fix stale default value in sort-compaction.range-strategy description

### DIFF
--- a/docs/generated/core_configuration.html
+++ b/docs/generated/core_configuration.html
@@ -1612,8 +1612,8 @@ For an internal format table in a REST catalog, it also makes the catalog own th
             <td><h5>sort-compaction.range-strategy</h5></td>
             <td style="word-wrap: break-word;">SIZE</td>
             <td><p>Enum</p></td>
-            <td>The range strategy of sort compaction, the default value is quantity.
-If the data size allocated for the sorting task is uneven,which may lead to performance bottlenecks, the config can be set to size.<br /><br />Possible values:<ul><li>"SIZE"</li><li>"QUANTITY"</li></ul></td>
+            <td>The range strategy of sort compaction, the default value is size.
+The size strategy ranges by the data size allocated to each sorting task, which avoids the performance bottlenecks caused by uneven data size. The config can be set to quantity to range by the number of rows instead.<br /><br />Possible values:<ul><li>"SIZE"</li><li>"QUANTITY"</li></ul></td>
         </tr>
         <tr>
             <td><h5>sort-engine</h5></td>

--- a/paimon-api/src/main/java/org/apache/paimon/CoreOptions.java
+++ b/paimon-api/src/main/java/org/apache/paimon/CoreOptions.java
@@ -2166,9 +2166,10 @@ public class CoreOptions implements Serializable {
                     .enumType(RangeStrategy.class)
                     .defaultValue(RangeStrategy.SIZE)
                     .withDescription(
-                            "The range strategy of sort compaction, the default value is quantity.\n"
-                                    + "If the data size allocated for the sorting task is uneven,which may lead to performance bottlenecks, "
-                                    + "the config can be set to size.");
+                            "The range strategy of sort compaction, the default value is size.\n"
+                                    + "The size strategy ranges by the data size allocated to each sorting task, which avoids "
+                                    + "the performance bottlenecks caused by uneven data size. "
+                                    + "The config can be set to quantity to range by the number of rows instead.");
 
     public static final ConfigOption<Integer> SORT_COMPACTION_SAMPLE_MAGNIFICATION =
             key("sort-compaction.local-sample.magnification")


### PR DESCRIPTION
### Purpose

`sort-compaction.range-strategy` describes itself as "the default value is quantity", but
#6826 changed `defaultValue` to `RangeStrategy.SIZE`. The generated docs render both, so the
Default column says `SIZE` while the description says quantity.

Reworded the description to match, and rewrote the second sentence which described the old
default as the opt-in. Regenerated `core_configuration.html`.

### Tests

`ConfigOptionsDocsCompletenessITCase` — passes; fails if the generated html is left stale.
