### PR TITLE
[python] Fix native-plan CI with updated paimon-rust

### DIFF
--- a/.github/workflows/paimon-python-checks.yml
+++ b/.github/workflows/paimon-python-checks.yml
@@ -34,7 +34,7 @@ env:
   JDK_VERSION: 8
   MAVEN_OPTS: -Dmaven.wagon.httpconnectionManager.ttlSeconds=30 -Dmaven.wagon.http.retryHandler.requestSentEnabled=true
   LUMINA_DATA_VERSION: 0.1.0
-  PYPAIMON_RUST_REV: b8d590521eb4cfde916ce3589cda88e75f31046a
+  PYPAIMON_RUST_REV: b27c30054e17ee11f7400bf07a8fd41cf264f08b
 
 
 concurrency:


### PR DESCRIPTION
### Purpose

Update the `paimon-rust` revision used by the Python 3.11 native-plan CI lane to include [apache/paimon-rust#692](https://github.com/apache/paimon-rust/pull/692).

The Rust fix preserves partition and bucket group order during split planning, preventing deferred BLOB limit tests from depending on `HashMap` iteration order.

### Tests

- The two previously failing deferred BLOB limit tests pass with the updated Rust code
- `git diff --check`
