### PR TITLE
[core] Use radix sort in binary external sort buffer

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/operation/ManifestEntryExternalSort.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/ManifestEntryExternalSort.java
@@ -211,7 +211,7 @@ public class ManifestEntryExternalSort {
                             : config.ioManager;
             this.ownedIOManager = config.ioManager == null;
             this.sortBuffer =
-                    BinaryExternalSortBuffer.createWithRadixSort(
+                    BinaryExternalSortBuffer.create(
                             ioManager,
                             sortKey.externalSortRowType(),
                             sortKey.externalSortKeyFields(),

--- a/paimon-core/src/main/java/org/apache/paimon/operation/ManifestEntryExternalSort.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/ManifestEntryExternalSort.java
@@ -211,7 +211,7 @@ public class ManifestEntryExternalSort {
                             : config.ioManager;
             this.ownedIOManager = config.ioManager == null;
             this.sortBuffer =
-                    BinaryExternalSortBuffer.create(
+                    BinaryExternalSortBuffer.createWithRadixSort(
                             ioManager,
                             sortKey.externalSortRowType(),
                             sortKey.externalSortKeyFields(),

--- a/paimon-core/src/main/java/org/apache/paimon/sort/BinaryExternalSortBuffer.java
+++ b/paimon-core/src/main/java/org/apache/paimon/sort/BinaryExternalSortBuffer.java
@@ -54,6 +54,7 @@ public class BinaryExternalSortBuffer implements SortBuffer {
     private final BlockCompressionFactory compressionCodecFactory;
     private final int compressionBlockSize;
     private final BinaryExternalMerger merger;
+    private final IndexedSorter inMemorySorter;
 
     private final FileIOChannel.Enumerator enumerator;
     private final List<ChannelWithMeta> spillChannelIDs;
@@ -70,6 +71,28 @@ public class BinaryExternalSortBuffer implements SortBuffer {
             int maxNumFileHandles,
             CompressOptions compression,
             MemorySize maxDiskSize) {
+        this(
+                serializer,
+                comparator,
+                pageSize,
+                inMemorySortBuffer,
+                ioManager,
+                maxNumFileHandles,
+                compression,
+                maxDiskSize,
+                new QuickSort());
+    }
+
+    BinaryExternalSortBuffer(
+            BinaryRowSerializer serializer,
+            RecordComparator comparator,
+            int pageSize,
+            BinaryInMemorySortBuffer inMemorySortBuffer,
+            IOManager ioManager,
+            int maxNumFileHandles,
+            CompressOptions compression,
+            MemorySize maxDiskSize,
+            IndexedSorter inMemorySorter) {
         this.serializer = serializer;
         this.inMemorySortBuffer = inMemorySortBuffer;
         this.ioManager = ioManager;
@@ -78,6 +101,7 @@ public class BinaryExternalSortBuffer implements SortBuffer {
         this.compressionCodecFactory = BlockCompressionFactory.create(compression);
         this.compressionBlockSize = (int) MemorySize.parse("64 kb").getBytes();
         this.maxDiskSize = maxDiskSize;
+        this.inMemorySorter = inMemorySorter;
         this.merger =
                 new BinaryExternalMerger(
                         ioManager,
@@ -101,6 +125,50 @@ public class BinaryExternalSortBuffer implements SortBuffer {
             int maxNumFileHandles,
             CompressOptions compression,
             MemorySize maxDiskSize) {
+        return create(
+                ioManager,
+                rowType,
+                keyFields,
+                bufferSize,
+                pageSize,
+                maxNumFileHandles,
+                compression,
+                maxDiskSize,
+                new QuickSort());
+    }
+
+    /** Creates a buffer which radix sorts each in-memory run by its generated normalized key. */
+    public static BinaryExternalSortBuffer createWithRadixSort(
+            IOManager ioManager,
+            RowType rowType,
+            int[] keyFields,
+            long bufferSize,
+            int pageSize,
+            int maxNumFileHandles,
+            CompressOptions compression,
+            MemorySize maxDiskSize) {
+        return create(
+                ioManager,
+                rowType,
+                keyFields,
+                bufferSize,
+                pageSize,
+                maxNumFileHandles,
+                compression,
+                maxDiskSize,
+                new NormalizedKeyRadixSort());
+    }
+
+    private static BinaryExternalSortBuffer create(
+            IOManager ioManager,
+            RowType rowType,
+            int[] keyFields,
+            long bufferSize,
+            int pageSize,
+            int maxNumFileHandles,
+            CompressOptions compression,
+            MemorySize maxDiskSize,
+            IndexedSorter inMemorySorter) {
         RecordComparator comparator = newRecordComparator(rowType.getFieldTypes(), keyFields);
         HeapMemorySegmentPool pool = new HeapMemorySegmentPool(bufferSize, pageSize);
         BinaryInMemorySortBuffer sortBuffer =
@@ -117,7 +185,8 @@ public class BinaryExternalSortBuffer implements SortBuffer {
                 ioManager,
                 maxNumFileHandles,
                 compression,
-                maxDiskSize);
+                maxDiskSize,
+                inMemorySorter);
     }
 
     @Override
@@ -209,7 +278,7 @@ public class BinaryExternalSortBuffer implements SortBuffer {
     @Override
     public final MutableObjectIterator<BinaryRow> sortedIterator() throws IOException {
         if (spillChannelIDs.isEmpty()) {
-            return inMemorySortBuffer.sortedIterator();
+            return inMemorySortBuffer.sortedIterator(inMemorySorter);
         }
         return spilledIterator();
     }
@@ -254,7 +323,7 @@ public class BinaryExternalSortBuffer implements SortBuffer {
             output =
                     FileChannelUtil.createOutputView(
                             ioManager, channel, compressionCodecFactory, compressionBlockSize);
-            new QuickSort().sort(inMemorySortBuffer);
+            inMemorySorter.sort(inMemorySortBuffer);
             inMemorySortBuffer.writeToOutput(output);
             output.close();
             blockCount = output.getBlockCount();

--- a/paimon-core/src/main/java/org/apache/paimon/sort/BinaryExternalSortBuffer.java
+++ b/paimon-core/src/main/java/org/apache/paimon/sort/BinaryExternalSortBuffer.java
@@ -71,28 +71,6 @@ public class BinaryExternalSortBuffer implements SortBuffer {
             int maxNumFileHandles,
             CompressOptions compression,
             MemorySize maxDiskSize) {
-        this(
-                serializer,
-                comparator,
-                pageSize,
-                inMemorySortBuffer,
-                ioManager,
-                maxNumFileHandles,
-                compression,
-                maxDiskSize,
-                new QuickSort());
-    }
-
-    BinaryExternalSortBuffer(
-            BinaryRowSerializer serializer,
-            RecordComparator comparator,
-            int pageSize,
-            BinaryInMemorySortBuffer inMemorySortBuffer,
-            IOManager ioManager,
-            int maxNumFileHandles,
-            CompressOptions compression,
-            MemorySize maxDiskSize,
-            IndexedSorter inMemorySorter) {
         this.serializer = serializer;
         this.inMemorySortBuffer = inMemorySortBuffer;
         this.ioManager = ioManager;
@@ -101,7 +79,7 @@ public class BinaryExternalSortBuffer implements SortBuffer {
         this.compressionCodecFactory = BlockCompressionFactory.create(compression);
         this.compressionBlockSize = (int) MemorySize.parse("64 kb").getBytes();
         this.maxDiskSize = maxDiskSize;
-        this.inMemorySorter = inMemorySorter;
+        this.inMemorySorter = new NormalizedKeyRadixSort();
         this.merger =
                 new BinaryExternalMerger(
                         ioManager,
@@ -125,50 +103,6 @@ public class BinaryExternalSortBuffer implements SortBuffer {
             int maxNumFileHandles,
             CompressOptions compression,
             MemorySize maxDiskSize) {
-        return create(
-                ioManager,
-                rowType,
-                keyFields,
-                bufferSize,
-                pageSize,
-                maxNumFileHandles,
-                compression,
-                maxDiskSize,
-                new QuickSort());
-    }
-
-    /** Creates a buffer which radix sorts each in-memory run by its generated normalized key. */
-    public static BinaryExternalSortBuffer createWithRadixSort(
-            IOManager ioManager,
-            RowType rowType,
-            int[] keyFields,
-            long bufferSize,
-            int pageSize,
-            int maxNumFileHandles,
-            CompressOptions compression,
-            MemorySize maxDiskSize) {
-        return create(
-                ioManager,
-                rowType,
-                keyFields,
-                bufferSize,
-                pageSize,
-                maxNumFileHandles,
-                compression,
-                maxDiskSize,
-                new NormalizedKeyRadixSort());
-    }
-
-    private static BinaryExternalSortBuffer create(
-            IOManager ioManager,
-            RowType rowType,
-            int[] keyFields,
-            long bufferSize,
-            int pageSize,
-            int maxNumFileHandles,
-            CompressOptions compression,
-            MemorySize maxDiskSize,
-            IndexedSorter inMemorySorter) {
         RecordComparator comparator = newRecordComparator(rowType.getFieldTypes(), keyFields);
         HeapMemorySegmentPool pool = new HeapMemorySegmentPool(bufferSize, pageSize);
         BinaryInMemorySortBuffer sortBuffer =
@@ -185,8 +119,7 @@ public class BinaryExternalSortBuffer implements SortBuffer {
                 ioManager,
                 maxNumFileHandles,
                 compression,
-                maxDiskSize,
-                inMemorySorter);
+                maxDiskSize);
     }
 
     @Override

--- a/paimon-core/src/main/java/org/apache/paimon/sort/BinaryExternalSortBuffer.java
+++ b/paimon-core/src/main/java/org/apache/paimon/sort/BinaryExternalSortBuffer.java
@@ -54,7 +54,6 @@ public class BinaryExternalSortBuffer implements SortBuffer {
     private final BlockCompressionFactory compressionCodecFactory;
     private final int compressionBlockSize;
     private final BinaryExternalMerger merger;
-    private final IndexedSorter inMemorySorter;
 
     private final FileIOChannel.Enumerator enumerator;
     private final List<ChannelWithMeta> spillChannelIDs;
@@ -79,7 +78,6 @@ public class BinaryExternalSortBuffer implements SortBuffer {
         this.compressionCodecFactory = BlockCompressionFactory.create(compression);
         this.compressionBlockSize = (int) MemorySize.parse("64 kb").getBytes();
         this.maxDiskSize = maxDiskSize;
-        this.inMemorySorter = new NormalizedKeyRadixSort();
         this.merger =
                 new BinaryExternalMerger(
                         ioManager,
@@ -211,7 +209,7 @@ public class BinaryExternalSortBuffer implements SortBuffer {
     @Override
     public final MutableObjectIterator<BinaryRow> sortedIterator() throws IOException {
         if (spillChannelIDs.isEmpty()) {
-            return inMemorySortBuffer.sortedIterator(inMemorySorter);
+            return inMemorySortBuffer.sortedIterator();
         }
         return spilledIterator();
     }
@@ -256,7 +254,7 @@ public class BinaryExternalSortBuffer implements SortBuffer {
             output =
                     FileChannelUtil.createOutputView(
                             ioManager, channel, compressionCodecFactory, compressionBlockSize);
-            inMemorySorter.sort(inMemorySortBuffer);
+            inMemorySortBuffer.sort();
             inMemorySortBuffer.writeToOutput(output);
             output.close();
             blockCount = output.getBlockCount();

--- a/paimon-core/src/main/java/org/apache/paimon/sort/BinaryInMemorySortBuffer.java
+++ b/paimon-core/src/main/java/org/apache/paimon/sort/BinaryInMemorySortBuffer.java
@@ -245,8 +245,12 @@ public class BinaryInMemorySortBuffer extends BinaryIndexedSortable implements S
 
     @Override
     public final MutableObjectIterator<BinaryRow> sortedIterator() {
+        return sortedIterator(new QuickSort());
+    }
+
+    final MutableObjectIterator<BinaryRow> sortedIterator(IndexedSorter sorter) {
         if (numRecords > 0) {
-            new QuickSort().sort(this);
+            sorter.sort(this);
         }
         return iterator();
     }

--- a/paimon-core/src/main/java/org/apache/paimon/sort/BinaryInMemorySortBuffer.java
+++ b/paimon-core/src/main/java/org/apache/paimon/sort/BinaryInMemorySortBuffer.java
@@ -46,6 +46,7 @@ import static org.apache.paimon.utils.Preconditions.checkArgument;
 public class BinaryInMemorySortBuffer extends BinaryIndexedSortable implements SortBuffer {
 
     private static final int MIN_REQUIRED_BUFFERS = 3;
+    private static final IndexedSorter SORTER = new NormalizedKeyRadixSort();
 
     private final AbstractRowDataSerializer<InternalRow> inputSerializer;
     private final ArrayList<MemorySegment> recordBufferSegments;
@@ -245,13 +246,13 @@ public class BinaryInMemorySortBuffer extends BinaryIndexedSortable implements S
 
     @Override
     public final MutableObjectIterator<BinaryRow> sortedIterator() {
-        return sortedIterator(new QuickSort());
+        sort();
+        return iterator();
     }
 
-    final MutableObjectIterator<BinaryRow> sortedIterator(IndexedSorter sorter) {
+    void sort() {
         if (numRecords > 0) {
-            sorter.sort(this);
+            SORTER.sort(this);
         }
-        return iterator();
     }
 }

--- a/paimon-core/src/main/java/org/apache/paimon/sort/BinaryIndexedSortable.java
+++ b/paimon-core/src/main/java/org/apache/paimon/sort/BinaryIndexedSortable.java
@@ -175,6 +175,23 @@ public abstract class BinaryIndexedSortable implements IndexedSortable {
         return compareRecords(pointerI, pointerJ);
     }
 
+    int normalizedKeyBytes() {
+        return numKeyBytes;
+    }
+
+    boolean normalizedKeyFullyDetermines() {
+        return normalizedKeyFullyDetermines;
+    }
+
+    int normalizedKeyByte(int index, int physicalKeyOffset) {
+        final int segmentNumber = index / this.indexEntriesPerSegment;
+        final int segmentOffset = (index % this.indexEntriesPerSegment) * this.indexEntrySize;
+        int value =
+                sortIndex.get(segmentNumber).get(segmentOffset + OFFSET_LEN + physicalKeyOffset)
+                        & 0xFF;
+        return useNormKeyUninverted ? value : 0xFF - value;
+    }
+
     private int compareRecords(long pointer1, long pointer2) {
         this.recordBuffer.setReadPosition(pointer1);
         this.recordBufferForComparison.setReadPosition(pointer2);

--- a/paimon-core/src/main/java/org/apache/paimon/sort/NormalizedKeyRadixSort.java
+++ b/paimon-core/src/main/java/org/apache/paimon/sort/NormalizedKeyRadixSort.java
@@ -1,0 +1,140 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.sort;
+
+import org.apache.paimon.data.BinaryRow;
+
+import java.util.Arrays;
+
+/** In-place MSD radix sort for binary sort-buffer normalized keys. */
+final class NormalizedKeyRadixSort implements IndexedSorter {
+
+    private static final int MIN_RADIX_SIZE = 1 << 10;
+    private static final int RADIX_BUCKETS = 1 << 8;
+    private static final QuickSort FALLBACK = new QuickSort();
+
+    @Override
+    public void sort(IndexedSortable sortable) {
+        sort(sortable, 0, sortable.size());
+    }
+
+    @Override
+    public void sort(IndexedSortable sortable, int from, int to) {
+        int size = to - from;
+        if (!(sortable instanceof BinaryIndexedSortable) || size < MIN_RADIX_SIZE) {
+            FALLBACK.sort(sortable, from, to);
+            return;
+        }
+
+        BinaryIndexedSortable binary = (BinaryIndexedSortable) sortable;
+        int keyBytes = binary.normalizedKeyBytes();
+        if (keyBytes == 0) {
+            FALLBACK.sort(sortable, from, to);
+            return;
+        }
+
+        int[][] counts = new int[keyBytes][RADIX_BUCKETS];
+        int[][] starts = new int[keyBytes][RADIX_BUCKETS];
+        radixSort(binary, from, to, 0, physicalKeyOffsets(keyBytes), counts, starts);
+    }
+
+    private static void radixSort(
+            BinaryIndexedSortable sortable,
+            int from,
+            int to,
+            int keyOffset,
+            int[] physicalKeyOffsets,
+            int[][] countsByDepth,
+            int[][] startsByDepth) {
+        if (to - from < MIN_RADIX_SIZE) {
+            FALLBACK.sort(sortable, from, to);
+            return;
+        }
+        if (keyOffset == sortable.normalizedKeyBytes()) {
+            // A partial normalized key only narrows the final comparator work to equal prefixes.
+            if (!sortable.normalizedKeyFullyDetermines()) {
+                FALLBACK.sort(sortable, from, to);
+            }
+            return;
+        }
+
+        int[] counts = countsByDepth[keyOffset];
+        int[] starts = startsByDepth[keyOffset];
+        Arrays.fill(counts, 0);
+        for (int position = from; position < to; position++) {
+            counts[sortable.normalizedKeyByte(position, physicalKeyOffsets[keyOffset])]++;
+        }
+
+        int position = from;
+        for (int bucket = 0; bucket < RADIX_BUCKETS; bucket++) {
+            int bucketSize = counts[bucket];
+            starts[bucket] = position;
+            position += bucketSize;
+            counts[bucket] = position;
+        }
+
+        for (int bucket = 0; bucket < RADIX_BUCKETS; bucket++) {
+            int bucketEnd = counts[bucket];
+            int current = starts[bucket];
+            while (current < bucketEnd) {
+                int targetBucket =
+                        sortable.normalizedKeyByte(current, physicalKeyOffsets[keyOffset]);
+                if (targetBucket == bucket) {
+                    current++;
+                } else {
+                    sortable.swap(current, starts[targetBucket]++);
+                }
+            }
+        }
+
+        position = from;
+        for (int bucket = 0; bucket < RADIX_BUCKETS; bucket++) {
+            int bucketEnd = counts[bucket];
+            int bucketSize = bucketEnd - position;
+            if (bucketSize > 1) {
+                radixSort(
+                        sortable,
+                        position,
+                        bucketEnd,
+                        keyOffset + 1,
+                        physicalKeyOffsets,
+                        countsByDepth,
+                        startsByDepth);
+            }
+            position = bucketEnd;
+        }
+    }
+
+    private static int[] physicalKeyOffsets(int keyBytes) {
+        int[] offsets = new int[keyBytes];
+        int chunkStart = 0;
+        int remaining = keyBytes;
+        while (remaining > 0) {
+            // Generated normalized keys use native-endian chunks of 8, 4, 2, or 1 byte.
+            int chunkSize = remaining >= 8 ? 8 : remaining >= 4 ? 4 : remaining >= 2 ? 2 : 1;
+            for (int i = 0; i < chunkSize; i++) {
+                offsets[chunkStart + i] =
+                        BinaryRow.LITTLE_ENDIAN ? chunkStart + chunkSize - i - 1 : chunkStart + i;
+            }
+            chunkStart += chunkSize;
+            remaining -= chunkSize;
+        }
+        return offsets;
+    }
+}

--- a/paimon-core/src/test/java/org/apache/paimon/manifest/ManifestFileMetaTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/manifest/ManifestFileMetaTest.java
@@ -1210,6 +1210,67 @@ public class ManifestFileMetaTest extends ManifestFileMetaTestBase {
     }
 
     @Test
+    public void testLargeManifestSortEliminatesDeletesAndPreservesOrder() {
+        int addCount = 4_096;
+        int inputManifestCount = 8;
+        List<ManifestFileMeta> input = new ArrayList<>();
+        Set<String> expectedFileNames = new HashSet<>();
+
+        for (int manifest = 0; manifest < inputManifestCount; manifest++) {
+            List<ManifestEntry> entries = new ArrayList<>();
+            for (int id = manifest; id < addCount; id += inputManifestCount) {
+                String fileName = String.format("large-manifest-entry-%08d.parquet", id);
+                entries.add(makeEntry(true, fileName, Math.floorMod(id * 104_729, 97)));
+                expectedFileNames.add(fileName);
+            }
+            input.add(makeManifest(entries.toArray(new ManifestEntry[0])));
+        }
+
+        List<ManifestEntry> deletes = new ArrayList<>();
+        for (int id = 0; id < addCount; id += 7) {
+            String fileName = String.format("large-manifest-entry-%08d.parquet", id);
+            deletes.add(makeEntry(false, fileName, Math.floorMod(id * 104_729, 97)));
+            expectedFileNames.remove(fileName);
+        }
+        input.add(makeManifest(deletes.toArray(new ManifestEntry[0])));
+
+        Options testOptions = new Options();
+        testOptions.set("manifest-sort.enabled", "true");
+        testOptions.set("manifest.target-file-size", "64kb");
+        testOptions.set("manifest.full-compaction-threshold-size", "1B");
+        testOptions.set("manifest-sort.max-rewrite-size", Long.MAX_VALUE + "B");
+        testOptions.set("sort-spill-buffer-size", "64mb");
+
+        List<ManifestFileMeta> merged =
+                ManifestFileMerger.merge(
+                        input,
+                        manifestFile,
+                        getPartitionType(),
+                        CoreOptions.fromMap(testOptions.toMap()));
+
+        assertEquivalentEntries(input, merged);
+        List<ManifestEntry> outputEntries = readEntries(merged);
+        assertThat(outputEntries).hasSize(expectedFileNames.size());
+        assertThat(outputEntries).allMatch(entry -> entry.kind() == FileKind.ADD);
+        assertThat(
+                        outputEntries.stream()
+                                .map(entry -> entry.file().fileName())
+                                .collect(Collectors.toSet()))
+                .isEqualTo(expectedFileNames);
+
+        for (int i = 1; i < outputEntries.size(); i++) {
+            ManifestEntry previous = outputEntries.get(i - 1);
+            ManifestEntry current = outputEntries.get(i);
+            int comparison =
+                    Integer.compare(previous.partition().getInt(0), current.partition().getInt(0));
+            if (comparison == 0) {
+                comparison = previous.file().fileName().compareTo(current.file().fileName());
+            }
+            assertThat(comparison).isLessThanOrEqualTo(0);
+        }
+    }
+
+    @Test
     public void testDataEvolutionManifestSortByPartitionAndRowId() {
         List<ManifestFileMeta> input = new ArrayList<>();
 

--- a/paimon-core/src/test/java/org/apache/paimon/sort/NormalizedKeyRadixSortTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/sort/NormalizedKeyRadixSortTest.java
@@ -1,0 +1,145 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.sort;
+
+import org.apache.paimon.compression.CompressOptions;
+import org.apache.paimon.data.BinaryRow;
+import org.apache.paimon.data.BinaryRowWriter;
+import org.apache.paimon.data.BinaryString;
+import org.apache.paimon.disk.IOManager;
+import org.apache.paimon.memory.MemorySegmentPool;
+import org.apache.paimon.options.MemorySize;
+import org.apache.paimon.types.IntType;
+import org.apache.paimon.types.RowType;
+import org.apache.paimon.types.VarCharType;
+import org.apache.paimon.utils.MutableObjectIterator;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Random;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Tests for {@link NormalizedKeyRadixSort}. */
+class NormalizedKeyRadixSortTest {
+
+    @TempDir Path tempDir;
+
+    @Test
+    void testFullyDeterminedKey() throws Exception {
+        List<TestRecord> records = records(10_000, false, false);
+        assertSorted(
+                records, new int[] {0}, Comparator.comparingInt(record -> record.key), 32L << 20);
+    }
+
+    @Test
+    void testPartialKeyAndNulls() throws Exception {
+        List<TestRecord> records = records(10_000, true, true);
+        assertSorted(records, new int[] {0, 1}, recordComparator(), 32L << 20);
+    }
+
+    @Test
+    void testSpilledRuns() throws Exception {
+        List<TestRecord> records = records(20_000, true, false);
+        assertSorted(records, new int[] {0, 1}, recordComparator(), 256L << 10);
+    }
+
+    private void assertSorted(
+            List<TestRecord> records,
+            int[] keyFields,
+            Comparator<TestRecord> expectedComparator,
+            long memorySize)
+            throws Exception {
+        List<TestRecord> expected = new ArrayList<>(records);
+        expected.sort(expectedComparator);
+        Collections.shuffle(records, new Random(42));
+
+        IOManager ioManager = IOManager.create(tempDir.toString());
+        BinaryExternalSortBuffer sorter =
+                BinaryExternalSortBuffer.createWithRadixSort(
+                        ioManager,
+                        RowType.of(new IntType(), new VarCharType()),
+                        keyFields,
+                        memorySize,
+                        MemorySegmentPool.DEFAULT_PAGE_SIZE,
+                        128,
+                        CompressOptions.defaultOptions(),
+                        MemorySize.MAX_VALUE);
+        try {
+            BinaryRow row = new BinaryRow(2);
+            BinaryRowWriter writer = new BinaryRowWriter(row);
+            for (TestRecord record : records) {
+                writer.reset();
+                writer.writeInt(0, record.key);
+                if (record.value == null) {
+                    writer.setNullAt(1);
+                } else {
+                    writer.writeString(1, BinaryString.fromString(record.value));
+                }
+                writer.complete();
+                sorter.write(row);
+            }
+
+            MutableObjectIterator<BinaryRow> iterator = sorter.sortedIterator();
+            BinaryRow reuse = new BinaryRow(2);
+            for (TestRecord record : expected) {
+                reuse = iterator.next(reuse);
+                assertThat(reuse.getInt(0)).isEqualTo(record.key);
+                assertThat(reuse.isNullAt(1) ? null : reuse.getString(1).toString())
+                        .isEqualTo(record.value);
+            }
+            assertThat(iterator.next(reuse)).isNull();
+        } finally {
+            sorter.clear();
+            ioManager.close();
+        }
+    }
+
+    private static Comparator<TestRecord> recordComparator() {
+        return Comparator.comparingInt((TestRecord record) -> record.key)
+                .thenComparing(
+                        record -> record.value, Comparator.nullsFirst(Comparator.naturalOrder()));
+    }
+
+    private static List<TestRecord> records(int size, boolean repeatedKeys, boolean withNulls) {
+        List<TestRecord> records = new ArrayList<>(size);
+        for (int i = 0; i < size; i++) {
+            int key = repeatedKeys ? i % 37 : i - size / 2;
+            String value = withNulls && i % 17 == 0 ? null : String.format("value-%08d", size - i);
+            records.add(new TestRecord(key, value));
+        }
+        return records;
+    }
+
+    private static class TestRecord {
+        private final int key;
+        private final String value;
+
+        private TestRecord(int key, String value) {
+            this.key = key;
+            this.value = value;
+        }
+    }
+}

--- a/paimon-core/src/test/java/org/apache/paimon/sort/NormalizedKeyRadixSortTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/sort/NormalizedKeyRadixSortTest.java
@@ -24,9 +24,7 @@ import org.apache.paimon.data.BinaryString;
 import org.apache.paimon.data.Decimal;
 import org.apache.paimon.data.GenericRow;
 import org.apache.paimon.data.Timestamp;
-import org.apache.paimon.data.serializer.InternalRowSerializer;
 import org.apache.paimon.disk.IOManager;
-import org.apache.paimon.memory.HeapMemorySegmentPool;
 import org.apache.paimon.memory.MemorySegmentPool;
 import org.apache.paimon.options.MemorySize;
 import org.apache.paimon.types.BigIntType;
@@ -62,7 +60,6 @@ import java.util.Random;
 import java.util.function.IntFunction;
 import java.util.stream.Stream;
 
-import static org.apache.paimon.codegen.CodeGenUtils.newNormalizedKeyComputer;
 import static org.apache.paimon.codegen.CodeGenUtils.newRecordComparator;
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -75,40 +72,27 @@ class NormalizedKeyRadixSortTest {
 
     @ParameterizedTest(name = "{0}")
     @MethodSource("typeCases")
-    void testMatchesQuickSort(TypeCase typeCase) throws Exception {
+    void testMatchesComparisonSort(TypeCase typeCase) throws Exception {
         List<GenericRow> rows = rows(typeCase, RECORD_COUNT);
-        List<Integer> quickSortResult = sortInMemory(typeCase, rows, new QuickSort(), 32L << 20);
-        assertThat(sortInMemory(typeCase, rows, new NormalizedKeyRadixSort(), 32L << 20))
-                .containsExactlyElementsOf(quickSortResult);
+        assertThat(sortExternal(typeCase, rows, 32L << 20))
+                .containsExactlyElementsOf(sortWithComparator(typeCase, rows));
     }
 
     @Test
-    void testSpilledRunsMatchQuickSort() throws Exception {
+    void testSpilledRunsMatchComparisonSort() throws Exception {
         TypeCase typeCase = stringCase();
         List<GenericRow> rows = rows(typeCase, 20_000);
-        List<Integer> quickSortResult = sortInMemory(typeCase, rows, new QuickSort(), 32L << 20);
         assertThat(sortExternal(typeCase, rows, 256L << 10))
-                .containsExactlyElementsOf(quickSortResult);
+                .containsExactlyElementsOf(sortWithComparator(typeCase, rows));
     }
 
-    private List<Integer> sortInMemory(
-            TypeCase typeCase, List<GenericRow> rows, IndexedSorter sorter, long memorySize)
-            throws Exception {
+    private static List<Integer> sortWithComparator(TypeCase typeCase, List<GenericRow> rows) {
         RowType rowType = RowType.of(typeCase.dataType, new IntType());
-        BinaryInMemorySortBuffer sortBuffer =
-                BinaryInMemorySortBuffer.createBuffer(
-                        newNormalizedKeyComputer(rowType.getFieldTypes(), new int[] {0, 1}),
-                        new InternalRowSerializer(rowType),
-                        newRecordComparator(rowType.getFieldTypes(), new int[] {0, 1}),
-                        new HeapMemorySegmentPool(memorySize, MemorySegmentPool.DEFAULT_PAGE_SIZE));
-        try {
-            for (GenericRow row : rows) {
-                assertThat(sortBuffer.write(row)).isTrue();
-            }
-            return collectIds(sortBuffer.sortedIterator(sorter), rows.size());
-        } finally {
-            sortBuffer.clear();
-        }
+        List<GenericRow> expected = new ArrayList<>(rows);
+        expected.sort(newRecordComparator(rowType.getFieldTypes(), new int[] {0, 1})::compare);
+        List<Integer> result = new ArrayList<>(expected.size());
+        expected.forEach(row -> result.add(row.getInt(1)));
+        return result;
     }
 
     private List<Integer> sortExternal(TypeCase typeCase, List<GenericRow> rows, long memorySize)

--- a/paimon-core/src/test/java/org/apache/paimon/sort/NormalizedKeyRadixSortTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/sort/NormalizedKeyRadixSortTest.java
@@ -24,7 +24,9 @@ import org.apache.paimon.data.BinaryString;
 import org.apache.paimon.data.Decimal;
 import org.apache.paimon.data.GenericRow;
 import org.apache.paimon.data.Timestamp;
+import org.apache.paimon.data.serializer.InternalRowSerializer;
 import org.apache.paimon.disk.IOManager;
+import org.apache.paimon.memory.HeapMemorySegmentPool;
 import org.apache.paimon.memory.MemorySegmentPool;
 import org.apache.paimon.options.MemorySize;
 import org.apache.paimon.types.BigIntType;
@@ -60,6 +62,8 @@ import java.util.Random;
 import java.util.function.IntFunction;
 import java.util.stream.Stream;
 
+import static org.apache.paimon.codegen.CodeGenUtils.newNormalizedKeyComputer;
+import static org.apache.paimon.codegen.CodeGenUtils.newRecordComparator;
 import static org.assertj.core.api.Assertions.assertThat;
 
 /** Tests for {@link NormalizedKeyRadixSort}. */
@@ -73,8 +77,8 @@ class NormalizedKeyRadixSortTest {
     @MethodSource("typeCases")
     void testMatchesQuickSort(TypeCase typeCase) throws Exception {
         List<GenericRow> rows = rows(typeCase, RECORD_COUNT);
-        List<Integer> quickSortResult = sort(typeCase, rows, false, 32L << 20);
-        assertThat(sort(typeCase, rows, true, 32L << 20))
+        List<Integer> quickSortResult = sortInMemory(typeCase, rows, new QuickSort(), 32L << 20);
+        assertThat(sortInMemory(typeCase, rows, new NormalizedKeyRadixSort(), 32L << 20))
                 .containsExactlyElementsOf(quickSortResult);
     }
 
@@ -82,53 +86,65 @@ class NormalizedKeyRadixSortTest {
     void testSpilledRunsMatchQuickSort() throws Exception {
         TypeCase typeCase = stringCase();
         List<GenericRow> rows = rows(typeCase, 20_000);
-        List<Integer> quickSortResult = sort(typeCase, rows, false, 256L << 10);
-        assertThat(sort(typeCase, rows, true, 256L << 10))
+        List<Integer> quickSortResult = sortInMemory(typeCase, rows, new QuickSort(), 32L << 20);
+        assertThat(sortExternal(typeCase, rows, 256L << 10))
                 .containsExactlyElementsOf(quickSortResult);
     }
 
-    private List<Integer> sort(
-            TypeCase typeCase, List<GenericRow> rows, boolean radix, long memorySize)
+    private List<Integer> sortInMemory(
+            TypeCase typeCase, List<GenericRow> rows, IndexedSorter sorter, long memorySize)
             throws Exception {
-        java.nio.file.Path ioPath = tempDir.resolve(typeCase.name + '-' + radix + '-' + memorySize);
+        RowType rowType = RowType.of(typeCase.dataType, new IntType());
+        BinaryInMemorySortBuffer sortBuffer =
+                BinaryInMemorySortBuffer.createBuffer(
+                        newNormalizedKeyComputer(rowType.getFieldTypes(), new int[] {0, 1}),
+                        new InternalRowSerializer(rowType),
+                        newRecordComparator(rowType.getFieldTypes(), new int[] {0, 1}),
+                        new HeapMemorySegmentPool(memorySize, MemorySegmentPool.DEFAULT_PAGE_SIZE));
+        try {
+            for (GenericRow row : rows) {
+                assertThat(sortBuffer.write(row)).isTrue();
+            }
+            return collectIds(sortBuffer.sortedIterator(sorter), rows.size());
+        } finally {
+            sortBuffer.clear();
+        }
+    }
+
+    private List<Integer> sortExternal(TypeCase typeCase, List<GenericRow> rows, long memorySize)
+            throws Exception {
+        java.nio.file.Path ioPath = tempDir.resolve(typeCase.name + '-' + memorySize);
         java.nio.file.Files.createDirectories(ioPath);
         IOManager ioManager = IOManager.create(ioPath.toString());
         BinaryExternalSortBuffer sorter =
-                radix
-                        ? BinaryExternalSortBuffer.createWithRadixSort(
-                                ioManager,
-                                RowType.of(typeCase.dataType, new IntType()),
-                                new int[] {0, 1},
-                                memorySize,
-                                MemorySegmentPool.DEFAULT_PAGE_SIZE,
-                                128,
-                                CompressOptions.defaultOptions(),
-                                MemorySize.MAX_VALUE)
-                        : BinaryExternalSortBuffer.create(
-                                ioManager,
-                                RowType.of(typeCase.dataType, new IntType()),
-                                new int[] {0, 1},
-                                memorySize,
-                                MemorySegmentPool.DEFAULT_PAGE_SIZE,
-                                128,
-                                CompressOptions.defaultOptions(),
-                                MemorySize.MAX_VALUE);
+                BinaryExternalSortBuffer.create(
+                        ioManager,
+                        RowType.of(typeCase.dataType, new IntType()),
+                        new int[] {0, 1},
+                        memorySize,
+                        MemorySegmentPool.DEFAULT_PAGE_SIZE,
+                        128,
+                        CompressOptions.defaultOptions(),
+                        MemorySize.MAX_VALUE);
         try {
             for (GenericRow row : rows) {
                 sorter.write(row);
             }
-
-            List<Integer> result = new ArrayList<>(rows.size());
-            MutableObjectIterator<BinaryRow> iterator = sorter.sortedIterator();
-            BinaryRow reuse = new BinaryRow(2);
-            while ((reuse = iterator.next(reuse)) != null) {
-                result.add(reuse.getInt(1));
-            }
-            return result;
+            return collectIds(sorter.sortedIterator(), rows.size());
         } finally {
             sorter.clear();
             ioManager.close();
         }
+    }
+
+    private static List<Integer> collectIds(
+            MutableObjectIterator<BinaryRow> iterator, int expectedSize) throws Exception {
+        List<Integer> result = new ArrayList<>(expectedSize);
+        BinaryRow reuse = new BinaryRow(2);
+        while ((reuse = iterator.next(reuse)) != null) {
+            result.add(reuse.getInt(1));
+        }
+        return result;
     }
 
     private static List<GenericRow> rows(TypeCase typeCase, int count) {

--- a/paimon-core/src/test/java/org/apache/paimon/sort/NormalizedKeyRadixSortTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/sort/NormalizedKeyRadixSortTest.java
@@ -49,8 +49,6 @@ import org.apache.paimon.utils.MutableObjectIterator;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.MethodSource;
 
 import java.nio.file.Path;
 import java.util.ArrayList;
@@ -58,7 +56,6 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Random;
 import java.util.function.IntFunction;
-import java.util.stream.Stream;
 
 import static org.apache.paimon.codegen.CodeGenUtils.newRecordComparator;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -70,20 +67,20 @@ class NormalizedKeyRadixSortTest {
 
     @TempDir Path tempDir;
 
-    @ParameterizedTest(name = "{0}")
-    @MethodSource("typeCases")
-    void testMatchesComparisonSort(TypeCase typeCase) throws Exception {
-        List<GenericRow> rows = rows(typeCase, RECORD_COUNT);
-        assertThat(sortExternal(typeCase, rows, 32L << 20))
-                .containsExactlyElementsOf(sortWithComparator(typeCase, rows));
-    }
-
     @Test
-    void testSpilledRunsMatchComparisonSort() throws Exception {
-        TypeCase typeCase = stringCase();
-        List<GenericRow> rows = rows(typeCase, 20_000);
-        assertThat(sortExternal(typeCase, rows, 256L << 10))
-                .containsExactlyElementsOf(sortWithComparator(typeCase, rows));
+    void testMatchesComparisonSort() throws Exception {
+        for (TypeCase typeCase : typeCases()) {
+            List<GenericRow> rows = rows(typeCase, RECORD_COUNT);
+            assertThat(sortExternal(typeCase, rows, 32L << 20))
+                    .as(typeCase.name)
+                    .containsExactlyElementsOf(sortWithComparator(typeCase, rows));
+        }
+
+        TypeCase string = stringCase();
+        List<GenericRow> spilledRows = rows(string, 20_000);
+        assertThat(sortExternal(string, spilledRows, 256L << 10))
+                .as("spilled runs")
+                .containsExactlyElementsOf(sortWithComparator(string, spilledRows));
     }
 
     private static List<Integer> sortWithComparator(TypeCase typeCase, List<GenericRow> rows) {
@@ -145,47 +142,42 @@ class NormalizedKeyRadixSortTest {
         return rows;
     }
 
-    private static Stream<TypeCase> typeCases() {
-        return Stream.of(
-                new TypeCase("boolean", new BooleanType(), i -> (i & 1) == 0),
-                new TypeCase("tinyint", new TinyIntType(), i -> (byte) (i * 31)),
-                new TypeCase("smallint", new SmallIntType(), i -> (short) (i * 257)),
-                new TypeCase("int", new IntType(), i -> (i - 2_048) * 104_729),
-                new TypeCase("bigint", new BigIntType(), i -> (i - 2_048L) * 10_000_019L),
-                new TypeCase("float", new FloatType(), NormalizedKeyRadixSortTest::floatValue),
-                new TypeCase("double", new DoubleType(), NormalizedKeyRadixSortTest::doubleValue),
-                new TypeCase(
-                        "decimal",
-                        new DecimalType(18, 4),
-                        i -> Decimal.fromUnscaledLong((i - 2_048L) * 100_003L, 18, 4)),
-                new TypeCase("date", new DateType(), i -> i - 2_048),
-                new TypeCase("time", new TimeType(3), i -> (i * 104_729) % 86_400_000),
-                new TypeCase(
-                        "timestamp-compact",
-                        new TimestampType(3),
-                        i -> Timestamp.fromEpochMillis((i - 2_048L) * 100_003L)),
-                new TypeCase(
-                        "timestamp",
-                        new TimestampType(9),
-                        i ->
-                                Timestamp.fromEpochMillis(
-                                        (i - 2_048L) * 100_003L, (i * 257) % 1_000_000)),
-                new TypeCase(
-                        "local-zoned-timestamp",
-                        new LocalZonedTimestampType(9),
-                        i ->
-                                Timestamp.fromEpochMillis(
-                                        (i - 2_048L) * 100_003L, (i * 509) % 1_000_000)),
-                new TypeCase(
-                        "char",
-                        new CharType(32),
-                        i -> BinaryString.fromString(String.format("char-prefix-%08d", i))),
-                stringCase(),
-                new TypeCase("binary", new BinaryType(8), NormalizedKeyRadixSortTest::binaryValue),
-                new TypeCase(
-                        "varbinary",
-                        new VarBinaryType(16),
-                        NormalizedKeyRadixSortTest::binaryValue));
+    private static TypeCase[] typeCases() {
+        return new TypeCase[] {
+            new TypeCase("boolean", new BooleanType(), i -> (i & 1) == 0),
+            new TypeCase("tinyint", new TinyIntType(), i -> (byte) (i * 31)),
+            new TypeCase("smallint", new SmallIntType(), i -> (short) (i * 257)),
+            new TypeCase("int", new IntType(), i -> (i - 2_048) * 104_729),
+            new TypeCase("bigint", new BigIntType(), i -> (i - 2_048L) * 10_000_019L),
+            new TypeCase("float", new FloatType(), NormalizedKeyRadixSortTest::floatValue),
+            new TypeCase("double", new DoubleType(), NormalizedKeyRadixSortTest::doubleValue),
+            new TypeCase(
+                    "decimal",
+                    new DecimalType(18, 4),
+                    i -> Decimal.fromUnscaledLong((i - 2_048L) * 100_003L, 18, 4)),
+            new TypeCase("date", new DateType(), i -> i - 2_048),
+            new TypeCase("time", new TimeType(3), i -> (i * 104_729) % 86_400_000),
+            new TypeCase(
+                    "timestamp-compact",
+                    new TimestampType(3),
+                    i -> Timestamp.fromEpochMillis((i - 2_048L) * 100_003L)),
+            new TypeCase(
+                    "timestamp",
+                    new TimestampType(9),
+                    i -> Timestamp.fromEpochMillis((i - 2_048L) * 100_003L, (i * 257) % 1_000_000)),
+            new TypeCase(
+                    "local-zoned-timestamp",
+                    new LocalZonedTimestampType(9),
+                    i -> Timestamp.fromEpochMillis((i - 2_048L) * 100_003L, (i * 509) % 1_000_000)),
+            new TypeCase(
+                    "char",
+                    new CharType(32),
+                    i -> BinaryString.fromString(String.format("char-prefix-%08d", i))),
+            stringCase(),
+            new TypeCase("binary", new BinaryType(8), NormalizedKeyRadixSortTest::binaryValue),
+            new TypeCase(
+                    "varbinary", new VarBinaryType(16), NormalizedKeyRadixSortTest::binaryValue)
+        };
     }
 
     private static Float floatValue(int i) {
@@ -255,11 +247,6 @@ class NormalizedKeyRadixSortTest {
 
         private Object value(int id) {
             return id % 31 == 0 ? null : values.apply(id);
-        }
-
-        @Override
-        public String toString() {
-            return name;
         }
     }
 }

--- a/paimon-core/src/test/java/org/apache/paimon/sort/NormalizedKeyRadixSortTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/sort/NormalizedKeyRadixSortTest.java
@@ -20,126 +20,246 @@ package org.apache.paimon.sort;
 
 import org.apache.paimon.compression.CompressOptions;
 import org.apache.paimon.data.BinaryRow;
-import org.apache.paimon.data.BinaryRowWriter;
 import org.apache.paimon.data.BinaryString;
+import org.apache.paimon.data.Decimal;
+import org.apache.paimon.data.GenericRow;
+import org.apache.paimon.data.Timestamp;
 import org.apache.paimon.disk.IOManager;
 import org.apache.paimon.memory.MemorySegmentPool;
 import org.apache.paimon.options.MemorySize;
+import org.apache.paimon.types.BigIntType;
+import org.apache.paimon.types.BinaryType;
+import org.apache.paimon.types.BooleanType;
+import org.apache.paimon.types.CharType;
+import org.apache.paimon.types.DataType;
+import org.apache.paimon.types.DateType;
+import org.apache.paimon.types.DecimalType;
+import org.apache.paimon.types.DoubleType;
+import org.apache.paimon.types.FloatType;
 import org.apache.paimon.types.IntType;
+import org.apache.paimon.types.LocalZonedTimestampType;
 import org.apache.paimon.types.RowType;
+import org.apache.paimon.types.SmallIntType;
+import org.apache.paimon.types.TimeType;
+import org.apache.paimon.types.TimestampType;
+import org.apache.paimon.types.TinyIntType;
+import org.apache.paimon.types.VarBinaryType;
 import org.apache.paimon.types.VarCharType;
 import org.apache.paimon.utils.MutableObjectIterator;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.Comparator;
 import java.util.List;
 import java.util.Random;
+import java.util.function.IntFunction;
+import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 /** Tests for {@link NormalizedKeyRadixSort}. */
 class NormalizedKeyRadixSortTest {
 
+    private static final int RECORD_COUNT = 4_096;
+
     @TempDir Path tempDir;
 
-    @Test
-    void testFullyDeterminedKey() throws Exception {
-        List<TestRecord> records = records(10_000, false, false);
-        assertSorted(
-                records, new int[] {0}, Comparator.comparingInt(record -> record.key), 32L << 20);
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("typeCases")
+    void testMatchesQuickSort(TypeCase typeCase) throws Exception {
+        List<GenericRow> rows = rows(typeCase, RECORD_COUNT);
+        List<Integer> quickSortResult = sort(typeCase, rows, false, 32L << 20);
+        assertThat(sort(typeCase, rows, true, 32L << 20))
+                .containsExactlyElementsOf(quickSortResult);
     }
 
     @Test
-    void testPartialKeyAndNulls() throws Exception {
-        List<TestRecord> records = records(10_000, true, true);
-        assertSorted(records, new int[] {0, 1}, recordComparator(), 32L << 20);
+    void testSpilledRunsMatchQuickSort() throws Exception {
+        TypeCase typeCase = stringCase();
+        List<GenericRow> rows = rows(typeCase, 20_000);
+        List<Integer> quickSortResult = sort(typeCase, rows, false, 256L << 10);
+        assertThat(sort(typeCase, rows, true, 256L << 10))
+                .containsExactlyElementsOf(quickSortResult);
     }
 
-    @Test
-    void testSpilledRuns() throws Exception {
-        List<TestRecord> records = records(20_000, true, false);
-        assertSorted(records, new int[] {0, 1}, recordComparator(), 256L << 10);
-    }
-
-    private void assertSorted(
-            List<TestRecord> records,
-            int[] keyFields,
-            Comparator<TestRecord> expectedComparator,
-            long memorySize)
+    private List<Integer> sort(
+            TypeCase typeCase, List<GenericRow> rows, boolean radix, long memorySize)
             throws Exception {
-        List<TestRecord> expected = new ArrayList<>(records);
-        expected.sort(expectedComparator);
-        Collections.shuffle(records, new Random(42));
-
-        IOManager ioManager = IOManager.create(tempDir.toString());
+        java.nio.file.Path ioPath = tempDir.resolve(typeCase.name + '-' + radix + '-' + memorySize);
+        java.nio.file.Files.createDirectories(ioPath);
+        IOManager ioManager = IOManager.create(ioPath.toString());
         BinaryExternalSortBuffer sorter =
-                BinaryExternalSortBuffer.createWithRadixSort(
-                        ioManager,
-                        RowType.of(new IntType(), new VarCharType()),
-                        keyFields,
-                        memorySize,
-                        MemorySegmentPool.DEFAULT_PAGE_SIZE,
-                        128,
-                        CompressOptions.defaultOptions(),
-                        MemorySize.MAX_VALUE);
+                radix
+                        ? BinaryExternalSortBuffer.createWithRadixSort(
+                                ioManager,
+                                RowType.of(typeCase.dataType, new IntType()),
+                                new int[] {0, 1},
+                                memorySize,
+                                MemorySegmentPool.DEFAULT_PAGE_SIZE,
+                                128,
+                                CompressOptions.defaultOptions(),
+                                MemorySize.MAX_VALUE)
+                        : BinaryExternalSortBuffer.create(
+                                ioManager,
+                                RowType.of(typeCase.dataType, new IntType()),
+                                new int[] {0, 1},
+                                memorySize,
+                                MemorySegmentPool.DEFAULT_PAGE_SIZE,
+                                128,
+                                CompressOptions.defaultOptions(),
+                                MemorySize.MAX_VALUE);
         try {
-            BinaryRow row = new BinaryRow(2);
-            BinaryRowWriter writer = new BinaryRowWriter(row);
-            for (TestRecord record : records) {
-                writer.reset();
-                writer.writeInt(0, record.key);
-                if (record.value == null) {
-                    writer.setNullAt(1);
-                } else {
-                    writer.writeString(1, BinaryString.fromString(record.value));
-                }
-                writer.complete();
+            for (GenericRow row : rows) {
                 sorter.write(row);
             }
 
+            List<Integer> result = new ArrayList<>(rows.size());
             MutableObjectIterator<BinaryRow> iterator = sorter.sortedIterator();
             BinaryRow reuse = new BinaryRow(2);
-            for (TestRecord record : expected) {
-                reuse = iterator.next(reuse);
-                assertThat(reuse.getInt(0)).isEqualTo(record.key);
-                assertThat(reuse.isNullAt(1) ? null : reuse.getString(1).toString())
-                        .isEqualTo(record.value);
+            while ((reuse = iterator.next(reuse)) != null) {
+                result.add(reuse.getInt(1));
             }
-            assertThat(iterator.next(reuse)).isNull();
+            return result;
         } finally {
             sorter.clear();
             ioManager.close();
         }
     }
 
-    private static Comparator<TestRecord> recordComparator() {
-        return Comparator.comparingInt((TestRecord record) -> record.key)
-                .thenComparing(
-                        record -> record.value, Comparator.nullsFirst(Comparator.naturalOrder()));
-    }
-
-    private static List<TestRecord> records(int size, boolean repeatedKeys, boolean withNulls) {
-        List<TestRecord> records = new ArrayList<>(size);
-        for (int i = 0; i < size; i++) {
-            int key = repeatedKeys ? i % 37 : i - size / 2;
-            String value = withNulls && i % 17 == 0 ? null : String.format("value-%08d", size - i);
-            records.add(new TestRecord(key, value));
+    private static List<GenericRow> rows(TypeCase typeCase, int count) {
+        List<Integer> ids = new ArrayList<>(count);
+        for (int i = 0; i < count; i++) {
+            ids.add(i);
         }
-        return records;
+        Collections.shuffle(ids, new Random(42));
+
+        List<GenericRow> rows = new ArrayList<>(count);
+        for (int id : ids) {
+            rows.add(GenericRow.of(typeCase.value(id), id));
+        }
+        return rows;
     }
 
-    private static class TestRecord {
-        private final int key;
-        private final String value;
+    private static Stream<TypeCase> typeCases() {
+        return Stream.of(
+                new TypeCase("boolean", new BooleanType(), i -> (i & 1) == 0),
+                new TypeCase("tinyint", new TinyIntType(), i -> (byte) (i * 31)),
+                new TypeCase("smallint", new SmallIntType(), i -> (short) (i * 257)),
+                new TypeCase("int", new IntType(), i -> (i - 2_048) * 104_729),
+                new TypeCase("bigint", new BigIntType(), i -> (i - 2_048L) * 10_000_019L),
+                new TypeCase("float", new FloatType(), NormalizedKeyRadixSortTest::floatValue),
+                new TypeCase("double", new DoubleType(), NormalizedKeyRadixSortTest::doubleValue),
+                new TypeCase(
+                        "decimal",
+                        new DecimalType(18, 4),
+                        i -> Decimal.fromUnscaledLong((i - 2_048L) * 100_003L, 18, 4)),
+                new TypeCase("date", new DateType(), i -> i - 2_048),
+                new TypeCase("time", new TimeType(3), i -> (i * 104_729) % 86_400_000),
+                new TypeCase(
+                        "timestamp-compact",
+                        new TimestampType(3),
+                        i -> Timestamp.fromEpochMillis((i - 2_048L) * 100_003L)),
+                new TypeCase(
+                        "timestamp",
+                        new TimestampType(9),
+                        i ->
+                                Timestamp.fromEpochMillis(
+                                        (i - 2_048L) * 100_003L, (i * 257) % 1_000_000)),
+                new TypeCase(
+                        "local-zoned-timestamp",
+                        new LocalZonedTimestampType(9),
+                        i ->
+                                Timestamp.fromEpochMillis(
+                                        (i - 2_048L) * 100_003L, (i * 509) % 1_000_000)),
+                new TypeCase(
+                        "char",
+                        new CharType(32),
+                        i -> BinaryString.fromString(String.format("char-prefix-%08d", i))),
+                stringCase(),
+                new TypeCase("binary", new BinaryType(8), NormalizedKeyRadixSortTest::binaryValue),
+                new TypeCase(
+                        "varbinary",
+                        new VarBinaryType(16),
+                        NormalizedKeyRadixSortTest::binaryValue));
+    }
 
-        private TestRecord(int key, String value) {
-            this.key = key;
-            this.value = value;
+    private static Float floatValue(int i) {
+        switch (i % 257) {
+            case 0:
+                return Float.NEGATIVE_INFINITY;
+            case 1:
+                return -0.0f;
+            case 2:
+                return 0.0f;
+            case 3:
+                return Float.POSITIVE_INFINITY;
+            case 4:
+                return Float.NaN;
+            default:
+                return (i - 2_048) / 7.0f;
+        }
+    }
+
+    private static Double doubleValue(int i) {
+        switch (i % 257) {
+            case 0:
+                return Double.NEGATIVE_INFINITY;
+            case 1:
+                return -0.0d;
+            case 2:
+                return 0.0d;
+            case 3:
+                return Double.POSITIVE_INFINITY;
+            case 4:
+                return Double.NaN;
+            default:
+                return (i - 2_048) / 11.0d;
+        }
+    }
+
+    private static byte[] binaryValue(int i) {
+        return new byte[] {
+            (byte) (i * 193),
+            (byte) (i >>> 1),
+            (byte) 0x80,
+            (byte) 0xff,
+            (byte) (i >>> 24),
+            (byte) (i >>> 16),
+            (byte) (i >>> 8),
+            (byte) i
+        };
+    }
+
+    private static TypeCase stringCase() {
+        return new TypeCase(
+                "string",
+                VarCharType.STRING_TYPE,
+                i -> BinaryString.fromString(String.format("共同-prefix-%08d", i * 104_729)));
+    }
+
+    private static class TypeCase {
+        private final String name;
+        private final DataType dataType;
+        private final IntFunction<Object> values;
+
+        private TypeCase(String name, DataType dataType, IntFunction<Object> values) {
+            this.name = name;
+            this.dataType = dataType;
+            this.values = values;
+        }
+
+        private Object value(int id) {
+            return id % 31 == 0 ? null : values.apply(id);
+        }
+
+        @Override
+        public String toString() {
+            return name;
         }
     }
 }


### PR DESCRIPTION
### Purpose

`BinaryExternalSortBuffer` currently uses QuickSort for every in-memory run. This follows the radix-sort optimization in #8904 and applies it to the generated normalized keys already maintained by the external sort buffer. Manifest sort compaction is the motivating workload.

### Changes

- Add an in-place MSD radix sorter for generated normalized keys.
- Fall back to QuickSort for small ranges and for equal partial normalized keys.
- Use a single radix-sort path in `BinaryInMemorySortBuffer`; `BinaryExternalSortBuffer` uses it for both in-memory output and spilled runs.
- Keep the existing constructor and `create(...)` API without adding an algorithm-specific entry point or configuration.

The in-place implementation uses bounded auxiliary memory (at most two 256-entry arrays per normalized-key byte), so it preserves the external sort buffer's memory bound.

### Benchmark

`ManifestFileSorterBenchmark`, 48 manifests x 10,000 entries, 64 MiB sort buffer, one warmup and two measured iterations:

| Case | QuickSort best | Radix best | QuickSort allocation | Radix allocation |
| --- | ---: | ---: | ---: | ---: |
| Full, 480k entries | 2687.7 ms | 2636.5 ms | 2243.2 MiB | 2228.8 MiB |
| Minor with deletes, 660k entries | 4081.5 ms | 3979.9 ms | 3033.9 MiB | 2998.5 MiB |

This is an end-to-end benchmark including manifest read and rewrite I/O.

### Tests

- In one consolidated test, compare the complete comparator-sort and radix-sort output for 17 normalized-key type cases, including nulls, signed values, floating-point special values, common string prefixes, binary values, and spilled runs.
- Compact 4,096 ADD entries plus interleaved DELETE entries and verify the exact surviving files and global manifest order.
- Run `NormalizedKeyRadixSortTest`, `BinaryExternalSortBufferTest`, and `ManifestFileMetaTest`: 64 tests, 0 failures, 1 skipped.
- Spotless, Checkstyle, and `git diff --check`.
