### PR TITLE
feat: add append-table global-index query service

### DIFF
--- a/docs/docs/multimodal-table/global-index/query-service.mdx
+++ b/docs/docs/multimodal-table/global-index/query-service.mdx
@@ -1,0 +1,201 @@
+---
+title: "Append Global-Index Query Service"
+sidebar_position: 6
+---
+
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+# Append Global-Index Query Service
+
+The append global-index query service provides remote exact-key lookup for an unpartitioned
+data-evolution append table on the main branch. It is intended for a table that has no primary key
+but whose application contract makes one non-null column unique. A request returns only the value
+fields selected when the service starts.
+
+The service does not turn the lookup column into a primary key and does not change table
+metadata. It validates uniqueness while building each served snapshot. A duplicate non-null key
+invalidates the complete snapshot generation; it is never resolved with first-wins or last-wins
+behavior. Null table keys are outside the lookup domain and are skipped, while null request keys
+are rejected.
+
+## Start the service
+
+Build a BTree global index for the lookup column before starting the service. The table must use
+`bucket = -1`, `row-tracking.enabled = true`, and `data-evolution.enabled = true`, and it must not
+have primary or partition keys. Configure a persistent `consumer.expiration-time` on the table so
+abandoned per-attempt snapshot leases are eventually cleaned up.
+
+```shell
+flink run paimon-flink-action.jar query_service \
+  --warehouse <warehouse-path> \
+  --database my_database \
+  --table my_append_table \
+  --parallelism 8 \
+  --lookup-key url \
+  --value-fields descriptor \
+  --consumer-id my-append-query-service \
+  --lease-grace-period '10 min'
+```
+
+The equivalent Flink procedure is:
+
+```sql
+CALL sys.query_service(
+  'my_database.my_append_table',
+  8,
+  'url',
+  'descriptor',
+  'my-append-query-service',
+  '10 min');
+```
+
+`--lookup-key` is an exact table value. Paimon does not parse or normalize application URLs. For
+example, an application may choose to remove a URL path prefix in its gateway before it serializes
+the remaining object name as a lookup key. Binary row kind is not part of key identity; the client,
+router, and materialized state canonicalize every key to `INSERT` before hashing or comparison.
+
+Value fields are returned in the configured order. A selected top-level raw blob-file `BLOB` field
+is automatically read in descriptor mode and cached as `BlobDescriptor.serialize()` bytes; its
+payload is never fetched into query-service state. Non-BLOB binary fields remain unchanged.
+Nested BLOB, inline descriptor, and BlobView value fields are rejected in v1 so the wire contract is
+unambiguous. Clients can deserialize returned raw-BLOB bytes with `BlobDescriptor.deserialize()`
+and use the descriptor for range reads. A BLOB lookup key is not supported.
+
+The service rejects configurations that could turn incomplete data into a false miss, including
+`query-auth.enabled = true`, `scan.ignore-corrupt-files = true`,
+`scan.ignore-lost-files = true`, and `global-index.column-update-action = ignore`.
+
+## Snapshot and readiness semantics
+
+The BTree files are an exact coverage gate. They prove that every live data-file row range in one
+pinned snapshot is indexed. Requests do not perform point reads against BTree files. After the
+coverage check, the service reads the pinned snapshot once, projects the lookup and value fields,
+and shuffles each non-null key to one key-hash executor. The monitor plans all snapshot splits
+centrally, so every data split is read by one bootstrap subtask rather than once per executor.
+Hash layout version 1 routes the single-field Paimon `BinaryRow` with
+`floorMod(BinaryRow.hashCode(), parallelism)`; changing parallelism therefore requires a complete
+new generation.
+
+Only an empty snapshot or a fully indexed non-empty snapshot can become ready. An append tail
+without BTree coverage remains `NOT_READY`; the absence of a materialized key is not reported as a
+miss for that snapshot. A new fully indexed snapshot causes a full shadow-state rebuild. As soon as
+an executor observes the newer generation it stops accepting requests for the retained old state;
+this also fences clients which cached the old descriptor before discovery was withdrawn. Discovery
+is republished only after every executor has swapped to the same snapshot. This creates a refresh
+availability gap, but prevents false misses and mixed-generation results.
+
+The contract is exact for the snapshot advertised in discovery and converges to newer snapshots as
+the monitor observes them. It is not an implicit read-after-write API: immediately after a writer
+commits, discovery may still advertise the previous complete snapshot. Use
+`GlobalIndexQueryClient.getValuesWithMetadata` to receive the values together with their
+`servedGeneration`, `servedSnapshotId`, and snapshot UUID. The existing `getValues` method is a
+convenience projection of the same call. A gateway which requires a minimum committed snapshot must
+force-refresh its location and compare the returned `servedSnapshotId` before it accepts a MISS; if
+the advertised snapshot is older, it must treat the service as unavailable and retry later. The
+current API does not perform catalog I/O or enforce a caller-supplied minimum snapshot for each
+batch.
+
+The discovery descriptor includes the table UUID and branch, protocol and key-hash versions, schema
+fingerprint, served snapshot ID, optional snapshot UUID, generation, and one address and server
+epoch per shard. Modern snapshots publish their UUID; historical snapshots without one are
+additionally fenced by table UUID, branch, owner, generation, and server epoch. The client includes
+the expected server epoch and generation in each request and validates the snapshot fence on every
+response. Protocol version 2 carries expected failures as normal, versioned response frames with a
+stable error code, retryable flag, and bounded message; clients do not deserialize Java exceptions
+for these business outcomes. The global-index client also rejects legacy Java-serialized Throwable
+failure frames without deserializing their payload, and a malformed frame closes the connection.
+It refreshes discovery at most once for a stale generation, unknown shard, overload, request
+timeout, or connection failure. Other structured failures are not retried.
+
+To verify readiness, inspect the service descriptor under the table's `service` directory or make
+a client lookup. A descriptor is ready only when `ready` is `true`, all endpoint slots are present,
+and the schema, protocol, layout, generation, and snapshot fields match the client. A missing or
+`NOT_READY` descriptor must be treated as unavailable, not as an empty lookup result.
+
+## Refresh, compaction, and recovery
+
+Ordinary and Blob compaction are handled as new snapshots: once the new snapshot has complete
+BTree coverage, the service rebuilds and publishes a new fenced generation. For an initial
+deployment, keeping `blob-compaction.enabled = false` (the default) is recommended to reduce
+descriptor churn, but it is not a correctness requirement of the generation protocol. Row-ID
+reassignment may drop incompatible global indexes; the affected snapshot stays unavailable until
+its BTree coverage is rebuilt.
+
+The monitor creates a per-attempt consumer lease before it plans a snapshot. A replacement attempt
+first inherits the oldest live consumer pin; during refresh its `nextSnapshot` is the minimum active
+or building snapshot. It advances to the newly published snapshot only after
+`--lease-grace-period` elapses, which keeps in-flight Blob descriptors readable during handover. For
+an unavailable snapshot, that grace clock starts only after discovery has acknowledged the exact
+withdrawn generation and snapshot, not when the upstream monitor first emits the event. The
+supplied `--consumer-id` is a readable prefix; a random attempt token is
+appended so attempts never overwrite each other's lease. The lease is heartbeated while its task
+is alive. Task close performs one final lease write and then stops the heartbeat, but does not
+delete the lease, because Flink uses the same callback for failover and terminal cancellation;
+retaining it preserves the complete expiration window before a replacement attempt pins the
+snapshot. `consumer.expiration-time` cleans up all stopped-attempt leases, including a cleanly
+cancelled job, and must be configured on the persisted table so writer maintenance observes it.
+
+The consumer prefix is limited to one alphanumeric path segment (up to 128 characters, with `.`,
+`_`, and `-` allowed after the first character). Safety and retention options are validated from
+persisted schema options as well as dynamic options, so `table_conf` cannot disable persisted
+`query-auth.enabled`, `consumer.changelog-only`, corrupt/lost-file checks, or lease expiration
+requirements. Persisted `consumer.expiration-time` must be at least 10 seconds, and service startup
+also requires it to be at least `lease-grace-period + 1 minute` for failover recovery. The persisted
+value is used to schedule heartbeats. If coverage remains `NOT_READY`, the old accepted generation
+is fenced immediately and its snapshot is released after the acknowledged handover grace; the lease
+then follows the latest unavailable snapshot instead of pinning the historical minimum forever.
+
+Executor state is local and is rebuilt after task or job restart. A new publisher attempt first
+writes a `NOT_READY` descriptor and each server receives a new random epoch. This is deliberately
+fail-closed: recovery does not restore a partially built cache and never interprets missing local
+state as a table miss.
+
+Publisher attempts write owner-scoped descriptor files. Discovery selects the highest persisted
+owner sequence and Flink attempt number. The highest owner leaves a `NOT_READY` tombstone on clean
+shutdown, so a delayed old attempt cannot overwrite, delete, or revive an older ready descriptor.
+Start only one logical query-service job for a lookup projection: sequence allocation is not a
+cross-job compare-and-set protocol, and concurrent independent submissions are unsupported. A
+later, non-concurrent submission intentionally takes ownership from an earlier one.
+
+Owner fencing also requires the table `FileIO` to provide read-after-write visibility and a
+consistent listing of the service directory. A filesystem which can omit an existing owner file
+from a listing is not supported by this v1 discovery layout.
+
+## Resource and protocol limits
+
+Each ready generation stores one copied projected value per non-null lookup key on local executor
+disk, plus lookup cache overhead. Refresh performs one full projected snapshot scan across all
+bootstrap subtasks. Lookup access to the current local KV implementation is serialized per
+executor because its codecs reuse mutable buffers. Increase parallelism to distribute keys and
+request load, while accounting for the full-scan shuffle and local state size.
+
+Servers bind an ephemeral port on each executor and publish the resolved addresses. All clients
+must have network reachability to those TaskManager ports. One request accepts at most 10,000 keys
+and 16 MiB of serialized key data; one response accepts at most 64 MiB of serialized value data.
+The dedicated server uses one query thread and a bounded queue of 16 requests per shard; excess
+requests receive the structured retryable `OVERLOADED` status instead of growing an unbounded
+executor queue. `GlobalIndexQueryClient` applies a 30-second request timeout by default, has a
+constructor overload for a caller-selected positive timeout, cancels timed-out network requests,
+and still performs at most one discovery refresh retry for the complete batch.
+The service does not implement end-user authentication and rejects tables with
+`query-auth.enabled=true`; expose executor ports only on a trusted internal network and put an
+authenticated Gateway in front of external callers. The append protocol is consumed explicitly via
+`GlobalIndexQueryClient` or `RemoteGlobalIndexTableQuery`; it does not replace the existing
+primary-key query-service selection path.

--- a/paimon-common/src/main/java/org/apache/paimon/fs/local/LocalFileIO.java
+++ b/paimon-common/src/main/java/org/apache/paimon/fs/local/LocalFileIO.java
@@ -95,6 +95,31 @@ public class LocalFileIO implements FileIO {
     }
 
     @Override
+    public void overwriteFileUtf8(Path path, String content) throws IOException {
+        Path tempPath = path.createTempPath();
+        boolean success = false;
+        try {
+            writeFile(tempPath, content, false);
+
+            RENAME_LOCK.lock();
+            try {
+                Files.move(
+                        toPath(tempPath),
+                        toPath(path),
+                        StandardCopyOption.ATOMIC_MOVE,
+                        StandardCopyOption.REPLACE_EXISTING);
+                success = true;
+            } finally {
+                RENAME_LOCK.unlock();
+            }
+        } finally {
+            if (!success) {
+                deleteQuietly(tempPath);
+            }
+        }
+    }
+
+    @Override
     public FileStatus getFileStatus(Path path) throws IOException {
         LOG.debug("Invoking getFileStatus for {}", path);
         final File file = toFile(path);

--- a/paimon-common/src/test/java/org/apache/paimon/fs/local/LocalFileIOTest.java
+++ b/paimon-common/src/test/java/org/apache/paimon/fs/local/LocalFileIOTest.java
@@ -20,9 +20,17 @@ package org.apache.paimon.fs.local;
 
 import org.apache.paimon.fs.FileIO;
 import org.apache.paimon.fs.Path;
+import org.apache.paimon.fs.PositionOutputStream;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -45,5 +53,133 @@ public class LocalFileIOTest {
 
         fileIO.copyFile(srcFile, dstFile, false);
         assertThat(fileIO.readFileUtf8(dstFile)).isEqualTo("foobar");
+    }
+
+    @Test
+    public void testOverwriteFileUtf8IsAtomicForConcurrentReaders() throws Exception {
+        Path file = new Path(tempDir.resolve("atomic-overwrite.txt").toUri());
+        BlockingLocalFileIO fileIO = new BlockingLocalFileIO();
+        String oldContent = "old:" + repeated('a', 64 * 1024);
+        String newContent = "new:" + repeated('b', 128 * 1024);
+        fileIO.writeFile(file, oldContent, false);
+
+        fileIO.blockNextWrite();
+        AtomicReference<Throwable> writeFailure = new AtomicReference<>();
+        Thread writer =
+                new Thread(
+                        () -> {
+                            try {
+                                fileIO.overwriteFileUtf8(file, newContent);
+                            } catch (Throwable t) {
+                                writeFailure.set(t);
+                            }
+                        });
+        writer.start();
+
+        try {
+            assertThat(fileIO.awaitPartialWrite()).isTrue();
+            for (int i = 0; i < 100; i++) {
+                assertThat(fileIO.readFileUtf8(file)).isEqualTo(oldContent);
+            }
+        } finally {
+            fileIO.finishWrite();
+        }
+
+        writer.join(TimeUnit.SECONDS.toMillis(10));
+        assertThat(writer.isAlive()).isFalse();
+        assertThat(writeFailure.get()).isNull();
+        assertThat(fileIO.readFileUtf8(file)).isEqualTo(newContent);
+    }
+
+    private static String repeated(char value, int length) {
+        char[] chars = new char[length];
+        Arrays.fill(chars, value);
+        return new String(chars);
+    }
+
+    private static class BlockingLocalFileIO extends LocalFileIO {
+
+        private final AtomicBoolean blockNextWrite = new AtomicBoolean();
+        private final CountDownLatch partialWrite = new CountDownLatch(1);
+        private final CountDownLatch finishWrite = new CountDownLatch(1);
+
+        private void blockNextWrite() {
+            blockNextWrite.set(true);
+        }
+
+        private boolean awaitPartialWrite() throws InterruptedException {
+            return partialWrite.await(10, TimeUnit.SECONDS);
+        }
+
+        private void finishWrite() {
+            finishWrite.countDown();
+        }
+
+        @Override
+        public PositionOutputStream newOutputStream(Path path, boolean overwrite)
+                throws IOException {
+            PositionOutputStream delegate = super.newOutputStream(path, overwrite);
+            if (!blockNextWrite.compareAndSet(true, false)) {
+                return delegate;
+            }
+
+            return new PositionOutputStream() {
+                private boolean blocked;
+
+                @Override
+                public long getPos() throws IOException {
+                    return delegate.getPos();
+                }
+
+                @Override
+                public void write(int value) throws IOException {
+                    delegate.write(value);
+                    blockAfterPartialWrite();
+                }
+
+                @Override
+                public void write(byte[] bytes) throws IOException {
+                    write(bytes, 0, bytes.length);
+                }
+
+                @Override
+                public void write(byte[] bytes, int offset, int length) throws IOException {
+                    if (length == 0) {
+                        return;
+                    }
+                    int firstLength = Math.max(1, length / 2);
+                    delegate.write(bytes, offset, firstLength);
+                    blockAfterPartialWrite();
+                    delegate.write(bytes, offset + firstLength, length - firstLength);
+                }
+
+                private void blockAfterPartialWrite() throws IOException {
+                    if (blocked) {
+                        return;
+                    }
+                    blocked = true;
+                    partialWrite.countDown();
+                    try {
+                        if (!finishWrite.await(10, TimeUnit.SECONDS)) {
+                            throw new IOException("Timed out waiting to finish the test write.");
+                        }
+                    } catch (InterruptedException e) {
+                        Thread.currentThread().interrupt();
+                        throw new IOException(
+                                "Interrupted while waiting to finish the test write.", e);
+                    }
+                }
+
+                @Override
+                public void flush() throws IOException {
+                    delegate.flush();
+                }
+
+                @Override
+                public void close() throws IOException {
+                    delegate.close();
+                }
+            };
+        }
     }
 }

--- a/paimon-core/src/main/java/org/apache/paimon/globalindex/DataEvolutionGlobalIndexCoverage.java
+++ b/paimon-core/src/main/java/org/apache/paimon/globalindex/DataEvolutionGlobalIndexCoverage.java
@@ -109,6 +109,42 @@ public class DataEvolutionGlobalIndexCoverage {
         return Range.sortAndMergeOverlap(unindexedRanges, true);
     }
 
+    /**
+     * Returns whether every live data-file row range in the pinned snapshot is covered by the given
+     * field's global index.
+     *
+     * <p>Unlike {@link #unindexedRanges(int)}, this method never follows the configured search
+     * mode. In particular, {@code FAST} must not make an incompletely built index look complete to
+     * an online query service.
+     */
+    public boolean isFullyCovered(int fieldId) {
+        if (snapshot == null) {
+            return true;
+        }
+
+        List<Range> indexedRanges =
+                Range.sortAndMergeOverlap(indexedRanges(Collections.singleton(fieldId)), true);
+        SnapshotReader snapshotReader =
+                table.newSnapshotReader()
+                        .withPartitionFilter(partitionFilter)
+                        .withMode(ScanMode.ALL)
+                        .withSnapshot(snapshot);
+        for (Split split : snapshotReader.read().splits()) {
+            if (!(split instanceof DataSplit)) {
+                continue;
+            }
+            for (DataFileMeta file : ((DataSplit) split).dataFiles()) {
+                // A data-evolution lookup cannot safely reason about a file without row IDs.
+                if (file.firstRowId() == null
+                        || indexedRanges.isEmpty()
+                        || !file.nonNullRowIdRange().exclude(indexedRanges).isEmpty()) {
+                    return false;
+                }
+            }
+        }
+        return true;
+    }
+
     private void addCoverage(int fieldId, Range range) {
         coverageByField.computeIfAbsent(fieldId, k -> new ArrayList<>()).add(range);
     }

--- a/paimon-core/src/main/java/org/apache/paimon/query/GlobalIndexQueryEndpoint.java
+++ b/paimon-core/src/main/java/org/apache/paimon/query/GlobalIndexQueryEndpoint.java
@@ -1,0 +1,101 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.query;
+
+import javax.annotation.Nullable;
+
+import java.io.Serializable;
+import java.net.InetSocketAddress;
+import java.util.Objects;
+
+/** A snapshot-fenced endpoint for one logical global-index key shard. */
+public class GlobalIndexQueryEndpoint implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    private final int shardId;
+    private final InetSocketAddress address;
+    private final String serverEpoch;
+    private final long servedGeneration;
+    private final long servedSnapshotId;
+    @Nullable private final String snapshotUuid;
+
+    public GlobalIndexQueryEndpoint(
+            int shardId,
+            InetSocketAddress address,
+            String serverEpoch,
+            long servedGeneration,
+            long servedSnapshotId,
+            @Nullable String snapshotUuid) {
+        this.shardId = shardId;
+        this.address = address;
+        this.serverEpoch = serverEpoch;
+        this.servedGeneration = servedGeneration;
+        this.servedSnapshotId = servedSnapshotId;
+        this.snapshotUuid = snapshotUuid;
+    }
+
+    public int shardId() {
+        return shardId;
+    }
+
+    public InetSocketAddress address() {
+        return address;
+    }
+
+    public String serverEpoch() {
+        return serverEpoch;
+    }
+
+    public long servedGeneration() {
+        return servedGeneration;
+    }
+
+    public long servedSnapshotId() {
+        return servedSnapshotId;
+    }
+
+    @Nullable
+    public String snapshotUuid() {
+        return snapshotUuid;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof GlobalIndexQueryEndpoint)) {
+            return false;
+        }
+        GlobalIndexQueryEndpoint that = (GlobalIndexQueryEndpoint) o;
+        return shardId == that.shardId
+                && servedGeneration == that.servedGeneration
+                && servedSnapshotId == that.servedSnapshotId
+                && address.equals(that.address)
+                && serverEpoch.equals(that.serverEpoch)
+                && Objects.equals(snapshotUuid, that.snapshotUuid);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(
+                shardId, address, serverEpoch, servedGeneration, servedSnapshotId, snapshotUuid);
+    }
+}

--- a/paimon-core/src/main/java/org/apache/paimon/query/GlobalIndexQueryLocation.java
+++ b/paimon-core/src/main/java/org/apache/paimon/query/GlobalIndexQueryLocation.java
@@ -1,0 +1,29 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.query;
+
+import org.apache.paimon.data.BinaryRow;
+
+import java.io.IOException;
+
+/** Locates the owner of a logical global-index lookup key. */
+public interface GlobalIndexQueryLocation {
+
+    GlobalIndexQueryEndpoint getLocation(BinaryRow key, boolean forceUpdate) throws IOException;
+}

--- a/paimon-core/src/main/java/org/apache/paimon/query/GlobalIndexQueryLocationImpl.java
+++ b/paimon-core/src/main/java/org/apache/paimon/query/GlobalIndexQueryLocationImpl.java
@@ -1,0 +1,206 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.query;
+
+import org.apache.paimon.data.BinaryRow;
+import org.apache.paimon.service.GlobalIndexQueryServiceDescriptor;
+import org.apache.paimon.service.GlobalIndexQueryServiceDescriptor.Endpoint;
+import org.apache.paimon.service.ServiceManager;
+import org.apache.paimon.table.query.GlobalIndexQueryServiceUtils.QuerySpec;
+import org.apache.paimon.table.query.QueryServiceNotReadyException;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.util.Optional;
+
+import static org.apache.paimon.service.GlobalIndexQueryServiceDescriptor.KEY_HASH_VERSION;
+import static org.apache.paimon.service.GlobalIndexQueryServiceDescriptor.LAYOUT;
+import static org.apache.paimon.service.GlobalIndexQueryServiceDescriptor.PROTOCOL_VERSION;
+import static org.apache.paimon.table.query.GlobalIndexQueryServiceUtils.EMPTY_SNAPSHOT_ID;
+import static org.apache.paimon.table.query.GlobalIndexQueryServiceUtils.route;
+
+/** Service-manager backed {@link GlobalIndexQueryLocation}. */
+public class GlobalIndexQueryLocationImpl implements GlobalIndexQueryLocation {
+
+    private final ServiceManager manager;
+    private final String serviceId;
+    private final String expectedTableUuid;
+    private final String expectedBranch;
+    private final long expectedSchemaId;
+    private final String expectedSchemaFingerprint;
+
+    private volatile GlobalIndexQueryServiceDescriptor descriptorCache;
+
+    public GlobalIndexQueryLocationImpl(
+            ServiceManager manager,
+            String expectedTableUuid,
+            String expectedBranch,
+            long expectedSchemaId,
+            QuerySpec spec) {
+        this.manager = manager;
+        this.serviceId = spec.serviceId();
+        this.expectedTableUuid = expectedTableUuid;
+        this.expectedBranch = expectedBranch;
+        this.expectedSchemaId = expectedSchemaId;
+        this.expectedSchemaFingerprint = spec.schemaFingerprint();
+    }
+
+    @Override
+    public GlobalIndexQueryEndpoint getLocation(BinaryRow key, boolean forceUpdate)
+            throws IOException {
+        GlobalIndexQueryServiceDescriptor descriptor = descriptorCache;
+        if (descriptor == null || forceUpdate) {
+            descriptor = loadDescriptor();
+            descriptorCache = descriptor;
+        }
+        // Keep one immutable descriptor snapshot for the whole endpoint. A concurrent forced
+        // refresh must not combine an old address/epoch with a new generation fence.
+        Endpoint[] endpoints = descriptor.endpoints();
+        int shardId = route(key, endpoints.length);
+        Endpoint endpoint = endpoints[shardId];
+        return new GlobalIndexQueryEndpoint(
+                shardId,
+                endpoint.address(),
+                endpoint.serverEpoch(),
+                descriptor.servedGeneration(),
+                descriptor.servedSnapshotId(),
+                descriptor.snapshotUuid());
+    }
+
+    /**
+     * Returns whether discovery currently contains a ready descriptor valid for this table/spec.
+     */
+    public boolean isServiceReady() {
+        try {
+            GlobalIndexQueryServiceDescriptor descriptor = loadDescriptor();
+            descriptorCache = descriptor;
+            return true;
+        } catch (IOException e) {
+            return false;
+        }
+    }
+
+    private GlobalIndexQueryServiceDescriptor loadDescriptor() throws IOException {
+        final Optional<GlobalIndexQueryServiceDescriptor> descriptor;
+        try {
+            descriptor = manager.globalIndexService(serviceId);
+        } catch (UncheckedIOException e) {
+            throw e.getCause();
+        } catch (RuntimeException e) {
+            throw new IOException(
+                    "Cannot decode global-index query service '"
+                            + serviceId
+                            + "' for table path: "
+                            + manager.tablePath(),
+                    e);
+        }
+        if (!descriptor.isPresent()) {
+            throw new QueryServiceNotReadyException(
+                    "Cannot find global-index query service '"
+                            + serviceId
+                            + "' for table path: "
+                            + manager.tablePath());
+        }
+
+        GlobalIndexQueryServiceDescriptor result = descriptor.get();
+        if (!result.ready()) {
+            throw new QueryServiceNotReadyException(
+                    "Global-index query service '"
+                            + serviceId
+                            + "' is not ready: "
+                            + result.reason());
+        }
+        validateDescriptor(result);
+        return result;
+    }
+
+    private void validateDescriptor(GlobalIndexQueryServiceDescriptor descriptor)
+            throws IOException {
+        if (descriptor.protocolVersion() != PROTOCOL_VERSION
+                || descriptor.hashVersion() != KEY_HASH_VERSION
+                || !LAYOUT.equals(descriptor.layout())) {
+            throw new IOException(
+                    "Unsupported global-index query service descriptor for '"
+                            + serviceId
+                            + "': protocol="
+                            + descriptor.protocolVersion()
+                            + ", hash="
+                            + descriptor.hashVersion()
+                            + ", layout="
+                            + descriptor.layout());
+        }
+        if (!expectedTableUuid.equals(descriptor.tableUuid())
+                || !expectedBranch.equals(descriptor.branch())) {
+            throw new IOException(
+                    "Global-index query service table identity does not match the requested table."
+                            + " Expected UUID "
+                            + expectedTableUuid
+                            + " on branch "
+                            + expectedBranch
+                            + ", but found UUID "
+                            + descriptor.tableUuid()
+                            + " on branch "
+                            + descriptor.branch()
+                            + '.');
+        }
+        if (descriptor.schemaId() != expectedSchemaId
+                || !expectedSchemaFingerprint.equals(descriptor.schemaFingerprint())) {
+            throw new IOException(
+                    "Global-index query service schema does not match the requested table schema."
+                            + " Expected schema "
+                            + expectedSchemaId
+                            + " with fingerprint "
+                            + expectedSchemaFingerprint
+                            + ", but found "
+                            + descriptor.schemaId()
+                            + " with fingerprint "
+                            + descriptor.schemaFingerprint()
+                            + '.');
+        }
+        if (descriptor.servedGeneration() < EMPTY_SNAPSHOT_ID
+                || descriptor.servedSnapshotId() < EMPTY_SNAPSHOT_ID
+                || descriptor.snapshotUuid() != null && descriptor.snapshotUuid().isEmpty()) {
+            throw new IOException(
+                    "Global-index query service '"
+                            + serviceId
+                            + "' has an invalid generation/snapshot fence.");
+        }
+        Endpoint[] endpoints = descriptor.endpoints();
+        if (endpoints.length == 0) {
+            throw new IOException(
+                    "Global-index query service '" + serviceId + "' has an invalid endpoint set.");
+        }
+        for (int i = 0; i < endpoints.length; i++) {
+            Endpoint endpoint = endpoints[i];
+            if (endpoint == null
+                    || endpoint.shardId() != i
+                    || endpoint.address() == null
+                    || endpoint.address().getPort() <= 0
+                    || endpoint.serverEpoch() == null
+                    || endpoint.serverEpoch().isEmpty()) {
+                throw new IOException(
+                        "Global-index query service '"
+                                + serviceId
+                                + "' has an invalid endpoint at shard "
+                                + i
+                                + '.');
+            }
+        }
+    }
+}

--- a/paimon-core/src/main/java/org/apache/paimon/service/GlobalIndexQueryServiceDescriptor.java
+++ b/paimon-core/src/main/java/org/apache/paimon/service/GlobalIndexQueryServiceDescriptor.java
@@ -1,0 +1,305 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.service;
+
+import org.apache.paimon.shade.jackson2.com.fasterxml.jackson.annotation.JsonCreator;
+import org.apache.paimon.shade.jackson2.com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import org.apache.paimon.shade.jackson2.com.fasterxml.jackson.annotation.JsonProperty;
+
+import javax.annotation.Nullable;
+
+import java.io.Serializable;
+import java.net.InetSocketAddress;
+import java.util.Arrays;
+import java.util.Objects;
+
+/**
+ * Versioned discovery descriptor for one materialized global-index generation.
+ *
+ * <p>For a ready descriptor, {@code servedGeneration}, {@code servedSnapshotId}, and {@code
+ * snapshotUuid} fence the snapshot accepted by the endpoints. For a not-ready descriptor, the
+ * generation and snapshot identify the target which has been fenced and acknowledged; no snapshot
+ * is served and the endpoint set is empty.
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class GlobalIndexQueryServiceDescriptor implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    public static final int PROTOCOL_VERSION = 2;
+    public static final int KEY_HASH_VERSION = 1;
+    public static final String LAYOUT = "key-hash-materialized-v1";
+
+    @JsonProperty("protocolVersion")
+    private final int protocolVersion;
+
+    @JsonProperty("tableUuid")
+    private final String tableUuid;
+
+    @JsonProperty("branch")
+    private final String branch;
+
+    @JsonProperty("schemaId")
+    private final long schemaId;
+
+    @JsonProperty("schemaFingerprint")
+    private final String schemaFingerprint;
+
+    @JsonProperty("lookupFieldId")
+    private final int lookupFieldId;
+
+    @JsonProperty("valueFieldIds")
+    private final int[] valueFieldIds;
+
+    @JsonProperty("servedGeneration")
+    private final long servedGeneration;
+
+    @JsonProperty("servedSnapshotId")
+    private final long servedSnapshotId;
+
+    @JsonProperty("snapshotUuid")
+    @Nullable
+    private final String snapshotUuid;
+
+    @JsonProperty("hashVersion")
+    private final int hashVersion;
+
+    @JsonProperty("layout")
+    private final String layout;
+
+    @JsonProperty("ownerToken")
+    private final String ownerToken;
+
+    @JsonProperty("ready")
+    private final boolean ready;
+
+    @JsonProperty("reason")
+    private final String reason;
+
+    @JsonProperty("endpoints")
+    private final Endpoint[] endpoints;
+
+    @JsonCreator
+    public GlobalIndexQueryServiceDescriptor(
+            @JsonProperty("protocolVersion") int protocolVersion,
+            @JsonProperty("tableUuid") String tableUuid,
+            @JsonProperty("branch") String branch,
+            @JsonProperty("schemaId") long schemaId,
+            @JsonProperty("schemaFingerprint") String schemaFingerprint,
+            @JsonProperty("lookupFieldId") int lookupFieldId,
+            @JsonProperty("valueFieldIds") int[] valueFieldIds,
+            @JsonProperty("servedGeneration") long servedGeneration,
+            @JsonProperty("servedSnapshotId") long servedSnapshotId,
+            @JsonProperty("snapshotUuid") @Nullable String snapshotUuid,
+            @JsonProperty("hashVersion") int hashVersion,
+            @JsonProperty("layout") String layout,
+            @JsonProperty("ownerToken") String ownerToken,
+            @JsonProperty("ready") boolean ready,
+            @JsonProperty("reason") String reason,
+            @JsonProperty("endpoints") Endpoint[] endpoints) {
+        this.protocolVersion = protocolVersion;
+        this.tableUuid = tableUuid;
+        this.branch = branch;
+        this.schemaId = schemaId;
+        this.schemaFingerprint = schemaFingerprint;
+        this.lookupFieldId = lookupFieldId;
+        this.valueFieldIds = Arrays.copyOf(valueFieldIds, valueFieldIds.length);
+        this.servedGeneration = servedGeneration;
+        this.servedSnapshotId = servedSnapshotId;
+        this.snapshotUuid = snapshotUuid;
+        this.hashVersion = hashVersion;
+        this.layout = layout;
+        this.ownerToken = ownerToken;
+        this.ready = ready;
+        this.reason = reason;
+        this.endpoints = Arrays.copyOf(endpoints, endpoints.length);
+    }
+
+    public int protocolVersion() {
+        return protocolVersion;
+    }
+
+    public String tableUuid() {
+        return tableUuid;
+    }
+
+    public String branch() {
+        return branch;
+    }
+
+    public long schemaId() {
+        return schemaId;
+    }
+
+    public String schemaFingerprint() {
+        return schemaFingerprint;
+    }
+
+    public int lookupFieldId() {
+        return lookupFieldId;
+    }
+
+    public int[] valueFieldIds() {
+        return Arrays.copyOf(valueFieldIds, valueFieldIds.length);
+    }
+
+    public long servedGeneration() {
+        return servedGeneration;
+    }
+
+    public long servedSnapshotId() {
+        return servedSnapshotId;
+    }
+
+    @Nullable
+    public String snapshotUuid() {
+        return snapshotUuid;
+    }
+
+    public int hashVersion() {
+        return hashVersion;
+    }
+
+    public String layout() {
+        return layout;
+    }
+
+    public String ownerToken() {
+        return ownerToken;
+    }
+
+    public boolean ready() {
+        return ready;
+    }
+
+    public String reason() {
+        return reason;
+    }
+
+    public Endpoint[] endpoints() {
+        return Arrays.copyOf(endpoints, endpoints.length);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof GlobalIndexQueryServiceDescriptor)) {
+            return false;
+        }
+        GlobalIndexQueryServiceDescriptor that = (GlobalIndexQueryServiceDescriptor) o;
+        return protocolVersion == that.protocolVersion
+                && schemaId == that.schemaId
+                && lookupFieldId == that.lookupFieldId
+                && servedGeneration == that.servedGeneration
+                && servedSnapshotId == that.servedSnapshotId
+                && hashVersion == that.hashVersion
+                && ready == that.ready
+                && Objects.equals(tableUuid, that.tableUuid)
+                && Objects.equals(branch, that.branch)
+                && schemaFingerprint.equals(that.schemaFingerprint)
+                && Arrays.equals(valueFieldIds, that.valueFieldIds)
+                && Objects.equals(snapshotUuid, that.snapshotUuid)
+                && layout.equals(that.layout)
+                && ownerToken.equals(that.ownerToken)
+                && reason.equals(that.reason)
+                && Arrays.equals(endpoints, that.endpoints);
+    }
+
+    @Override
+    public int hashCode() {
+        int result =
+                Objects.hash(
+                        protocolVersion,
+                        tableUuid,
+                        branch,
+                        schemaId,
+                        schemaFingerprint,
+                        lookupFieldId,
+                        servedGeneration,
+                        servedSnapshotId,
+                        snapshotUuid,
+                        hashVersion,
+                        layout,
+                        ownerToken,
+                        ready,
+                        reason);
+        result = 31 * result + Arrays.hashCode(valueFieldIds);
+        result = 31 * result + Arrays.hashCode(endpoints);
+        return result;
+    }
+
+    /** One independently fenced query shard published by a service executor. */
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public static class Endpoint implements Serializable {
+
+        private static final long serialVersionUID = 1L;
+
+        @JsonProperty("shardId")
+        private final int shardId;
+
+        @JsonProperty("address")
+        private final InetSocketAddress address;
+
+        @JsonProperty("serverEpoch")
+        private final String serverEpoch;
+
+        @JsonCreator
+        public Endpoint(
+                @JsonProperty("shardId") int shardId,
+                @JsonProperty("address") InetSocketAddress address,
+                @JsonProperty("serverEpoch") String serverEpoch) {
+            this.shardId = shardId;
+            this.address = address;
+            this.serverEpoch = serverEpoch;
+        }
+
+        public int shardId() {
+            return shardId;
+        }
+
+        public InetSocketAddress address() {
+            return address;
+        }
+
+        public String serverEpoch() {
+            return serverEpoch;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (!(o instanceof Endpoint)) {
+                return false;
+            }
+            Endpoint endpoint = (Endpoint) o;
+            return shardId == endpoint.shardId
+                    && address.equals(endpoint.address)
+                    && serverEpoch.equals(endpoint.serverEpoch);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(shardId, address, serverEpoch);
+        }
+    }
+}

--- a/paimon-core/src/main/java/org/apache/paimon/service/ServiceManager.java
+++ b/paimon-core/src/main/java/org/apache/paimon/service/ServiceManager.java
@@ -19,6 +19,7 @@
 package org.apache.paimon.service;
 
 import org.apache.paimon.fs.FileIO;
+import org.apache.paimon.fs.FileStatus;
 import org.apache.paimon.fs.Path;
 import org.apache.paimon.utils.JsonSerdeUtil;
 
@@ -26,7 +27,9 @@ import java.io.IOException;
 import java.io.Serializable;
 import java.io.UncheckedIOException;
 import java.net.InetSocketAddress;
+import java.nio.charset.StandardCharsets;
 import java.util.Optional;
+import java.util.UUID;
 
 /** A manager to manage services, for example, the service to lookup row from the primary key. */
 public class ServiceManager implements Serializable {
@@ -36,6 +39,33 @@ public class ServiceManager implements Serializable {
     public static final String SERVICE_PREFIX = "service-";
 
     public static final String PRIMARY_KEY_LOOKUP = "primary-key-lookup";
+
+    public static final String GLOBAL_INDEX_LOOKUP = "global-index-lookup";
+
+    /** A schema-specific service ID prevents clients from decoding a different projection. */
+    public static String globalIndexLookupService(
+            long schemaId, int lookupFieldId, int[] valueFieldIds) {
+        StringBuilder builder =
+                new StringBuilder("v")
+                        .append(GlobalIndexQueryServiceDescriptor.PROTOCOL_VERSION)
+                        .append("-s")
+                        .append(schemaId)
+                        .append("-k")
+                        .append(lookupFieldId)
+                        .append("-v");
+        for (int fieldId : valueFieldIds) {
+            builder.append(fieldId).append('-');
+        }
+        String canonical = builder.substring(0, builder.length() - 1);
+        // Service IDs become file names. Hash the complete ordered projection so wide tables can
+        // never exceed common 255-byte path-component limits; the descriptor retains all IDs for
+        // collision-safe schema validation.
+        return GLOBAL_INDEX_LOOKUP
+                + "-v"
+                + GlobalIndexQueryServiceDescriptor.PROTOCOL_VERSION
+                + '-'
+                + UUID.nameUUIDFromBytes(canonical.getBytes(StandardCharsets.UTF_8));
+    }
 
     private final FileIO fileIO;
     private final Path tablePath;
@@ -66,11 +96,225 @@ public class ServiceManager implements Serializable {
         }
     }
 
+    public Optional<GlobalIndexQueryServiceDescriptor> globalIndexService(String id) {
+        try {
+            return selectGlobalIndexService(id);
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+
+    /**
+     * Returns the next persisted publisher sequence for one logical query-service job. Independent
+     * jobs must not concurrently publish the same service because file systems do not provide a
+     * compare-and-set primitive for allocating this sequence.
+     */
+    public long nextGlobalIndexOwnerSequence(String id) {
+        try {
+            long maximum = -1L;
+            Path directory = serviceDirectory();
+            if (fileIO.exists(directory)) {
+                String prefix = ownerServicePrefix(id);
+                for (FileStatus status : fileIO.listStatus(directory)) {
+                    if (status.isDir() || !status.getPath().getName().startsWith(prefix)) {
+                        continue;
+                    }
+                    Optional<GlobalIndexQueryServiceDescriptor> descriptor =
+                            readGlobalIndexDescriptor(status.getPath());
+                    if (descriptor.isPresent()) {
+                        maximum = Math.max(maximum, ownerSequence(descriptor.get().ownerToken()));
+                    }
+                }
+            }
+            Optional<GlobalIndexQueryServiceDescriptor> legacy =
+                    readGlobalIndexDescriptor(servicePath(id));
+            if (legacy.isPresent()) {
+                maximum = Math.max(maximum, ownerSequence(legacy.get().ownerToken()));
+            }
+            if (maximum == Long.MAX_VALUE) {
+                throw new IllegalStateException("Global-index service owner sequence overflow.");
+            }
+            return maximum + 1L;
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+
+    public void resetGlobalIndexService(String id, GlobalIndexQueryServiceDescriptor descriptor) {
+        try {
+            fileIO.overwriteFileUtf8(
+                    ownerServicePath(id, descriptor.ownerToken()),
+                    JsonSerdeUtil.toJson(descriptor));
+            // Once an owner-scoped publisher has claimed the service, an old canonical descriptor
+            // must never become visible again after that publisher closes.
+            fileIO.deleteQuietly(servicePath(id));
+            deleteOlderOwnerServices(id, descriptor.ownerToken());
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+
+    /**
+     * Owner-aware cleanup. Each publisher writes an independent descriptor file, so an old attempt
+     * can neither overwrite nor delete a newer attempt. The current owner leaves a not-ready
+     * tombstone on close so a delayed old write cannot expose an old ready descriptor again.
+     */
+    public void deleteGlobalIndexServiceIfOwned(String id, String ownerToken) {
+        try {
+            // Read the deterministic owner path first. Closing must not depend on a directory
+            // listing observing the current file; otherwise a temporarily omitted READY file can
+            // reappear after close without a tombstone.
+            Optional<GlobalIndexQueryServiceDescriptor> ownDescriptor =
+                    readGlobalIndexDescriptor(ownerServicePath(id, ownerToken));
+            Optional<GlobalIndexQueryServiceDescriptor> selected = selectGlobalIndexService(id);
+            if (selected.isPresent()
+                    && compareOwnerTokens(selected.get().ownerToken(), ownerToken) > 0) {
+                // A newer attempt owns discovery. Remove only this attempt's file.
+                fileIO.deleteQuietly(ownerServicePath(id, ownerToken));
+                return;
+            }
+
+            GlobalIndexQueryServiceDescriptor owned;
+            if (ownDescriptor.isPresent()) {
+                owned = ownDescriptor.get();
+            } else if (selected.isPresent() && selected.get().ownerToken().equals(ownerToken)) {
+                // Compatibility path for a canonical descriptor written before owner-scoped files.
+                owned = selected.get();
+            } else {
+                return;
+            }
+
+            GlobalIndexQueryServiceDescriptor tombstone =
+                    new GlobalIndexQueryServiceDescriptor(
+                            owned.protocolVersion(),
+                            owned.tableUuid(),
+                            owned.branch(),
+                            owned.schemaId(),
+                            owned.schemaFingerprint(),
+                            owned.lookupFieldId(),
+                            owned.valueFieldIds(),
+                            Long.MIN_VALUE,
+                            -1L,
+                            null,
+                            owned.hashVersion(),
+                            owned.layout(),
+                            ownerToken,
+                            false,
+                            "Query service publisher is closed.",
+                            new GlobalIndexQueryServiceDescriptor.Endpoint[0]);
+            fileIO.overwriteFileUtf8(
+                    ownerServicePath(id, ownerToken), JsonSerdeUtil.toJson(tombstone));
+            fileIO.deleteQuietly(servicePath(id));
+            deleteOlderOwnerServices(id, ownerToken);
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+
     public void deleteService(String id) {
         fileIO.deleteQuietly(servicePath(id));
     }
 
     private Path servicePath(String id) {
-        return new Path(tablePath + "/service/" + SERVICE_PREFIX + id);
+        return new Path(serviceDirectory() + "/" + SERVICE_PREFIX + id);
+    }
+
+    private Path serviceDirectory() {
+        return new Path(tablePath + "/service");
+    }
+
+    private String ownerServicePrefix(String id) {
+        return SERVICE_PREFIX + id + "-owner-";
+    }
+
+    private Path ownerServicePath(String id, String ownerToken) {
+        String tokenHash =
+                UUID.nameUUIDFromBytes(ownerToken.getBytes(StandardCharsets.UTF_8)).toString();
+        return new Path(serviceDirectory() + "/" + ownerServicePrefix(id) + tokenHash);
+    }
+
+    private Optional<GlobalIndexQueryServiceDescriptor> readGlobalIndexDescriptor(Path path)
+            throws IOException {
+        return fileIO.readOverwrittenFileUtf8(path)
+                .map(json -> JsonSerdeUtil.fromJson(json, GlobalIndexQueryServiceDescriptor.class));
+    }
+
+    private Optional<GlobalIndexQueryServiceDescriptor> selectGlobalIndexService(String id)
+            throws IOException {
+        Optional<GlobalIndexQueryServiceDescriptor> selected = Optional.empty();
+        Path directory = serviceDirectory();
+        if (fileIO.exists(directory)) {
+            String prefix = ownerServicePrefix(id);
+            for (FileStatus status : fileIO.listStatus(directory)) {
+                if (status.isDir() || !status.getPath().getName().startsWith(prefix)) {
+                    continue;
+                }
+                Optional<GlobalIndexQueryServiceDescriptor> descriptor =
+                        readGlobalIndexDescriptor(status.getPath());
+                if (descriptor.isPresent()
+                        && (!selected.isPresent()
+                                || compareOwnerTokens(
+                                                descriptor.get().ownerToken(),
+                                                selected.get().ownerToken())
+                                        > 0)) {
+                    selected = descriptor;
+                }
+            }
+        }
+        // Compatibility fallback for a descriptor written before owner-scoped files existed.
+        return selected.isPresent() ? selected : readGlobalIndexDescriptor(servicePath(id));
+    }
+
+    private static int compareOwnerTokens(String left, String right) {
+        long leftSequence = ownerSequence(left);
+        long rightSequence = ownerSequence(right);
+        if (leftSequence >= 0L || rightSequence >= 0L) {
+            if (leftSequence < 0L) {
+                return -1;
+            }
+            if (rightSequence < 0L) {
+                return 1;
+            }
+            int sequenceComparison = Long.compare(leftSequence, rightSequence);
+            if (sequenceComparison != 0) {
+                return sequenceComparison;
+            }
+        }
+        return left.compareTo(right);
+    }
+
+    private static long ownerSequence(String ownerToken) {
+        int separator = ownerToken.indexOf('-');
+        if (separator <= 0) {
+            return -1L;
+        }
+        try {
+            long sequence = Long.parseLong(ownerToken.substring(0, separator));
+            return sequence < 0L ? -1L : sequence;
+        } catch (NumberFormatException ignored) {
+            return -1L;
+        }
+    }
+
+    private void deleteOlderOwnerServices(String id, String ownerToken) throws IOException {
+        Path directory = serviceDirectory();
+        if (!fileIO.exists(directory)) {
+            return;
+        }
+        String prefix = ownerServicePrefix(id);
+        for (FileStatus status : fileIO.listStatus(directory)) {
+            if (status.isDir() || !status.getPath().getName().startsWith(prefix)) {
+                continue;
+            }
+            Optional<GlobalIndexQueryServiceDescriptor> descriptor =
+                    readGlobalIndexDescriptor(status.getPath());
+            if (!descriptor.isPresent()) {
+                continue;
+            }
+            int comparison = compareOwnerTokens(descriptor.get().ownerToken(), ownerToken);
+            if (comparison < 0) {
+                fileIO.deleteQuietly(status.getPath());
+            }
+        }
     }
 }

--- a/paimon-core/src/main/java/org/apache/paimon/table/query/DataEvolutionGlobalIndexTableQuery.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/query/DataEvolutionGlobalIndexTableQuery.java
@@ -1,0 +1,406 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.table.query;
+
+import org.apache.paimon.data.BinaryRow;
+import org.apache.paimon.data.InternalRow;
+import org.apache.paimon.data.serializer.BinaryRowSerializer;
+import org.apache.paimon.data.serializer.InternalRowSerializer;
+import org.apache.paimon.data.serializer.InternalSerializers;
+import org.apache.paimon.lookup.ValueState;
+import org.apache.paimon.lookup.local.LocalKvStateFactory;
+import org.apache.paimon.options.Options;
+import org.apache.paimon.table.FileStoreTable;
+import org.apache.paimon.types.RowType;
+import org.apache.paimon.utils.FileIOUtils;
+import org.apache.paimon.utils.TypeUtils;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.annotation.Nullable;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.locks.ReadWriteLock;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
+
+import static org.apache.paimon.CoreOptions.LOOKUP_CACHE_ROWS;
+import static org.apache.paimon.table.query.GlobalIndexQueryServiceUtils.normalizeKey;
+import static org.apache.paimon.table.query.GlobalIndexQueryServiceUtils.querySpec;
+import static org.apache.paimon.utils.Preconditions.checkArgument;
+
+/**
+ * Shard-local materialized query for an append table whose completeness is gated by a global BTree
+ * index.
+ *
+ * <p>A refresh builds a shadow key-to-single-value state. The previous state remains allocated
+ * until the new generation is atomically swapped in, but request admission is fenced as soon as a
+ * newer generation is observed. This fail-closed gap prevents a key in an unindexed append tail
+ * from being interpreted as a table miss through a cached endpoint. A fresh process has no active
+ * generation and also fails closed until bootstrap completes. Null keys are outside the lookup
+ * domain. Duplicate non-null keys or a projected value which cannot fit in one protocol response
+ * invalidate the whole building generation before it can become ready.
+ */
+public class DataEvolutionGlobalIndexTableQuery implements TableQuery {
+
+    private static final Logger LOG =
+            LoggerFactory.getLogger(DataEvolutionGlobalIndexTableQuery.class);
+
+    private final FileStoreTable table;
+    private final GlobalIndexQueryServiceUtils.QuerySpec spec;
+    private final File stateRoot;
+    private final BinaryRowSerializer keySerializer;
+    private final InternalRowSerializer logicalKeySerializer;
+    private final InternalRowSerializer valueSerializer;
+    private final int[] valueProjection;
+    private final ReadWriteLock lock;
+
+    @Nullable private LocalKvStateFactory activeStateFactory;
+    @Nullable private ValueState<BinaryRow, BinaryRow> activeState;
+    @Nullable private File activeStatePath;
+    @Nullable private LocalKvStateFactory buildingStateFactory;
+    @Nullable private ValueState<BinaryRow, BinaryRow> buildingState;
+    @Nullable private File buildingStatePath;
+    private long latestGeneration;
+    private long buildingSnapshotId;
+    private long servedGeneration;
+    private long servedSnapshotId;
+    private boolean buildingDuplicateDetected;
+    private boolean buildingOversizedValueDetected;
+    private String notReadyReason;
+
+    public DataEvolutionGlobalIndexTableQuery(
+            FileStoreTable table, String lookupField, List<String> valueFields, File stateRoot) {
+        this.table = table;
+        this.spec = querySpec(table, lookupField, valueFields);
+        this.stateRoot = stateRoot;
+        RowType keyType = TypeUtils.project(table.rowType(), new int[] {spec.lookupPosition()});
+        RowType valueType = TypeUtils.project(table.rowType(), spec.valuePositions());
+        this.keySerializer = new BinaryRowSerializer(keyType.getFieldCount());
+        this.logicalKeySerializer = InternalSerializers.create(keyType);
+        this.valueSerializer = InternalSerializers.create(valueType);
+        this.valueProjection = spec.valuePositions();
+        this.lock = new ReentrantReadWriteLock();
+        this.latestGeneration = Long.MIN_VALUE;
+        this.buildingSnapshotId = GlobalIndexQueryServiceUtils.EMPTY_SNAPSHOT_ID;
+        this.servedGeneration = Long.MIN_VALUE;
+        this.servedSnapshotId = GlobalIndexQueryServiceUtils.EMPTY_SNAPSHOT_ID;
+        this.buildingDuplicateDetected = false;
+        this.buildingOversizedValueDetected = false;
+        this.notReadyReason = "Query service bootstrap has not started.";
+    }
+
+    public GlobalIndexQueryServiceUtils.QuerySpec spec() {
+        return spec;
+    }
+
+    public void beginRefresh(long generation, long snapshotId) throws IOException {
+        lock.writeLock().lock();
+        try {
+            checkArgument(
+                    generation > this.latestGeneration,
+                    "Refresh generation %s must be newer than %s.",
+                    generation,
+                    this.latestGeneration);
+            this.latestGeneration = generation;
+            this.buildingSnapshotId = snapshotId;
+            this.buildingDuplicateDetected = false;
+            this.buildingOversizedValueDetected = false;
+            this.notReadyReason = "Refreshing snapshot " + snapshotId + '.';
+            closeBuildingState();
+            Options options = table.coreOptions().toConfiguration();
+            this.buildingStatePath = new File(stateRoot, "generation-" + generation);
+            FileIOUtils.deleteDirectoryQuietly(buildingStatePath);
+            this.buildingStateFactory =
+                    new LocalKvStateFactory(
+                            buildingStatePath.toString(), options, null, null, false);
+            this.buildingState =
+                    buildingStateFactory.valueState(
+                            "global-index-query",
+                            keySerializer,
+                            new BinaryRowSerializer(valueSerializer.getArity()),
+                            options.get(LOOKUP_CACHE_ROWS));
+        } finally {
+            lock.writeLock().unlock();
+        }
+    }
+
+    public void put(long generation, BinaryRow key, BinaryRow value) throws IOException {
+        lock.writeLock().lock();
+        try {
+            checkGeneration(generation);
+            long serializedValueBytes = Integer.BYTES + (long) value.getSizeInBytes();
+            if (serializedValueBytes > GlobalIndexQueryServiceUtils.MAX_TOTAL_VALUE_BYTES) {
+                buildingOversizedValueDetected = true;
+                throw new OversizedLookupValueException(
+                        String.format(
+                                "Projected value for lookup field '%s' is %s serialized bytes; the query protocol limit is %s bytes.",
+                                spec.lookupField(),
+                                serializedValueBytes,
+                                GlobalIndexQueryServiceUtils.MAX_TOTAL_VALUE_BYTES));
+            }
+            BinaryRow normalizedKey = normalizeKey(key);
+            checkArgument(
+                    !normalizedKey.anyNull(), "Global-index query lookup key must not be null.");
+            if (currentBuildingState().get(normalizedKey) != null) {
+                buildingDuplicateDetected = true;
+                throw new DuplicateLookupKeyException(
+                        String.format(
+                                "Lookup field '%s' is configured as unique but a duplicate key was found while bootstrapping snapshot %s.",
+                                spec.lookupField(), buildingSnapshotId));
+            }
+            currentBuildingState().put(normalizedKey, value.copy());
+        } finally {
+            lock.writeLock().unlock();
+        }
+    }
+
+    public void finishRefresh(long generation) throws IOException {
+        lock.writeLock().lock();
+        try {
+            checkGeneration(generation);
+            checkArgument(buildingState != null, "Query state has not been initialized.");
+            checkArgument(
+                    !buildingDuplicateDetected,
+                    "Duplicate lookup keys prevent generation %s from becoming ready.",
+                    generation);
+            checkArgument(
+                    !buildingOversizedValueDetected,
+                    "An oversized projected value prevents generation %s from becoming ready.",
+                    generation);
+            LocalKvStateFactory oldStateFactory = activeStateFactory;
+            File oldStatePath = activeStatePath;
+            activeStateFactory = buildingStateFactory;
+            activeState = buildingState;
+            activeStatePath = buildingStatePath;
+            servedGeneration = generation;
+            servedSnapshotId = buildingSnapshotId;
+            buildingStateFactory = null;
+            buildingState = null;
+            buildingStatePath = null;
+            this.notReadyReason = "";
+            closeOldActiveState(oldStateFactory, oldStatePath);
+        } finally {
+            lock.writeLock().unlock();
+        }
+    }
+
+    public void markNotReady(long generation, long snapshotId, String reason) throws IOException {
+        lock.writeLock().lock();
+        try {
+            if (generation < this.latestGeneration) {
+                return;
+            }
+            this.latestGeneration = generation;
+            this.buildingSnapshotId = snapshotId;
+            this.buildingDuplicateDetected = false;
+            this.buildingOversizedValueDetected = false;
+            this.notReadyReason = reason;
+            closeBuildingState();
+        } finally {
+            lock.writeLock().unlock();
+        }
+    }
+
+    public boolean ready() {
+        lock.readLock().lock();
+        try {
+            return activeState != null && latestGeneration == servedGeneration;
+        } finally {
+            lock.readLock().unlock();
+        }
+    }
+
+    @Nullable
+    @Override
+    public InternalRow lookup(BinaryRow partition, int bucket, InternalRow key) throws IOException {
+        // LocalKv state and its codecs reuse mutable serializers. Serialize lookups on one
+        // executor instead of allowing concurrent read-lock holders to corrupt shared buffers.
+        lock.writeLock().lock();
+        try {
+            if (activeState == null || latestGeneration != servedGeneration) {
+                throw new QueryServiceNotReadyException(
+                        String.format(
+                                "Global-index query service is not ready for generation %s and snapshot %s: %s",
+                                latestGeneration, buildingSnapshotId, notReadyReason));
+            }
+            BinaryRow binaryKey = valueToBinaryKey(key);
+            checkArgument(
+                    !binaryKey.anyNull(), "Global-index query does not support null lookup keys.");
+            BinaryRow value = currentActiveState().get(binaryKey);
+            return value == null ? null : value.copy();
+        } finally {
+            lock.writeLock().unlock();
+        }
+    }
+
+    @Override
+    public DataEvolutionGlobalIndexTableQuery withValueProjection(int[] projection) {
+        checkArgument(
+                Arrays.equals(valueProjection, projection),
+                "Global-index query value projection is fixed by the service ID.");
+        return this;
+    }
+
+    @Override
+    public InternalRowSerializer createValueSerializer() {
+        return valueSerializer;
+    }
+
+    public long servedGeneration() {
+        lock.readLock().lock();
+        try {
+            return servedGeneration;
+        } finally {
+            lock.readLock().unlock();
+        }
+    }
+
+    /** The newest generation observed by this executor, including one which is not ready yet. */
+    public long latestGeneration() {
+        lock.readLock().lock();
+        try {
+            return latestGeneration;
+        } finally {
+            lock.readLock().unlock();
+        }
+    }
+
+    public long servedSnapshotId() {
+        lock.readLock().lock();
+        try {
+            return servedSnapshotId;
+        } finally {
+            lock.readLock().unlock();
+        }
+    }
+
+    @Override
+    public void close() throws IOException {
+        lock.writeLock().lock();
+        try {
+            IOException failure = null;
+            try {
+                closeBuildingState();
+            } catch (IOException e) {
+                failure = e;
+            }
+            try {
+                closeActiveState();
+            } catch (IOException e) {
+                if (failure == null) {
+                    failure = e;
+                } else {
+                    failure.addSuppressed(e);
+                }
+            } finally {
+                FileIOUtils.deleteDirectoryQuietly(stateRoot);
+            }
+            if (failure != null) {
+                throw failure;
+            }
+        } finally {
+            lock.writeLock().unlock();
+        }
+    }
+
+    private void checkGeneration(long generation) {
+        checkArgument(
+                generation == this.latestGeneration,
+                "Received generation %s while current generation is %s.",
+                generation,
+                this.latestGeneration);
+    }
+
+    private BinaryRow valueToBinaryKey(InternalRow key) {
+        if (key instanceof BinaryRow) {
+            // Schemaless protocol deserialization may return a row at a non-zero segment offset.
+            // Copy to an offset-zero row before using offset-insensitive BinaryRow methods.
+            return normalizeKey((BinaryRow) key);
+        }
+        return normalizeKey(logicalKeySerializer.toBinaryRow(key));
+    }
+
+    private ValueState<BinaryRow, BinaryRow> currentActiveState() {
+        if (activeState == null) {
+            throw new IllegalStateException("Global-index query state is not initialized.");
+        }
+        return activeState;
+    }
+
+    private ValueState<BinaryRow, BinaryRow> currentBuildingState() {
+        if (buildingState == null) {
+            throw new IllegalStateException("Global-index query refresh has not started.");
+        }
+        return buildingState;
+    }
+
+    private void closeActiveState() throws IOException {
+        activeState = null;
+        LocalKvStateFactory stateFactory = activeStateFactory;
+        File statePath = activeStatePath;
+        activeStateFactory = null;
+        activeStatePath = null;
+        try {
+            if (stateFactory != null) {
+                stateFactory.close();
+            }
+        } finally {
+            if (statePath != null) {
+                FileIOUtils.deleteDirectoryQuietly(statePath);
+            }
+        }
+    }
+
+    private void closeOldActiveState(
+            @Nullable LocalKvStateFactory oldStateFactory, @Nullable File oldStatePath) {
+        try {
+            if (oldStateFactory != null) {
+                oldStateFactory.close();
+            }
+        } catch (IOException e) {
+            // The new generation is already atomically active. Cleanup failure must not roll it
+            // back or expose a transient not-ready state.
+            LOG.warn("Failed to close previous global-index query generation.", e);
+        }
+        if (oldStatePath != null) {
+            FileIOUtils.deleteDirectoryQuietly(oldStatePath);
+        }
+    }
+
+    private void closeBuildingState() throws IOException {
+        buildingState = null;
+        LocalKvStateFactory stateFactory = buildingStateFactory;
+        File statePath = buildingStatePath;
+        buildingStateFactory = null;
+        buildingStatePath = null;
+        try {
+            if (stateFactory != null) {
+                stateFactory.close();
+            }
+        } finally {
+            if (statePath != null) {
+                FileIOUtils.deleteDirectoryQuietly(statePath);
+            }
+        }
+    }
+}

--- a/paimon-core/src/main/java/org/apache/paimon/table/query/DuplicateLookupKeyException.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/query/DuplicateLookupKeyException.java
@@ -1,0 +1,31 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.table.query;
+
+import java.io.IOException;
+
+/** Thrown when a lookup configured as unique resolves to more than one live row. */
+public class DuplicateLookupKeyException extends IOException {
+
+    private static final long serialVersionUID = 1L;
+
+    public DuplicateLookupKeyException(String message) {
+        super(message);
+    }
+}

--- a/paimon-core/src/main/java/org/apache/paimon/table/query/GlobalIndexQueryServiceUtils.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/query/GlobalIndexQueryServiceUtils.java
@@ -1,0 +1,355 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.table.query;
+
+import org.apache.paimon.CoreOptions;
+import org.apache.paimon.Snapshot;
+import org.apache.paimon.data.BinaryRow;
+import org.apache.paimon.globalindex.DataEvolutionGlobalIndexCoverage;
+import org.apache.paimon.globalindex.btree.BTreeGlobalIndexerFactory;
+import org.apache.paimon.index.GlobalIndexMeta;
+import org.apache.paimon.index.IndexFileMeta;
+import org.apache.paimon.manifest.IndexManifestEntry;
+import org.apache.paimon.table.BucketMode;
+import org.apache.paimon.table.FileStoreTable;
+import org.apache.paimon.types.BlobType;
+import org.apache.paimon.types.DataField;
+import org.apache.paimon.types.DataTypeRoot;
+import org.apache.paimon.types.RowKind;
+import org.apache.paimon.types.RowType;
+
+import javax.annotation.Nullable;
+
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static org.apache.paimon.CoreOptions.GlobalIndexColumnUpdateAction.IGNORE;
+import static org.apache.paimon.CoreOptions.GlobalIndexSearchMode.FAST;
+import static org.apache.paimon.catalog.Identifier.DEFAULT_MAIN_BRANCH;
+import static org.apache.paimon.service.ServiceManager.globalIndexLookupService;
+import static org.apache.paimon.utils.Preconditions.checkArgument;
+
+/** Shared validation, discovery, routing, and coverage rules for global-index query service. */
+public final class GlobalIndexQueryServiceUtils {
+
+    public static final long EMPTY_SNAPSHOT_ID = -1L;
+    public static final int MAX_TOTAL_VALUE_BYTES = 64 * 1024 * 1024;
+
+    private GlobalIndexQueryServiceUtils() {}
+
+    public static QuerySpec querySpec(
+            FileStoreTable table, String lookupField, List<String> valueFields) {
+        checkArgument(
+                table.schema().primaryKeys().isEmpty(),
+                "Global-index query service only supports append tables without primary keys.");
+        checkArgument(
+                table.schema().partitionKeys().isEmpty(),
+                "Global-index query service currently supports only unpartitioned tables so lookup-key uniqueness is global.");
+        checkArgument(
+                table.bucketMode() == BucketMode.BUCKET_UNAWARE,
+                "Global-index query service requires bucket=-1, but table '%s' uses %s.",
+                table.name(),
+                table.bucketMode());
+        CoreOptions options = table.coreOptions();
+        CoreOptions persistedOptions = persistedCoreOptions(table);
+        checkArgument(
+                DEFAULT_MAIN_BRANCH.equals(options.branch()),
+                "Global-index query service currently supports only the main branch because service discovery is table-scoped.");
+        checkArgument(
+                options.rowTrackingEnabled() && options.dataEvolutionEnabled(),
+                "Global-index query service requires row-tracking.enabled=true and data-evolution.enabled=true.");
+        checkArgument(
+                options.globalIndexColumnUpdateAction() != IGNORE
+                        && persistedOptions.globalIndexColumnUpdateAction() != IGNORE,
+                "Global-index query service does not support global-index.column-update-action=IGNORE because it can return false misses.");
+        checkArgument(
+                !options.queryAuthEnabled() && !persistedOptions.queryAuthEnabled(),
+                "Global-index query service does not support persisted or dynamic query-auth.enabled because its materialized state is shared by all clients.");
+        checkArgument(
+                !options.scanIgnoreCorruptFile()
+                        && !options.scanIgnoreLostFile()
+                        && !persistedOptions.scanIgnoreCorruptFile()
+                        && !persistedOptions.scanIgnoreLostFile(),
+                "Global-index query service requires persisted and dynamic scan.ignore-corrupt-files=false and scan.ignore-lost-files=false.");
+        checkArgument(
+                persistedOptions.consumerExpireTime() != null
+                        && persistedOptions
+                                        .consumerExpireTime()
+                                        .compareTo(
+                                                GlobalIndexQuerySnapshotLease.MIN_EXPIRATION_TIME)
+                                >= 0,
+                "Global-index query service requires a persisted consumer.expiration-time of at least %s so leases can be heartbeated safely and abandoned attempts can be cleaned up by writers.",
+                GlobalIndexQuerySnapshotLease.MIN_EXPIRATION_TIME);
+        checkArgument(
+                !options.consumerChangelogOnly() && !persistedOptions.consumerChangelogOnly(),
+                "Global-index query service requires persisted and dynamic consumer.changelog-only=false so its lease protects table snapshots.");
+        checkArgument(
+                valueFields != null && !valueFields.isEmpty(), "Value fields must not be empty.");
+
+        RowType rowType = table.rowType();
+        int lookupPosition = rowType.getFieldIndex(lookupField);
+        checkArgument(lookupPosition >= 0, "Lookup field '%s' does not exist.", lookupField);
+        int[] valuePositions = new int[valueFields.size()];
+        int[] valueFieldIds = new int[valueFields.size()];
+        for (int i = 0; i < valueFields.size(); i++) {
+            String field = valueFields.get(i);
+            int position = rowType.getFieldIndex(field);
+            checkArgument(position >= 0, "Value field '%s' does not exist.", field);
+            checkArgument(
+                    !field.equals(lookupField),
+                    "Lookup field '%s' must not also be a value field.",
+                    lookupField);
+            checkArgument(
+                    !BlobType.isBlobFileField(rowType.getTypeAt(position))
+                            || rowType.getTypeAt(position).getTypeRoot() == DataTypeRoot.BLOB,
+                    "Global-index query service does not support nested BLOB value field '%s'.",
+                    field);
+            if (rowType.getTypeAt(position).getTypeRoot() == DataTypeRoot.BLOB) {
+                checkArgument(
+                        !options.blobInlineField().contains(field)
+                                && !persistedOptions.blobInlineField().contains(field),
+                        "Global-index query service only supports raw blob-file value field '%s'; inline descriptor and BlobView fields are not supported.",
+                        field);
+            }
+            for (int j = 0; j < i; j++) {
+                checkArgument(
+                        !valueFields.get(j).equals(field), "Duplicate value field '%s'.", field);
+            }
+            valuePositions[i] = position;
+            valueFieldIds[i] = rowType.getFields().get(position).id();
+        }
+
+        DataField lookupDataField = rowType.getFields().get(lookupPosition);
+        checkArgument(
+                !BlobType.isBlobFileField(lookupDataField.type()),
+                "Global-index query service does not support BLOB lookup field '%s'.",
+                lookupField);
+        return new QuerySpec(
+                lookupField,
+                lookupPosition,
+                lookupDataField.id(),
+                valueFields,
+                valuePositions,
+                valueFieldIds,
+                schemaFingerprint(table.schema().id(), rowType, lookupPosition, valuePositions),
+                globalIndexLookupService(table.schema().id(), lookupDataField.id(), valueFieldIds));
+    }
+
+    private static String schemaFingerprint(
+            long schemaId, RowType rowType, int lookupPosition, int[] valuePositions) {
+        StringBuilder canonical = new StringBuilder().append(schemaId);
+        DataField lookup = rowType.getFields().get(lookupPosition);
+        canonical.append('|').append(lookup.id()).append(':').append(lookup.type());
+        for (int position : valuePositions) {
+            DataField value = rowType.getFields().get(position);
+            canonical.append('|').append(value.id()).append(':').append(value.type());
+        }
+        try {
+            byte[] digest =
+                    MessageDigest.getInstance("SHA-256")
+                            .digest(canonical.toString().getBytes(StandardCharsets.UTF_8));
+            StringBuilder hex = new StringBuilder(digest.length * 2);
+            for (byte value : digest) {
+                hex.append(String.format("%02x", value & 0xff));
+            }
+            return hex.toString();
+        } catch (NoSuchAlgorithmException e) {
+            throw new IllegalStateException("SHA-256 is not available.", e);
+        }
+    }
+
+    /** Stable key-only routing shared by the client, bootstrap shuffle, and server. */
+    public static int route(BinaryRow key, int numShards) {
+        checkArgument(numShards > 0, "Number of query shards must be positive.");
+        return Math.floorMod(normalizeKey(key).hashCode(), numShards);
+    }
+
+    /** Lookup keys are value-only; row kind must not affect routing or state equality. */
+    public static BinaryRow normalizeKey(BinaryRow key) {
+        BinaryRow normalized = key.copy();
+        normalized.setRowKind(RowKind.INSERT);
+        return normalized;
+    }
+
+    /**
+     * Read persisted schema options, excluding untrusted dynamic options from {@code table.copy}.
+     */
+    public static CoreOptions persistedCoreOptions(FileStoreTable table) {
+        return CoreOptions.fromMap(table.schemaManager().schema(table.schema().id()).options());
+    }
+
+    /** Validate BTree coverage for one exact snapshot without opening every BTree reader. */
+    public static SnapshotReadiness snapshotReadiness(
+            FileStoreTable table, QuerySpec spec, @Nullable Snapshot snapshot) {
+        if (snapshot == null) {
+            return SnapshotReadiness.ready(EMPTY_SNAPSHOT_ID);
+        }
+        if (snapshot.schemaId() != table.schema().id()) {
+            return SnapshotReadiness.notReady(
+                    snapshot.id(),
+                    String.format(
+                            "Snapshot schema %s differs from query-service schema %s; restart the service.",
+                            snapshot.schemaId(), table.schema().id()));
+        }
+
+        List<IndexFileMeta> indexFiles =
+                table.store().newIndexFileHandler()
+                        .scan(snapshot, entry -> isLookupBTree(entry, spec.lookupFieldId()))
+                        .stream()
+                        .map(IndexManifestEntry::indexFile)
+                        .collect(Collectors.toList());
+        DataEvolutionGlobalIndexCoverage coverage =
+                new DataEvolutionGlobalIndexCoverage(table, snapshot, null, indexFiles, FAST);
+        if (coverage.isFullyCovered(spec.lookupFieldId())) {
+            // A snapshot with no live data files is complete without an index file.
+            return SnapshotReadiness.ready(snapshot.id());
+        }
+        if (indexFiles.isEmpty()) {
+            return SnapshotReadiness.notReady(
+                    snapshot.id(),
+                    String.format(
+                            "No BTree global index is available for lookup field '%s'.",
+                            spec.lookupField()));
+        }
+        return SnapshotReadiness.notReady(
+                snapshot.id(),
+                String.format(
+                        "BTree global index for lookup field '%s' does not cover every live row range in snapshot %s.",
+                        spec.lookupField(), snapshot.id()));
+    }
+
+    private static boolean isLookupBTree(IndexManifestEntry entry, int fieldId) {
+        IndexFileMeta indexFile = entry.indexFile();
+        GlobalIndexMeta meta = indexFile.globalIndexMeta();
+        return meta != null
+                && meta.indexFieldId() == fieldId
+                && BTreeGlobalIndexerFactory.IDENTIFIER.equals(indexFile.indexType());
+    }
+
+    /** Immutable validated query schema. */
+    public static final class QuerySpec {
+
+        private final String lookupField;
+        private final int lookupPosition;
+        private final int lookupFieldId;
+        private final List<String> valueFields;
+        private final int[] valuePositions;
+        private final int[] valueFieldIds;
+        private final String schemaFingerprint;
+        private final String serviceId;
+
+        private QuerySpec(
+                String lookupField,
+                int lookupPosition,
+                int lookupFieldId,
+                List<String> valueFields,
+                int[] valuePositions,
+                int[] valueFieldIds,
+                String schemaFingerprint,
+                String serviceId) {
+            this.lookupField = lookupField;
+            this.lookupPosition = lookupPosition;
+            this.lookupFieldId = lookupFieldId;
+            this.valueFields = Collections.unmodifiableList(new ArrayList<>(valueFields));
+            this.valuePositions = Arrays.copyOf(valuePositions, valuePositions.length);
+            this.valueFieldIds = Arrays.copyOf(valueFieldIds, valueFieldIds.length);
+            this.schemaFingerprint = schemaFingerprint;
+            this.serviceId = serviceId;
+        }
+
+        public String lookupField() {
+            return lookupField;
+        }
+
+        public int lookupPosition() {
+            return lookupPosition;
+        }
+
+        public int lookupFieldId() {
+            return lookupFieldId;
+        }
+
+        public List<String> valueFields() {
+            return valueFields;
+        }
+
+        public int[] valuePositions() {
+            return Arrays.copyOf(valuePositions, valuePositions.length);
+        }
+
+        public int[] valueFieldIds() {
+            return Arrays.copyOf(valueFieldIds, valueFieldIds.length);
+        }
+
+        public String schemaFingerprint() {
+            return schemaFingerprint;
+        }
+
+        public int[] bootstrapProjection() {
+            int[] projection = new int[valuePositions.length + 1];
+            projection[0] = lookupPosition;
+            System.arraycopy(valuePositions, 0, projection, 1, valuePositions.length);
+            return projection;
+        }
+
+        public String serviceId() {
+            return serviceId;
+        }
+    }
+
+    /** Snapshot readiness is deliberately different from an empty lookup result. */
+    public static final class SnapshotReadiness {
+
+        private final long snapshotId;
+        private final boolean ready;
+        private final String reason;
+
+        private SnapshotReadiness(long snapshotId, boolean ready, String reason) {
+            this.snapshotId = snapshotId;
+            this.ready = ready;
+            this.reason = reason;
+        }
+
+        public static SnapshotReadiness ready(long snapshotId) {
+            return new SnapshotReadiness(snapshotId, true, "");
+        }
+
+        public static SnapshotReadiness notReady(long snapshotId, String reason) {
+            return new SnapshotReadiness(snapshotId, false, reason);
+        }
+
+        public long snapshotId() {
+            return snapshotId;
+        }
+
+        public boolean ready() {
+            return ready;
+        }
+
+        public String reason() {
+            return reason;
+        }
+    }
+}

--- a/paimon-core/src/main/java/org/apache/paimon/table/query/GlobalIndexQuerySnapshotLease.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/query/GlobalIndexQuerySnapshotLease.java
@@ -1,0 +1,181 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.table.query;
+
+import org.apache.paimon.consumer.Consumer;
+import org.apache.paimon.consumer.ConsumerManager;
+
+import javax.annotation.Nullable;
+
+import java.time.Duration;
+import java.util.UUID;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.regex.Pattern;
+
+import static org.apache.paimon.utils.Preconditions.checkArgument;
+
+/**
+ * Per-attempt consumer lease which protects building and published query snapshots from expiry.
+ *
+ * <p>The consumer ID contains a random attempt token and a daemon heartbeat updates its file while
+ * the attempt is alive. {@link #close()} stops the heartbeat but deliberately leaves the lease for
+ * {@code consumer.expiration-time}: a Flink source close callback cannot distinguish a terminal
+ * cancellation from a failover, and deleting immediately would leave an expiry window before the
+ * replacement attempt pins the snapshot. Table maintenance eventually removes every abandoned
+ * attempt lease.
+ *
+ * <p>{@link #pinBuilding(long)} only moves the lease backwards, to the minimum of the currently
+ * active and building snapshots. The caller may move it forward with {@link #promote(long)} only
+ * after the new generation is globally published and its configured handover grace period has
+ * elapsed.
+ */
+public class GlobalIndexQuerySnapshotLease implements AutoCloseable {
+
+    private static final long MIN_HEARTBEAT_MILLIS = 1_000L;
+    private static final long MAX_HEARTBEAT_MILLIS = 60_000L;
+    public static final Duration MIN_EXPIRATION_TIME = Duration.ofSeconds(10);
+    private static final int MAX_CONSUMER_ID_PREFIX_LENGTH = 128;
+    private static final Pattern CONSUMER_ID_PREFIX = Pattern.compile("[A-Za-z0-9][A-Za-z0-9._-]*");
+
+    private final ConsumerManager consumerManager;
+    private final String consumerId;
+    private final ScheduledExecutorService heartbeatExecutor;
+
+    @Nullable private Long pinnedSnapshotId;
+    @Nullable private RuntimeException heartbeatFailure;
+    private boolean closed;
+
+    public GlobalIndexQuerySnapshotLease(
+            ConsumerManager consumerManager, String consumerIdPrefix, Duration expirationTime) {
+        validateConsumerIdPrefix(consumerIdPrefix);
+        checkArgument(
+                expirationTime != null && expirationTime.compareTo(MIN_EXPIRATION_TIME) >= 0,
+                "consumer.expiration-time must be at least %s.",
+                MIN_EXPIRATION_TIME);
+        this.consumerManager = consumerManager;
+        this.consumerId = consumerIdPrefix + '-' + UUID.randomUUID();
+        this.heartbeatExecutor =
+                Executors.newSingleThreadScheduledExecutor(
+                        runnable -> {
+                            Thread thread =
+                                    new Thread(
+                                            runnable, "paimon-global-index-query-lease-heartbeat");
+                            thread.setDaemon(true);
+                            return thread;
+                        });
+        long heartbeatMillis =
+                Math.max(
+                        MIN_HEARTBEAT_MILLIS,
+                        Math.min(MAX_HEARTBEAT_MILLIS, expirationTime.toMillis() / 3));
+        heartbeatExecutor.scheduleWithFixedDelay(
+                this::heartbeatSafely, heartbeatMillis, heartbeatMillis, TimeUnit.MILLISECONDS);
+    }
+
+    /** Validate a single safe consumer-path segment before a Flink job is submitted. */
+    public static void validateConsumerIdPrefix(String consumerIdPrefix) {
+        checkArgument(
+                consumerIdPrefix != null
+                        && consumerIdPrefix.length() <= MAX_CONSUMER_ID_PREFIX_LENGTH
+                        && CONSUMER_ID_PREFIX.matcher(consumerIdPrefix).matches()
+                        && !consumerIdPrefix.contains(".."),
+                "--consumer-id prefix must be a single alphanumeric path segment of at most %s characters and may contain only '.', '_', or '-'.",
+                MAX_CONSUMER_ID_PREFIX_LENGTH);
+    }
+
+    /** Pin the minimum snapshot needed by the active and currently building generations. */
+    public synchronized void pinBuilding(long snapshotId) {
+        checkOpenAndHealthy();
+        checkArgument(snapshotId >= 0, "Cannot lease negative snapshot ID %s.", snapshotId);
+        if (pinnedSnapshotId == null || snapshotId < pinnedSnapshotId) {
+            pinnedSnapshotId = snapshotId;
+        }
+        writeLease();
+    }
+
+    /** Advance the lease after a new generation has been published and its grace period elapsed. */
+    public synchronized void promote(long snapshotId) {
+        checkOpenAndHealthy();
+        checkArgument(snapshotId >= 0, "Cannot lease negative snapshot ID %s.", snapshotId);
+        pinnedSnapshotId = snapshotId;
+        writeLease();
+    }
+
+    public synchronized void checkHealthy() {
+        checkOpenAndHealthy();
+    }
+
+    public String consumerId() {
+        return consumerId;
+    }
+
+    @Nullable
+    public synchronized Long pinnedSnapshotId() {
+        return pinnedSnapshotId;
+    }
+
+    @Override
+    public synchronized void close() {
+        if (closed) {
+            return;
+        }
+        RuntimeException failure = null;
+        try {
+            // Refresh the modification time before abandoning the attempt. This preserves the
+            // complete configured expiration window for a replacement task instead of shortening
+            // it by up to one heartbeat interval.
+            if (pinnedSnapshotId != null) {
+                writeLease();
+            }
+        } catch (RuntimeException e) {
+            failure = e;
+        } finally {
+            closed = true;
+            heartbeatExecutor.shutdownNow();
+        }
+        if (failure != null) {
+            throw failure;
+        }
+    }
+
+    private synchronized void heartbeatSafely() {
+        if (closed || pinnedSnapshotId == null) {
+            return;
+        }
+        try {
+            writeLease();
+            heartbeatFailure = null;
+        } catch (RuntimeException e) {
+            heartbeatFailure = e;
+        }
+    }
+
+    private void writeLease() {
+        consumerManager.resetConsumer(consumerId, new Consumer(pinnedSnapshotId));
+    }
+
+    private void checkOpenAndHealthy() {
+        checkArgument(!closed, "Snapshot lease is already closed.");
+        if (heartbeatFailure != null) {
+            throw new IllegalStateException(
+                    "Global-index query snapshot lease heartbeat failed.", heartbeatFailure);
+        }
+    }
+}

--- a/paimon-core/src/main/java/org/apache/paimon/table/query/OversizedLookupValueException.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/query/OversizedLookupValueException.java
@@ -1,0 +1,31 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.table.query;
+
+import java.io.IOException;
+
+/** Thrown when one projected value can never fit in a global-index query response. */
+public class OversizedLookupValueException extends IOException {
+
+    private static final long serialVersionUID = 1L;
+
+    public OversizedLookupValueException(String message) {
+        super(message);
+    }
+}

--- a/paimon-core/src/main/java/org/apache/paimon/table/query/QueryServiceNotReadyException.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/query/QueryServiceNotReadyException.java
@@ -1,0 +1,31 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.table.query;
+
+import java.io.IOException;
+
+/** Thrown when a query service has not published a complete snapshot view yet. */
+public class QueryServiceNotReadyException extends IOException {
+
+    private static final long serialVersionUID = 1L;
+
+    public QueryServiceNotReadyException(String message) {
+        super(message);
+    }
+}

--- a/paimon-core/src/test/java/org/apache/paimon/query/GlobalIndexQueryLocationTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/query/GlobalIndexQueryLocationTest.java
@@ -1,0 +1,282 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.query;
+
+import org.apache.paimon.CoreOptions;
+import org.apache.paimon.data.BinaryRow;
+import org.apache.paimon.data.BinaryString;
+import org.apache.paimon.data.GenericRow;
+import org.apache.paimon.data.serializer.InternalRowSerializer;
+import org.apache.paimon.data.serializer.InternalSerializers;
+import org.apache.paimon.schema.Schema;
+import org.apache.paimon.service.GlobalIndexQueryServiceDescriptor;
+import org.apache.paimon.service.GlobalIndexQueryServiceDescriptor.Endpoint;
+import org.apache.paimon.service.ServiceManager;
+import org.apache.paimon.table.FileStoreTable;
+import org.apache.paimon.table.TableTestBase;
+import org.apache.paimon.table.query.GlobalIndexQueryServiceUtils;
+import org.apache.paimon.table.query.GlobalIndexQueryServiceUtils.QuerySpec;
+import org.apache.paimon.table.query.QueryServiceNotReadyException;
+import org.apache.paimon.types.DataTypes;
+import org.apache.paimon.types.RowType;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.util.Collections;
+import java.util.stream.IntStream;
+
+import static org.apache.paimon.table.query.GlobalIndexQueryServiceUtils.route;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/** Tests versioned, snapshot-fenced global-index service discovery. */
+public class GlobalIndexQueryLocationTest extends TableTestBase {
+
+    @Test
+    public void testWideProjectionUsesBoundedStableServiceId() {
+        int[] wideProjection = IntStream.range(0, 200).toArray();
+        String serviceId = ServiceManager.globalIndexLookupService(7L, 3, wideProjection);
+
+        assertThat(serviceId).hasSizeLessThan(100);
+        assertThat(ServiceManager.globalIndexLookupService(7L, 3, wideProjection))
+                .isEqualTo(serviceId);
+        int[] reordered = wideProjection.clone();
+        int value = reordered[0];
+        reordered[0] = reordered[1];
+        reordered[1] = value;
+        assertThat(ServiceManager.globalIndexLookupService(7L, 3, reordered))
+                .isNotEqualTo(serviceId);
+    }
+
+    @Test
+    public void testDiscoveryValidationAndRouting() throws Exception {
+        FileStoreTable table = createTable();
+        QuerySpec spec =
+                GlobalIndexQueryServiceUtils.querySpec(
+                        table, "url", Collections.singletonList("descriptor"));
+        ServiceManager manager = table.store().newServiceManager();
+        InetSocketAddress[] addresses =
+                new InetSocketAddress[] {
+                    new InetSocketAddress("127.0.0.1", 7000),
+                    new InetSocketAddress("127.0.0.1", 7001)
+                };
+        String[] epochs = new String[] {"epoch-0", "epoch-1"};
+        manager.resetGlobalIndexService(
+                spec.serviceId(),
+                descriptor(table, spec, true, "", spec.schemaFingerprint(), addresses, epochs));
+
+        GlobalIndexQueryLocationImpl location =
+                new GlobalIndexQueryLocationImpl(
+                        manager,
+                        table.uuid(),
+                        table.coreOptions().branch(),
+                        table.schema().id(),
+                        spec);
+        BinaryRow key = key("O1CN.jpg");
+        int shard = route(key, addresses.length);
+        GlobalIndexQueryEndpoint endpoint = location.getLocation(key, false);
+        assertThat(endpoint.shardId()).isEqualTo(shard);
+        assertThat(endpoint.address()).isEqualTo(addresses[shard]);
+        assertThat(endpoint.serverEpoch()).isEqualTo(epochs[shard]);
+        assertThat(endpoint.servedGeneration()).isEqualTo(12L);
+        assertThat(endpoint.servedSnapshotId()).isEqualTo(12L);
+        assertThat(endpoint.snapshotUuid()).isEqualTo("snapshot-uuid");
+        assertThat(location.isServiceReady()).isTrue();
+
+        manager.deleteGlobalIndexServiceIfOwned(spec.serviceId(), "owner");
+        assertThat(location.isServiceReady()).isFalse();
+        manager.resetGlobalIndexService(
+                spec.serviceId(),
+                descriptor(table, spec, true, "", spec.schemaFingerprint(), addresses, epochs));
+
+        // Snapshot UUID was added after snapshot IDs. Legacy snapshots remain safely fenced by
+        // generation, server epoch and schema even when no UUID is available.
+        manager.resetGlobalIndexService(
+                spec.serviceId(),
+                new GlobalIndexQueryServiceDescriptor(
+                        GlobalIndexQueryServiceDescriptor.PROTOCOL_VERSION,
+                        table.uuid(),
+                        table.coreOptions().branch(),
+                        table.schema().id(),
+                        spec.schemaFingerprint(),
+                        spec.lookupFieldId(),
+                        spec.valueFieldIds(),
+                        13L,
+                        12L,
+                        null,
+                        GlobalIndexQueryServiceDescriptor.KEY_HASH_VERSION,
+                        GlobalIndexQueryServiceDescriptor.LAYOUT,
+                        "owner",
+                        true,
+                        "",
+                        endpoints(addresses, epochs)));
+        GlobalIndexQueryEndpoint legacyEndpoint = location.getLocation(key, true);
+        assertThat(legacyEndpoint.servedGeneration()).isEqualTo(13L);
+        assertThat(legacyEndpoint.servedSnapshotId()).isEqualTo(12L);
+        assertThat(legacyEndpoint.snapshotUuid()).isNull();
+
+        manager.resetGlobalIndexService(
+                spec.serviceId(),
+                descriptor(
+                        table,
+                        spec,
+                        false,
+                        "bootstrap incomplete",
+                        spec.schemaFingerprint(),
+                        new InetSocketAddress[0],
+                        new String[0]));
+        assertThatThrownBy(() -> location.getLocation(key, true))
+                .isInstanceOf(QueryServiceNotReadyException.class)
+                .hasMessageContaining("bootstrap incomplete");
+        assertThat(location.isServiceReady()).isFalse();
+
+        manager.resetGlobalIndexService(
+                spec.serviceId(), descriptor(table, spec, true, "", "wrong", addresses, epochs));
+        assertThatThrownBy(() -> location.getLocation(key, true))
+                .isInstanceOf(IOException.class)
+                .hasMessageContaining("schema does not match");
+
+        manager.resetGlobalIndexService(
+                spec.serviceId(),
+                new GlobalIndexQueryServiceDescriptor(
+                        GlobalIndexQueryServiceDescriptor.PROTOCOL_VERSION,
+                        "recreated-table-uuid",
+                        table.coreOptions().branch(),
+                        table.schema().id(),
+                        spec.schemaFingerprint(),
+                        spec.lookupFieldId(),
+                        spec.valueFieldIds(),
+                        13L,
+                        12L,
+                        "snapshot-uuid",
+                        GlobalIndexQueryServiceDescriptor.KEY_HASH_VERSION,
+                        GlobalIndexQueryServiceDescriptor.LAYOUT,
+                        "owner",
+                        true,
+                        "",
+                        endpoints(addresses, epochs)));
+        assertThatThrownBy(() -> location.getLocation(key, true))
+                .isInstanceOf(IOException.class)
+                .hasMessageContaining("table identity does not match");
+
+        Endpoint[] reversed =
+                new Endpoint[] {
+                    new Endpoint(1, addresses[0], epochs[0]),
+                    new Endpoint(0, addresses[1], epochs[1])
+                };
+        manager.resetGlobalIndexService(
+                spec.serviceId(), descriptor(table, spec, true, "", reversed));
+        assertThatThrownBy(() -> location.getLocation(key, true))
+                .isInstanceOf(IOException.class)
+                .hasMessageContaining("invalid endpoint");
+        assertThat(location.isServiceReady()).isFalse();
+    }
+
+    private FileStoreTable createTable() throws Exception {
+        Schema schema =
+                Schema.newBuilder()
+                        .column("url", DataTypes.STRING())
+                        .column("descriptor", DataTypes.BYTES())
+                        .option(CoreOptions.BUCKET.key(), "-1")
+                        .option(CoreOptions.ROW_TRACKING_ENABLED.key(), "true")
+                        .option(CoreOptions.DATA_EVOLUTION_ENABLED.key(), "true")
+                        .option(CoreOptions.CONSUMER_EXPIRATION_TIME.key(), "1 d")
+                        .build();
+        catalog.createTable(identifier(), schema, false);
+        return (FileStoreTable) catalog.getTable(identifier());
+    }
+
+    private GlobalIndexQueryServiceDescriptor descriptor(
+            FileStoreTable table,
+            QuerySpec spec,
+            boolean ready,
+            String reason,
+            String fingerprint,
+            InetSocketAddress[] addresses,
+            String[] epochs) {
+        return new GlobalIndexQueryServiceDescriptor(
+                GlobalIndexQueryServiceDescriptor.PROTOCOL_VERSION,
+                table.uuid(),
+                table.coreOptions().branch(),
+                table.schema().id(),
+                fingerprint,
+                spec.lookupFieldId(),
+                spec.valueFieldIds(),
+                12L,
+                12L,
+                "snapshot-uuid",
+                GlobalIndexQueryServiceDescriptor.KEY_HASH_VERSION,
+                GlobalIndexQueryServiceDescriptor.LAYOUT,
+                "owner",
+                ready,
+                reason,
+                endpoints(addresses, epochs));
+    }
+
+    private GlobalIndexQueryServiceDescriptor descriptor(
+            FileStoreTable table,
+            QuerySpec spec,
+            boolean ready,
+            String reason,
+            Endpoint[] endpoints) {
+        return descriptor(table, spec, ready, reason, endpoints, "owner");
+    }
+
+    private GlobalIndexQueryServiceDescriptor descriptor(
+            FileStoreTable table,
+            QuerySpec spec,
+            boolean ready,
+            String reason,
+            Endpoint[] endpoints,
+            String ownerToken) {
+        return new GlobalIndexQueryServiceDescriptor(
+                GlobalIndexQueryServiceDescriptor.PROTOCOL_VERSION,
+                table.uuid(),
+                table.coreOptions().branch(),
+                table.schema().id(),
+                spec.schemaFingerprint(),
+                spec.lookupFieldId(),
+                spec.valueFieldIds(),
+                12L,
+                12L,
+                "snapshot-uuid",
+                GlobalIndexQueryServiceDescriptor.KEY_HASH_VERSION,
+                GlobalIndexQueryServiceDescriptor.LAYOUT,
+                ownerToken,
+                ready,
+                reason,
+                endpoints);
+    }
+
+    private Endpoint[] endpoints(InetSocketAddress[] addresses, String[] epochs) {
+        Endpoint[] endpoints = new Endpoint[addresses.length];
+        for (int i = 0; i < endpoints.length; i++) {
+            endpoints[i] = new Endpoint(i, addresses[i], epochs[i]);
+        }
+        return endpoints;
+    }
+
+    private BinaryRow key(String value) {
+        InternalRowSerializer serializer =
+                InternalSerializers.create(RowType.of(DataTypes.STRING()));
+        return serializer.toBinaryRow(GenericRow.of(BinaryString.fromString(value))).copy();
+    }
+}

--- a/paimon-core/src/test/java/org/apache/paimon/service/ServiceManagerTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/service/ServiceManagerTest.java
@@ -20,6 +20,7 @@ package org.apache.paimon.service;
 
 import org.apache.paimon.fs.Path;
 import org.apache.paimon.fs.local.LocalFileIO;
+import org.apache.paimon.utils.JsonSerdeUtil;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
@@ -55,5 +56,110 @@ class ServiceManagerTest {
 
         Optional<InetSocketAddress[]> result = manager.service(PRIMARY_KEY_LOOKUP);
         assertThat(result).hasValue(addresses);
+    }
+
+    @Test
+    public void testOwnerScopedPublicationAndCloseFencing() {
+        ServiceManager manager = manager();
+        String serviceId = "global-index-test";
+        String oldOwner = "0000000000000000001-0000000000-old";
+        String newOwner = "0000000000000000001-0000000001-new";
+        GlobalIndexQueryServiceDescriptor oldAttempt = descriptor(oldOwner, true, "old");
+        GlobalIndexQueryServiceDescriptor newAttempt = descriptor(newOwner, false, "new attempt");
+
+        manager.resetGlobalIndexService(serviceId, oldAttempt);
+        manager.resetGlobalIndexService(serviceId, newAttempt);
+        // A delayed write and close from the old attempt cannot replace or delete the newer owner.
+        manager.resetGlobalIndexService(serviceId, oldAttempt);
+        assertThat(manager.globalIndexService(serviceId)).contains(newAttempt);
+        manager.deleteGlobalIndexServiceIfOwned(serviceId, oldOwner);
+        assertThat(manager.globalIndexService(serviceId)).contains(newAttempt);
+
+        manager.deleteGlobalIndexServiceIfOwned(serviceId, newOwner);
+        assertThat(manager.globalIndexService(serviceId))
+                .hasValueSatisfying(
+                        tombstone -> {
+                            assertThat(tombstone.ownerToken()).isEqualTo(newOwner);
+                            assertThat(tombstone.ready()).isFalse();
+                            assertThat(tombstone.reason()).contains("publisher is closed");
+                        });
+        // The highest owner token remains as a tombstone, so an even later old READY write cannot
+        // revive discovery.
+        manager.resetGlobalIndexService(serviceId, oldAttempt);
+        assertThat(manager.globalIndexService(serviceId))
+                .hasValueSatisfying(
+                        tombstone -> {
+                            assertThat(tombstone.ownerToken()).isEqualTo(newOwner);
+                            assertThat(tombstone.ready()).isFalse();
+                        });
+        assertThat(manager.nextGlobalIndexOwnerSequence(serviceId)).isEqualTo(2L);
+    }
+
+    @Test
+    public void testSameSequenceHasDeterministicTieBreak() {
+        ServiceManager manager = manager();
+        String serviceId = "global-index-same-sequence";
+        GlobalIndexQueryServiceDescriptor lower =
+                descriptor("0000000000000000005-0000000000-aaa", true, "lower");
+        GlobalIndexQueryServiceDescriptor higher =
+                descriptor("0000000000000000005-0000000000-bbb", false, "higher");
+
+        manager.resetGlobalIndexService(serviceId, lower);
+        manager.resetGlobalIndexService(serviceId, higher);
+        manager.resetGlobalIndexService(serviceId, lower);
+
+        assertThat(manager.globalIndexService(serviceId)).contains(higher);
+        assertThat(manager.nextGlobalIndexOwnerSequence(serviceId)).isEqualTo(6L);
+    }
+
+    @Test
+    public void testOwnerClaimRemovesCanonicalCompatibilityDescriptor() throws IOException {
+        LocalFileIO fileIO = LocalFileIO.create();
+        Path tablePath = new Path(tempDir.resolve("legacy").toUri());
+        ServiceManager manager = new ServiceManager(fileIO, tablePath);
+        String serviceId = "global-index-legacy";
+        GlobalIndexQueryServiceDescriptor legacy = descriptor("legacy-owner", true, "legacy");
+        Path canonicalPath =
+                new Path(new Path(tablePath, "service"), ServiceManager.SERVICE_PREFIX + serviceId);
+        fileIO.overwriteFileUtf8(canonicalPath, JsonSerdeUtil.toJson(legacy));
+        assertThat(manager.globalIndexService(serviceId)).contains(legacy);
+
+        GlobalIndexQueryServiceDescriptor replacement =
+                descriptor("0000000000000000001-0000000000-replacement", false, "replacement");
+        manager.resetGlobalIndexService(serviceId, replacement);
+        assertThat(fileIO.exists(canonicalPath)).isFalse();
+        manager.deleteGlobalIndexServiceIfOwned(serviceId, replacement.ownerToken());
+
+        assertThat(manager.globalIndexService(serviceId))
+                .hasValueSatisfying(
+                        tombstone -> {
+                            assertThat(tombstone.ownerToken()).isEqualTo(replacement.ownerToken());
+                            assertThat(tombstone.ready()).isFalse();
+                        });
+    }
+
+    private ServiceManager manager() {
+        return new ServiceManager(LocalFileIO.create(), new Path(tempDir.toUri()));
+    }
+
+    private GlobalIndexQueryServiceDescriptor descriptor(
+            String ownerToken, boolean ready, String reason) {
+        return new GlobalIndexQueryServiceDescriptor(
+                GlobalIndexQueryServiceDescriptor.PROTOCOL_VERSION,
+                "table-uuid",
+                "main",
+                1L,
+                "schema-fingerprint",
+                1,
+                new int[] {2},
+                3L,
+                3L,
+                "snapshot-uuid",
+                GlobalIndexQueryServiceDescriptor.KEY_HASH_VERSION,
+                GlobalIndexQueryServiceDescriptor.LAYOUT,
+                ownerToken,
+                ready,
+                reason,
+                new GlobalIndexQueryServiceDescriptor.Endpoint[0]);
     }
 }

--- a/paimon-core/src/test/java/org/apache/paimon/table/BtreeGlobalIndexTableTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/table/BtreeGlobalIndexTableTest.java
@@ -611,6 +611,25 @@ public class BtreeGlobalIndexTableTest extends DataEvolutionTestBase {
     }
 
     @Test
+    public void testExactCoverageDoesNotTrustFastSearchMode() throws Exception {
+        write(100L);
+        FileStoreTable table = (FileStoreTable) catalog.getTable(identifier());
+        assertThat(exactCoverage(table, 1)).isFalse();
+
+        createIndex("f1");
+        table = (FileStoreTable) catalog.getTable(identifier());
+        assertThat(exactCoverage(table, 1)).isTrue();
+
+        appendRows(100, 200);
+        table = (FileStoreTable) catalog.getTable(identifier());
+        assertThat(exactCoverage(table, 1)).isFalse();
+
+        createIndexIncremental("f1");
+        table = (FileStoreTable) catalog.getTable(identifier());
+        assertThat(exactCoverage(table, 1)).isTrue();
+    }
+
+    @Test
     public void testOrdinaryAndSourceBackedBTreeIndexCoverageCanCoexist() throws Exception {
         write(10L);
         FileStoreTable table =
@@ -850,6 +869,21 @@ public class BtreeGlobalIndexTableTest extends DataEvolutionTestBase {
         return splits.stream()
                 .map(split -> ((IndexedSplit) split).dataSplit())
                 .collect(Collectors.toList());
+    }
+
+    private boolean exactCoverage(FileStoreTable table, int fieldId) {
+        Snapshot snapshot = table.snapshotManager().latestSnapshot();
+        List<IndexFileMeta> indexFiles =
+                table.store().newIndexFileHandler().scan(snapshot, "btree").stream()
+                        .map(IndexManifestEntry::indexFile)
+                        .collect(Collectors.toList());
+        return new DataEvolutionGlobalIndexCoverage(
+                        table,
+                        snapshot,
+                        PartitionPredicate.ALWAYS_TRUE,
+                        indexFiles,
+                        CoreOptions.GlobalIndexSearchMode.FAST)
+                .isFullyCovered(fieldId);
     }
 
     private List<String> readF1(ReadBuilder readBuilder, TableScan.Plan plan) throws Exception {

--- a/paimon-core/src/test/java/org/apache/paimon/table/query/DataEvolutionGlobalIndexTableQueryTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/table/query/DataEvolutionGlobalIndexTableQueryTest.java
@@ -1,0 +1,329 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.table.query;
+
+import org.apache.paimon.CoreOptions;
+import org.apache.paimon.data.BinaryRow;
+import org.apache.paimon.data.BinaryString;
+import org.apache.paimon.data.GenericRow;
+import org.apache.paimon.data.serializer.InternalRowSerializer;
+import org.apache.paimon.data.serializer.InternalSerializers;
+import org.apache.paimon.memory.MemorySegment;
+import org.apache.paimon.schema.Schema;
+import org.apache.paimon.table.FileStoreTable;
+import org.apache.paimon.table.TableTestBase;
+import org.apache.paimon.types.DataType;
+import org.apache.paimon.types.DataTypes;
+import org.apache.paimon.types.RowKind;
+import org.apache.paimon.types.RowType;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+
+import static org.apache.paimon.utils.SerializationUtils.deserializeBinaryRow;
+import static org.apache.paimon.utils.SerializationUtils.serializeBinaryRow;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/** Tests fail-closed refresh, uniqueness, and concurrent access of materialized query state. */
+public class DataEvolutionGlobalIndexTableQueryTest extends TableTestBase {
+
+    @Test
+    public void testRefreshAndDuplicatePolicy() throws Exception {
+        FileStoreTable table = createAppendTable();
+        try (DataEvolutionGlobalIndexTableQuery query = newQuery(table)) {
+            BinaryRow key = key("https://example/a");
+            BinaryRow value = value("descriptor-a");
+
+            assertThatThrownBy(
+                            () ->
+                                    query.lookup(
+                                            BinaryRow.EMPTY_ROW,
+                                            0,
+                                            GenericRow.of(
+                                                    BinaryString.fromString("https://example/a"))))
+                    .isInstanceOf(QueryServiceNotReadyException.class);
+
+            query.beginRefresh(1L, 10L);
+            query.put(1L, key, value);
+            query.finishRefresh(1L);
+            assertThat(
+                            query.lookup(
+                                            BinaryRow.EMPTY_ROW,
+                                            0,
+                                            GenericRow.of(
+                                                    BinaryString.fromString("https://example/a")))
+                                    .getString(0)
+                                    .toString())
+                    .isEqualTo("descriptor-a");
+
+            query.beginRefresh(2L, 11L);
+            query.put(2L, key, value("first"));
+            assertThatThrownBy(() -> query.put(2L, key, value("second")))
+                    .isInstanceOf(DuplicateLookupKeyException.class)
+                    .hasMessageContaining("configured as unique");
+            query.markNotReady(2L, 11L, "duplicate key");
+            assertThatThrownBy(() -> query.lookup(BinaryRow.EMPTY_ROW, 0, key))
+                    .isInstanceOf(QueryServiceNotReadyException.class)
+                    .hasMessageContaining("duplicate key");
+            assertThat(query.ready()).isFalse();
+            assertThat(query.latestGeneration()).isEqualTo(2L);
+            assertThat(query.servedGeneration()).isEqualTo(1L);
+            assertThat(query.servedSnapshotId()).isEqualTo(10L);
+
+            query.beginRefresh(3L, 12L);
+            query.put(3L, key, value("descriptor-new"));
+            query.finishRefresh(3L);
+            assertThat(query.lookup(BinaryRow.EMPTY_ROW, 0, key).getString(0).toString())
+                    .isEqualTo("descriptor-new");
+        }
+    }
+
+    @Test
+    public void testConcurrentLookupIsSerializedSafely() throws Exception {
+        FileStoreTable table = createAppendTable();
+        try (DataEvolutionGlobalIndexTableQuery query = newQuery(table)) {
+            BinaryRow key = key("https://example/concurrent");
+            query.beginRefresh(1L, 1L);
+            query.put(1L, key, value("descriptor"));
+            query.finishRefresh(1L);
+
+            ExecutorService executor = Executors.newFixedThreadPool(8);
+            try {
+                Callable<String> lookup =
+                        () -> query.lookup(BinaryRow.EMPTY_ROW, 0, key).getString(0).toString();
+                List<Future<String>> futures = executor.invokeAll(Collections.nCopies(200, lookup));
+                for (Future<String> future : futures) {
+                    assertThat(future.get()).isEqualTo("descriptor");
+                }
+            } finally {
+                executor.shutdownNow();
+            }
+        }
+    }
+
+    @Test
+    public void testSchemalessBinaryKeyOffsetIsNormalized() throws Exception {
+        FileStoreTable table = createAppendTable();
+        try (DataEvolutionGlobalIndexTableQuery query = newQuery(table)) {
+            BinaryRow wireKey = deserializeBinaryRow(serializeBinaryRow(key("wire-key")));
+            assertThat(wireKey.getOffset()).isNotZero();
+            wireKey.setRowKind(RowKind.DELETE);
+            assertThat(GlobalIndexQueryServiceUtils.route(wireKey, 17))
+                    .isEqualTo(GlobalIndexQueryServiceUtils.route(key("wire-key"), 17));
+
+            query.beginRefresh(1L, 1L);
+            query.put(1L, wireKey, value("descriptor"));
+            query.finishRefresh(1L);
+
+            BinaryRow updateKey = key("wire-key");
+            updateKey.setRowKind(RowKind.UPDATE_AFTER);
+            assertThat(query.lookup(BinaryRow.EMPTY_ROW, 0, updateKey).getString(0).toString())
+                    .isEqualTo("descriptor");
+        }
+    }
+
+    @Test
+    public void testOversizedValueCannotBecomeReady() throws Exception {
+        FileStoreTable table = createAppendTable();
+        try (DataEvolutionGlobalIndexTableQuery query = newQuery(table)) {
+            BinaryRow oversized = new BinaryRow(1);
+            oversized.pointTo(
+                    MemorySegment.wrap(new byte[BinaryRow.calculateFixPartSizeInBytes(1)]),
+                    0,
+                    GlobalIndexQueryServiceUtils.MAX_TOTAL_VALUE_BYTES);
+
+            query.beginRefresh(1L, 1L);
+            assertThatThrownBy(() -> query.put(1L, key("too-large"), oversized))
+                    .isInstanceOf(OversizedLookupValueException.class)
+                    .hasMessageContaining("query protocol limit");
+            assertThatThrownBy(() -> query.finishRefresh(1L))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessageContaining("oversized projected value");
+            assertThat(query.ready()).isFalse();
+        }
+    }
+
+    @Test
+    public void testPersistedQueryAuthCannotBeDisabledDynamically() throws Exception {
+        Map<String, String> options = new HashMap<>();
+        options.put(CoreOptions.BUCKET.key(), "-1");
+        options.put(CoreOptions.ROW_TRACKING_ENABLED.key(), "true");
+        options.put(CoreOptions.DATA_EVOLUTION_ENABLED.key(), "true");
+        options.put(CoreOptions.CONSUMER_EXPIRATION_TIME.key(), "1 d");
+        options.put(CoreOptions.QUERY_AUTH_ENABLED.key(), "true");
+        Schema schema =
+                Schema.newBuilder()
+                        .column("url", DataTypes.STRING())
+                        .column("descriptor", DataTypes.STRING())
+                        .options(options)
+                        .build();
+        catalog.createTable(identifier("AuthTable"), schema, false);
+        FileStoreTable persistedAuth = (FileStoreTable) catalog.getTable(identifier("AuthTable"));
+        FileStoreTable dynamicallyDisabled =
+                (FileStoreTable)
+                        persistedAuth.copy(
+                                Collections.singletonMap(
+                                        CoreOptions.QUERY_AUTH_ENABLED.key(), "false"));
+
+        assertThatThrownBy(
+                        () ->
+                                GlobalIndexQueryServiceUtils.querySpec(
+                                        dynamicallyDisabled,
+                                        "url",
+                                        Collections.singletonList("descriptor")))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("persisted or dynamic query-auth.enabled");
+    }
+
+    @Test
+    public void testOnlyRawScalarBlobValueFieldIsSupported() throws Exception {
+        FileStoreTable descriptorTable =
+                createBlobTable(
+                        "DescriptorBlobTable",
+                        "url",
+                        DataTypes.STRING(),
+                        "payload",
+                        DataTypes.BLOB(),
+                        CoreOptions.BLOB_DESCRIPTOR_FIELD.key(),
+                        "payload");
+        assertThatThrownBy(
+                        () ->
+                                GlobalIndexQueryServiceUtils.querySpec(
+                                        descriptorTable,
+                                        "url",
+                                        Collections.singletonList("payload")))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("only supports raw blob-file value field");
+
+        FileStoreTable viewTable =
+                createBlobTable(
+                        "ViewBlobTable",
+                        "url",
+                        DataTypes.STRING(),
+                        "payload",
+                        DataTypes.BLOB(),
+                        CoreOptions.BLOB_VIEW_FIELD.key(),
+                        "payload");
+        assertThatThrownBy(
+                        () ->
+                                GlobalIndexQueryServiceUtils.querySpec(
+                                        viewTable, "url", Collections.singletonList("payload")))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("only supports raw blob-file value field");
+
+        FileStoreTable nestedTable =
+                createBlobTable(
+                        "NestedBlobTable",
+                        "url",
+                        DataTypes.STRING(),
+                        "payload",
+                        DataTypes.ARRAY(DataTypes.BLOB()),
+                        CoreOptions.BLOB_FIELD.key(),
+                        "payload");
+        assertThatThrownBy(
+                        () ->
+                                GlobalIndexQueryServiceUtils.querySpec(
+                                        nestedTable, "url", Collections.singletonList("payload")))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("does not support nested BLOB value field");
+
+        FileStoreTable blobKeyTable =
+                createBlobTable(
+                        "BlobKeyTable",
+                        "url",
+                        DataTypes.BLOB(),
+                        "payload",
+                        DataTypes.STRING(),
+                        CoreOptions.BLOB_FIELD.key(),
+                        "url");
+        assertThatThrownBy(
+                        () ->
+                                GlobalIndexQueryServiceUtils.querySpec(
+                                        blobKeyTable, "url", Collections.singletonList("payload")))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("does not support BLOB lookup field");
+    }
+
+    private FileStoreTable createAppendTable() throws Exception {
+        Schema schema =
+                Schema.newBuilder()
+                        .column("url", DataTypes.STRING().notNull())
+                        .column("descriptor", DataTypes.STRING())
+                        .option(CoreOptions.BUCKET.key(), "-1")
+                        .option(CoreOptions.ROW_TRACKING_ENABLED.key(), "true")
+                        .option(CoreOptions.DATA_EVOLUTION_ENABLED.key(), "true")
+                        .option(CoreOptions.CONSUMER_EXPIRATION_TIME.key(), "1 d")
+                        .build();
+        catalog.createTable(identifier(), schema, false);
+        return (FileStoreTable) catalog.getTable(identifier());
+    }
+
+    private FileStoreTable createBlobTable(
+            String tableName,
+            String keyName,
+            DataType keyType,
+            String valueName,
+            DataType valueType,
+            String blobOption,
+            String blobField)
+            throws Exception {
+        Schema schema =
+                Schema.newBuilder()
+                        .column(keyName, keyType)
+                        .column(valueName, valueType)
+                        .option(CoreOptions.BUCKET.key(), "-1")
+                        .option(CoreOptions.ROW_TRACKING_ENABLED.key(), "true")
+                        .option(CoreOptions.DATA_EVOLUTION_ENABLED.key(), "true")
+                        .option(CoreOptions.CONSUMER_EXPIRATION_TIME.key(), "1 d")
+                        .option(blobOption, blobField)
+                        .build();
+        catalog.createTable(identifier(tableName), schema, false);
+        return (FileStoreTable) catalog.getTable(identifier(tableName));
+    }
+
+    private DataEvolutionGlobalIndexTableQuery newQuery(FileStoreTable table) {
+        return new DataEvolutionGlobalIndexTableQuery(
+                table,
+                "url",
+                Collections.singletonList("descriptor"),
+                new File(tempPath.toFile(), "query-state-" + System.nanoTime()));
+    }
+
+    private BinaryRow key(String key) {
+        InternalRowSerializer serializer =
+                InternalSerializers.create(RowType.of(DataTypes.STRING().notNull()));
+        return serializer.toBinaryRow(GenericRow.of(BinaryString.fromString(key))).copy();
+    }
+
+    private BinaryRow value(String value) {
+        InternalRowSerializer serializer =
+                InternalSerializers.create(RowType.of(DataTypes.STRING()));
+        return serializer.toBinaryRow(GenericRow.of(BinaryString.fromString(value))).copy();
+    }
+}

--- a/paimon-core/src/test/java/org/apache/paimon/table/query/GlobalIndexQuerySnapshotLeaseTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/table/query/GlobalIndexQuerySnapshotLeaseTest.java
@@ -1,0 +1,147 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.table.query;
+
+import org.apache.paimon.CoreOptions;
+import org.apache.paimon.consumer.Consumer;
+import org.apache.paimon.consumer.ConsumerManager;
+import org.apache.paimon.data.BinaryString;
+import org.apache.paimon.data.GenericRow;
+import org.apache.paimon.options.ExpireConfig;
+import org.apache.paimon.schema.Schema;
+import org.apache.paimon.table.FileStoreTable;
+import org.apache.paimon.table.TableTestBase;
+import org.apache.paimon.types.DataTypes;
+import org.apache.paimon.utils.SnapshotManager;
+
+import org.junit.jupiter.api.Test;
+
+import java.time.Duration;
+import java.time.LocalDateTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.clearInvocations;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+/** Integration tests for query-service consumer leases and snapshot expiration. */
+public class GlobalIndexQuerySnapshotLeaseTest extends TableTestBase {
+
+    @Test
+    public void testCloseRefreshesLeaseForCompleteFailoverExpirationWindow() {
+        ConsumerManager consumerManager = mock(ConsumerManager.class);
+        GlobalIndexQuerySnapshotLease lease =
+                new GlobalIndexQuerySnapshotLease(
+                        consumerManager, "global-index-query-test", Duration.ofMinutes(2));
+        lease.pinBuilding(7L);
+        clearInvocations(consumerManager);
+
+        lease.close();
+
+        verify(consumerManager).resetConsumer(eq(lease.consumerId()), any(Consumer.class));
+    }
+
+    @Test
+    public void testConsumerIdPrefixRejectsPathTraversal() throws Exception {
+        FileStoreTable table = createAppendTable();
+        assertThatThrownBy(
+                        () ->
+                                new GlobalIndexQuerySnapshotLease(
+                                        table.consumerManager(),
+                                        "x/../../service/service-owner-poison",
+                                        table.coreOptions().consumerExpireTime()))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("single alphanumeric path segment");
+    }
+
+    @Test
+    public void testBuildingAndActiveSnapshotsAreProtectedUntilRelease() throws Exception {
+        FileStoreTable table = createAppendTable();
+        for (int i = 1; i <= 4; i++) {
+            write(
+                    table,
+                    GenericRow.of(
+                            BinaryString.fromString("key-" + i),
+                            BinaryString.fromString("value-" + i)));
+        }
+
+        SnapshotManager snapshots = table.snapshotManager();
+        ExpireConfig expireAllButLatest =
+                ExpireConfig.builder()
+                        .snapshotRetainMin(1)
+                        .snapshotRetainMax(1)
+                        .snapshotMaxDeletes(Integer.MAX_VALUE)
+                        .snapshotTimeRetain(Duration.ZERO)
+                        .build();
+        GlobalIndexQuerySnapshotLease lease =
+                new GlobalIndexQuerySnapshotLease(
+                        table.consumerManager(),
+                        "global-index-query-test",
+                        table.coreOptions().consumerExpireTime());
+        try {
+            lease.pinBuilding(1L);
+            table.newExpireSnapshots().config(expireAllButLatest).expire();
+            assertThat(snapshots.earliestSnapshotId()).isEqualTo(1L);
+            assertThat(table.fileIO().exists(snapshots.snapshotPath(1L))).isTrue();
+
+            // Simulate the globally published generation and completed handover grace period.
+            lease.promote(4L);
+            table.newExpireSnapshots().config(expireAllButLatest).expire();
+            assertThat(snapshots.earliestSnapshotId()).isEqualTo(4L);
+            assertThat(table.fileIO().exists(snapshots.snapshotPath(1L))).isFalse();
+
+            write(
+                    table,
+                    GenericRow.of(
+                            BinaryString.fromString("key-5"), BinaryString.fromString("value-5")));
+            table.newExpireSnapshots().config(expireAllButLatest).expire();
+            assertThat(snapshots.earliestSnapshotId()).isEqualTo(4L);
+        } finally {
+            lease.close();
+        }
+
+        // Closing may be part of Flink failover. The stopped attempt keeps its last pin until
+        // consumer expiration, closing the gap before a replacement attempt creates a new lease.
+        table.newExpireSnapshots().config(expireAllButLatest).expire();
+        assertThat(snapshots.earliestSnapshotId()).isEqualTo(4L);
+        assertThat(table.consumerManager().consumer(lease.consumerId())).isPresent();
+
+        table.consumerManager().expire(LocalDateTime.now().plusDays(2));
+        table.newExpireSnapshots().config(expireAllButLatest).expire();
+        assertThat(snapshots.earliestSnapshotId()).isEqualTo(5L);
+        assertThat(table.consumerManager().consumer(lease.consumerId())).isEmpty();
+    }
+
+    private FileStoreTable createAppendTable() throws Exception {
+        Schema schema =
+                Schema.newBuilder()
+                        .column("url", DataTypes.STRING())
+                        .column("descriptor", DataTypes.STRING())
+                        .option(CoreOptions.BUCKET.key(), "-1")
+                        .option(CoreOptions.ROW_TRACKING_ENABLED.key(), "true")
+                        .option(CoreOptions.DATA_EVOLUTION_ENABLED.key(), "true")
+                        .option(CoreOptions.CONSUMER_EXPIRATION_TIME.key(), "1 d")
+                        .build();
+        catalog.createTable(identifier(), schema, false);
+        return (FileStoreTable) catalog.getTable(identifier());
+    }
+}

--- a/paimon-flink/paimon-flink-1.18/pom.xml
+++ b/paimon-flink/paimon-flink-1.18/pom.xml
@@ -93,6 +93,20 @@ under the License.
         </dependency>
 
         <dependency>
+            <groupId>org.apache.paimon</groupId>
+            <artifactId>paimon-common</artifactId>
+            <version>${project.version}</version>
+            <type>test-jar</type>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
+        <dependency>
             <groupId>org.apache.flink</groupId>
             <artifactId>flink-test-utils</artifactId>
             <version>${flink.version}</version>

--- a/paimon-flink/paimon-flink-1.18/src/main/java/org/apache/paimon/flink/procedure/QueryServiceProcedure.java
+++ b/paimon-flink/paimon-flink-1.18/src/main/java/org/apache/paimon/flink/procedure/QueryServiceProcedure.java
@@ -25,9 +25,6 @@ import org.apache.paimon.table.query.GlobalIndexQuerySnapshotLease;
 import org.apache.paimon.utils.TimeUtils;
 
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
-import org.apache.flink.table.annotation.ArgumentHint;
-import org.apache.flink.table.annotation.DataTypeHint;
-import org.apache.flink.table.annotation.ProcedureHint;
 import org.apache.flink.table.procedure.ProcedureContext;
 
 import java.util.Arrays;
@@ -35,42 +32,31 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 /**
- * Query Service procedure. Usage:
+ * Flink 1.18 positional-argument compatibility for the query-service procedure.
  *
- * <pre><code>
- *  CALL sys.query_service('tableId', 'parallelism')
- * </code></pre>
+ * <p>Flink 1.18 cannot omit optional procedure arguments declared with {@code ProcedureHint}, so
+ * this class keeps the original two-argument primary-key service and adds positional global-index
+ * overloads. Newer Flink versions use the annotated implementation from paimon-flink-common.
  */
 public class QueryServiceProcedure extends ProcedureBase {
 
     public static final String IDENTIFIER = "query_service";
 
-    @Override
-    public String identifier() {
-        return IDENTIFIER;
+    public String[] call(ProcedureContext procedureContext, String tableId, Integer parallelism)
+            throws Exception {
+        return call(procedureContext, tableId, parallelism, null, null, null, null);
     }
 
-    @ProcedureHint(
-            argument = {
-                @ArgumentHint(name = "table", type = @DataTypeHint("STRING")),
-                @ArgumentHint(name = "parallelism", type = @DataTypeHint("INT")),
-                @ArgumentHint(
-                        name = "lookup_key",
-                        type = @DataTypeHint("STRING"),
-                        isOptional = true),
-                @ArgumentHint(
-                        name = "value_fields",
-                        type = @DataTypeHint("STRING"),
-                        isOptional = true),
-                @ArgumentHint(
-                        name = "consumer_id",
-                        type = @DataTypeHint("STRING"),
-                        isOptional = true),
-                @ArgumentHint(
-                        name = "lease_grace_period",
-                        type = @DataTypeHint("STRING"),
-                        isOptional = true)
-            })
+    public String[] call(
+            ProcedureContext procedureContext,
+            String tableId,
+            Integer parallelism,
+            String lookupKey,
+            String valueFields)
+            throws Exception {
+        return call(procedureContext, tableId, parallelism, lookupKey, valueFields, null, null);
+    }
+
     public String[] call(
             ProcedureContext procedureContext,
             String tableId,
@@ -119,5 +105,10 @@ public class QueryServiceProcedure extends ProcedureBase {
                             : TimeUtils.parseDuration(leaseGracePeriod));
         }
         return execute(env, IDENTIFIER);
+    }
+
+    @Override
+    public String identifier() {
+        return IDENTIFIER;
     }
 }

--- a/paimon-flink/paimon-flink-1.18/src/test/java/org/apache/paimon/flink/procedure/ProcedurePositionalArgumentsITCase.java
+++ b/paimon-flink/paimon-flink-1.18/src/test/java/org/apache/paimon/flink/procedure/ProcedurePositionalArgumentsITCase.java
@@ -20,17 +20,22 @@ package org.apache.paimon.flink.procedure;
 
 import org.apache.paimon.flink.CatalogITCaseBase;
 import org.apache.paimon.privilege.NoPrivilegeException;
+import org.apache.paimon.service.GlobalIndexQueryServiceDescriptor;
 import org.apache.paimon.table.FileStoreTable;
+import org.apache.paimon.table.query.GlobalIndexQueryServiceUtils;
+import org.apache.paimon.table.query.GlobalIndexQueryServiceUtils.QuerySpec;
 
 import org.apache.flink.types.Row;
 import org.apache.flink.util.CloseableIterator;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 import org.junit.jupiter.api.function.Executable;
 
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.ThreadLocalRandom;
 
@@ -432,6 +437,55 @@ public class ProcedurePositionalArgumentsITCase extends CatalogITCaseBase {
                             service.close();
                         })
                 .doesNotThrowAnyException();
+    }
+
+    @Test
+    @Timeout(120)
+    public void testGlobalIndexQueryServiceWithPositionalArguments() throws Exception {
+        sql(
+                "CREATE TABLE GLOBAL_IMAGE (url STRING, descriptor BYTES) WITH ("
+                        + "'bucket'='-1', "
+                        + "'global-index.enabled'='true', "
+                        + "'row-tracking.enabled'='true', "
+                        + "'data-evolution.enabled'='true', "
+                        + "'file.format'='avro', "
+                        + "'continuous.discovery-interval'='20 ms', "
+                        + "'consumer.expiration-time'='10 min')");
+        sql("INSERT INTO GLOBAL_IMAGE VALUES ('object.jpg', X'010203')");
+        sql("CALL sys.create_global_index('default.GLOBAL_IMAGE', 'url', 'btree', '', '')");
+
+        FileStoreTable table = paimonTable("GLOBAL_IMAGE");
+        QuerySpec spec =
+                GlobalIndexQueryServiceUtils.querySpec(
+                        table, "url", Collections.singletonList("descriptor"));
+        try (CloseableIterator<Row> service =
+                streamSqlIter(
+                        "CALL sys.query_service('default.GLOBAL_IMAGE', 2, 'url', "
+                                + "'descriptor', 'flink118-global-index-it', '0 s')")) {
+            GlobalIndexQueryServiceDescriptor descriptor = waitForGlobalIndexService(table, spec);
+            assertThat(descriptor.ready()).isTrue();
+            assertThat(descriptor.endpoints()).hasSize(2);
+            assertThat(descriptor.lookupFieldId()).isEqualTo(spec.lookupFieldId());
+            assertThat(descriptor.valueFieldIds()).containsExactly(spec.valueFieldIds());
+        }
+    }
+
+    private GlobalIndexQueryServiceDescriptor waitForGlobalIndexService(
+            FileStoreTable table, QuerySpec spec) throws Exception {
+        long deadline = System.nanoTime() + java.time.Duration.ofSeconds(60).toNanos();
+        GlobalIndexQueryServiceDescriptor last = null;
+        while (System.nanoTime() < deadline) {
+            last =
+                    table.store()
+                            .newServiceManager()
+                            .globalIndexService(spec.serviceId())
+                            .orElse(null);
+            if (last != null && last.ready()) {
+                return last;
+            }
+            Thread.sleep(50L);
+        }
+        throw new AssertionError("Timed out waiting for positional global-index service: " + last);
     }
 
     @Test

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/action/QueryServiceActionFactory.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/action/QueryServiceActionFactory.java
@@ -19,9 +19,17 @@
 package org.apache.paimon.flink.action;
 
 import org.apache.paimon.flink.service.QueryService;
+import org.apache.paimon.table.FileStoreTable;
+import org.apache.paimon.table.query.GlobalIndexQueryServiceUtils;
+import org.apache.paimon.table.query.GlobalIndexQuerySnapshotLease;
+import org.apache.paimon.utils.TimeUtils;
 
+import java.time.Duration;
+import java.util.Arrays;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 /** Factory to create QueryService Action. */
 public class QueryServiceActionFactory implements ActionFactory {
@@ -29,6 +37,14 @@ public class QueryServiceActionFactory implements ActionFactory {
     public static final String IDENTIFIER = "query_service";
 
     public static final String PARALLELISM = "parallelism";
+
+    public static final String LOOKUP_KEY = "lookup-key";
+
+    public static final String VALUE_FIELDS = "value-fields";
+
+    public static final String CONSUMER_ID = "consumer-id";
+
+    public static final String LEASE_GRACE_PERIOD = "lease-grace-period";
 
     @Override
     public String identifier() {
@@ -41,12 +57,58 @@ public class QueryServiceActionFactory implements ActionFactory {
         Map<String, String> tableConfig = optionalConfigMap(params, TABLE_CONF);
         String parallStr = params.get(PARALLELISM);
         int parallelism = parallStr == null ? 1 : Integer.parseInt(parallStr);
+        String lookupKey = params.get(LOOKUP_KEY);
+        String valueFieldsOption = params.get(VALUE_FIELDS);
+        String consumerId = params.get(CONSUMER_ID);
+        if (consumerId != null) {
+            GlobalIndexQuerySnapshotLease.validateConsumerIdPrefix(consumerId);
+        }
+        if (lookupKey == null && (consumerId != null || params.has(LEASE_GRACE_PERIOD))) {
+            throw new IllegalArgumentException(
+                    "Options --consumer-id and --lease-grace-period require --lookup-key and --value-fields.");
+        }
+        Duration leaseGracePeriod =
+                params.has(LEASE_GRACE_PERIOD)
+                        ? TimeUtils.parseDuration(params.get(LEASE_GRACE_PERIOD))
+                        : QueryService.DEFAULT_LEASE_GRACE_PERIOD;
+        if ((lookupKey == null) != (valueFieldsOption == null)) {
+            throw new IllegalArgumentException(
+                    "Options --lookup-key and --value-fields must be specified together.");
+        }
+        List<String> valueFields =
+                valueFieldsOption == null
+                        ? null
+                        : Arrays.stream(valueFieldsOption.split(","))
+                                .map(String::trim)
+                                .filter(value -> !value.isEmpty())
+                                .collect(Collectors.toList());
         Action action =
                 new TableActionBase(
                         params.getRequired(DATABASE), params.getRequired(TABLE), catalogConfig) {
                     @Override
                     public void run() throws Exception {
-                        QueryService.build(env, table.copy(tableConfig), parallelism);
+                        FileStoreTable serviceTable = (FileStoreTable) table.copy(tableConfig);
+                        if (lookupKey == null) {
+                            QueryService.build(env, serviceTable, parallelism);
+                        } else {
+                            String consumerIdPrefix =
+                                    consumerId == null
+                                            ? "global-index-query-"
+                                                    + GlobalIndexQueryServiceUtils.querySpec(
+                                                                    serviceTable,
+                                                                    lookupKey,
+                                                                    valueFields)
+                                                            .serviceId()
+                                            : consumerId;
+                            QueryService.build(
+                                    env,
+                                    serviceTable,
+                                    parallelism,
+                                    lookupKey,
+                                    valueFields,
+                                    consumerIdPrefix,
+                                    leaseGracePeriod);
+                        }
                         execute("Query Service job");
                     }
                 };
@@ -56,16 +118,20 @@ public class QueryServiceActionFactory implements ActionFactory {
     @Override
     public void printHelp() {
         System.out.println(
-                "Action \"query-service\" runs a dedicated job starting query service for a table.");
+                "Action \"query_service\" runs a dedicated job starting query service for a table.");
         System.out.println();
 
         System.out.println("Syntax:");
         System.out.println(
-                "  query-service \\\n"
+                "  query_service \\\n"
                         + "--warehouse <warehouse-path> \\\n"
                         + "--database <database-name> \\\n"
                         + "--table <table-name> \\\n"
                         + "--parallelism <parallelism> \\\n"
+                        + "[--lookup-key <unique-lookup-field> \\\n"
+                        + " --value-fields <field>[,<field>...]] \\\n"
+                        + "[--consumer-id <snapshot-lease-prefix>] \\\n"
+                        + "[--lease-grace-period <duration>] \\\n"
                         + "[--catalog_conf <key>=<value> [--catalog_conf <key>=<value> ...]] \\\n"
                         + "[--table_conf <key>=<value> [--table_conf <key>=<value> ...]]");
     }

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/query/RemoteGlobalIndexTableQuery.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/query/RemoteGlobalIndexTableQuery.java
@@ -1,0 +1,129 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.flink.query;
+
+import org.apache.paimon.annotation.VisibleForTesting;
+import org.apache.paimon.data.BinaryRow;
+import org.apache.paimon.data.InternalRow;
+import org.apache.paimon.data.serializer.InternalRowSerializer;
+import org.apache.paimon.data.serializer.InternalSerializers;
+import org.apache.paimon.query.GlobalIndexQueryLocationImpl;
+import org.apache.paimon.service.ServiceManager;
+import org.apache.paimon.service.client.GlobalIndexQueryClient;
+import org.apache.paimon.table.FileStoreTable;
+import org.apache.paimon.table.Table;
+import org.apache.paimon.table.query.GlobalIndexQueryServiceUtils;
+import org.apache.paimon.table.query.GlobalIndexQueryServiceUtils.QuerySpec;
+import org.apache.paimon.table.query.TableQuery;
+import org.apache.paimon.utils.TypeUtils;
+
+import javax.annotation.Nullable;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+
+import static org.apache.paimon.utils.Preconditions.checkArgument;
+
+/** Client-side {@link TableQuery} for the dedicated append global-index query service. */
+public class RemoteGlobalIndexTableQuery implements TableQuery {
+
+    private final FileStoreTable table;
+    private final QuerySpec spec;
+    private final GlobalIndexQueryClient client;
+    private final InternalRowSerializer keySerializer;
+    private final InternalRowSerializer valueSerializer;
+
+    public RemoteGlobalIndexTableQuery(Table table, String lookupField, List<String> valueFields) {
+        this.table = (FileStoreTable) table;
+        this.spec = GlobalIndexQueryServiceUtils.querySpec(this.table, lookupField, valueFields);
+        ServiceManager manager = this.table.store().newServiceManager();
+        this.client =
+                new GlobalIndexQueryClient(
+                        new GlobalIndexQueryLocationImpl(
+                                manager,
+                                this.table.uuid(),
+                                this.table.coreOptions().branch(),
+                                this.table.schema().id(),
+                                spec),
+                        1);
+        this.keySerializer =
+                InternalSerializers.create(
+                        TypeUtils.project(this.table.rowType(), new int[] {spec.lookupPosition()}));
+        this.valueSerializer =
+                InternalSerializers.create(
+                        TypeUtils.project(this.table.rowType(), spec.valuePositions()));
+    }
+
+    public static boolean isRemoteServiceAvailable(
+            FileStoreTable table, String lookupField, List<String> valueFields) {
+        QuerySpec spec = GlobalIndexQueryServiceUtils.querySpec(table, lookupField, valueFields);
+        return new GlobalIndexQueryLocationImpl(
+                        table.store().newServiceManager(),
+                        table.uuid(),
+                        table.coreOptions().branch(),
+                        table.schema().id(),
+                        spec)
+                .isServiceReady();
+    }
+
+    @Nullable
+    @Override
+    public InternalRow lookup(BinaryRow partition, int bucket, InternalRow key) throws IOException {
+        BinaryRow binaryKey = keySerializer.toBinaryRow(key).copy();
+        checkArgument(!binaryKey.anyNull(), "Global-index query lookup key must not be null.");
+        try {
+            return client.getValues(new BinaryRow[] {binaryKey}).get()[0];
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new IOException(e);
+        } catch (ExecutionException e) {
+            Throwable cause = e.getCause();
+            if (cause instanceof IOException) {
+                throw (IOException) cause;
+            }
+            throw new IOException(cause);
+        }
+    }
+
+    @Override
+    public RemoteGlobalIndexTableQuery withValueProjection(int[] projection) {
+        checkArgument(
+                Arrays.equals(spec.valuePositions(), projection),
+                "Global-index query value projection is fixed by the service ID.");
+        return this;
+    }
+
+    @Override
+    public InternalRowSerializer createValueSerializer() {
+        return valueSerializer;
+    }
+
+    @Override
+    public void close() {
+        client.shutdown();
+    }
+
+    @VisibleForTesting
+    public CompletableFuture<Void> cancel() {
+        return client.shutdownFuture();
+    }
+}

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/service/GlobalIndexQueryAddressRegister.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/service/GlobalIndexQueryAddressRegister.java
@@ -1,0 +1,364 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.flink.service;
+
+import org.apache.paimon.data.InternalRow;
+import org.apache.paimon.service.GlobalIndexQueryServiceDescriptor;
+import org.apache.paimon.service.GlobalIndexQueryServiceDescriptor.Endpoint;
+import org.apache.paimon.service.ServiceManager;
+import org.apache.paimon.table.FileStoreTable;
+import org.apache.paimon.table.query.GlobalIndexQueryServiceUtils;
+import org.apache.paimon.table.query.GlobalIndexQueryServiceUtils.QuerySpec;
+
+import org.apache.flink.api.connector.sink2.InitContext;
+import org.apache.flink.api.connector.sink2.Sink;
+import org.apache.flink.api.connector.sink2.SinkWriter;
+import org.apache.flink.api.connector.sink2.WriterInitContext;
+
+import java.net.InetSocketAddress;
+import java.util.HashMap;
+import java.util.Locale;
+import java.util.Map;
+import java.util.TreeMap;
+import java.util.UUID;
+
+/** Publishes a generation only after every global-index executor reports ready. */
+public class GlobalIndexQueryAddressRegister implements Sink<InternalRow> {
+
+    private final ServiceManager serviceManager;
+    private final String serviceId;
+    private final String tableUuid;
+    private final String branch;
+    private final long schemaId;
+    private final String schemaFingerprint;
+    private final int lookupFieldId;
+    private final int[] valueFieldIds;
+    private final String publisherId;
+
+    public GlobalIndexQueryAddressRegister(FileStoreTable table, QuerySpec spec) {
+        this.serviceManager = table.store().newServiceManager();
+        this.serviceId = spec.serviceId();
+        this.tableUuid = table.uuid();
+        this.branch = table.coreOptions().branch();
+        this.schemaId = table.schema().id();
+        this.schemaFingerprint = spec.schemaFingerprint();
+        this.lookupFieldId = spec.lookupFieldId();
+        this.valueFieldIds = spec.valueFieldIds();
+        this.publisherId = UUID.randomUUID().toString();
+    }
+
+    /** Do not annotate to maintain compatibility with Flink 2.0+. */
+    public SinkWriter<InternalRow> createWriter(InitContext context) {
+        return new Writer(
+                serviceManager,
+                serviceId,
+                tableUuid,
+                branch,
+                schemaId,
+                schemaFingerprint,
+                lookupFieldId,
+                valueFieldIds,
+                nextOwnerToken(context.getAttemptNumber()));
+    }
+
+    /** Do not annotate to maintain compatibility with Flink 1.18-. */
+    public SinkWriter<InternalRow> createWriter(WriterInitContext context) {
+        return new Writer(
+                serviceManager,
+                serviceId,
+                tableUuid,
+                branch,
+                schemaId,
+                schemaFingerprint,
+                lookupFieldId,
+                valueFieldIds,
+                nextOwnerToken(context.getAttemptNumber()));
+    }
+
+    private String nextOwnerToken(int attemptNumber) {
+        long sequence = serviceManager.nextGlobalIndexOwnerSequence(serviceId);
+        return String.format(Locale.ROOT, "%019d-%010d-%s", sequence, attemptNumber, publisherId);
+    }
+
+    private static class Writer implements SinkWriter<InternalRow> {
+
+        private final ServiceManager serviceManager;
+        private final String serviceId;
+        private final String tableUuid;
+        private final String branch;
+        private final long schemaId;
+        private final String schemaFingerprint;
+        private final int lookupFieldId;
+        private final int[] valueFieldIds;
+        private final String ownerToken;
+        private final Map<Long, Candidate> candidates = new HashMap<>();
+
+        private long eventGeneration = Long.MIN_VALUE;
+        private long publishedServedGeneration = Long.MIN_VALUE;
+        private int numExecutors;
+        private UnavailableCandidate unavailableCandidate;
+
+        private Writer(
+                ServiceManager serviceManager,
+                String serviceId,
+                String tableUuid,
+                String branch,
+                long schemaId,
+                String schemaFingerprint,
+                int lookupFieldId,
+                int[] valueFieldIds,
+                String ownerToken) {
+            this.serviceManager = serviceManager;
+            this.serviceId = serviceId;
+            this.tableUuid = tableUuid;
+            this.branch = branch;
+            this.schemaId = schemaId;
+            this.schemaFingerprint = schemaFingerprint;
+            this.lookupFieldId = lookupFieldId;
+            this.valueFieldIds = valueFieldIds;
+            this.ownerToken = ownerToken;
+            publishNotReady(
+                    "Query service attempt is bootstrapping.",
+                    Long.MIN_VALUE,
+                    GlobalIndexQueryServiceUtils.EMPTY_SNAPSHOT_ID);
+        }
+
+        @Override
+        public void write(InternalRow row, Context context) {
+            long rowEventGeneration = row.getLong(0);
+            if (rowEventGeneration < eventGeneration) {
+                return;
+            }
+            int eventNumExecutors = row.getInt(2);
+            if (rowEventGeneration > eventGeneration) {
+                eventGeneration = rowEventGeneration;
+                numExecutors = eventNumExecutors;
+                candidates.clear();
+                unavailableCandidate = null;
+                // Withdraw discovery as soon as the first executor observes the generation. The
+                // empty snapshot fence deliberately does not acknowledge the target yet; the
+                // monitor starts its retention grace only after every executor reports that its
+                // accepted-generation fence has advanced.
+                publishNotReady(
+                        "Refreshing global-index query snapshot.",
+                        rowEventGeneration,
+                        GlobalIndexQueryServiceUtils.EMPTY_SNAPSHOT_ID);
+            } else if (numExecutors != eventNumExecutors) {
+                throw new IllegalArgumentException(
+                        "Executor count changed within global-index event generation "
+                                + eventGeneration);
+            }
+
+            if (!row.getBoolean(1)) {
+                int executorId = row.getInt(3);
+                if (executorId < 0 || executorId >= numExecutors) {
+                    throw new IllegalArgumentException(
+                            "Invalid global-index executor ID "
+                                    + executorId
+                                    + " for "
+                                    + numExecutors
+                                    + " executors.");
+                }
+                long targetSnapshotId = row.getLong(8);
+                String reason = row.getString(6).toString();
+                if (unavailableCandidate == null) {
+                    unavailableCandidate = new UnavailableCandidate(targetSnapshotId);
+                } else {
+                    unavailableCandidate.checkSnapshot(targetSnapshotId);
+                }
+                unavailableCandidate.acknowledge(executorId, reason);
+                if (unavailableCandidate.size() == numExecutors) {
+                    publishNotReady(
+                            unavailableCandidate.reason(), rowEventGeneration, targetSnapshotId);
+                }
+                return;
+            }
+
+            long servedGeneration = row.getLong(7);
+            if (servedGeneration != rowEventGeneration) {
+                // An executor may still serve its previous shadow generation locally while a
+                // rebuild is in progress. It must not republish that old generation after the
+                // discovery descriptor has been withdrawn.
+                return;
+            }
+            if (servedGeneration < publishedServedGeneration) {
+                return;
+            }
+            long servedSnapshotId = row.getLong(8);
+            String snapshotUuid = row.isNullAt(9) ? null : row.getString(9).toString();
+            Candidate candidate =
+                    candidates.computeIfAbsent(
+                            servedGeneration,
+                            ignored -> new Candidate(servedSnapshotId, snapshotUuid));
+            candidate.checkSnapshot(servedSnapshotId, snapshotUuid);
+            candidate.put(
+                    row.getInt(3),
+                    new InetSocketAddress(row.getString(4).toString(), row.getInt(5)),
+                    row.getString(10).toString());
+            if (candidate.size() == numExecutors) {
+                serviceManager.resetGlobalIndexService(
+                        serviceId,
+                        descriptor(
+                                true,
+                                "",
+                                servedGeneration,
+                                servedSnapshotId,
+                                snapshotUuid,
+                                candidate.endpoints(numExecutors)));
+                publishedServedGeneration = servedGeneration;
+                candidates.entrySet().removeIf(entry -> entry.getKey() < servedGeneration);
+            }
+        }
+
+        private void publishNotReady(String reason, long generation, long snapshotId) {
+            serviceManager.resetGlobalIndexService(
+                    serviceId,
+                    descriptor(false, reason, generation, snapshotId, null, new Endpoint[0]));
+        }
+
+        private GlobalIndexQueryServiceDescriptor descriptor(
+                boolean ready,
+                String reason,
+                long servedGeneration,
+                long servedSnapshotId,
+                String snapshotUuid,
+                Endpoint[] endpoints) {
+            return new GlobalIndexQueryServiceDescriptor(
+                    GlobalIndexQueryServiceDescriptor.PROTOCOL_VERSION,
+                    tableUuid,
+                    branch,
+                    schemaId,
+                    schemaFingerprint,
+                    lookupFieldId,
+                    valueFieldIds,
+                    servedGeneration,
+                    servedSnapshotId,
+                    snapshotUuid,
+                    GlobalIndexQueryServiceDescriptor.KEY_HASH_VERSION,
+                    GlobalIndexQueryServiceDescriptor.LAYOUT,
+                    ownerToken,
+                    ready,
+                    reason,
+                    endpoints);
+        }
+
+        @Override
+        public void flush(boolean endOfInput) {}
+
+        @Override
+        public void close() {
+            serviceManager.deleteGlobalIndexServiceIfOwned(serviceId, ownerToken);
+        }
+
+        private static class Candidate {
+
+            private final long snapshotId;
+            private final String snapshotUuid;
+            private final TreeMap<Integer, InetSocketAddress> addresses = new TreeMap<>();
+            private final TreeMap<Integer, String> serverEpochs = new TreeMap<>();
+
+            private Candidate(long snapshotId, String snapshotUuid) {
+                this.snapshotId = snapshotId;
+                this.snapshotUuid = snapshotUuid;
+            }
+
+            private void checkSnapshot(long snapshotId, String snapshotUuid) {
+                if (this.snapshotId != snapshotId
+                        || !java.util.Objects.equals(this.snapshotUuid, snapshotUuid)) {
+                    throw new IllegalArgumentException(
+                            "Executors reported different snapshots for one served generation.");
+                }
+            }
+
+            private void put(int executorId, InetSocketAddress address, String serverEpoch) {
+                addresses.put(executorId, address);
+                serverEpochs.put(executorId, serverEpoch);
+            }
+
+            private int size() {
+                return addresses.size();
+            }
+
+            private Endpoint[] endpoints(int expectedSize) {
+                checkExecutorIds(expectedSize);
+                Endpoint[] result = new Endpoint[expectedSize];
+                for (int shard = 0; shard < expectedSize; shard++) {
+                    result[shard] =
+                            new Endpoint(shard, addresses.get(shard), serverEpochs.get(shard));
+                }
+                return result;
+            }
+
+            private void checkExecutorIds(int expectedSize) {
+                for (int i = 0; i < expectedSize; i++) {
+                    if (!addresses.containsKey(i) || !serverEpochs.containsKey(i)) {
+                        throw new IllegalArgumentException("Missing executor ID " + i);
+                    }
+                }
+            }
+        }
+
+        private static class UnavailableCandidate {
+
+            private final long snapshotId;
+            private final Map<Integer, String> acknowledgements = new HashMap<>();
+            private String latestReason;
+
+            private UnavailableCandidate(long snapshotId) {
+                this.snapshotId = snapshotId;
+            }
+
+            private void checkSnapshot(long snapshotId) {
+                if (this.snapshotId != snapshotId) {
+                    throw new IllegalArgumentException(
+                            "Executors reported different unavailable global-index snapshots for"
+                                    + " one generation: "
+                                    + this.snapshotId
+                                    + " and "
+                                    + snapshotId);
+                }
+            }
+
+            private void acknowledge(int executorId, String reason) {
+                acknowledgements.put(executorId, reason);
+                if (reason != null
+                        && !reason.isEmpty()
+                        && (latestReason == null
+                                || isRefreshing(latestReason)
+                                || !isRefreshing(reason))) {
+                    latestReason = reason;
+                }
+            }
+
+            private int size() {
+                return acknowledgements.size();
+            }
+
+            private String reason() {
+                return latestReason == null
+                        ? "Global-index query snapshot is unavailable."
+                        : latestReason;
+            }
+
+            private static boolean isRefreshing(String reason) {
+                return "Refreshing".equalsIgnoreCase(reason);
+            }
+        }
+    }
+}

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/service/GlobalIndexQueryAddressRegister.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/service/GlobalIndexQueryAddressRegister.java
@@ -19,6 +19,7 @@
 package org.apache.paimon.flink.service;
 
 import org.apache.paimon.data.InternalRow;
+import org.apache.paimon.flink.utils.SinkContextUtils;
 import org.apache.paimon.service.GlobalIndexQueryServiceDescriptor;
 import org.apache.paimon.service.GlobalIndexQueryServiceDescriptor.Endpoint;
 import org.apache.paimon.service.ServiceManager;
@@ -74,7 +75,7 @@ public class GlobalIndexQueryAddressRegister implements Sink<InternalRow> {
                 schemaFingerprint,
                 lookupFieldId,
                 valueFieldIds,
-                nextOwnerToken(context.getAttemptNumber()));
+                nextOwnerToken(SinkContextUtils.getAttemptNumber(context)));
     }
 
     /** Do not annotate to maintain compatibility with Flink 1.18-. */
@@ -88,7 +89,7 @@ public class GlobalIndexQueryAddressRegister implements Sink<InternalRow> {
                 schemaFingerprint,
                 lookupFieldId,
                 valueFieldIds,
-                nextOwnerToken(context.getAttemptNumber()));
+                nextOwnerToken(SinkContextUtils.getAttemptNumber(context)));
     }
 
     private String nextOwnerToken(int attemptNumber) {

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/service/GlobalIndexQueryBootstrapOperator.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/service/GlobalIndexQueryBootstrapOperator.java
@@ -1,0 +1,199 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.flink.service;
+
+import org.apache.paimon.data.BinaryRow;
+import org.apache.paimon.data.BinaryString;
+import org.apache.paimon.data.GenericRow;
+import org.apache.paimon.data.InternalRow;
+import org.apache.paimon.data.serializer.InternalRowSerializer;
+import org.apache.paimon.data.serializer.InternalSerializers;
+import org.apache.paimon.flink.utils.RuntimeContextUtils;
+import org.apache.paimon.reader.RecordReaderIterator;
+import org.apache.paimon.table.FileStoreTable;
+import org.apache.paimon.table.query.GlobalIndexQueryServiceUtils;
+import org.apache.paimon.table.query.GlobalIndexQueryServiceUtils.QuerySpec;
+import org.apache.paimon.table.source.InnerTableRead;
+import org.apache.paimon.table.source.Split;
+import org.apache.paimon.table.source.SplitSerializer;
+import org.apache.paimon.types.DataTypes;
+import org.apache.paimon.types.RowType;
+import org.apache.paimon.utils.ProjectedRow;
+
+import org.apache.flink.metrics.Counter;
+import org.apache.flink.streaming.api.operators.AbstractStreamOperator;
+import org.apache.flink.streaming.api.operators.OneInputStreamOperator;
+import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
+
+import java.util.List;
+
+import static org.apache.paimon.table.query.GlobalIndexQueryServiceUtils.normalizeKey;
+import static org.apache.paimon.utils.SerializationUtils.serializeBinaryRow;
+
+/** Reads one pinned-snapshot shard and materializes key/value rows for key-hash executors. */
+public class GlobalIndexQueryBootstrapOperator extends AbstractStreamOperator<InternalRow>
+        implements OneInputStreamOperator<InternalRow, InternalRow> {
+
+    private static final long serialVersionUID = 1L;
+
+    public static final int START = 0;
+    public static final int PUT = 1;
+    public static final int COMPLETE = 2;
+    public static final int NOT_READY = 3;
+
+    public static final int TARGET = 3;
+
+    private final FileStoreTable table;
+    private final String lookupField;
+    private final List<String> valueFields;
+    private final int numExecutors;
+
+    private transient QuerySpec spec;
+    private transient RowType readType;
+    private transient InternalRowSerializer keySerializer;
+    private transient InternalRowSerializer valueSerializer;
+    private transient ProjectedRow keyProjection;
+    private transient ProjectedRow valueProjection;
+    private transient Counter nullLookupKeysSkipped;
+    private transient InnerTableRead read;
+
+    public GlobalIndexQueryBootstrapOperator(
+            FileStoreTable table, String lookupField, List<String> valueFields, int numExecutors) {
+        this.table = table;
+        this.lookupField = lookupField;
+        this.valueFields = valueFields;
+        this.numExecutors = numExecutors;
+    }
+
+    public static RowType outputType() {
+        return RowType.of(
+                DataTypes.BIGINT(),
+                DataTypes.BIGINT(),
+                DataTypes.INT(),
+                DataTypes.INT(),
+                DataTypes.INT(),
+                DataTypes.BYTES(),
+                DataTypes.BYTES(),
+                DataTypes.STRING());
+    }
+
+    @Override
+    public void open() throws Exception {
+        super.open();
+        this.spec = GlobalIndexQueryServiceUtils.querySpec(table, lookupField, valueFields);
+        this.readType = table.rowType().project(spec.bootstrapProjection());
+        this.keySerializer = InternalSerializers.create(readType.project(new int[] {0}));
+        int[] valuePositions = new int[valueFields.size()];
+        for (int i = 0; i < valuePositions.length; i++) {
+            valuePositions[i] = i + 1;
+        }
+        this.valueSerializer = InternalSerializers.create(readType.project(valuePositions));
+        this.keyProjection = ProjectedRow.from(new int[] {0});
+        this.valueProjection = ProjectedRow.from(valuePositions);
+        this.read = table.newRead().withReadType(readType);
+        this.nullLookupKeysSkipped =
+                getRuntimeContext()
+                        .getMetricGroup()
+                        .counter("globalIndexQueryNullLookupKeysSkipped");
+    }
+
+    @Override
+    public void processElement(StreamRecord<InternalRow> streamRecord) throws Exception {
+        InternalRow event = streamRecord.getValue();
+        long generation = event.getLong(0);
+        long snapshotId = event.getLong(1);
+        int monitorType = event.getInt(2);
+        String reason = event.getString(5).toString();
+        int bootstrapId = RuntimeContextUtils.getIndexOfThisSubtask(getRuntimeContext());
+
+        if (monitorType == GlobalIndexQuerySnapshotMonitor.NOT_READY) {
+            for (int target = 0; target < numExecutors; target++) {
+                emit(generation, snapshotId, NOT_READY, target, bootstrapId, null, null, reason);
+            }
+            return;
+        }
+        if (monitorType == GlobalIndexQuerySnapshotMonitor.START) {
+            // Every target observes START before any PUT from this input channel.
+            for (int target = 0; target < numExecutors; target++) {
+                emit(generation, snapshotId, START, target, bootstrapId, null, null, "");
+            }
+            return;
+        }
+        if (monitorType == GlobalIndexQuerySnapshotMonitor.SPLIT) {
+            Split split = SplitSerializer.deserialize(event.getBinary(4));
+            try (RecordReaderIterator<InternalRow> rows =
+                    new RecordReaderIterator<>(read.createReader(split))) {
+                while (rows.hasNext()) {
+                    InternalRow row = rows.next();
+                    if (row.isNullAt(0)) {
+                        // Null is outside the service lookup domain. Non-null keys remain globally
+                        // unique; callers receive a validation error rather than a false MISS.
+                        nullLookupKeysSkipped.inc();
+                        continue;
+                    }
+                    BinaryRow key =
+                            normalizeKey(keySerializer.toBinaryRow(keyProjection.replaceRow(row)));
+                    BinaryRow value =
+                            valueSerializer.toBinaryRow(valueProjection.replaceRow(row)).copy();
+                    int target = GlobalIndexQueryServiceUtils.route(key, numExecutors);
+                    emit(
+                            generation,
+                            snapshotId,
+                            PUT,
+                            target,
+                            bootstrapId,
+                            serializeBinaryRow(key),
+                            serializeBinaryRow(value),
+                            "");
+                }
+            }
+            return;
+        }
+        if (monitorType == GlobalIndexQuerySnapshotMonitor.COMPLETE) {
+            for (int target = 0; target < numExecutors; target++) {
+                emit(generation, snapshotId, COMPLETE, target, bootstrapId, null, null, "");
+            }
+            return;
+        }
+        throw new IllegalArgumentException(
+                "Unknown global-index monitor event type " + monitorType);
+    }
+
+    private void emit(
+            long generation,
+            long snapshotId,
+            int type,
+            int target,
+            int bootstrapId,
+            byte[] key,
+            byte[] value,
+            String message) {
+        output.collect(
+                new StreamRecord<>(
+                        GenericRow.of(
+                                generation,
+                                snapshotId,
+                                type,
+                                target,
+                                bootstrapId,
+                                key,
+                                value,
+                                BinaryString.fromString(message))));
+    }
+}

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/service/GlobalIndexQueryExecutorOperator.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/service/GlobalIndexQueryExecutorOperator.java
@@ -1,0 +1,278 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.flink.service;
+
+import org.apache.paimon.data.BinaryRow;
+import org.apache.paimon.data.BinaryString;
+import org.apache.paimon.data.GenericRow;
+import org.apache.paimon.data.InternalRow;
+import org.apache.paimon.flink.utils.RuntimeContextUtils;
+import org.apache.paimon.service.network.NetworkUtils;
+import org.apache.paimon.service.network.stats.DisabledServiceRequestStats;
+import org.apache.paimon.service.server.GlobalIndexQueryServer;
+import org.apache.paimon.table.FileStoreTable;
+import org.apache.paimon.table.query.DataEvolutionGlobalIndexTableQuery;
+import org.apache.paimon.table.query.DuplicateLookupKeyException;
+import org.apache.paimon.table.query.GlobalIndexQueryServiceUtils;
+import org.apache.paimon.table.query.GlobalIndexQueryServiceUtils.QuerySpec;
+import org.apache.paimon.table.query.OversizedLookupValueException;
+import org.apache.paimon.types.DataTypes;
+import org.apache.paimon.types.RowType;
+
+import org.apache.flink.runtime.state.StateInitializationContext;
+import org.apache.flink.streaming.api.operators.AbstractStreamOperator;
+import org.apache.flink.streaming.api.operators.OneInputStreamOperator;
+import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
+
+import java.io.File;
+import java.net.InetSocketAddress;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.UUID;
+
+import static org.apache.paimon.flink.service.GlobalIndexQueryBootstrapOperator.COMPLETE;
+import static org.apache.paimon.flink.service.GlobalIndexQueryBootstrapOperator.NOT_READY;
+import static org.apache.paimon.flink.service.GlobalIndexQueryBootstrapOperator.PUT;
+import static org.apache.paimon.flink.service.GlobalIndexQueryBootstrapOperator.START;
+import static org.apache.paimon.utils.SerializationUtils.deserializeBinaryRow;
+
+/** Owns one key-hash state shard and only advertises it after a complete snapshot bootstrap. */
+public class GlobalIndexQueryExecutorOperator extends AbstractStreamOperator<InternalRow>
+        implements OneInputStreamOperator<InternalRow, InternalRow> {
+
+    private static final long serialVersionUID = 1L;
+
+    private final FileStoreTable table;
+    private final String lookupField;
+    private final List<String> valueFields;
+    private final int numBootstraps;
+
+    private transient QuerySpec spec;
+    private transient DataEvolutionGlobalIndexTableQuery query;
+    private transient GlobalIndexQueryServer server;
+    private transient InetSocketAddress address;
+    private transient boolean[] completedBootstraps;
+    private transient String serverEpoch;
+    private transient String servedSnapshotUuid;
+
+    private long generation = Long.MIN_VALUE;
+    private long snapshotId = GlobalIndexQueryServiceUtils.EMPTY_SNAPSHOT_ID;
+    private boolean publishedReady;
+    private String invalidReason;
+
+    public GlobalIndexQueryExecutorOperator(
+            FileStoreTable table, String lookupField, List<String> valueFields, int numBootstraps) {
+        this.table = table;
+        this.lookupField = lookupField;
+        this.valueFields = valueFields;
+        this.numBootstraps = numBootstraps;
+    }
+
+    public static RowType outputType() {
+        return RowType.of(
+                DataTypes.BIGINT(),
+                DataTypes.BOOLEAN(),
+                DataTypes.INT(),
+                DataTypes.INT(),
+                DataTypes.STRING(),
+                DataTypes.INT(),
+                DataTypes.STRING(),
+                DataTypes.BIGINT(),
+                DataTypes.BIGINT(),
+                DataTypes.STRING(),
+                DataTypes.STRING());
+    }
+
+    @Override
+    public void initializeState(StateInitializationContext context) throws Exception {
+        super.initializeState(context);
+        this.spec = GlobalIndexQueryServiceUtils.querySpec(table, lookupField, valueFields);
+
+        int executorId = RuntimeContextUtils.getIndexOfThisSubtask(getRuntimeContext());
+        int numExecutors = RuntimeContextUtils.getNumberOfParallelSubtasks(getRuntimeContext());
+        String[] tempDirs =
+                getContainingTask().getEnvironment().getIOManager().getSpillingDirectoriesPaths();
+        File stateRoot =
+                new File(
+                        tempDirs[Math.floorMod(executorId, tempDirs.length)],
+                        "paimon-global-index-query-" + executorId + '-' + UUID.randomUUID());
+        this.query =
+                new DataEvolutionGlobalIndexTableQuery(table, lookupField, valueFields, stateRoot);
+
+        // Executor state is local and deliberately rebuilt after a restart. Remove a stale
+        // endpoint before accepting requests so missing bootstrap state can never become a MISS.
+        this.serverEpoch = UUID.randomUUID().toString();
+        this.server =
+                new GlobalIndexQueryServer(
+                        executorId,
+                        numExecutors,
+                        serverEpoch,
+                        NetworkUtils.findHostAddress(),
+                        Collections.singletonList(0).iterator(),
+                        1,
+                        1,
+                        query,
+                        new DisabledServiceRequestStats());
+        try {
+            server.start();
+        } catch (Throwable t) {
+            // Flink does not invoke operator close when initializeState fails. Release both
+            // resources here so a bind/start failure cannot leak Netty threads or the local KV
+            // directory until the TaskManager process exits.
+            try {
+                server.shutdown();
+            } catch (Throwable cleanupFailure) {
+                t.addSuppressed(cleanupFailure);
+            }
+            try {
+                query.close();
+            } catch (Throwable cleanupFailure) {
+                t.addSuppressed(cleanupFailure);
+            }
+            throw new RuntimeException("Failed to start global-index query server.", t);
+        }
+        this.address = server.getServerAddress();
+        this.completedBootstraps = new boolean[numBootstraps];
+        this.servedSnapshotUuid = null;
+    }
+
+    @Override
+    public void processElement(StreamRecord<InternalRow> streamRecord) throws Exception {
+        InternalRow row = streamRecord.getValue();
+        long eventGeneration = row.getLong(0);
+        if (eventGeneration < generation) {
+            return;
+        }
+
+        long eventSnapshotId = row.getLong(1);
+        int type = row.getInt(2);
+        if (eventGeneration > generation) {
+            generation = eventGeneration;
+            snapshotId = eventSnapshotId;
+            Arrays.fill(completedBootstraps, false);
+            publishedReady = false;
+            invalidReason = null;
+            if (type == NOT_READY) {
+                query.markNotReady(generation, snapshotId, row.getString(7).toString());
+            } else {
+                query.beginRefresh(generation, snapshotId);
+            }
+            // A generation is published only after every executor has swapped. Withdrawing the
+            // descriptor here prevents a client from discovering a partially swapped generation.
+            // Clients which cached the previous descriptor are fenced by servedGeneration.
+            emitAddress(false, type == NOT_READY ? row.getString(7).toString() : "Refreshing");
+        }
+
+        if (type == START || type == NOT_READY) {
+            return;
+        }
+        if (type == PUT) {
+            if (invalidReason != null) {
+                return;
+            }
+            // Schemaless deserialization keeps an arity prefix before the row. Normalize the
+            // offset because BinaryRow#anyNull currently reads null bits from segment offset 0.
+            BinaryRow key = deserializeBinaryRow(row.getBinary(5)).copy();
+            int executorId = RuntimeContextUtils.getIndexOfThisSubtask(getRuntimeContext());
+            int numExecutors = RuntimeContextUtils.getNumberOfParallelSubtasks(getRuntimeContext());
+            if (GlobalIndexQueryServiceUtils.route(key, numExecutors) != executorId) {
+                throw new IllegalStateException(
+                        "Global-index bootstrap row was sent to the wrong executor shard.");
+            }
+            try {
+                query.put(generation, key, deserializeBinaryRow(row.getBinary(6)).copy());
+            } catch (DuplicateLookupKeyException | OversizedLookupValueException e) {
+                invalidReason = e.getMessage();
+                query.markNotReady(generation, snapshotId, invalidReason);
+                // Keep discovery explicitly NOT_READY and expose the validation reason. The old
+                // shadow state stays allocated for atomic cleanup, but its accepted generation was
+                // already fenced when START arrived.
+                emitAddress(false, invalidReason);
+            }
+            return;
+        }
+        if (type == COMPLETE) {
+            if (invalidReason != null) {
+                return;
+            }
+            int bootstrapId = row.getInt(4);
+            if (bootstrapId < 0 || bootstrapId >= completedBootstraps.length) {
+                throw new IllegalArgumentException("Invalid bootstrap subtask " + bootstrapId);
+            }
+            completedBootstraps[bootstrapId] = true;
+            if (!publishedReady && allBootstrapsComplete()) {
+                query.finishRefresh(generation);
+                servedSnapshotUuid =
+                        query.servedSnapshotId() == GlobalIndexQueryServiceUtils.EMPTY_SNAPSHOT_ID
+                                ? null
+                                : table.snapshotManager().snapshot(query.servedSnapshotId()).uuid();
+                publishedReady = true;
+                emitAddress(true, "");
+            }
+            return;
+        }
+        throw new IllegalArgumentException("Unknown global-index bootstrap event type " + type);
+    }
+
+    private boolean allBootstrapsComplete() {
+        for (boolean complete : completedBootstraps) {
+            if (!complete) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private void emitAddress(boolean ready, String reason) {
+        long descriptorGeneration = ready ? query.servedGeneration() : generation;
+        long descriptorSnapshotId = ready ? query.servedSnapshotId() : snapshotId;
+        output.collect(
+                new StreamRecord<>(
+                        GenericRow.of(
+                                generation,
+                                ready,
+                                RuntimeContextUtils.getNumberOfParallelSubtasks(
+                                        getRuntimeContext()),
+                                RuntimeContextUtils.getIndexOfThisSubtask(getRuntimeContext()),
+                                BinaryString.fromString(address.getHostName()),
+                                address.getPort(),
+                                BinaryString.fromString(reason),
+                                descriptorGeneration,
+                                descriptorSnapshotId,
+                                !ready || servedSnapshotUuid == null
+                                        ? null
+                                        : BinaryString.fromString(servedSnapshotUuid),
+                                BinaryString.fromString(serverEpoch))));
+    }
+
+    @Override
+    public void close() throws Exception {
+        try {
+            if (server != null) {
+                server.shutdown();
+            }
+            if (query != null) {
+                query.close();
+            }
+        } finally {
+            super.close();
+        }
+    }
+}

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/service/GlobalIndexQuerySnapshotMonitor.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/service/GlobalIndexQuerySnapshotMonitor.java
@@ -1,0 +1,512 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.flink.service;
+
+import org.apache.paimon.CoreOptions;
+import org.apache.paimon.Snapshot;
+import org.apache.paimon.data.BinaryString;
+import org.apache.paimon.data.GenericRow;
+import org.apache.paimon.data.InternalRow;
+import org.apache.paimon.flink.source.AbstractNonCoordinatedSource;
+import org.apache.paimon.flink.source.AbstractNonCoordinatedSourceReader;
+import org.apache.paimon.flink.source.SimpleSourceSplit;
+import org.apache.paimon.flink.utils.InternalTypeInfo;
+import org.apache.paimon.options.Options;
+import org.apache.paimon.service.GlobalIndexQueryServiceDescriptor;
+import org.apache.paimon.table.FileStoreTable;
+import org.apache.paimon.table.query.GlobalIndexQueryServiceUtils;
+import org.apache.paimon.table.query.GlobalIndexQueryServiceUtils.QuerySpec;
+import org.apache.paimon.table.query.GlobalIndexQueryServiceUtils.SnapshotReadiness;
+import org.apache.paimon.table.query.GlobalIndexQuerySnapshotLease;
+import org.apache.paimon.table.source.ScanMode;
+import org.apache.paimon.table.source.Split;
+import org.apache.paimon.table.source.SplitSerializer;
+import org.apache.paimon.table.source.snapshot.SnapshotReader;
+import org.apache.paimon.types.DataTypes;
+import org.apache.paimon.types.RowType;
+import org.apache.paimon.utils.Preconditions;
+import org.apache.paimon.utils.SnapshotManager;
+
+import org.apache.flink.api.common.eventtime.WatermarkStrategy;
+import org.apache.flink.api.connector.source.Boundedness;
+import org.apache.flink.api.connector.source.ReaderOutput;
+import org.apache.flink.api.connector.source.SourceReader;
+import org.apache.flink.api.connector.source.SourceReaderContext;
+import org.apache.flink.core.io.InputStatus;
+import org.apache.flink.streaming.api.datastream.DataStream;
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+
+import javax.annotation.Nullable;
+
+import java.time.Duration;
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Comparator;
+import java.util.Deque;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.OptionalLong;
+
+import static org.apache.paimon.table.query.GlobalIndexQueryServiceUtils.persistedCoreOptions;
+
+/** Monitors exact snapshots and emits a fail-closed global-index coverage decision once. */
+public class GlobalIndexQuerySnapshotMonitor extends AbstractNonCoordinatedSource<InternalRow> {
+
+    private static final long serialVersionUID = 1L;
+
+    public static final int START = 0;
+    public static final int SPLIT = 1;
+    public static final int COMPLETE = 2;
+    public static final int NOT_READY = 3;
+    public static final int TARGET = 3;
+
+    private final FileStoreTable table;
+    private final String lookupField;
+    private final List<String> valueFields;
+    private final int numBootstraps;
+    private final String leaseIdPrefix;
+    private final Duration leaseGracePeriod;
+    private final long monitorInterval;
+    private final String expectedTableUuid;
+    private final String expectedBranch;
+
+    public GlobalIndexQuerySnapshotMonitor(
+            FileStoreTable table,
+            String lookupField,
+            List<String> valueFields,
+            int numBootstraps,
+            String leaseIdPrefix,
+            Duration leaseGracePeriod) {
+        this.table = table;
+        this.lookupField = lookupField;
+        this.valueFields = valueFields;
+        this.numBootstraps = numBootstraps;
+        this.leaseIdPrefix = leaseIdPrefix;
+        this.leaseGracePeriod = leaseGracePeriod;
+        this.expectedTableUuid = table.uuid();
+        this.expectedBranch = table.coreOptions().branch();
+        this.monitorInterval =
+                Options.fromMap(table.options())
+                        .get(CoreOptions.CONTINUOUS_DISCOVERY_INTERVAL)
+                        .toMillis();
+    }
+
+    public static RowType outputType() {
+        return RowType.of(
+                DataTypes.BIGINT(),
+                DataTypes.BIGINT(),
+                DataTypes.INT(),
+                DataTypes.INT(),
+                DataTypes.BYTES(),
+                DataTypes.STRING());
+    }
+
+    @Override
+    public Boundedness getBoundedness() {
+        return Boundedness.CONTINUOUS_UNBOUNDED;
+    }
+
+    @Override
+    public SourceReader<InternalRow, SimpleSourceSplit> createReader(
+            SourceReaderContext sourceReaderContext) {
+        return new Reader();
+    }
+
+    private class Reader extends AbstractNonCoordinatedSourceReader<InternalRow> {
+
+        private transient SnapshotManager snapshotManager;
+        private transient QuerySpec spec;
+        private transient GlobalIndexQuerySnapshotLease snapshotLease;
+        @Nullable private Long lastSnapshotId;
+        @Nullable private String lastSnapshotUuid;
+        @Nullable private String lastTableUuid;
+        @Nullable private String lastBranch;
+        @Nullable private Long lastGeneration;
+        private transient LeaseHandoverTracker leaseHandovers;
+        private boolean leaseInitialized;
+
+        @Override
+        public void start() {
+            this.snapshotManager = table.store().snapshotManager();
+            this.spec = GlobalIndexQueryServiceUtils.querySpec(table, lookupField, valueFields);
+            this.snapshotLease =
+                    new GlobalIndexQuerySnapshotLease(
+                            table.consumerManager(),
+                            leaseIdPrefix,
+                            persistedCoreOptions(table).consumerExpireTime());
+            this.leaseHandovers = new LeaseHandoverTracker(leaseGracePeriod);
+        }
+
+        @Override
+        public InputStatus pollNext(ReaderOutput<InternalRow> output) throws Exception {
+            snapshotLease.checkHealthy();
+            Long latestSnapshotId = snapshotManager.latestSnapshotIdFromFileSystem();
+            long snapshotId =
+                    latestSnapshotId == null
+                            ? GlobalIndexQueryServiceUtils.EMPTY_SNAPSHOT_ID
+                            : latestSnapshotId;
+            if (latestSnapshotId != null) {
+                // Acquire the consumer lease before opening or planning the exact snapshot. The
+                // lease stays at min(active, building) until global publication plus grace. On a
+                // replacement attempt, first inherit the oldest existing consumer pin so the
+                // previous attempt's served Blob descriptors remain protected during handover.
+                long snapshotToPin = latestSnapshotId;
+                if (!leaseInitialized) {
+                    OptionalLong inherited = table.consumerManager().minNextSnapshot();
+                    if (inherited.isPresent()) {
+                        snapshotToPin = Math.min(snapshotToPin, inherited.getAsLong());
+                    }
+                }
+                snapshotLease.pinBuilding(snapshotToPin);
+            }
+            leaseInitialized = true;
+            Snapshot snapshot =
+                    latestSnapshotId == null ? null : snapshotManager.snapshot(latestSnapshotId);
+            String snapshotUuid = snapshot == null ? null : snapshot.uuid();
+            String currentTableUuid = table.uuid();
+            String currentBranch = table.coreOptions().branch();
+            if (lastSnapshotId != null
+                    && lastSnapshotId == snapshotId
+                    && Objects.equals(lastSnapshotUuid, snapshotUuid)
+                    && Objects.equals(lastTableUuid, currentTableUuid)
+                    && Objects.equals(lastBranch, currentBranch)) {
+                maybeAdvanceLease();
+                Thread.sleep(monitorInterval);
+                return InputStatus.MORE_AVAILABLE;
+            }
+
+            SnapshotReadiness readiness;
+            if (!expectedTableUuid.equals(currentTableUuid)
+                    || !expectedBranch.equals(currentBranch)) {
+                readiness =
+                        SnapshotReadiness.notReady(
+                                snapshotId,
+                                String.format(
+                                        "Table identity changed from UUID %s branch %s to UUID %s branch %s; restart the query service.",
+                                        expectedTableUuid,
+                                        expectedBranch,
+                                        currentTableUuid,
+                                        currentBranch));
+            } else {
+                readiness = GlobalIndexQueryServiceUtils.snapshotReadiness(table, spec, snapshot);
+            }
+            // Snapshot IDs normally provide the generation. If a table path is recreated or a
+            // snapshot ID is reused with another UUID, keep the request fence strictly increasing.
+            long generation =
+                    lastGeneration == null
+                            ? readiness.snapshotId()
+                            : Math.max(readiness.snapshotId(), lastGeneration + 1L);
+            if (!readiness.ready()) {
+                // Start the grace clock only after discovery acknowledges this exact unavailable
+                // generation. Starting it here would let downstream backpressure consume the grace
+                // period before executors have fenced old requests and the register has withdrawn
+                // the ready descriptor.
+                for (int target = 0; target < numBootstraps; target++) {
+                    emit(
+                            output,
+                            generation,
+                            readiness.snapshotId(),
+                            NOT_READY,
+                            target,
+                            null,
+                            readiness.reason());
+                }
+            } else {
+                List<Split> splits = planSnapshot(snapshot);
+                List<List<Split>> assignments = assignSplits(splits, numBootstraps);
+                for (int target = 0; target < numBootstraps; target++) {
+                    emit(output, generation, readiness.snapshotId(), START, target, null, "");
+                }
+                for (int target = 0; target < numBootstraps; target++) {
+                    for (Split split : assignments.get(target)) {
+                        emit(
+                                output,
+                                generation,
+                                readiness.snapshotId(),
+                                SPLIT,
+                                target,
+                                SplitSerializer.serialize(split),
+                                "");
+                    }
+                }
+                for (int target = 0; target < numBootstraps; target++) {
+                    emit(output, generation, readiness.snapshotId(), COMPLETE, target, null, "");
+                }
+            }
+            lastSnapshotId = snapshotId;
+            lastSnapshotUuid = snapshotUuid;
+            lastTableUuid = currentTableUuid;
+            lastBranch = currentBranch;
+            lastGeneration = generation;
+            maybeAdvanceLease();
+            return InputStatus.MORE_AVAILABLE;
+        }
+
+        private void maybeAdvanceLease() {
+            long now = System.nanoTime();
+            Optional<GlobalIndexQueryServiceDescriptor> descriptor =
+                    table.store().newServiceManager().globalIndexService(spec.serviceId());
+            if (lastSnapshotId != null
+                    && lastSnapshotId != GlobalIndexQueryServiceUtils.EMPTY_SNAPSHOT_ID
+                    && lastGeneration != null
+                    && acknowledgesTargetDescriptor(
+                            descriptor,
+                            table.schema().id(),
+                            expectedTableUuid,
+                            expectedBranch,
+                            spec.schemaFingerprint(),
+                            spec.lookupFieldId(),
+                            spec.valueFieldIds(),
+                            lastGeneration,
+                            lastSnapshotId,
+                            lastSnapshotUuid,
+                            numBootstraps)) {
+                leaseHandovers.acknowledge(lastGeneration, lastSnapshotId, now);
+            }
+            leaseHandovers.promotableSnapshot(now).ifPresent(snapshotLease::promote);
+        }
+
+        @Override
+        public void close() {
+            if (snapshotLease != null) {
+                snapshotLease.close();
+            }
+        }
+
+        private List<Split> planSnapshot(@Nullable Snapshot snapshot) {
+            return GlobalIndexQuerySnapshotMonitor.planSnapshot(table, spec, snapshot);
+        }
+    }
+
+    static List<Split> planSnapshot(
+            FileStoreTable table, QuerySpec spec, @Nullable Snapshot snapshot) {
+        if (snapshot == null) {
+            return new ArrayList<>();
+        }
+        RowType readType = table.rowType().project(spec.bootstrapProjection());
+        // Do not use FileStoreTable.newScan here. Its StartingScanner is configured from dynamic
+        // scan options and can replace the explicitly requested snapshot with the latest snapshot,
+        // while scan.bucket can silently prune a bucket-unaware table to zero splits. This reader
+        // is the source of truth for the generation fence and must plan exactly the leased target.
+        SnapshotReader.Plan plan =
+                table.newSnapshotReader()
+                        .withMode(ScanMode.ALL)
+                        .withSnapshot(snapshot)
+                        .withReadType(readType)
+                        .read();
+        Preconditions.checkState(
+                Objects.equals(plan.snapshotId(), snapshot.id()),
+                "Expected bootstrap snapshot %s (%s) but planned snapshot %s.",
+                snapshot.id(),
+                snapshot.uuid(),
+                plan.snapshotId());
+        return plan.splits();
+    }
+
+    static boolean acknowledgesTargetDescriptor(
+            Optional<GlobalIndexQueryServiceDescriptor> descriptor,
+            long schemaId,
+            String tableUuid,
+            String branch,
+            String schemaFingerprint,
+            int lookupFieldId,
+            int[] valueFieldIds,
+            long generation,
+            long snapshotId,
+            @Nullable String snapshotUuid,
+            int numExecutors) {
+        // Coverage is only a pre-bootstrap gate. The bootstrap may still invalidate the target
+        // because it discovers a duplicate key or an individually oversized value. Either a READY
+        // publication or an all-executor exact NOT_READY publication proves that every executor's
+        // accepted-generation fence has advanced, so both safely start the handover grace.
+        return acknowledgesDescriptor(
+                        descriptor,
+                        true,
+                        schemaId,
+                        tableUuid,
+                        branch,
+                        schemaFingerprint,
+                        lookupFieldId,
+                        valueFieldIds,
+                        generation,
+                        snapshotId,
+                        snapshotUuid,
+                        numExecutors)
+                || acknowledgesDescriptor(
+                        descriptor,
+                        false,
+                        schemaId,
+                        tableUuid,
+                        branch,
+                        schemaFingerprint,
+                        lookupFieldId,
+                        valueFieldIds,
+                        generation,
+                        snapshotId,
+                        null,
+                        numExecutors);
+    }
+
+    static boolean acknowledgesDescriptor(
+            Optional<GlobalIndexQueryServiceDescriptor> optionalDescriptor,
+            boolean ready,
+            long schemaId,
+            String tableUuid,
+            String branch,
+            String schemaFingerprint,
+            int lookupFieldId,
+            int[] valueFieldIds,
+            long generation,
+            long snapshotId,
+            @Nullable String snapshotUuid,
+            int numExecutors) {
+        if (!optionalDescriptor.isPresent()) {
+            return false;
+        }
+        GlobalIndexQueryServiceDescriptor descriptor = optionalDescriptor.get();
+        return descriptor.protocolVersion() == GlobalIndexQueryServiceDescriptor.PROTOCOL_VERSION
+                && descriptor.hashVersion() == GlobalIndexQueryServiceDescriptor.KEY_HASH_VERSION
+                && GlobalIndexQueryServiceDescriptor.LAYOUT.equals(descriptor.layout())
+                && descriptor.ready() == ready
+                && descriptor.schemaId() == schemaId
+                && tableUuid.equals(descriptor.tableUuid())
+                && branch.equals(descriptor.branch())
+                && schemaFingerprint.equals(descriptor.schemaFingerprint())
+                && descriptor.lookupFieldId() == lookupFieldId
+                && Arrays.equals(descriptor.valueFieldIds(), valueFieldIds)
+                && descriptor.servedGeneration() == generation
+                && descriptor.servedSnapshotId() == snapshotId
+                && (ready
+                        ? Objects.equals(descriptor.snapshotUuid(), snapshotUuid)
+                                && descriptor.endpoints().length == numExecutors
+                        : descriptor.snapshotUuid() == null && descriptor.endpoints().length == 0);
+    }
+
+    /**
+     * Tracks each descriptor handover independently so a newer snapshot cannot restart an older
+     * snapshot's grace period. Entries are bounded by the snapshots acknowledged during one grace
+     * window and are removed in acknowledgement order.
+     */
+    static class LeaseHandoverTracker {
+
+        private final long graceNanos;
+        private final Deque<LeaseHandover> handovers = new ArrayDeque<>();
+        private long lastAcknowledgedGeneration = Long.MIN_VALUE;
+
+        LeaseHandoverTracker(Duration gracePeriod) {
+            this.graceNanos = gracePeriod.toNanos();
+        }
+
+        void acknowledge(long generation, long snapshotId, long acknowledgedNanos) {
+            if (generation <= lastAcknowledgedGeneration) {
+                return;
+            }
+            handovers.addLast(new LeaseHandover(snapshotId, acknowledgedNanos));
+            lastAcknowledgedGeneration = generation;
+        }
+
+        OptionalLong promotableSnapshot(long nowNanos) {
+            OptionalLong result = OptionalLong.empty();
+            while (!handovers.isEmpty()
+                    && nowNanos - handovers.peekFirst().acknowledgedNanos >= graceNanos) {
+                result = OptionalLong.of(handovers.removeFirst().snapshotId);
+            }
+            return result;
+        }
+    }
+
+    private static class LeaseHandover {
+
+        private final long snapshotId;
+        private final long acknowledgedNanos;
+
+        private LeaseHandover(long snapshotId, long acknowledgedNanos) {
+            this.snapshotId = snapshotId;
+            this.acknowledgedNanos = acknowledgedNanos;
+        }
+    }
+
+    static List<List<Split>> assignSplits(List<Split> splits, int parallelism) {
+        List<List<Split>> assignments = new ArrayList<>(parallelism);
+        long[] loads = new long[parallelism];
+        for (int i = 0; i < parallelism; i++) {
+            assignments.add(new ArrayList<>());
+        }
+        List<Split> orderedSplits = new ArrayList<>(splits);
+        orderedSplits.sort(
+                Comparator.comparingLong(GlobalIndexQuerySnapshotMonitor::weight).reversed());
+        for (Split split : orderedSplits) {
+            int target = 0;
+            for (int i = 1; i < loads.length; i++) {
+                if (loads[i] < loads[target]) {
+                    target = i;
+                }
+            }
+            assignments.get(target).add(split);
+            loads[target] += weight(split);
+        }
+        return assignments;
+    }
+
+    private static long weight(Split split) {
+        return Math.max(1L, split.mergedRowCount().orElse(split.rowCount()));
+    }
+
+    private static void emit(
+            ReaderOutput<InternalRow> output,
+            long generation,
+            long snapshotId,
+            int type,
+            int target,
+            @Nullable byte[] split,
+            String reason) {
+        output.collect(
+                GenericRow.of(
+                        generation,
+                        snapshotId,
+                        type,
+                        target,
+                        split,
+                        BinaryString.fromString(reason)));
+    }
+
+    public static DataStream<InternalRow> build(
+            StreamExecutionEnvironment env,
+            FileStoreTable table,
+            String lookupField,
+            List<String> valueFields,
+            int numBootstraps,
+            String leaseIdPrefix,
+            Duration leaseGracePeriod) {
+        return env.fromSource(
+                        new GlobalIndexQuerySnapshotMonitor(
+                                table,
+                                lookupField,
+                                valueFields,
+                                numBootstraps,
+                                leaseIdPrefix,
+                                leaseGracePeriod),
+                        WatermarkStrategy.noWatermarks(),
+                        "GlobalIndexSnapshotMonitor-" + table.name(),
+                        InternalTypeInfo.fromRowType(outputType()))
+                .setParallelism(1);
+    }
+}

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/service/QueryService.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/service/QueryService.java
@@ -18,11 +18,16 @@
 
 package org.apache.paimon.flink.service;
 
+import org.apache.paimon.CoreOptions;
 import org.apache.paimon.data.InternalRow;
 import org.apache.paimon.flink.utils.InternalTypeInfo;
 import org.apache.paimon.table.BucketMode;
 import org.apache.paimon.table.FileStoreTable;
 import org.apache.paimon.table.Table;
+import org.apache.paimon.table.query.GlobalIndexQueryServiceUtils;
+import org.apache.paimon.table.query.GlobalIndexQuerySnapshotLease;
+import org.apache.paimon.table.sink.ChannelComputer;
+import org.apache.paimon.types.BlobType;
 import org.apache.paimon.utils.Preconditions;
 
 import org.apache.flink.api.common.RuntimeExecutionMode;
@@ -32,10 +37,18 @@ import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.streaming.api.datastream.DataStreamSink;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 
+import java.time.Duration;
+import java.util.Collections;
+import java.util.List;
+
 import static org.apache.paimon.flink.sink.FlinkStreamPartitioner.partition;
+import static org.apache.paimon.table.query.GlobalIndexQueryServiceUtils.persistedCoreOptions;
 
 /** A class to build Query Service topology. */
 public class QueryService {
+
+    public static final Duration DEFAULT_LEASE_GRACE_PERIOD = Duration.ofMinutes(10);
+    public static final Duration MIN_FAILOVER_RECOVERY_MARGIN = Duration.ofMinutes(1);
 
     public static void build(StreamExecutionEnvironment env, Table table, int parallelism) {
         ReadableConfig conf = env.getConfiguration();
@@ -66,5 +79,154 @@ public class QueryService {
                         .setParallelism(1);
 
         sink.getTransformation().setMaxParallelism(1);
+    }
+
+    /**
+     * Build a snapshot-scoped query service for a data-evolution append table global index.
+     *
+     * <p>The BTree index is an exact coverage gate; requests read key-hash-sharded materialized
+     * state, not BTree files. The monitor plans each pinned snapshot once, and bootstrap readers
+     * consume every planned split exactly once before shuffling projected key/value rows. A new
+     * fully indexed snapshot triggers a full rebuild. Discovery is NOT_READY during that rebuild
+     * and is published atomically only after all executors report the same served snapshot. This v1
+     * behavior deliberately favors fail-closed correctness over refresh availability and does not
+     * expose the old descriptor through discovery during refresh. A per-attempt consumer lease pins
+     * the minimum active/building snapshot, inherits the previous attempt's live pin after
+     * failover, and advances only after discovery acknowledges the handover plus a configurable
+     * grace period.
+     *
+     * <p>Lookup is exact and does not normalize application identifiers such as URLs. Callers may
+     * normalize keys before invoking the client. Null table keys are skipped, null request keys are
+     * rejected, and any duplicate non-null key prevents the generation from becoming ready.
+     * Selected BLOB value fields are read in descriptor mode and cached as serialized {@code
+     * BlobDescriptor} bytes; the service never materializes their payload into query state.
+     */
+    public static void build(
+            StreamExecutionEnvironment env,
+            Table table,
+            int parallelism,
+            String lookupField,
+            List<String> valueFields) {
+        FileStoreTable storeTable = (FileStoreTable) table;
+        GlobalIndexQueryServiceUtils.QuerySpec spec =
+                GlobalIndexQueryServiceUtils.querySpec(storeTable, lookupField, valueFields);
+        build(
+                env,
+                table,
+                parallelism,
+                lookupField,
+                valueFields,
+                "global-index-query-" + spec.serviceId(),
+                DEFAULT_LEASE_GRACE_PERIOD);
+    }
+
+    public static void build(
+            StreamExecutionEnvironment env,
+            Table table,
+            int parallelism,
+            String lookupField,
+            List<String> valueFields,
+            String consumerIdPrefix,
+            Duration leaseGracePeriod) {
+        ReadableConfig conf = env.getConfiguration();
+        Preconditions.checkArgument(
+                conf.get(ExecutionOptions.RUNTIME_MODE) == RuntimeExecutionMode.STREAMING,
+                "Query Service only supports streaming mode.");
+        Preconditions.checkArgument(parallelism > 0, "Parallelism must be positive.");
+
+        FileStoreTable storeTable = (FileStoreTable) table;
+        GlobalIndexQueryServiceUtils.QuerySpec spec =
+                GlobalIndexQueryServiceUtils.querySpec(storeTable, lookupField, valueFields);
+        if (consumerIdPrefix == null) {
+            consumerIdPrefix = "global-index-query-" + spec.serviceId();
+        }
+        GlobalIndexQuerySnapshotLease.validateConsumerIdPrefix(consumerIdPrefix);
+        Preconditions.checkArgument(
+                leaseGracePeriod != null && !leaseGracePeriod.isNegative(),
+                "Lease grace period must not be negative.");
+
+        Duration persistedExpiration = persistedCoreOptions(storeTable).consumerExpireTime();
+        validateLeaseTiming(persistedExpiration, leaseGracePeriod);
+        FileStoreTable queryTable = descriptorReadTable(storeTable, spec);
+
+        DataStream<InternalRow> snapshots =
+                GlobalIndexQuerySnapshotMonitor.build(
+                        env,
+                        queryTable,
+                        lookupField,
+                        valueFields,
+                        parallelism,
+                        consumerIdPrefix,
+                        leaseGracePeriod);
+        snapshots = partition(snapshots, new GlobalIndexEventChannelComputer(), parallelism);
+        DataStream<InternalRow> cacheEvents =
+                snapshots
+                        .transform(
+                                "GlobalIndexBootstrap",
+                                InternalTypeInfo.fromRowType(
+                                        GlobalIndexQueryBootstrapOperator.outputType()),
+                                new GlobalIndexQueryBootstrapOperator(
+                                        queryTable, lookupField, valueFields, parallelism))
+                        .setParallelism(parallelism);
+        cacheEvents = partition(cacheEvents, new GlobalIndexEventChannelComputer(), parallelism);
+
+        DataStreamSink<?> sink =
+                cacheEvents
+                        .transform(
+                                "GlobalIndexExecutor",
+                                InternalTypeInfo.fromRowType(
+                                        GlobalIndexQueryExecutorOperator.outputType()),
+                                new GlobalIndexQueryExecutorOperator(
+                                        queryTable, lookupField, valueFields, parallelism))
+                        .setParallelism(parallelism)
+                        .sinkTo(new GlobalIndexQueryAddressRegister(queryTable, spec))
+                        .setParallelism(1);
+        sink.getTransformation().setMaxParallelism(1);
+    }
+
+    static void validateLeaseTiming(Duration persistedExpiration, Duration leaseGracePeriod) {
+        Preconditions.checkArgument(
+                persistedExpiration != null
+                        && persistedExpiration.compareTo(leaseGracePeriod) >= 0
+                        && persistedExpiration
+                                        .minus(leaseGracePeriod)
+                                        .compareTo(MIN_FAILOVER_RECOVERY_MARGIN)
+                                >= 0,
+                "Persisted consumer.expiration-time must be at least lease-grace-period + %s so a stopped attempt protects its served snapshot through failover.",
+                MIN_FAILOVER_RECOVERY_MARGIN);
+    }
+
+    private static FileStoreTable descriptorReadTable(
+            FileStoreTable table, GlobalIndexQueryServiceUtils.QuerySpec spec) {
+        for (int position : spec.valuePositions()) {
+            if (BlobType.isBlobFileField(table.rowType().getTypeAt(position))) {
+                return (FileStoreTable)
+                        table.copy(
+                                Collections.singletonMap(
+                                        CoreOptions.BLOB_AS_DESCRIPTOR.key(), "true"));
+            }
+        }
+        return table;
+    }
+
+    private static class GlobalIndexEventChannelComputer implements ChannelComputer<InternalRow> {
+
+        private int numChannels;
+
+        @Override
+        public void setup(int numChannels) {
+            this.numChannels = numChannels;
+        }
+
+        @Override
+        public int channel(InternalRow row) {
+            int target = row.getInt(GlobalIndexQueryBootstrapOperator.TARGET);
+            Preconditions.checkArgument(
+                    target >= 0 && target < numChannels,
+                    "Invalid global-index query target %s for %s channels.",
+                    target,
+                    numChannels);
+            return target;
+        }
     }
 }

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/GlobalIndexQueryServiceITCase.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/GlobalIndexQueryServiceITCase.java
@@ -1,0 +1,1005 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.flink;
+
+import org.apache.paimon.CoreOptions;
+import org.apache.paimon.data.BinaryRow;
+import org.apache.paimon.data.BinaryString;
+import org.apache.paimon.data.Blob;
+import org.apache.paimon.data.BlobDescriptor;
+import org.apache.paimon.data.GenericRow;
+import org.apache.paimon.data.InternalRow;
+import org.apache.paimon.data.serializer.InternalRowSerializer;
+import org.apache.paimon.data.serializer.InternalSerializers;
+import org.apache.paimon.flink.action.Action;
+import org.apache.paimon.flink.action.ActionBase;
+import org.apache.paimon.flink.action.ActionFactory;
+import org.apache.paimon.flink.procedure.QueryServiceProcedure;
+import org.apache.paimon.flink.query.RemoteGlobalIndexTableQuery;
+import org.apache.paimon.flink.service.QueryService;
+import org.apache.paimon.fs.Path;
+import org.apache.paimon.options.ExpireConfig;
+import org.apache.paimon.query.GlobalIndexQueryEndpoint;
+import org.apache.paimon.query.GlobalIndexQueryLocation;
+import org.apache.paimon.query.GlobalIndexQueryLocationImpl;
+import org.apache.paimon.service.GlobalIndexQueryServiceDescriptor;
+import org.apache.paimon.service.GlobalIndexQueryServiceDescriptor.Endpoint;
+import org.apache.paimon.service.ServiceManager;
+import org.apache.paimon.service.client.GlobalIndexQueryClient;
+import org.apache.paimon.service.client.GlobalIndexQueryClient.LookupResult;
+import org.apache.paimon.service.exceptions.GlobalIndexQueryException;
+import org.apache.paimon.table.FileStoreTable;
+import org.apache.paimon.table.query.GlobalIndexQueryServiceUtils;
+import org.apache.paimon.table.query.GlobalIndexQueryServiceUtils.QuerySpec;
+import org.apache.paimon.table.query.QueryServiceNotReadyException;
+import org.apache.paimon.types.DataTypes;
+import org.apache.paimon.types.RowType;
+import org.apache.paimon.utils.UriReader;
+
+import org.apache.flink.api.common.JobStatus;
+import org.apache.flink.client.program.ClusterClient;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.PipelineOptions;
+import org.apache.flink.core.execution.JobClient;
+import org.apache.flink.runtime.client.JobStatusMessage;
+import org.apache.flink.runtime.minicluster.MiniCluster;
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.table.api.config.TableConfigOptions;
+import org.apache.flink.types.Row;
+import org.apache.flink.util.CloseableIterator;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+
+import java.lang.reflect.Field;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
+
+import static org.apache.paimon.service.exceptions.GlobalIndexQueryErrorCode.STALE_GENERATION;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
+
+/** End-to-end MiniCluster tests for the data-evolution global-index query service. */
+@SuppressWarnings("BusyWait")
+public class GlobalIndexQueryServiceITCase extends CatalogITCaseBase {
+
+    private static final String TABLE = "IMAGE_BLOB";
+    private static final String LOOKUP_FIELD = "url";
+    private static final String VALUE_FIELD = "descriptor";
+    private static final String CONSUMER_ID = "global-index-query-it";
+    private static final Duration LEASE_GRACE_PERIOD = Duration.ofSeconds(2);
+    private static final Duration WAIT_TIMEOUT = Duration.ofSeconds(90);
+    private static final InternalRowSerializer KEY_SERIALIZER =
+            InternalSerializers.create(RowType.of(DataTypes.STRING()));
+
+    @Override
+    protected List<String> ddl() {
+        return Collections.singletonList(
+                "CREATE TABLE "
+                        + TABLE
+                        + " (url STRING, descriptor BYTES) WITH ("
+                        + "'bucket'='-1', "
+                        + "'global-index.enabled'='true', "
+                        + "'row-tracking.enabled'='true', "
+                        + "'data-evolution.enabled'='true', "
+                        + "'blob-field'='descriptor', "
+                        + "'blob-compaction.enabled'='true', "
+                        + "'compaction.min.file-num'='2', "
+                        + "'continuous.discovery-interval'='20 ms', "
+                        + "'consumer.expiration-time'='1 h')");
+    }
+
+    @Test
+    @Timeout(300)
+    public void testSnapshotFencedBlobLifecycleAndRescale() throws Exception {
+        tEnv.getConfig().set(TableConfigOptions.TABLE_DML_SYNC, true);
+        LinkedHashMap<String, byte[]> expected = initialRowsCoveringBothShards();
+        for (Map.Entry<String, byte[]> entry : expected.entrySet()) {
+            insert(entry.getKey(), entry.getValue());
+        }
+        buildBTreeIndex();
+
+        FileStoreTable table = paimonTable(TABLE);
+        QuerySpec spec = querySpec(table);
+        long initialSnapshotId = table.snapshotManager().latestSnapshot().id();
+        long initialBlobFiles = blobFileCount();
+        assertThat(initialBlobFiles).isGreaterThan(1L);
+
+        GlobalIndexQueryServiceDescriptor compactedDescriptor;
+        JobClient initialJob = startQueryService(table, 2);
+        try {
+            GlobalIndexQueryServiceDescriptor initialDescriptor =
+                    waitForDescriptor(
+                            table,
+                            spec,
+                            descriptor ->
+                                    descriptor.ready()
+                                            && descriptor.servedSnapshotId() == initialSnapshotId
+                                            && descriptor.endpoints().length == 2,
+                            initialJob,
+                            "initial two-shard service");
+            assertThat(initialDescriptor.tableUuid()).isEqualTo(table.uuid());
+            assertThat(initialDescriptor.branch()).isEqualTo(table.coreOptions().branch());
+            assertThat(initialDescriptor.snapshotUuid()).isNotBlank();
+            assertBatchLookup(table, spec, expected, true);
+
+            String existingKey = expected.keySet().iterator().next();
+
+            String appendedKey = "O1CN-appended-after-service.jpg";
+            byte[] appendedValue = "image-appended".getBytes(StandardCharsets.UTF_8);
+            // Prime and retain a client so its location cache contains the old ready descriptor.
+            // Once the executor observes the append generation, the same cached endpoint must
+            // fail closed for the new key instead of answering null from its retained old state.
+            try (ClientResource cachedClient = client(table, spec)) {
+                BinaryRow[] beforeAppend =
+                        cachedClient
+                                .client
+                                .getValues(new BinaryRow[] {key(existingKey)})
+                                .get(30, TimeUnit.SECONDS);
+                assertThat(beforeAppend[0]).isNotNull();
+
+                insert(appendedKey, appendedValue);
+                expected.put(appendedKey, appendedValue);
+                long uncoveredSnapshotId = table.snapshotManager().latestSnapshot().id();
+                assertThat(uncoveredSnapshotId).isGreaterThan(initialDescriptor.servedSnapshotId());
+
+                GlobalIndexQueryServiceDescriptor unavailable =
+                        waitForDescriptor(
+                                table,
+                                spec,
+                                descriptor ->
+                                        !descriptor.ready()
+                                                && descriptor
+                                                        .reason()
+                                                        .toLowerCase()
+                                                        .contains("btree"),
+                                initialJob,
+                                "uncovered snapshot to withdraw discovery");
+                assertThat(unavailable.reason()).containsIgnoringCase("BTree");
+                Throwable cachedFailure =
+                        failure(cachedClient.client.getValues(new BinaryRow[] {key(appendedKey)}));
+                assertThat(cachedFailure).isInstanceOf(QueryServiceNotReadyException.class);
+                assertFreshClientNotReady(table, spec, key(appendedKey));
+
+                String secondUnindexedKey = "O1CN-second-unindexed-tail.jpg";
+                byte[] secondUnindexedValue =
+                        "image-second-unindexed".getBytes(StandardCharsets.UTF_8);
+                insert(secondUnindexedKey, secondUnindexedValue);
+                expected.put(secondUnindexedKey, secondUnindexedValue);
+                long secondUnindexedSnapshotId = table.snapshotManager().latestSnapshot().id();
+                assertThat(secondUnindexedSnapshotId).isGreaterThan(uncoveredSnapshotId);
+                waitForConsumerSnapshot(
+                        table,
+                        secondUnindexedSnapshotId,
+                        initialJob,
+                        "continuous NOT_READY lease advancement");
+                expireAllButLatest(table);
+                assertThat(table.snapshotManager().earliestSnapshotId())
+                        .isEqualTo(secondUnindexedSnapshotId);
+                assertThat(
+                                table.fileIO()
+                                        .exists(
+                                                table.snapshotManager()
+                                                        .snapshotPath(initialSnapshotId)))
+                        .isFalse();
+                Throwable secondCachedFailure =
+                        failure(
+                                cachedClient.client.getValues(
+                                        new BinaryRow[] {key(secondUnindexedKey)}));
+                assertThat(secondCachedFailure).isInstanceOf(QueryServiceNotReadyException.class);
+            }
+
+            buildBTreeIndex();
+            long refreshedSnapshotId = table.snapshotManager().latestSnapshot().id();
+            GlobalIndexQueryServiceDescriptor refreshed =
+                    waitForDescriptor(
+                            table,
+                            spec,
+                            descriptor ->
+                                    descriptor.ready()
+                                            && descriptor.servedSnapshotId() == refreshedSnapshotId
+                                            && descriptor.servedGeneration()
+                                                    > initialDescriptor.servedGeneration(),
+                            initialJob,
+                            "newly indexed generation");
+            assertThat(refreshed.endpoints()).hasSize(2);
+            assertBatchLookup(table, spec, expected, true);
+
+            BlobDescriptor descriptorBeforeCompaction = lookupDescriptor(table, spec, existingKey);
+            GlobalIndexQueryLocation oldFence = frozenLocation(refreshed);
+            long blobsBeforeCompaction = blobFileCount();
+            batchSql("CALL sys.compact(`table` => 'default.%s')", TABLE);
+            long compactSnapshotId = table.snapshotManager().latestSnapshot().id();
+            assertThat(compactSnapshotId).isGreaterThan(refreshed.servedSnapshotId());
+            assertThat(blobFileCount()).isLessThan(blobsBeforeCompaction);
+
+            // The exact compacted target has withdrawn the old descriptor, but the non-zero
+            // handover grace still protects a BlobDescriptor returned by the previous generation.
+            // Snapshot expiry in this window must not delete its referenced Blob file.
+            waitForDescriptor(
+                    table,
+                    spec,
+                    descriptor -> descriptor.servedSnapshotId() == compactSnapshotId,
+                    initialJob,
+                    "compaction handover acknowledgement");
+            expireAllButLatest(table);
+            assertBlobReadable(table, descriptorBeforeCompaction, expected.get(existingKey));
+
+            // Refreshing an existing BTree is idempotent when compaction preserved its exact
+            // coverage, and repairs coverage when compaction replaced a covered row range.
+            buildBTreeIndex();
+            long postCompactionSnapshotId = table.snapshotManager().latestSnapshot().id();
+            compactedDescriptor =
+                    waitForDescriptor(
+                            table,
+                            spec,
+                            descriptor ->
+                                    descriptor.ready()
+                                            && descriptor.servedSnapshotId()
+                                                    == postCompactionSnapshotId
+                                            && descriptor.servedGeneration()
+                                                    > refreshed.servedGeneration(),
+                            initialJob,
+                            "post-compaction generation");
+            BlobDescriptor descriptorAfterCompaction = lookupDescriptor(table, spec, existingKey);
+            assertThat(descriptorAfterCompaction.uri())
+                    .isNotEqualTo(descriptorBeforeCompaction.uri());
+            assertBlobReadable(table, descriptorAfterCompaction, expected.get(existingKey));
+            assertStaleFenceRejected(oldFence, key(existingKey));
+            assertBatchLookup(table, spec, expected, true);
+
+            // Once the exact replacement generation has been acknowledged for the full grace,
+            // its lease may advance and ordinary expiry can reclaim the old Blob file.
+            waitForConsumerSnapshot(
+                    table,
+                    postCompactionSnapshotId,
+                    initialJob,
+                    "post-compaction Blob handover grace");
+            expireAllButLatest(table);
+            assertThat(table.fileIO().exists(new Path(descriptorBeforeCompaction.uri()))).isFalse();
+        } finally {
+            cancel(initialJob);
+        }
+
+        GlobalIndexQueryServiceDescriptor cancelled =
+                waitForDescriptor(
+                        table,
+                        spec,
+                        descriptor -> !descriptor.ready(),
+                        null,
+                        "cancelled service tombstone");
+        assertThat(cancelled.reason()).containsIgnoringCase("closed");
+        assertFreshClientNotReady(table, spec, key(expected.keySet().iterator().next()));
+
+        List<String> stoppedAttemptLeases =
+                table.consumerManager().listAllIds().stream()
+                        .filter(id -> id.startsWith(CONSUMER_ID + '-'))
+                        .collect(Collectors.toList());
+        assertThat(stoppedAttemptLeases).isNotEmpty();
+
+        // Source close is also used for Flink failover. The stopped attempt lease must protect the
+        // last served descriptor until a replacement attempt pins its snapshot, even if snapshot
+        // expiration runs in the handover gap.
+        String recoveryKey = "O1CN-recovery-gap.jpg";
+        byte[] recoveryValue = "image-recovery-gap".getBytes(StandardCharsets.UTF_8);
+        insert(recoveryKey, recoveryValue);
+        expected.put(recoveryKey, recoveryValue);
+        expireAllButLatest(table);
+        assertThat(
+                        table.fileIO()
+                                .exists(
+                                        table.snapshotManager()
+                                                .snapshotPath(
+                                                        compactedDescriptor.servedSnapshotId())))
+                .isTrue();
+        buildBTreeIndex();
+        long recoverySnapshotId = table.snapshotManager().latestSnapshot().id();
+
+        GlobalIndexQueryServiceDescriptor singleShardDescriptor;
+        JobClient oneShardJob = startQueryService(table, 1);
+        try {
+            singleShardDescriptor =
+                    waitForDescriptor(
+                            table,
+                            spec,
+                            descriptor ->
+                                    descriptor.ready()
+                                            && descriptor.servedGeneration()
+                                                    > compactedDescriptor.servedGeneration()
+                                            && descriptor.servedSnapshotId() == recoverySnapshotId
+                                            && descriptor.endpoints().length == 1,
+                            oneShardJob,
+                            "single-shard restart");
+            assertThat(singleShardDescriptor.ownerToken())
+                    .isNotEqualTo(compactedDescriptor.ownerToken());
+            assertThat(singleShardDescriptor.endpoints()[0].serverEpoch())
+                    .isNotEqualTo(compactedDescriptor.endpoints()[0].serverEpoch());
+            assertBatchLookup(table, spec, expected, false);
+        } finally {
+            cancel(oneShardJob);
+        }
+        waitForDescriptor(
+                table,
+                spec,
+                descriptor -> !descriptor.ready(),
+                null,
+                "single-shard cancellation tombstone");
+
+        Set<String> leasesBeforeRescale = new HashSet<>(table.consumerManager().listAllIds());
+        JobClient rescaledJob = startQueryService(table, 2);
+        try {
+            GlobalIndexQueryServiceDescriptor rescaled =
+                    waitForDescriptor(
+                            table,
+                            spec,
+                            descriptor ->
+                                    descriptor.ready()
+                                            && descriptor.servedGeneration()
+                                                    == singleShardDescriptor.servedGeneration()
+                                            && descriptor.endpoints().length == 2,
+                            rescaledJob,
+                            "P1 to P2 rebuild");
+            assertThat(rescaled.ownerToken()).isNotEqualTo(singleShardDescriptor.ownerToken());
+            List<String> rescaledLeaseIds =
+                    table.consumerManager().listAllIds().stream()
+                            .filter(id -> id.startsWith(CONSUMER_ID + '-'))
+                            .filter(id -> !leasesBeforeRescale.contains(id))
+                            .collect(Collectors.toList());
+            assertThat(rescaledLeaseIds).hasSize(1);
+            String rescaledLeaseId = rescaledLeaseIds.get(0);
+            assertThat(
+                            expected.keySet().stream()
+                                    .map(GlobalIndexQueryServiceITCase::key)
+                                    .map(
+                                            binaryKey ->
+                                                    GlobalIndexQueryServiceUtils.route(
+                                                            binaryKey, 2))
+                                    .collect(Collectors.toSet()))
+                    .containsExactlyInAnyOrder(0, 1);
+            assertBatchLookup(table, spec, expected, true);
+
+            // Exact BTree coverage is only the bootstrap gate. A duplicate discovered while
+            // materializing a covered snapshot must publish exact NOT_READY and, after the
+            // non-zero grace, advance this attempt's lease instead of pinning history forever.
+            String duplicateKey = expected.keySet().iterator().next();
+            insert(duplicateKey, "duplicate-image".getBytes(StandardCharsets.UTF_8));
+            buildBTreeIndex();
+            long duplicateSnapshotId = table.snapshotManager().latestSnapshot().id();
+            waitForDescriptor(
+                    table,
+                    spec,
+                    descriptor ->
+                            !descriptor.ready()
+                                    && descriptor.servedSnapshotId() == duplicateSnapshotId
+                                    && descriptor.reason().toLowerCase().contains("duplicate"),
+                    rescaledJob,
+                    "covered duplicate bootstrap rejection");
+            waitForConsumerSnapshot(
+                    table,
+                    rescaledLeaseId,
+                    duplicateSnapshotId,
+                    rescaledJob,
+                    "bootstrap-invalid lease advancement");
+        } finally {
+            cancel(rescaledJob);
+        }
+    }
+
+    @Test
+    @Timeout(180)
+    public void testPublicActionProcedureAndRemoteTableQuery() throws Exception {
+        tEnv.getConfig().set(TableConfigOptions.TABLE_DML_SYNC, true);
+        String lookupKey = "O1CN-public-entrypoint.jpg";
+        byte[] expected = "public-entrypoint-image".getBytes(StandardCharsets.UTF_8);
+        insert(lookupKey, expected);
+        buildBTreeIndex();
+
+        FileStoreTable table = paimonTable(TABLE);
+        QuerySpec spec = querySpec(table);
+        String actionJobName = "global-index-query-service-action-it";
+        Action action =
+                ActionFactory.createAction(
+                                new String[] {
+                                    "query_service",
+                                    "--warehouse",
+                                    path,
+                                    "--database",
+                                    "default",
+                                    "--table",
+                                    TABLE,
+                                    "--parallelism",
+                                    "2",
+                                    "--lookup-key",
+                                    LOOKUP_FIELD,
+                                    "--value-fields",
+                                    VALUE_FIELD,
+                                    "--consumer-id",
+                                    "global-index-action-it",
+                                    "--lease-grace-period",
+                                    "2 s"
+                                })
+                        .orElseThrow(
+                                () -> new AssertionError("Query-service action was not found"));
+        assertThat(action).isInstanceOf(ActionBase.class);
+        StreamExecutionEnvironment actionEnv =
+                streamExecutionEnvironmentBuilder()
+                        .streamingMode()
+                        .parallelism(2)
+                        .allowRestart()
+                        .build();
+        Configuration actionConfiguration = new Configuration();
+        actionConfiguration.set(PipelineOptions.NAME, actionJobName);
+        actionEnv.configure(actionConfiguration);
+        ((ActionBase) action).withStreamExecutionEnvironment(actionEnv);
+
+        CompletableFuture<Void> actionExecution = runActionAsync(action);
+        GlobalIndexQueryServiceDescriptor actionDescriptor =
+                waitForActionDescriptor(
+                        table,
+                        spec,
+                        descriptor -> descriptor.ready() && descriptor.endpoints().length == 2,
+                        actionExecution,
+                        "ActionFactory global-index service");
+        assertThat(actionDescriptor.ownerToken()).isNotBlank();
+        assertThat(table.consumerManager().listAllIds())
+                .anyMatch(id -> id.startsWith("global-index-action-it-"));
+        assertRemoteTableQuery(table, lookupKey, expected);
+
+        cancelClusterJob(actionJobName);
+        awaitActionTermination(actionExecution);
+        waitForDescriptor(
+                table,
+                spec,
+                descriptor ->
+                        !descriptor.ready()
+                                && descriptor.ownerToken().equals(actionDescriptor.ownerToken()),
+                null,
+                "ActionFactory cancellation tombstone");
+
+        GlobalIndexQueryServiceDescriptor procedureDescriptor;
+        try (CloseableIterator<Row> procedure =
+                streamSqlIter(
+                        "CALL sys.query_service("
+                                + "`table` => 'default.%s', parallelism => 2, "
+                                + "lookup_key => '%s', value_fields => '%s', "
+                                + "consumer_id => 'global-index-procedure-it', "
+                                + "lease_grace_period => '2 s')",
+                        TABLE, LOOKUP_FIELD, VALUE_FIELD)) {
+            procedureDescriptor =
+                    waitForDescriptor(
+                            table,
+                            spec,
+                            descriptor ->
+                                    descriptor.ready()
+                                            && descriptor.endpoints().length == 2
+                                            && !descriptor
+                                                    .ownerToken()
+                                                    .equals(actionDescriptor.ownerToken()),
+                            null,
+                            "named query-service procedure");
+            assertThat(table.consumerManager().listAllIds())
+                    .anyMatch(id -> id.startsWith("global-index-procedure-it-"));
+            assertRemoteTableQuery(table, lookupKey, expected);
+            // Closing a synchronous CALL result iterator does not cancel the streaming job. Cancel
+            // the actual procedure job explicitly so its owner-scoped tombstone is observable.
+            cancelClusterJob(QueryServiceProcedure.IDENTIFIER);
+        }
+        waitForDescriptor(
+                table,
+                spec,
+                descriptor ->
+                        !descriptor.ready()
+                                && descriptor.ownerToken().equals(procedureDescriptor.ownerToken()),
+                null,
+                "procedure cancellation tombstone");
+    }
+
+    @Test
+    @Timeout(180)
+    public void testAutomaticAttemptFailover() throws Exception {
+        tEnv.getConfig().set(TableConfigOptions.TABLE_DML_SYNC, true);
+        String lookupKey = "O1CN-automatic-failover.jpg";
+        byte[] expected = "automatic-failover-image".getBytes(StandardCharsets.UTF_8);
+        insert(lookupKey, expected);
+        buildBTreeIndex();
+
+        FileStoreTable table = paimonTable(TABLE);
+        QuerySpec spec = querySpec(table);
+        JobClient jobClient = startQueryService(table, 2);
+        try {
+            GlobalIndexQueryServiceDescriptor beforeFailover =
+                    waitForDescriptor(
+                            table,
+                            spec,
+                            descriptor -> descriptor.ready() && descriptor.endpoints().length == 2,
+                            jobClient,
+                            "pre-failover service");
+            MiniCluster miniCluster = miniCluster(jobClient);
+            miniCluster.terminateTaskManager(0).get(30, TimeUnit.SECONDS);
+            try {
+                waitForDescriptor(
+                        table,
+                        spec,
+                        descriptor ->
+                                !descriptor.ready()
+                                        && descriptor
+                                                .ownerToken()
+                                                .equals(beforeFailover.ownerToken()),
+                        jobClient,
+                        "same-job failover tombstone");
+            } finally {
+                miniCluster.startTaskManager();
+            }
+
+            GlobalIndexQueryServiceDescriptor recovered =
+                    waitForDescriptor(
+                            table,
+                            spec,
+                            descriptor ->
+                                    descriptor.ready()
+                                            && descriptor.endpoints().length == 2
+                                            && !descriptor
+                                                    .ownerToken()
+                                                    .equals(beforeFailover.ownerToken()),
+                            jobClient,
+                            "same-job replacement attempt");
+            assertThat(recovered.servedSnapshotId()).isEqualTo(beforeFailover.servedSnapshotId());
+            assertRemoteTableQuery(table, lookupKey, expected);
+        } finally {
+            cancel(jobClient);
+        }
+    }
+
+    private JobClient startQueryService(FileStoreTable table, int parallelism) throws Exception {
+        StreamExecutionEnvironment env =
+                streamExecutionEnvironmentBuilder()
+                        .streamingMode()
+                        .parallelism(parallelism)
+                        .allowRestart()
+                        .build();
+        // A caller-supplied generic scan option must not prune the bucket-unaware bootstrap. The
+        // query service plans its leased snapshot directly and intentionally ignores scan.bucket.
+        FileStoreTable serviceTable =
+                (FileStoreTable)
+                        table.copy(Collections.singletonMap(CoreOptions.SCAN_BUCKET.key(), "1"));
+        QueryService.build(
+                env,
+                serviceTable,
+                parallelism,
+                LOOKUP_FIELD,
+                Collections.singletonList(VALUE_FIELD),
+                CONSUMER_ID,
+                LEASE_GRACE_PERIOD);
+        return env.executeAsync("global-index-query-service-it-p" + parallelism);
+    }
+
+    private GlobalIndexQueryServiceDescriptor waitForDescriptor(
+            FileStoreTable table,
+            QuerySpec spec,
+            Predicate<GlobalIndexQueryServiceDescriptor> condition,
+            JobClient jobClient,
+            String description)
+            throws Exception {
+        ServiceManager manager = table.store().newServiceManager();
+        long deadline = System.nanoTime() + WAIT_TIMEOUT.toNanos();
+        GlobalIndexQueryServiceDescriptor last = null;
+        while (System.nanoTime() < deadline) {
+            last = manager.globalIndexService(spec.serviceId()).orElse(null);
+            if (last != null && condition.test(last)) {
+                return last;
+            }
+            if (jobClient != null) {
+                JobStatus status = jobClient.getJobStatus().get(10, TimeUnit.SECONDS);
+                if (status.isTerminalState()) {
+                    throw jobFailure(jobClient, status, description, last);
+                }
+            }
+            Thread.sleep(50L);
+        }
+        fail("Timed out waiting for %s. Last descriptor: %s", description, last);
+        return null;
+    }
+
+    private void waitForConsumerSnapshot(
+            FileStoreTable table, long expectedSnapshotId, JobClient jobClient, String description)
+            throws Exception {
+        long deadline = System.nanoTime() + WAIT_TIMEOUT.toNanos();
+        while (System.nanoTime() < deadline) {
+            java.util.OptionalLong nextSnapshot = table.consumerManager().minNextSnapshot();
+            if (nextSnapshot.isPresent() && nextSnapshot.getAsLong() == expectedSnapshotId) {
+                return;
+            }
+            JobStatus status = jobClient.getJobStatus().get(10, TimeUnit.SECONDS);
+            if (status.isTerminalState()) {
+                throw jobFailure(jobClient, status, description, null);
+            }
+            Thread.sleep(50L);
+        }
+        fail("Timed out waiting for %s.", description);
+    }
+
+    private void waitForConsumerSnapshot(
+            FileStoreTable table,
+            String consumerId,
+            long expectedSnapshotId,
+            JobClient jobClient,
+            String description)
+            throws Exception {
+        long deadline = System.nanoTime() + WAIT_TIMEOUT.toNanos();
+        while (System.nanoTime() < deadline) {
+            if (table.consumerManager()
+                    .consumer(consumerId)
+                    .map(consumer -> consumer.nextSnapshot() == expectedSnapshotId)
+                    .orElse(false)) {
+                return;
+            }
+            JobStatus status = jobClient.getJobStatus().get(10, TimeUnit.SECONDS);
+            if (status.isTerminalState()) {
+                throw jobFailure(jobClient, status, description, null);
+            }
+            Thread.sleep(50L);
+        }
+        fail("Timed out waiting for %s.", description);
+    }
+
+    private static AssertionError jobFailure(
+            JobClient jobClient,
+            JobStatus status,
+            String description,
+            GlobalIndexQueryServiceDescriptor descriptor) {
+        AssertionError failure =
+                new AssertionError(
+                        String.format(
+                                "Query-service job terminated as %s while waiting for %s. Last descriptor: %s",
+                                status, description, descriptor));
+        try {
+            jobClient.getJobExecutionResult().get(10, TimeUnit.SECONDS);
+        } catch (Exception e) {
+            failure.initCause(e);
+        }
+        return failure;
+    }
+
+    private void assertBatchLookup(
+            FileStoreTable table,
+            QuerySpec spec,
+            LinkedHashMap<String, byte[]> expected,
+            boolean expectBothShards)
+            throws Exception {
+        List<String> requested = new ArrayList<>(expected.keySet());
+        requested.add(1, "missing-object.jpg");
+        BinaryRow[] keys =
+                requested.stream()
+                        .map(GlobalIndexQueryServiceITCase::key)
+                        .toArray(BinaryRow[]::new);
+        if (expectBothShards) {
+            assertThat(
+                            Arrays.stream(keys)
+                                    .map(
+                                            binaryKey ->
+                                                    GlobalIndexQueryServiceUtils.route(
+                                                            binaryKey, 2))
+                                    .collect(Collectors.toSet()))
+                    .containsExactlyInAnyOrder(0, 1);
+        }
+
+        try (ClientResource client = client(table, spec)) {
+            LookupResult result =
+                    client.client.getValuesWithMetadata(keys).get(30, TimeUnit.SECONDS);
+            GlobalIndexQueryServiceDescriptor advertised =
+                    table.store()
+                            .newServiceManager()
+                            .globalIndexService(spec.serviceId())
+                            .orElseThrow(() -> new AssertionError("Missing ready descriptor"));
+            assertThat(result.servedGeneration()).isEqualTo(advertised.servedGeneration());
+            assertThat(result.servedSnapshotId()).isEqualTo(advertised.servedSnapshotId());
+            assertThat(result.snapshotUuid()).isEqualTo(advertised.snapshotUuid());
+            BinaryRow[] values = result.values();
+            assertThat(values).hasSameSizeAs(keys);
+            for (int i = 0; i < requested.size(); i++) {
+                String request = requested.get(i);
+                if (!expected.containsKey(request)) {
+                    assertThat(values[i]).isNull();
+                    continue;
+                }
+                assertThat(values[i]).isNotNull();
+                BlobDescriptor descriptor = BlobDescriptor.deserialize(values[i].getBinary(0));
+                assertBlobReadable(table, descriptor, expected.get(request));
+            }
+        }
+    }
+
+    private BlobDescriptor lookupDescriptor(FileStoreTable table, QuerySpec spec, String lookupKey)
+            throws Exception {
+        try (ClientResource client = client(table, spec)) {
+            BinaryRow[] values =
+                    client.client
+                            .getValues(new BinaryRow[] {key(lookupKey)})
+                            .get(30, TimeUnit.SECONDS);
+            assertThat(values[0]).isNotNull();
+            return BlobDescriptor.deserialize(values[0].getBinary(0));
+        }
+    }
+
+    private void assertBlobReadable(
+            FileStoreTable table, BlobDescriptor descriptor, byte[] expected) throws Exception {
+        assertThat(BlobDescriptor.deserialize(descriptor.serialize())).isEqualTo(descriptor);
+        assertThat(Blob.fromDescriptor(UriReader.fromFile(table.fileIO()), descriptor).toData())
+                .isEqualTo(expected);
+    }
+
+    private void assertFreshClientNotReady(FileStoreTable table, QuerySpec spec, BinaryRow key)
+            throws Exception {
+        try (ClientResource client = client(table, spec)) {
+            Throwable failure = failure(client.client.getValues(new BinaryRow[] {key}));
+            assertThat(failure).isInstanceOf(QueryServiceNotReadyException.class);
+        }
+    }
+
+    private void assertStaleFenceRejected(GlobalIndexQueryLocation oldFence, BinaryRow key)
+            throws Exception {
+        try (ClientResource client = new ClientResource(new GlobalIndexQueryClient(oldFence, 1))) {
+            Throwable failure = failure(client.client.getValues(new BinaryRow[] {key}));
+            assertThat(failure).isInstanceOf(GlobalIndexQueryException.class);
+            assertThat(((GlobalIndexQueryException) failure).errorCode())
+                    .isEqualTo(STALE_GENERATION);
+        }
+    }
+
+    private void assertRemoteTableQuery(FileStoreTable table, String lookupKey, byte[] expected)
+            throws Exception {
+        assertThat(
+                        RemoteGlobalIndexTableQuery.isRemoteServiceAvailable(
+                                table, LOOKUP_FIELD, Collections.singletonList(VALUE_FIELD)))
+                .isTrue();
+        RemoteGlobalIndexTableQuery query =
+                new RemoteGlobalIndexTableQuery(
+                        table, LOOKUP_FIELD, Collections.singletonList(VALUE_FIELD));
+        try {
+            InternalRow hit =
+                    query.lookup(
+                            BinaryRow.EMPTY_ROW,
+                            0,
+                            GenericRow.of(BinaryString.fromString(lookupKey)));
+            assertThat(hit).isNotNull();
+            assertBlobReadable(table, BlobDescriptor.deserialize(hit.getBinary(0)), expected);
+            assertThat(
+                            query.lookup(
+                                    BinaryRow.EMPTY_ROW,
+                                    0,
+                                    GenericRow.of(BinaryString.fromString("missing-object.jpg"))))
+                    .isNull();
+            assertThat(query.withValueProjection(new int[] {1})).isSameAs(query);
+            assertThat(query.createValueSerializer()).isNotNull();
+        } finally {
+            query.close();
+            query.cancel().get(30, TimeUnit.SECONDS);
+        }
+    }
+
+    private GlobalIndexQueryServiceDescriptor waitForActionDescriptor(
+            FileStoreTable table,
+            QuerySpec spec,
+            Predicate<GlobalIndexQueryServiceDescriptor> condition,
+            CompletableFuture<Void> actionExecution,
+            String description)
+            throws Exception {
+        ServiceManager manager = table.store().newServiceManager();
+        long deadline = System.nanoTime() + WAIT_TIMEOUT.toNanos();
+        GlobalIndexQueryServiceDescriptor last = null;
+        while (System.nanoTime() < deadline) {
+            last = manager.globalIndexService(spec.serviceId()).orElse(null);
+            if (last != null && condition.test(last)) {
+                return last;
+            }
+            if (actionExecution.isDone()) {
+                actionExecution.get(10, TimeUnit.SECONDS);
+                fail(
+                        "Action completed before publishing %s. Last descriptor: %s",
+                        description, last);
+            }
+            Thread.sleep(50L);
+        }
+        fail("Timed out waiting for %s. Last descriptor: %s", description, last);
+        return null;
+    }
+
+    private static CompletableFuture<Void> runActionAsync(Action action) {
+        CompletableFuture<Void> result = new CompletableFuture<>();
+        Thread thread =
+                new Thread(
+                        () -> {
+                            try {
+                                action.run();
+                                result.complete(null);
+                            } catch (Throwable t) {
+                                result.completeExceptionally(t);
+                            }
+                        },
+                        "global-index-query-service-action-it");
+        thread.setContextClassLoader(Thread.currentThread().getContextClassLoader());
+        thread.setDaemon(true);
+        thread.start();
+        return result;
+    }
+
+    private static void awaitActionTermination(CompletableFuture<Void> actionExecution)
+            throws Exception {
+        try {
+            actionExecution.get(30, TimeUnit.SECONDS);
+        } catch (ExecutionException expectedCancellation) {
+            // A blocking Action uses env.execute; cancelling its MiniCluster job completes the
+            // action exceptionally on some Flink versions and normally on others.
+        }
+    }
+
+    private void cancelClusterJob(String jobName) throws Exception {
+        try (ClusterClient<?> clusterClient = MINI_CLUSTER_EXTENSION.createRestClusterClient()) {
+            long deadline = System.nanoTime() + WAIT_TIMEOUT.toNanos();
+            while (System.nanoTime() < deadline) {
+                for (JobStatusMessage job : clusterClient.listJobs().get(10, TimeUnit.SECONDS)) {
+                    if (jobName.equals(job.getJobName()) && !job.getJobState().isTerminalState()) {
+                        clusterClient.cancel(job.getJobId()).get(30, TimeUnit.SECONDS);
+                        return;
+                    }
+                }
+                Thread.sleep(50L);
+            }
+            fail("Timed out waiting to cancel action job %s.", jobName);
+        }
+    }
+
+    private static MiniCluster miniCluster(JobClient jobClient) throws Exception {
+        Field field = jobClient.getClass().getDeclaredField("miniCluster");
+        field.setAccessible(true);
+        return (MiniCluster) field.get(jobClient);
+    }
+
+    private ClientResource client(FileStoreTable table, QuerySpec spec) {
+        return new ClientResource(
+                new GlobalIndexQueryClient(
+                        new GlobalIndexQueryLocationImpl(
+                                table.store().newServiceManager(),
+                                table.uuid(),
+                                table.coreOptions().branch(),
+                                table.schema().id(),
+                                spec),
+                        1));
+    }
+
+    private GlobalIndexQueryLocation frozenLocation(GlobalIndexQueryServiceDescriptor descriptor) {
+        Endpoint[] endpoints = descriptor.endpoints();
+        return (key, forceUpdate) -> {
+            int shard = GlobalIndexQueryServiceUtils.route(key, endpoints.length);
+            Endpoint endpoint = endpoints[shard];
+            return new GlobalIndexQueryEndpoint(
+                    shard,
+                    endpoint.address(),
+                    endpoint.serverEpoch(),
+                    descriptor.servedGeneration(),
+                    descriptor.servedSnapshotId(),
+                    descriptor.snapshotUuid());
+        };
+    }
+
+    private static Throwable failure(java.util.concurrent.CompletableFuture<?> future)
+            throws Exception {
+        try {
+            future.get(30, TimeUnit.SECONDS);
+            fail("Expected the query to fail.");
+            return null;
+        } catch (ExecutionException e) {
+            return e.getCause();
+        }
+    }
+
+    private LinkedHashMap<String, byte[]> initialRowsCoveringBothShards() {
+        LinkedHashMap<String, byte[]> rows = new LinkedHashMap<>();
+        int[] perShard = new int[2];
+        for (int candidate = 0; perShard[0] < 3 || perShard[1] < 3; candidate++) {
+            String lookupKey = String.format("O1CN-object-%03d.jpg", candidate);
+            int shard = GlobalIndexQueryServiceUtils.route(key(lookupKey), 2);
+            if (perShard[shard] >= 3) {
+                continue;
+            }
+            rows.put(lookupKey, ("image-" + candidate).getBytes(StandardCharsets.UTF_8));
+            perShard[shard]++;
+        }
+        return rows;
+    }
+
+    private void insert(String lookupKey, byte[] value) {
+        batchSql("INSERT INTO %s VALUES ('%s', X'%s')", TABLE, lookupKey, toHex(value));
+    }
+
+    private void buildBTreeIndex() {
+        batchSql(
+                "CALL sys.create_global_index(`table` => 'default.%s', "
+                        + "index_column => '%s', index_type => 'btree')",
+                TABLE, LOOKUP_FIELD);
+    }
+
+    private long blobFileCount() {
+        List<Row> rows =
+                batchSql("SELECT COUNT(*) FROM `%s$files` WHERE file_path LIKE '%%.blob'", TABLE);
+        return rows.get(0).getFieldAs(0);
+    }
+
+    private void expireAllButLatest(FileStoreTable table) {
+        table.newExpireSnapshots()
+                .config(
+                        ExpireConfig.builder()
+                                .snapshotRetainMin(1)
+                                .snapshotRetainMax(1)
+                                .snapshotMaxDeletes(Integer.MAX_VALUE)
+                                .snapshotTimeRetain(Duration.ZERO)
+                                .build())
+                .expire();
+    }
+
+    private static QuerySpec querySpec(FileStoreTable table) {
+        return GlobalIndexQueryServiceUtils.querySpec(
+                table, LOOKUP_FIELD, Collections.singletonList(VALUE_FIELD));
+    }
+
+    private static BinaryRow key(String value) {
+        return KEY_SERIALIZER.toBinaryRow(GenericRow.of(BinaryString.fromString(value))).copy();
+    }
+
+    private static String toHex(byte[] value) {
+        StringBuilder result = new StringBuilder(value.length * 2);
+        for (byte b : value) {
+            result.append(String.format("%02X", b & 0xff));
+        }
+        return result.toString();
+    }
+
+    private static void cancel(JobClient jobClient) throws Exception {
+        JobStatus status = jobClient.getJobStatus().get(10, TimeUnit.SECONDS);
+        if (!status.isTerminalState()) {
+            jobClient.cancel().get(30, TimeUnit.SECONDS);
+        }
+    }
+
+    private static class ClientResource implements AutoCloseable {
+
+        private final GlobalIndexQueryClient client;
+
+        private ClientResource(GlobalIndexQueryClient client) {
+            this.client = client;
+        }
+
+        @Override
+        public void close() {
+            client.shutdown();
+        }
+    }
+}

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/GlobalIndexQueryServiceITCase.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/GlobalIndexQueryServiceITCase.java
@@ -373,8 +373,10 @@ public class GlobalIndexQueryServiceITCase extends CatalogITCaseBase {
                             .filter(id -> id.startsWith(CONSUMER_ID + '-'))
                             .filter(id -> !leasesBeforeRescale.contains(id))
                             .collect(Collectors.toList());
-            assertThat(rescaledLeaseIds).hasSize(1);
-            String rescaledLeaseId = rescaledLeaseIds.get(0);
+            // Each restarted source attempt owns a distinct UUID lease. Stopped attempts are
+            // deliberately retained until consumer expiration, so a healthy rescale may create
+            // more than one lease even though only one replacement attempt remains live.
+            assertThat(rescaledLeaseIds).isNotEmpty();
             assertThat(
                             expected.keySet().stream()
                                     .map(GlobalIndexQueryServiceITCase::key)
@@ -402,9 +404,9 @@ public class GlobalIndexQueryServiceITCase extends CatalogITCaseBase {
                                     && descriptor.reason().toLowerCase().contains("duplicate"),
                     rescaledJob,
                     "covered duplicate bootstrap rejection");
-            waitForConsumerSnapshot(
+            waitForAnyNewConsumerSnapshot(
                     table,
-                    rescaledLeaseId,
+                    leasesBeforeRescale,
                     duplicateSnapshotId,
                     rescaledJob,
                     "bootstrap-invalid lease advancement");
@@ -646,19 +648,29 @@ public class GlobalIndexQueryServiceITCase extends CatalogITCaseBase {
         fail("Timed out waiting for %s.", description);
     }
 
-    private void waitForConsumerSnapshot(
+    private void waitForAnyNewConsumerSnapshot(
             FileStoreTable table,
-            String consumerId,
+            Set<String> previousConsumerIds,
             long expectedSnapshotId,
             JobClient jobClient,
             String description)
             throws Exception {
         long deadline = System.nanoTime() + WAIT_TIMEOUT.toNanos();
         while (System.nanoTime() < deadline) {
-            if (table.consumerManager()
-                    .consumer(consumerId)
-                    .map(consumer -> consumer.nextSnapshot() == expectedSnapshotId)
-                    .orElse(false)) {
+            boolean advanced =
+                    table.consumerManager().listAllIds().stream()
+                            .filter(id -> id.startsWith(CONSUMER_ID + '-'))
+                            .filter(id -> !previousConsumerIds.contains(id))
+                            .anyMatch(
+                                    id ->
+                                            table.consumerManager()
+                                                    .consumer(id)
+                                                    .map(
+                                                            consumer ->
+                                                                    consumer.nextSnapshot()
+                                                                            == expectedSnapshotId)
+                                                    .orElse(false));
+            if (advanced) {
                 return;
             }
             JobStatus status = jobClient.getJobStatus().get(10, TimeUnit.SECONDS);

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/GlobalIndexQueryServiceITCase.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/GlobalIndexQueryServiceITCase.java
@@ -134,7 +134,12 @@ public class GlobalIndexQueryServiceITCase extends CatalogITCaseBase {
         assertThat(initialBlobFiles).isGreaterThan(1L);
 
         GlobalIndexQueryServiceDescriptor compactedDescriptor;
-        JobClient initialJob = startQueryService(table, 2);
+        // A restarted source attempt deliberately retains its per-attempt lease until consumer
+        // expiration, so minNextSnapshot cannot identify the lease owned by the active publisher.
+        // Keep this lifecycle check on one dedicated attempt; automatic recovery is covered by
+        // testAutomaticAttemptFailover.
+        String initialConsumerId = CONSUMER_ID + "-initial";
+        JobClient initialJob = startQueryService(table, 2, initialConsumerId, false);
         try {
             GlobalIndexQueryServiceDescriptor initialDescriptor =
                     waitForDescriptor(
@@ -196,8 +201,9 @@ public class GlobalIndexQueryServiceITCase extends CatalogITCaseBase {
                 expected.put(secondUnindexedKey, secondUnindexedValue);
                 long secondUnindexedSnapshotId = table.snapshotManager().latestSnapshot().id();
                 assertThat(secondUnindexedSnapshotId).isGreaterThan(uncoveredSnapshotId);
-                waitForConsumerSnapshot(
+                waitForSingleConsumerSnapshot(
                         table,
+                        initialConsumerId,
                         secondUnindexedSnapshotId,
                         initialJob,
                         "continuous NOT_READY lease advancement");
@@ -278,8 +284,9 @@ public class GlobalIndexQueryServiceITCase extends CatalogITCaseBase {
 
             // Once the exact replacement generation has been acknowledged for the full grace,
             // its lease may advance and ordinary expiry can reclaim the old Blob file.
-            waitForConsumerSnapshot(
+            waitForSingleConsumerSnapshot(
                     table,
+                    initialConsumerId,
                     postCompactionSnapshotId,
                     initialJob,
                     "post-compaction Blob handover grace");
@@ -671,24 +678,6 @@ public class GlobalIndexQueryServiceITCase extends CatalogITCaseBase {
         }
         fail("Timed out waiting for %s. Last descriptor: %s", description, last);
         return null;
-    }
-
-    private void waitForConsumerSnapshot(
-            FileStoreTable table, long expectedSnapshotId, JobClient jobClient, String description)
-            throws Exception {
-        long deadline = System.nanoTime() + WAIT_TIMEOUT.toNanos();
-        while (System.nanoTime() < deadline) {
-            java.util.OptionalLong nextSnapshot = table.consumerManager().minNextSnapshot();
-            if (nextSnapshot.isPresent() && nextSnapshot.getAsLong() == expectedSnapshotId) {
-                return;
-            }
-            JobStatus status = jobClient.getJobStatus().get(10, TimeUnit.SECONDS);
-            if (status.isTerminalState()) {
-                throw jobFailure(jobClient, status, description, null);
-            }
-            Thread.sleep(50L);
-        }
-        fail("Timed out waiting for %s.", description);
     }
 
     private static void waitForJobStatus(

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/GlobalIndexQueryServiceITCase.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/GlobalIndexQueryServiceITCase.java
@@ -354,6 +354,7 @@ public class GlobalIndexQueryServiceITCase extends CatalogITCaseBase {
                 "single-shard cancellation tombstone");
 
         Set<String> leasesBeforeRescale = new HashSet<>(table.consumerManager().listAllIds());
+        long duplicateSnapshotId;
         JobClient rescaledJob = startQueryService(table, 2);
         try {
             GlobalIndexQueryServiceDescriptor rescaled =
@@ -389,12 +390,12 @@ public class GlobalIndexQueryServiceITCase extends CatalogITCaseBase {
             assertBatchLookup(table, spec, expected, true);
 
             // Exact BTree coverage is only the bootstrap gate. A duplicate discovered while
-            // materializing a covered snapshot must publish exact NOT_READY and, after the
-            // non-zero grace, advance this attempt's lease instead of pinning history forever.
+            // materializing a covered snapshot must publish exact NOT_READY. The no-restart job
+            // below then proves that its active lease advances after the non-zero grace.
             String duplicateKey = expected.keySet().iterator().next();
             insert(duplicateKey, "duplicate-image".getBytes(StandardCharsets.UTF_8));
             buildBTreeIndex();
-            long duplicateSnapshotId = table.snapshotManager().latestSnapshot().id();
+            duplicateSnapshotId = table.snapshotManager().latestSnapshot().id();
             waitForDescriptor(
                     table,
                     spec,
@@ -404,14 +405,50 @@ public class GlobalIndexQueryServiceITCase extends CatalogITCaseBase {
                                     && descriptor.reason().toLowerCase().contains("duplicate"),
                     rescaledJob,
                     "covered duplicate bootstrap rejection");
-            waitForAnyNewConsumerSnapshot(
-                    table,
-                    leasesBeforeRescale,
-                    duplicateSnapshotId,
-                    rescaledJob,
-                    "bootstrap-invalid lease advancement");
         } finally {
             cancel(rescaledJob);
+        }
+        waitForJobStatus(rescaledJob, JobStatus.CANCELED, "P2 query-service cancellation");
+        GlobalIndexQueryServiceDescriptor canceledDescriptor =
+                waitForDescriptor(
+                        table,
+                        spec,
+                        descriptor ->
+                                !descriptor.ready()
+                                        && descriptor
+                                                .reason()
+                                                .toLowerCase()
+                                                .contains("publisher is closed"),
+                        null,
+                        "P2 publisher cancellation tombstone");
+
+        // A restarted source attempt deliberately leaves its UUID lease until expiration, so the
+        // rescale job cannot deterministically identify one current lease. Verify advancement in a
+        // separate no-restart job with its own prefix; automatic attempt recovery is covered by
+        // testAutomaticAttemptFailover.
+        String leaseCheckConsumerId = CONSUMER_ID + "-lease-check";
+        JobClient leaseCheckJob = startQueryService(table, 2, leaseCheckConsumerId, false);
+        try {
+            waitForDescriptor(
+                    table,
+                    spec,
+                    descriptor ->
+                            !descriptor.ready()
+                                    && !descriptor
+                                            .ownerToken()
+                                            .equals(canceledDescriptor.ownerToken())
+                                    && descriptor.servedSnapshotId() == duplicateSnapshotId
+                                    && descriptor.reason().toLowerCase().contains("duplicate"),
+                    leaseCheckJob,
+                    "no-restart duplicate bootstrap rejection");
+            waitForSingleConsumerSnapshot(
+                    table,
+                    leaseCheckConsumerId,
+                    duplicateSnapshotId,
+                    leaseCheckJob,
+                    "bootstrap-invalid lease advancement");
+        } finally {
+            cancel(leaseCheckJob);
         }
     }
 
@@ -581,12 +618,18 @@ public class GlobalIndexQueryServiceITCase extends CatalogITCaseBase {
     }
 
     private JobClient startQueryService(FileStoreTable table, int parallelism) throws Exception {
-        StreamExecutionEnvironment env =
-                streamExecutionEnvironmentBuilder()
-                        .streamingMode()
-                        .parallelism(parallelism)
-                        .allowRestart()
-                        .build();
+        return startQueryService(table, parallelism, CONSUMER_ID, true);
+    }
+
+    private JobClient startQueryService(
+            FileStoreTable table, int parallelism, String consumerId, boolean allowRestart)
+            throws Exception {
+        StreamExecutionEnvironmentBuilder builder =
+                streamExecutionEnvironmentBuilder().streamingMode().parallelism(parallelism);
+        if (allowRestart) {
+            builder.allowRestart();
+        }
+        StreamExecutionEnvironment env = builder.build();
         // A caller-supplied generic scan option must not prune the bucket-unaware bootstrap. The
         // query service plans its leased snapshot directly and intentionally ignores scan.bucket.
         FileStoreTable serviceTable =
@@ -598,9 +641,9 @@ public class GlobalIndexQueryServiceITCase extends CatalogITCaseBase {
                 parallelism,
                 LOOKUP_FIELD,
                 Collections.singletonList(VALUE_FIELD),
-                CONSUMER_ID,
+                consumerId,
                 LEASE_GRACE_PERIOD);
-        return env.executeAsync("global-index-query-service-it-p" + parallelism);
+        return env.executeAsync("global-index-query-service-it-p" + parallelism + '-' + consumerId);
     }
 
     private GlobalIndexQueryServiceDescriptor waitForDescriptor(
@@ -648,29 +691,42 @@ public class GlobalIndexQueryServiceITCase extends CatalogITCaseBase {
         fail("Timed out waiting for %s.", description);
     }
 
-    private void waitForAnyNewConsumerSnapshot(
+    private static void waitForJobStatus(
+            JobClient jobClient, JobStatus expectedStatus, String description) throws Exception {
+        long deadline = System.nanoTime() + WAIT_TIMEOUT.toNanos();
+        while (System.nanoTime() < deadline) {
+            JobStatus status = jobClient.getJobStatus().get(10, TimeUnit.SECONDS);
+            if (status == expectedStatus) {
+                return;
+            }
+            if (status.isTerminalState()) {
+                throw jobFailure(jobClient, status, description, null);
+            }
+            Thread.sleep(50L);
+        }
+        fail("Timed out waiting for %s.", description);
+    }
+
+    private void waitForSingleConsumerSnapshot(
             FileStoreTable table,
-            Set<String> previousConsumerIds,
+            String consumerIdPrefix,
             long expectedSnapshotId,
             JobClient jobClient,
             String description)
             throws Exception {
         long deadline = System.nanoTime() + WAIT_TIMEOUT.toNanos();
         while (System.nanoTime() < deadline) {
-            boolean advanced =
+            List<String> matchingIds =
                     table.consumerManager().listAllIds().stream()
-                            .filter(id -> id.startsWith(CONSUMER_ID + '-'))
-                            .filter(id -> !previousConsumerIds.contains(id))
-                            .anyMatch(
-                                    id ->
-                                            table.consumerManager()
-                                                    .consumer(id)
-                                                    .map(
-                                                            consumer ->
-                                                                    consumer.nextSnapshot()
-                                                                            == expectedSnapshotId)
-                                                    .orElse(false));
-            if (advanced) {
+                            .filter(id -> id.startsWith(consumerIdPrefix + '-'))
+                            .collect(Collectors.toList());
+            if (matchingIds.size() == 1
+                    && table.consumerManager()
+                            .consumer(matchingIds.get(0))
+                            .map(consumer -> consumer.nextSnapshot() == expectedSnapshotId)
+                            .orElse(false)) {
+                assertThat(jobClient.getJobStatus().get(10, TimeUnit.SECONDS))
+                        .isEqualTo(JobStatus.RUNNING);
                 return;
             }
             JobStatus status = jobClient.getJobStatus().get(10, TimeUnit.SECONDS);

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/RemoteLookupJoinITCase.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/RemoteLookupJoinITCase.java
@@ -37,6 +37,7 @@ import org.apache.paimon.table.sink.BatchWriteBuilder;
 import org.apache.paimon.table.sink.CommitMessage;
 import org.apache.paimon.table.sink.CommitMessageImpl;
 import org.apache.paimon.utils.BlockingIterator;
+import org.apache.paimon.utils.CommonTestUtils;
 
 import org.apache.flink.core.execution.JobClient;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
@@ -51,6 +52,7 @@ import java.io.Closeable;
 import java.io.IOException;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
+import java.time.Duration;
 import java.util.Collections;
 import java.util.List;
 
@@ -84,6 +86,16 @@ public class RemoteLookupJoinITCase extends CatalogITCaseBase {
         RemoteTableQuery query = new RemoteTableQuery(paimonTable("DIM"));
 
         sql("INSERT INTO DIM VALUES (1, 11), (2, 22), (3, 33), (4, 44)");
+        ServiceManager serviceManager = paimonTable("DIM").store().newServiceManager();
+        CommonTestUtils.waitUtil(
+                () ->
+                        serviceManager
+                                .service(PRIMARY_KEY_LOOKUP)
+                                .map(addresses -> addresses.length == 2)
+                                .orElse(false),
+                Duration.ofSeconds(30),
+                Duration.ofMillis(100),
+                "Query service did not publish both executor addresses.");
         Thread.sleep(2000);
 
         assertThat(query.lookup(row(), 0, row(1)))

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/action/QueryServiceActionFactoryTest.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/action/QueryServiceActionFactoryTest.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.flink.action;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/** Tests for {@link QueryServiceActionFactory}. */
+class QueryServiceActionFactoryTest {
+
+    @Test
+    void testRejectsConsumerPathTraversalBeforeCatalogAccess() {
+        assertThatThrownBy(
+                        () ->
+                                ActionFactory.createAction(
+                                        new String[] {
+                                            "query_service",
+                                            "--warehouse",
+                                            "file:/not-accessed",
+                                            "--database",
+                                            "default",
+                                            "--table",
+                                            "images",
+                                            "--lookup-key",
+                                            "url",
+                                            "--value-fields",
+                                            "descriptor",
+                                            "--consumer-id",
+                                            "query\\..\\service"
+                                        }))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("consumer-id")
+                .hasMessageContaining("single alphanumeric path segment");
+    }
+}

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/procedure/ProcedureTest.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/procedure/ProcedureTest.java
@@ -98,6 +98,24 @@ public class ProcedureTest {
         }
     }
 
+    @Test
+    public void testQueryServiceRejectsConsumerPathTraversalBeforeCatalogAccess() {
+        QueryServiceProcedure procedure = new QueryServiceProcedure();
+        assertThatThrownBy(
+                        () ->
+                                procedure.call(
+                                        null,
+                                        "default.images",
+                                        1,
+                                        "url",
+                                        "descriptor",
+                                        "query/../../service",
+                                        "10 min"))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("consumer-id")
+                .hasMessageContaining("single alphanumeric path segment");
+    }
+
     private Method getMethodFromName(Class<?> clazz, String methodName) {
         // get all methods of current and parent class
         Method[] methods = clazz.getMethods();

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/service/GlobalIndexQueryAddressRegisterTest.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/service/GlobalIndexQueryAddressRegisterTest.java
@@ -37,8 +37,8 @@ import org.junit.jupiter.api.Test;
 import java.util.Collections;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Answers.RETURNS_DEEP_STUBS;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
 /** Tests durable unavailable-generation acknowledgements from the address register. */
 class GlobalIndexQueryAddressRegisterTest extends TableTestBase {
@@ -50,8 +50,7 @@ class GlobalIndexQueryAddressRegisterTest extends TableTestBase {
                 GlobalIndexQueryServiceUtils.querySpec(
                         table, "url", Collections.singletonList("descriptor"));
         GlobalIndexQueryAddressRegister register = new GlobalIndexQueryAddressRegister(table, spec);
-        WriterInitContext context = mock(WriterInitContext.class);
-        when(context.getAttemptNumber()).thenReturn(0);
+        WriterInitContext context = mock(WriterInitContext.class, RETURNS_DEEP_STUBS);
 
         try (SinkWriter<InternalRow> writer = register.createWriter(context)) {
             writer.write(notReadyRow(0, "BTree tail is not covered"), null);

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/service/GlobalIndexQueryAddressRegisterTest.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/service/GlobalIndexQueryAddressRegisterTest.java
@@ -1,0 +1,113 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.flink.service;
+
+import org.apache.paimon.CoreOptions;
+import org.apache.paimon.data.BinaryString;
+import org.apache.paimon.data.GenericRow;
+import org.apache.paimon.data.InternalRow;
+import org.apache.paimon.schema.Schema;
+import org.apache.paimon.service.GlobalIndexQueryServiceDescriptor;
+import org.apache.paimon.table.FileStoreTable;
+import org.apache.paimon.table.TableTestBase;
+import org.apache.paimon.table.query.GlobalIndexQueryServiceUtils;
+import org.apache.paimon.table.query.GlobalIndexQueryServiceUtils.QuerySpec;
+import org.apache.paimon.types.DataTypes;
+
+import org.apache.flink.api.connector.sink2.SinkWriter;
+import org.apache.flink.api.connector.sink2.WriterInitContext;
+import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/** Tests durable unavailable-generation acknowledgements from the address register. */
+class GlobalIndexQueryAddressRegisterTest extends TableTestBase {
+
+    @Test
+    void testNotReadyDescriptorAcknowledgesEventTargetFence() throws Exception {
+        FileStoreTable table = createTable();
+        QuerySpec spec =
+                GlobalIndexQueryServiceUtils.querySpec(
+                        table, "url", Collections.singletonList("descriptor"));
+        GlobalIndexQueryAddressRegister register = new GlobalIndexQueryAddressRegister(table, spec);
+        WriterInitContext context = mock(WriterInitContext.class);
+        when(context.getAttemptNumber()).thenReturn(0);
+
+        try (SinkWriter<InternalRow> writer = register.createWriter(context)) {
+            writer.write(notReadyRow(0, "BTree tail is not covered"), null);
+
+            GlobalIndexQueryServiceDescriptor partial =
+                    table.store()
+                            .newServiceManager()
+                            .globalIndexService(spec.serviceId())
+                            .orElseThrow(() -> new AssertionError("Missing descriptor"));
+            assertThat(partial.ready()).isFalse();
+            assertThat(partial.servedGeneration()).isEqualTo(17L);
+            assertThat(partial.servedSnapshotId())
+                    .isEqualTo(GlobalIndexQueryServiceUtils.EMPTY_SNAPSHOT_ID);
+
+            // A slower generic refresh acknowledgement must not overwrite a validation reason
+            // already reported by another executor.
+            writer.write(notReadyRow(1, "Refreshing"), null);
+
+            GlobalIndexQueryServiceDescriptor descriptor =
+                    table.store()
+                            .newServiceManager()
+                            .globalIndexService(spec.serviceId())
+                            .orElseThrow(() -> new AssertionError("Missing descriptor"));
+            assertThat(descriptor.ready()).isFalse();
+            assertThat(descriptor.servedGeneration()).isEqualTo(17L);
+            assertThat(descriptor.servedSnapshotId()).isEqualTo(23L);
+            assertThat(descriptor.reason()).contains("not covered");
+        }
+    }
+
+    private InternalRow notReadyRow(int executorId, String reason) {
+        return GenericRow.of(
+                17L,
+                false,
+                2,
+                executorId,
+                BinaryString.fromString("127.0.0.1"),
+                12345 + executorId,
+                BinaryString.fromString(reason),
+                17L,
+                23L,
+                null,
+                BinaryString.fromString("epoch-" + executorId));
+    }
+
+    private FileStoreTable createTable() throws Exception {
+        Schema schema =
+                Schema.newBuilder()
+                        .column("url", DataTypes.STRING())
+                        .column("descriptor", DataTypes.BYTES())
+                        .option(CoreOptions.BUCKET.key(), "-1")
+                        .option(CoreOptions.ROW_TRACKING_ENABLED.key(), "true")
+                        .option(CoreOptions.DATA_EVOLUTION_ENABLED.key(), "true")
+                        .option(CoreOptions.CONSUMER_EXPIRATION_TIME.key(), "1 h")
+                        .build();
+        catalog.createTable(identifier(), schema, false);
+        return (FileStoreTable) catalog.getTable(identifier());
+    }
+}

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/service/GlobalIndexQuerySnapshotMonitorTest.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/service/GlobalIndexQuerySnapshotMonitorTest.java
@@ -1,0 +1,398 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.flink.service;
+
+import org.apache.paimon.Snapshot;
+import org.apache.paimon.service.GlobalIndexQueryServiceDescriptor;
+import org.apache.paimon.service.GlobalIndexQueryServiceDescriptor.Endpoint;
+import org.apache.paimon.table.FileStoreTable;
+import org.apache.paimon.table.query.GlobalIndexQueryServiceUtils.QuerySpec;
+import org.apache.paimon.table.source.ScanMode;
+import org.apache.paimon.table.source.Split;
+import org.apache.paimon.table.source.snapshot.SnapshotReader;
+import org.apache.paimon.types.DataTypes;
+import org.apache.paimon.types.RowType;
+
+import org.junit.jupiter.api.Test;
+
+import java.net.InetSocketAddress;
+import java.time.Duration;
+import java.util.Arrays;
+import java.util.IdentityHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.OptionalLong;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/** Tests coordinator-side, data-evolution-safe split assignment. */
+class GlobalIndexQuerySnapshotMonitorTest {
+
+    @Test
+    void testLeaseExpirationCoversGraceAndFailoverMargin() {
+        assertThatCode(
+                        () ->
+                                QueryService.validateLeaseTiming(
+                                        Duration.ofMinutes(11), Duration.ofMinutes(10)))
+                .doesNotThrowAnyException();
+        assertThatThrownBy(
+                        () ->
+                                QueryService.validateLeaseTiming(
+                                        Duration.ofMinutes(10), Duration.ofMinutes(10)))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("lease-grace-period + PT1M");
+    }
+
+    @Test
+    void testEverySnapshotSplitIsAssignedExactlyOnce() {
+        List<Split> splits = Arrays.asList(split(7L), split(10L), split(8L), split(9L));
+
+        List<List<Split>> assignments = GlobalIndexQuerySnapshotMonitor.assignSplits(splits, 2);
+
+        assertThat(assignments).hasSize(2);
+        Map<Split, Integer> occurrences = new IdentityHashMap<>();
+        long[] loads = new long[2];
+        for (int target = 0; target < assignments.size(); target++) {
+            for (Split split : assignments.get(target)) {
+                occurrences.merge(split, 1, Integer::sum);
+                loads[target] += split.mergedRowCount().getAsLong();
+            }
+        }
+        assertThat(occurrences).hasSize(splits.size());
+        assertThat(occurrences.values()).containsOnly(1);
+        assertThat(loads).containsExactly(17L, 17L);
+        assertThat(splits)
+                .extracting(split -> split.mergedRowCount().getAsLong())
+                .containsExactly(7L, 10L, 8L, 9L);
+    }
+
+    @Test
+    void testPlanUsesExactSnapshotReaderAndRejectsMismatchedPlan() {
+        FileStoreTable table = mock(FileStoreTable.class);
+        QuerySpec spec = mock(QuerySpec.class);
+        SnapshotReader reader = mock(SnapshotReader.class);
+        SnapshotReader.Plan plan = mock(SnapshotReader.Plan.class);
+        Snapshot snapshot = mock(Snapshot.class);
+        List<Split> splits = Arrays.asList(split(3L), split(5L));
+        RowType rowType = RowType.of(DataTypes.INT(), DataTypes.STRING());
+        RowType projectedType = rowType.project(new int[] {1});
+
+        when(table.rowType()).thenReturn(rowType);
+        when(spec.bootstrapProjection()).thenReturn(new int[] {1});
+        when(table.newSnapshotReader()).thenReturn(reader);
+        when(reader.withMode(ScanMode.ALL)).thenReturn(reader);
+        when(snapshot.id()).thenReturn(7L);
+        when(snapshot.uuid()).thenReturn("snapshot-7");
+        when(reader.withSnapshot(snapshot)).thenReturn(reader);
+        when(reader.withReadType(projectedType)).thenReturn(reader);
+        when(reader.read()).thenReturn(plan);
+        when(plan.snapshotId()).thenReturn(7L);
+        when(plan.splits()).thenReturn(splits);
+
+        assertThat(GlobalIndexQuerySnapshotMonitor.planSnapshot(table, spec, snapshot))
+                .containsExactlyElementsOf(splits);
+        verify(reader).withMode(ScanMode.ALL);
+        verify(reader).withSnapshot(snapshot);
+        verify(reader).withReadType(projectedType);
+
+        when(plan.snapshotId()).thenReturn(8L);
+        assertThatThrownBy(
+                        () -> GlobalIndexQuerySnapshotMonitor.planSnapshot(table, spec, snapshot))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("Expected bootstrap snapshot 7")
+                .hasMessageContaining("planned snapshot 8");
+    }
+
+    @Test
+    void testConsecutiveReadyHandoversKeepIndependentGraceDeadlines() {
+        long minute = Duration.ofMinutes(1).toNanos();
+        GlobalIndexQuerySnapshotMonitor.LeaseHandoverTracker tracker =
+                new GlobalIndexQuerySnapshotMonitor.LeaseHandoverTracker(Duration.ofMinutes(10));
+
+        assertAcknowledged(
+                descriptor(true, 10L, 10L, "snapshot-10"), true, 10L, 10L, "snapshot-10");
+        tracker.acknowledge(10L, 10L, 0L);
+        assertAcknowledged(
+                descriptor(true, 11L, 11L, "snapshot-11"), true, 11L, 11L, "snapshot-11");
+        tracker.acknowledge(11L, 11L, 5L * minute);
+        assertThat(tracker.promotableSnapshot(9L * minute).isPresent()).isFalse();
+        assertThat(tracker.promotableSnapshot(10L * minute).getAsLong()).isEqualTo(10L);
+
+        tracker.acknowledge(12L, 12L, 12L * minute);
+        assertThat(tracker.promotableSnapshot(14L * minute).isPresent()).isFalse();
+        assertThat(tracker.promotableSnapshot(15L * minute).getAsLong()).isEqualTo(11L);
+        assertThat(tracker.promotableSnapshot(22L * minute).getAsLong()).isEqualTo(12L);
+    }
+
+    @Test
+    void testConsecutiveUnavailableHandoversAndSkippedGeneration() {
+        long minute = Duration.ofMinutes(1).toNanos();
+        GlobalIndexQuerySnapshotMonitor.LeaseHandoverTracker tracker =
+                new GlobalIndexQuerySnapshotMonitor.LeaseHandoverTracker(Duration.ofMinutes(10));
+
+        assertAcknowledged(descriptor(false, 20L, 20L, null), false, 20L, 20L, null);
+        tracker.acknowledge(20L, 20L, 0L);
+        // Generation 21 was never observed by the monitor. A later exact acknowledgement is a
+        // conservative handover point for all skipped generations.
+        assertAcknowledged(descriptor(false, 22L, 22L, null), false, 22L, 22L, null);
+        tracker.acknowledge(22L, 22L, 5L * minute);
+
+        assertThat(tracker.promotableSnapshot(10L * minute).getAsLong()).isEqualTo(20L);
+        assertThat(tracker.promotableSnapshot(14L * minute).isPresent()).isFalse();
+        assertThat(tracker.promotableSnapshot(15L * minute).getAsLong()).isEqualTo(22L);
+    }
+
+    @Test
+    void testDescriptorAcknowledgementRequiresExactIdentityStateAndFence() {
+        GlobalIndexQueryServiceDescriptor ready = descriptor(true, 30L, 30L, "snapshot-30");
+
+        assertAcknowledged(ready, true, 30L, 30L, "snapshot-30");
+        assertThat(
+                        acknowledges(
+                                ready,
+                                false,
+                                "table-uuid",
+                                "main",
+                                7L,
+                                "fingerprint",
+                                3,
+                                new int[] {4, 5},
+                                30L,
+                                30L,
+                                null))
+                .isFalse();
+        assertThat(
+                        acknowledges(
+                                ready,
+                                true,
+                                "other-table",
+                                "main",
+                                7L,
+                                "fingerprint",
+                                3,
+                                new int[] {4, 5},
+                                30L,
+                                30L,
+                                "snapshot-30"))
+                .isFalse();
+        assertThat(
+                        acknowledges(
+                                ready,
+                                true,
+                                "table-uuid",
+                                "main",
+                                7L,
+                                "fingerprint",
+                                3,
+                                new int[] {4, 6},
+                                30L,
+                                30L,
+                                "snapshot-30"))
+                .isFalse();
+        assertThat(
+                        acknowledges(
+                                ready,
+                                true,
+                                "table-uuid",
+                                "main",
+                                7L,
+                                "fingerprint",
+                                3,
+                                new int[] {4, 5},
+                                31L,
+                                30L,
+                                "snapshot-30"))
+                .isFalse();
+        assertThat(
+                        acknowledges(
+                                ready,
+                                true,
+                                "table-uuid",
+                                "main",
+                                7L,
+                                "fingerprint",
+                                3,
+                                new int[] {4, 5},
+                                30L,
+                                30L,
+                                "other-snapshot"))
+                .isFalse();
+
+        GlobalIndexQueryServiceDescriptor wrongProtocol =
+                descriptor(
+                        GlobalIndexQueryServiceDescriptor.PROTOCOL_VERSION + 1,
+                        true,
+                        30L,
+                        30L,
+                        "snapshot-30");
+        assertThat(
+                        acknowledges(
+                                wrongProtocol,
+                                true,
+                                "table-uuid",
+                                "main",
+                                7L,
+                                "fingerprint",
+                                3,
+                                new int[] {4, 5},
+                                30L,
+                                30L,
+                                "snapshot-30"))
+                .isFalse();
+    }
+
+    @Test
+    void testBootstrapInvalidTargetStillStartsLeaseGrace() {
+        GlobalIndexQueryServiceDescriptor bootstrapInvalid = descriptor(false, 40L, 40L, null);
+        // The coverage gate considered snapshot 40 ready and therefore retained its UUID, but the
+        // all-executor bootstrap result rejected it (for example, duplicate or oversized value).
+        assertThat(acknowledgesTarget(bootstrapInvalid, 40L, 40L, "snapshot-40")).isTrue();
+
+        GlobalIndexQuerySnapshotMonitor.LeaseHandoverTracker tracker =
+                new GlobalIndexQuerySnapshotMonitor.LeaseHandoverTracker(Duration.ofMinutes(10));
+        tracker.acknowledge(40L, 40L, 0L);
+        assertThat(tracker.promotableSnapshot(Duration.ofMinutes(9).toNanos()).isPresent())
+                .isFalse();
+        assertThat(tracker.promotableSnapshot(Duration.ofMinutes(10).toNanos()).getAsLong())
+                .isEqualTo(40L);
+    }
+
+    private void assertAcknowledged(
+            GlobalIndexQueryServiceDescriptor descriptor,
+            boolean ready,
+            long generation,
+            long snapshotId,
+            String snapshotUuid) {
+        assertThat(
+                        acknowledges(
+                                descriptor,
+                                ready,
+                                "table-uuid",
+                                "main",
+                                7L,
+                                "fingerprint",
+                                3,
+                                new int[] {4, 5},
+                                generation,
+                                snapshotId,
+                                snapshotUuid))
+                .isTrue();
+    }
+
+    private boolean acknowledges(
+            GlobalIndexQueryServiceDescriptor descriptor,
+            boolean ready,
+            String tableUuid,
+            String branch,
+            long schemaId,
+            String schemaFingerprint,
+            int lookupFieldId,
+            int[] valueFieldIds,
+            long generation,
+            long snapshotId,
+            String snapshotUuid) {
+        return GlobalIndexQuerySnapshotMonitor.acknowledgesDescriptor(
+                Optional.of(descriptor),
+                ready,
+                schemaId,
+                tableUuid,
+                branch,
+                schemaFingerprint,
+                lookupFieldId,
+                valueFieldIds,
+                generation,
+                snapshotId,
+                snapshotUuid,
+                2);
+    }
+
+    private boolean acknowledgesTarget(
+            GlobalIndexQueryServiceDescriptor descriptor,
+            long generation,
+            long snapshotId,
+            String snapshotUuid) {
+        return GlobalIndexQuerySnapshotMonitor.acknowledgesTargetDescriptor(
+                Optional.of(descriptor),
+                7L,
+                "table-uuid",
+                "main",
+                "fingerprint",
+                3,
+                new int[] {4, 5},
+                generation,
+                snapshotId,
+                snapshotUuid,
+                2);
+    }
+
+    private GlobalIndexQueryServiceDescriptor descriptor(
+            boolean ready, long generation, long snapshotId, String snapshotUuid) {
+        return descriptor(
+                GlobalIndexQueryServiceDescriptor.PROTOCOL_VERSION,
+                ready,
+                generation,
+                snapshotId,
+                snapshotUuid);
+    }
+
+    private GlobalIndexQueryServiceDescriptor descriptor(
+            int protocolVersion,
+            boolean ready,
+            long generation,
+            long snapshotId,
+            String snapshotUuid) {
+        Endpoint[] endpoints =
+                ready
+                        ? new Endpoint[] {
+                            new Endpoint(0, new InetSocketAddress("127.0.0.1", 10000), "epoch-0"),
+                            new Endpoint(1, new InetSocketAddress("127.0.0.1", 10001), "epoch-1")
+                        }
+                        : new Endpoint[0];
+        return new GlobalIndexQueryServiceDescriptor(
+                protocolVersion,
+                "table-uuid",
+                "main",
+                7L,
+                "fingerprint",
+                3,
+                new int[] {4, 5},
+                generation,
+                snapshotId,
+                snapshotUuid,
+                GlobalIndexQueryServiceDescriptor.KEY_HASH_VERSION,
+                GlobalIndexQueryServiceDescriptor.LAYOUT,
+                "owner",
+                ready,
+                ready ? "" : "not ready",
+                endpoints);
+    }
+
+    private Split split(long rows) {
+        Split split = mock(Split.class);
+        when(split.rowCount()).thenReturn(rows);
+        when(split.mergedRowCount()).thenReturn(OptionalLong.of(rows));
+        return split;
+    }
+}

--- a/paimon-flink/paimon-flink1-common/src/main/java/org/apache/paimon/flink/utils/SinkContextUtils.java
+++ b/paimon-flink/paimon-flink1-common/src/main/java/org/apache/paimon/flink/utils/SinkContextUtils.java
@@ -1,0 +1,34 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.flink.utils;
+
+import org.apache.flink.api.connector.sink2.Sink.InitContext;
+import org.apache.flink.api.connector.sink2.WriterInitContext;
+
+/** Utility methods about Flink sink contexts to resolve compatibility issues. */
+public class SinkContextUtils {
+
+    public static int getAttemptNumber(InitContext context) {
+        return context.getAttemptNumber();
+    }
+
+    public static int getAttemptNumber(WriterInitContext context) {
+        return context.getAttemptNumber();
+    }
+}

--- a/paimon-flink/paimon-flink1-common/src/test/java/org/apache/paimon/flink/utils/SinkContextUtilsTest.java
+++ b/paimon-flink/paimon-flink1-common/src/test/java/org/apache/paimon/flink/utils/SinkContextUtilsTest.java
@@ -1,0 +1,58 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.flink.utils;
+
+import org.apache.flink.api.connector.sink2.Sink.InitContext;
+import org.apache.flink.api.connector.sink2.WriterInitContext;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Proxy;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Tests for {@link SinkContextUtils}. */
+class SinkContextUtilsTest {
+
+    @Test
+    void testAttemptNumberFromInitContext() {
+        InitContext context = context(InitContext.class, 3);
+
+        assertThat(SinkContextUtils.getAttemptNumber(context)).isEqualTo(3);
+    }
+
+    @Test
+    void testAttemptNumberFromWriterInitContext() {
+        WriterInitContext context = context(WriterInitContext.class, 7);
+
+        assertThat(SinkContextUtils.getAttemptNumber(context)).isEqualTo(7);
+    }
+
+    private <T> T context(Class<T> contextClass, int attemptNumber) {
+        return contextClass.cast(
+                Proxy.newProxyInstance(
+                        contextClass.getClassLoader(),
+                        new Class<?>[] {contextClass},
+                        (proxy, method, arguments) -> {
+                            if ("getAttemptNumber".equals(method.getName())) {
+                                return attemptNumber;
+                            }
+                            throw new UnsupportedOperationException(method.getName());
+                        }));
+    }
+}

--- a/paimon-flink/paimon-flink2-common/src/main/java/org/apache/paimon/flink/utils/SinkContextUtils.java
+++ b/paimon-flink/paimon-flink2-common/src/main/java/org/apache/paimon/flink/utils/SinkContextUtils.java
@@ -1,0 +1,34 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.flink.utils;
+
+import org.apache.flink.api.connector.sink2.InitContext;
+import org.apache.flink.api.connector.sink2.WriterInitContext;
+
+/** Utility methods about Flink sink contexts to resolve compatibility issues. */
+public class SinkContextUtils {
+
+    public static int getAttemptNumber(InitContext context) {
+        return context.getTaskInfo().getAttemptNumber();
+    }
+
+    public static int getAttemptNumber(WriterInitContext context) {
+        return context.getTaskInfo().getAttemptNumber();
+    }
+}

--- a/paimon-flink/paimon-flink2-common/src/test/java/org/apache/paimon/flink/utils/SinkContextUtilsTest.java
+++ b/paimon-flink/paimon-flink2-common/src/test/java/org/apache/paimon/flink/utils/SinkContextUtilsTest.java
@@ -1,0 +1,61 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.flink.utils;
+
+import org.apache.flink.api.common.TaskInfo;
+import org.apache.flink.api.common.TaskInfoImpl;
+import org.apache.flink.api.connector.sink2.InitContext;
+import org.apache.flink.api.connector.sink2.WriterInitContext;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Proxy;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Tests for {@link SinkContextUtils}. */
+class SinkContextUtilsTest {
+
+    @Test
+    void testAttemptNumberFromInitContext() {
+        InitContext context = context(InitContext.class, 3);
+
+        assertThat(SinkContextUtils.getAttemptNumber(context)).isEqualTo(3);
+    }
+
+    @Test
+    void testAttemptNumberFromWriterInitContext() {
+        WriterInitContext context = context(WriterInitContext.class, 7);
+
+        assertThat(SinkContextUtils.getAttemptNumber(context)).isEqualTo(7);
+    }
+
+    private <T> T context(Class<T> contextClass, int attemptNumber) {
+        TaskInfo taskInfo = new TaskInfoImpl("task", 1, 0, 1, attemptNumber);
+        return contextClass.cast(
+                Proxy.newProxyInstance(
+                        contextClass.getClassLoader(),
+                        new Class<?>[] {contextClass},
+                        (proxy, method, arguments) -> {
+                            if ("getTaskInfo".equals(method.getName())) {
+                                return taskInfo;
+                            }
+                            throw new UnsupportedOperationException(method.getName());
+                        }));
+    }
+}

--- a/paimon-service/paimon-service-client/src/main/java/org/apache/paimon/service/client/GlobalIndexQueryClient.java
+++ b/paimon-service/paimon-service-client/src/main/java/org/apache/paimon/service/client/GlobalIndexQueryClient.java
@@ -1,0 +1,638 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.service.client;
+
+import org.apache.paimon.data.BinaryRow;
+import org.apache.paimon.query.GlobalIndexQueryEndpoint;
+import org.apache.paimon.query.GlobalIndexQueryLocation;
+import org.apache.paimon.service.exceptions.GlobalIndexQueryException;
+import org.apache.paimon.service.messages.GlobalIndexRequest;
+import org.apache.paimon.service.messages.GlobalIndexResponse;
+import org.apache.paimon.service.network.LegacyFailureFramePolicy;
+import org.apache.paimon.service.network.NetworkClient;
+import org.apache.paimon.service.network.messages.MessageSerializer;
+import org.apache.paimon.service.network.stats.DisabledServiceRequestStats;
+import org.apache.paimon.table.query.GlobalIndexQueryServiceUtils;
+import org.apache.paimon.utils.Preconditions;
+
+import org.apache.paimon.shade.guava30.com.google.common.util.concurrent.ThreadFactoryBuilder;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.annotation.Nullable;
+
+import java.io.IOException;
+import java.net.ConnectException;
+import java.net.InetSocketAddress;
+import java.nio.channels.ClosedChannelException;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+
+import static org.apache.paimon.service.exceptions.GlobalIndexQueryErrorCode.INVALID_REQUEST;
+import static org.apache.paimon.service.exceptions.GlobalIndexQueryErrorCode.REQUEST_TIMEOUT;
+import static org.apache.paimon.service.exceptions.GlobalIndexQueryErrorCode.REQUEST_TOO_LARGE;
+import static org.apache.paimon.service.exceptions.GlobalIndexQueryErrorCode.STALE_GENERATION;
+
+/** Client for querying values from a sharded global-index query service. */
+public class GlobalIndexQueryClient {
+
+    private static final Logger LOG = LoggerFactory.getLogger(GlobalIndexQueryClient.class);
+    private static final Duration DEFAULT_REQUEST_TIMEOUT = Duration.ofSeconds(30);
+    private static final ScheduledExecutorService TIMEOUT_SCHEDULER =
+            Executors.newSingleThreadScheduledExecutor(
+                    new ThreadFactoryBuilder()
+                            .setDaemon(true)
+                            .setNameFormat("Paimon Global Index Query Timeout %d")
+                            .build());
+
+    private final GlobalIndexQueryLocation queryLocation;
+    private final RequestSender requestSender;
+    private final long requestTimeoutNanos;
+    @Nullable private final NetworkClient<GlobalIndexRequest, GlobalIndexResponse> networkClient;
+
+    public GlobalIndexQueryClient(GlobalIndexQueryLocation queryLocation, int numEventLoopThreads) {
+        this(queryLocation, numEventLoopThreads, DEFAULT_REQUEST_TIMEOUT);
+    }
+
+    public GlobalIndexQueryClient(
+            GlobalIndexQueryLocation queryLocation,
+            int numEventLoopThreads,
+            Duration requestTimeout) {
+        this.queryLocation = Preconditions.checkNotNull(queryLocation);
+        this.requestTimeoutNanos = validateRequestTimeout(requestTimeout);
+        MessageSerializer<GlobalIndexRequest, GlobalIndexResponse> serializer =
+                new MessageSerializer<>(
+                        new GlobalIndexRequest.Deserializer(),
+                        new GlobalIndexResponse.Deserializer());
+        this.networkClient =
+                new NetworkClient<>(
+                        "Global Index Query Client",
+                        numEventLoopThreads,
+                        serializer,
+                        new DisabledServiceRequestStats(),
+                        GlobalIndexResponse.MAX_NETWORK_FRAME_BYTES,
+                        LegacyFailureFramePolicy.REJECT_SERIALIZED_THROWABLE);
+        this.requestSender = networkClient::sendRequest;
+    }
+
+    GlobalIndexQueryClient(GlobalIndexQueryLocation queryLocation, RequestSender requestSender) {
+        this(queryLocation, requestSender, DEFAULT_REQUEST_TIMEOUT);
+    }
+
+    GlobalIndexQueryClient(
+            GlobalIndexQueryLocation queryLocation,
+            RequestSender requestSender,
+            Duration requestTimeout) {
+        this.queryLocation = Preconditions.checkNotNull(queryLocation);
+        this.requestSender = Preconditions.checkNotNull(requestSender);
+        this.requestTimeoutNanos = validateRequestTimeout(requestTimeout);
+        this.networkClient = null;
+    }
+
+    /**
+     * Queries arbitrary keys, grouping them by their current server address and restoring the
+     * original key order in the result.
+     */
+    public CompletableFuture<BinaryRow[]> getValues(BinaryRow[] keys) {
+        return getValuesWithMetadata(keys).thenApply(LookupResult::values);
+    }
+
+    /** Queries arbitrary keys and returns the common advertised snapshot fence with the values. */
+    public CompletableFuture<LookupResult> getValuesWithMetadata(BinaryRow[] keys) {
+        Preconditions.checkNotNull(keys, "Global-index query keys are null.");
+        if (keys.length == 0) {
+            return CompletableFuture.completedFuture(
+                    new LookupResult(new BinaryRow[0], Long.MIN_VALUE, -1L, null));
+        }
+        if (keys.length > GlobalIndexRequest.MAX_KEYS) {
+            throw new GlobalIndexQueryException(
+                    REQUEST_TOO_LARGE,
+                    String.format(
+                            "Global-index query batch contains %s keys; maximum is %s.",
+                            keys.length, GlobalIndexRequest.MAX_KEYS));
+        }
+        long totalKeyBytes = 0L;
+        BinaryRow[] normalizedKeys = new BinaryRow[keys.length];
+        for (int i = 0; i < keys.length; i++) {
+            BinaryRow key = keys[i];
+            Preconditions.checkNotNull(key, "Global-index query key is null.");
+            BinaryRow normalized = GlobalIndexQueryServiceUtils.normalizeKey(key);
+            normalizedKeys[i] = normalized;
+            totalKeyBytes += Integer.BYTES + normalized.getSizeInBytes();
+            if (totalKeyBytes > GlobalIndexRequest.MAX_TOTAL_KEY_BYTES) {
+                throw new GlobalIndexQueryException(
+                        REQUEST_TOO_LARGE,
+                        String.format(
+                                "Global-index query key payload is %s bytes; maximum is %s.",
+                                totalKeyBytes, GlobalIndexRequest.MAX_TOTAL_KEY_BYTES));
+            }
+        }
+
+        CompletableFuture<LookupResult> result = new CompletableFuture<>();
+        execute(result, normalizedKeys, false, false);
+        return result;
+    }
+
+    private void execute(
+            CompletableFuture<LookupResult> result,
+            BinaryRow[] keys,
+            boolean forceUpdate,
+            boolean retried) {
+        if (result.isDone()) {
+            return;
+        }
+
+        final CompletableFuture<LookupResult> attempt;
+        try {
+            attempt = sendGrouped(keys, forceUpdate);
+        } catch (Throwable t) {
+            Throwable cause = unwrapCompletion(t);
+            if (!retried && isRetryable(cause)) {
+                LOG.debug(
+                        "Retrying global-index query after refreshing service addresses: {}",
+                        cause.getMessage());
+                execute(result, keys, true, true);
+            } else {
+                result.completeExceptionally(cause);
+            }
+            return;
+        }
+
+        attempt.whenComplete(
+                (values, throwable) -> {
+                    if (result.isDone()) {
+                        return;
+                    }
+                    if (throwable == null) {
+                        result.complete(values);
+                        return;
+                    }
+
+                    Throwable cause = unwrapCompletion(throwable);
+                    if (!retried && isRetryable(cause)) {
+                        LOG.debug(
+                                "Retrying global-index query after refreshing service addresses: {}",
+                                cause.getMessage());
+                        execute(result, keys, true, true);
+                    } else {
+                        result.completeExceptionally(cause);
+                    }
+                });
+        result.whenComplete((ignored, throwable) -> attempt.cancel(false));
+    }
+
+    private CompletableFuture<LookupResult> sendGrouped(BinaryRow[] keys, boolean forceUpdate)
+            throws IOException {
+        Map<EndpointKey, RequestGroup> groups = new LinkedHashMap<>();
+        ServiceFence serviceFence = null;
+        boolean refresh = forceUpdate;
+        for (int i = 0; i < keys.length; i++) {
+            GlobalIndexQueryEndpoint endpoint = queryLocation.getLocation(keys[i], refresh);
+            refresh = false;
+            Preconditions.checkNotNull(
+                    endpoint, "Cannot find endpoint for global-index query key.");
+            ServiceFence currentFence = ServiceFence.from(endpoint);
+            if (serviceFence == null) {
+                serviceFence = currentFence;
+            } else if (!serviceFence.equals(currentFence)) {
+                throw new GlobalIndexQueryException(
+                        STALE_GENERATION,
+                        "Global-index discovery returned mixed service generations for one batch.");
+            }
+            EndpointKey endpointKey = EndpointKey.from(endpoint);
+            groups.computeIfAbsent(endpointKey, ignored -> new RequestGroup()).add(i, keys[i]);
+        }
+
+        List<GroupRequest> requests = new ArrayList<>(groups.size());
+        try {
+            for (Map.Entry<EndpointKey, RequestGroup> entry : groups.entrySet()) {
+                EndpointKey endpoint = entry.getKey();
+                RequestGroup group = entry.getValue();
+                CompletableFuture<GlobalIndexResponse> response =
+                        withRequestTimeout(
+                                requestSender.send(
+                                        endpoint.address,
+                                        new GlobalIndexRequest(
+                                                endpoint.serverEpoch,
+                                                endpoint.servedGeneration,
+                                                group.keysArray())),
+                                endpoint.address);
+                requests.add(new GroupRequest(group, endpoint, response));
+            }
+        } catch (RuntimeException | Error t) {
+            for (GroupRequest request : requests) {
+                request.response.cancel(false);
+            }
+            throw t;
+        }
+        ServiceFence batchFence =
+                Preconditions.checkNotNull(
+                        serviceFence, "Global-index query batch has no discovery fence.");
+
+        CompletableFuture<?>[] futures =
+                requests.stream()
+                        .map(request -> request.response)
+                        .toArray(CompletableFuture[]::new);
+        CompletableFuture<LookupResult> combined =
+                CompletableFuture.allOf(futures)
+                        .handle(
+                                (ignored, throwable) -> {
+                                    if (throwable != null) {
+                                        throw new CompletionException(selectFailure(requests));
+                                    }
+
+                                    GlobalIndexQueryException responseFailure =
+                                            validateAndSelectResponseFailure(requests);
+                                    if (responseFailure != null) {
+                                        throw responseFailure;
+                                    }
+
+                                    BinaryRow[] values = new BinaryRow[keys.length];
+                                    for (GroupRequest request : requests) {
+                                        GlobalIndexResponse response = request.response.join();
+                                        BinaryRow[] groupValues = response.values();
+                                        if (groupValues.length != request.group.size()) {
+                                            throw new GlobalIndexQueryException(
+                                                    INVALID_REQUEST,
+                                                    String.format(
+                                                            "Global-index query response size %s does not match request size %s.",
+                                                            groupValues.length,
+                                                            request.group.size()));
+                                        }
+                                        for (int i = 0; i < groupValues.length; i++) {
+                                            values[request.group.position(i)] = groupValues[i];
+                                        }
+                                    }
+                                    return new LookupResult(
+                                            values,
+                                            batchFence.servedGeneration,
+                                            batchFence.servedSnapshotId,
+                                            batchFence.snapshotUuid);
+                                });
+        combined.whenComplete(
+                (ignored, throwable) -> {
+                    if (combined.isCancelled()) {
+                        for (GroupRequest request : requests) {
+                            request.response.cancel(false);
+                        }
+                    }
+                });
+        return combined;
+    }
+
+    @Nullable
+    private static GlobalIndexQueryException validateAndSelectResponseFailure(
+            List<GroupRequest> requests) {
+        // Validate every group before interpreting any structured business error. Otherwise an
+        // error response from a stale or replaced server could bypass the batch fence.
+        for (GroupRequest request : requests) {
+            request.validate(request.response.join());
+        }
+
+        GlobalIndexQueryException retryable = null;
+        for (GroupRequest request : requests) {
+            GlobalIndexResponse response = request.response.join();
+            if (!response.isSuccess()) {
+                GlobalIndexQueryException failure = response.toException();
+                if (!failure.retryable()) {
+                    return failure;
+                }
+                if (retryable == null) {
+                    retryable = failure;
+                }
+            }
+        }
+        return retryable;
+    }
+
+    private static Throwable selectFailure(List<GroupRequest> requests) {
+        Throwable retryable = null;
+        for (GroupRequest request : requests) {
+            try {
+                request.response.join();
+            } catch (CompletionException e) {
+                Throwable cause = unwrapCompletion(e);
+                if (!isRetryable(cause)) {
+                    return cause;
+                }
+                if (retryable == null) {
+                    retryable = cause;
+                }
+            }
+        }
+        return Preconditions.checkNotNull(retryable, "No failed global-index request found.");
+    }
+
+    private static boolean isRetryable(Throwable throwable) {
+        return throwable instanceof GlobalIndexQueryException
+                        && ((GlobalIndexQueryException) throwable).retryable()
+                || containsCause(throwable, ConnectException.class)
+                || containsCause(throwable, ClosedChannelException.class);
+    }
+
+    private CompletableFuture<GlobalIndexResponse> withRequestTimeout(
+            CompletableFuture<GlobalIndexResponse> source, InetSocketAddress address) {
+        CompletableFuture<GlobalIndexResponse> bounded = new CompletableFuture<>();
+        ScheduledFuture<?> timeout =
+                TIMEOUT_SCHEDULER.schedule(
+                        () -> {
+                            GlobalIndexQueryException failure =
+                                    new GlobalIndexQueryException(
+                                            REQUEST_TIMEOUT,
+                                            true,
+                                            String.format(
+                                                    "Global-index request to %s timed out after %s ms.",
+                                                    address,
+                                                    TimeUnit.NANOSECONDS.toMillis(
+                                                            requestTimeoutNanos)));
+                            if (bounded.completeExceptionally(failure)) {
+                                source.cancel(false);
+                            }
+                        },
+                        requestTimeoutNanos,
+                        TimeUnit.NANOSECONDS);
+        source.whenComplete(
+                (response, throwable) -> {
+                    timeout.cancel(false);
+                    if (throwable == null) {
+                        bounded.complete(response);
+                    } else {
+                        bounded.completeExceptionally(unwrapCompletion(throwable));
+                    }
+                });
+        bounded.whenComplete(
+                (ignored, throwable) -> {
+                    timeout.cancel(false);
+                    if (bounded.isCancelled()) {
+                        source.cancel(false);
+                    }
+                });
+        return bounded;
+    }
+
+    private static long validateRequestTimeout(Duration requestTimeout) {
+        Preconditions.checkNotNull(requestTimeout, "Global-index request timeout is null.");
+        Preconditions.checkArgument(
+                !requestTimeout.isZero() && !requestTimeout.isNegative(),
+                "Global-index request timeout must be positive.");
+        return requestTimeout.toNanos();
+    }
+
+    private static boolean containsCause(Throwable throwable, Class<? extends Throwable> expected) {
+        Throwable current = throwable;
+        while (current != null) {
+            if (expected.isInstance(current)) {
+                return true;
+            }
+            Throwable next = current.getCause();
+            if (next == current) {
+                return false;
+            }
+            current = next;
+        }
+        return false;
+    }
+
+    private static Throwable unwrapCompletion(Throwable throwable) {
+        Throwable current = throwable;
+        while ((current instanceof CompletionException || current instanceof ExecutionException)
+                && current.getCause() != null) {
+            current = current.getCause();
+        }
+        return current;
+    }
+
+    public void shutdown() {
+        try {
+            shutdownFuture().get(60L, TimeUnit.SECONDS);
+            if (networkClient != null) {
+                LOG.info("{} was shutdown successfully.", networkClient.getClientName());
+            }
+        } catch (Exception e) {
+            LOG.warn("Global Index Query Client shutdown failed.", e);
+        }
+    }
+
+    public CompletableFuture<Void> shutdownFuture() {
+        return networkClient == null
+                ? CompletableFuture.completedFuture(null)
+                : networkClient.shutdown();
+    }
+
+    int numPendingNetworkRequests() {
+        return networkClient == null ? 0 : networkClient.getNumPendingRequests();
+    }
+
+    /** Values returned from one consistently fenced discovery snapshot. */
+    public static final class LookupResult {
+        private final BinaryRow[] values;
+        private final long servedGeneration;
+        private final long servedSnapshotId;
+        @Nullable private final String snapshotUuid;
+
+        private LookupResult(
+                BinaryRow[] values,
+                long servedGeneration,
+                long servedSnapshotId,
+                @Nullable String snapshotUuid) {
+            this.values = values;
+            this.servedGeneration = servedGeneration;
+            this.servedSnapshotId = servedSnapshotId;
+            this.snapshotUuid = snapshotUuid;
+        }
+
+        public BinaryRow[] values() {
+            return values;
+        }
+
+        public long servedGeneration() {
+            return servedGeneration;
+        }
+
+        public long servedSnapshotId() {
+            return servedSnapshotId;
+        }
+
+        @Nullable
+        public String snapshotUuid() {
+            return snapshotUuid;
+        }
+    }
+
+    @FunctionalInterface
+    interface RequestSender {
+        CompletableFuture<GlobalIndexResponse> send(
+                InetSocketAddress address, GlobalIndexRequest request);
+    }
+
+    private static class RequestGroup {
+        private final List<Integer> positions = new ArrayList<>();
+        private final List<BinaryRow> keys = new ArrayList<>();
+
+        private void add(int position, BinaryRow key) {
+            positions.add(position);
+            keys.add(key);
+        }
+
+        private int size() {
+            return keys.size();
+        }
+
+        private int position(int index) {
+            return positions.get(index);
+        }
+
+        private BinaryRow[] keysArray() {
+            return keys.toArray(new BinaryRow[0]);
+        }
+    }
+
+    private static class GroupRequest {
+        private final RequestGroup group;
+        private final EndpointKey endpoint;
+        private final CompletableFuture<GlobalIndexResponse> response;
+
+        private GroupRequest(
+                RequestGroup group,
+                EndpointKey endpoint,
+                CompletableFuture<GlobalIndexResponse> response) {
+            this.group = group;
+            this.endpoint = endpoint;
+            this.response = response;
+        }
+
+        private void validate(GlobalIndexResponse response) {
+            if (!endpoint.serverEpoch.equals(response.serverEpoch())
+                    || endpoint.servedGeneration != response.servedGeneration()
+                    || endpoint.servedSnapshotId != response.servedSnapshotId()) {
+                throw new GlobalIndexQueryException(
+                        STALE_GENERATION,
+                        String.format(
+                                "Global-index response fence (%s, %s, %s) does not match expected (%s, %s, %s).",
+                                response.serverEpoch(),
+                                response.servedGeneration(),
+                                response.servedSnapshotId(),
+                                endpoint.serverEpoch,
+                                endpoint.servedGeneration,
+                                endpoint.servedSnapshotId));
+            }
+        }
+    }
+
+    private static class EndpointKey {
+        private final InetSocketAddress address;
+        private final String serverEpoch;
+        private final long servedGeneration;
+        private final long servedSnapshotId;
+
+        private EndpointKey(
+                InetSocketAddress address,
+                String serverEpoch,
+                long servedGeneration,
+                long servedSnapshotId) {
+            this.address = address;
+            this.serverEpoch = serverEpoch;
+            this.servedGeneration = servedGeneration;
+            this.servedSnapshotId = servedSnapshotId;
+        }
+
+        private static EndpointKey from(GlobalIndexQueryEndpoint endpoint) {
+            return new EndpointKey(
+                    endpoint.address(),
+                    endpoint.serverEpoch(),
+                    endpoint.servedGeneration(),
+                    endpoint.servedSnapshotId());
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (!(o instanceof EndpointKey)) {
+                return false;
+            }
+            EndpointKey that = (EndpointKey) o;
+            return servedGeneration == that.servedGeneration
+                    && servedSnapshotId == that.servedSnapshotId
+                    && address.equals(that.address)
+                    && serverEpoch.equals(that.serverEpoch);
+        }
+
+        @Override
+        public int hashCode() {
+            int result = address.hashCode();
+            result = 31 * result + serverEpoch.hashCode();
+            result = 31 * result + Long.hashCode(servedGeneration);
+            return 31 * result + Long.hashCode(servedSnapshotId);
+        }
+    }
+
+    private static class ServiceFence {
+        private final long servedGeneration;
+        private final long servedSnapshotId;
+        @Nullable private final String snapshotUuid;
+
+        private ServiceFence(
+                long servedGeneration, long servedSnapshotId, @Nullable String snapshotUuid) {
+            this.servedGeneration = servedGeneration;
+            this.servedSnapshotId = servedSnapshotId;
+            this.snapshotUuid = snapshotUuid;
+        }
+
+        private static ServiceFence from(GlobalIndexQueryEndpoint endpoint) {
+            return new ServiceFence(
+                    endpoint.servedGeneration(),
+                    endpoint.servedSnapshotId(),
+                    endpoint.snapshotUuid());
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (!(o instanceof ServiceFence)) {
+                return false;
+            }
+            ServiceFence that = (ServiceFence) o;
+            return servedGeneration == that.servedGeneration
+                    && servedSnapshotId == that.servedSnapshotId
+                    && java.util.Objects.equals(snapshotUuid, that.snapshotUuid);
+        }
+
+        @Override
+        public int hashCode() {
+            int result = Long.hashCode(servedGeneration);
+            result = 31 * result + Long.hashCode(servedSnapshotId);
+            return 31 * result + (snapshotUuid == null ? 0 : snapshotUuid.hashCode());
+        }
+    }
+}

--- a/paimon-service/paimon-service-client/src/main/java/org/apache/paimon/service/exceptions/GlobalIndexQueryErrorCode.java
+++ b/paimon-service/paimon-service-client/src/main/java/org/apache/paimon/service/exceptions/GlobalIndexQueryErrorCode.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.service.exceptions;
+
+/** Stable machine-readable failure codes for global-index query protocol. */
+public enum GlobalIndexQueryErrorCode {
+    UNKNOWN_KEY_SHARD(1, true),
+    STALE_GENERATION(2, true),
+    NOT_READY(3, false),
+    DUPLICATE_KEY(4, false),
+    UNSUPPORTED_PROTOCOL(5, false),
+    REQUEST_TOO_LARGE(6, false),
+    INVALID_REQUEST(7, false),
+    OVERLOADED(8, true),
+    REQUEST_TIMEOUT(9, true),
+    INTERNAL_ERROR(10, false);
+
+    private final int wireCode;
+    private final boolean retryable;
+
+    GlobalIndexQueryErrorCode(int wireCode, boolean retryable) {
+        this.wireCode = wireCode;
+        this.retryable = retryable;
+    }
+
+    public int wireCode() {
+        return wireCode;
+    }
+
+    public boolean retryable() {
+        return retryable;
+    }
+
+    public static GlobalIndexQueryErrorCode fromWireCode(int wireCode) {
+        for (GlobalIndexQueryErrorCode value : values()) {
+            if (value.wireCode == wireCode) {
+                return value;
+            }
+        }
+        throw new IllegalArgumentException(
+                "Unknown global-index query error code " + wireCode + '.');
+    }
+}

--- a/paimon-service/paimon-service-client/src/main/java/org/apache/paimon/service/exceptions/GlobalIndexQueryException.java
+++ b/paimon-service/paimon-service-client/src/main/java/org/apache/paimon/service/exceptions/GlobalIndexQueryException.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.service.exceptions;
+
+import org.apache.paimon.utils.Preconditions;
+
+/** Structured failure returned by the global-index query protocol. */
+public class GlobalIndexQueryException extends RuntimeException {
+
+    private static final long serialVersionUID = 1L;
+
+    private final GlobalIndexQueryErrorCode errorCode;
+    private final boolean retryable;
+
+    public GlobalIndexQueryException(GlobalIndexQueryErrorCode errorCode, String message) {
+        this(errorCode, errorCode.retryable(), message);
+    }
+
+    public GlobalIndexQueryException(
+            GlobalIndexQueryErrorCode errorCode, boolean retryable, String message) {
+        super(message);
+        this.errorCode = Preconditions.checkNotNull(errorCode);
+        this.retryable = retryable;
+    }
+
+    public GlobalIndexQueryException(
+            GlobalIndexQueryErrorCode errorCode, String message, Throwable cause) {
+        this(errorCode, errorCode.retryable(), message, cause);
+    }
+
+    public GlobalIndexQueryException(
+            GlobalIndexQueryErrorCode errorCode,
+            boolean retryable,
+            String message,
+            Throwable cause) {
+        super(message, cause);
+        this.errorCode = Preconditions.checkNotNull(errorCode);
+        this.retryable = retryable;
+    }
+
+    public GlobalIndexQueryErrorCode errorCode() {
+        return errorCode;
+    }
+
+    public boolean retryable() {
+        return retryable;
+    }
+}

--- a/paimon-service/paimon-service-client/src/main/java/org/apache/paimon/service/messages/GlobalIndexRequest.java
+++ b/paimon-service/paimon-service-client/src/main/java/org/apache/paimon/service/messages/GlobalIndexRequest.java
@@ -1,0 +1,294 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.service.messages;
+
+import org.apache.paimon.data.BinaryRow;
+import org.apache.paimon.service.exceptions.GlobalIndexQueryException;
+import org.apache.paimon.service.network.messages.MessageBody;
+import org.apache.paimon.service.network.messages.MessageDeserializer;
+import org.apache.paimon.table.query.GlobalIndexQueryServiceUtils;
+
+import org.apache.paimon.shade.netty4.io.netty.buffer.ByteBuf;
+
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.apache.paimon.service.exceptions.GlobalIndexQueryErrorCode.INVALID_REQUEST;
+import static org.apache.paimon.service.exceptions.GlobalIndexQueryErrorCode.REQUEST_TOO_LARGE;
+import static org.apache.paimon.service.exceptions.GlobalIndexQueryErrorCode.UNSUPPORTED_PROTOCOL;
+import static org.apache.paimon.service.network.messages.MessageDeserializer.readBytes;
+import static org.apache.paimon.utils.SerializationUtils.deserializeBinaryRow;
+import static org.apache.paimon.utils.SerializationUtils.serializeBinaryRow;
+
+/** Request for keys which all belong to the same logical global-index shard. */
+public class GlobalIndexRequest extends MessageBody {
+
+    public static final int PROTOCOL_VERSION = 2;
+    public static final int MAX_KEYS = 10_000;
+    public static final int MAX_TOTAL_KEY_BYTES = 16 * 1024 * 1024;
+    public static final int MAX_SERVER_EPOCH_BYTES = 256;
+
+    /** Maximum request payload before the network envelope is added. */
+    public static final int MAX_SERIALIZED_PAYLOAD_BYTES =
+            Integer.BYTES
+                    + Integer.BYTES
+                    + MAX_SERVER_EPOCH_BYTES
+                    + Long.BYTES
+                    + Integer.BYTES
+                    + MAX_KEYS * Integer.BYTES
+                    + MAX_TOTAL_KEY_BYTES;
+
+    /** Maximum complete network frame, including length, message header, and request ID fields. */
+    public static final int MAX_NETWORK_FRAME_BYTES =
+            Integer.BYTES + 2 * Integer.BYTES + Long.BYTES + MAX_SERIALIZED_PAYLOAD_BYTES;
+
+    private final String serverEpoch;
+    private final long servedGeneration;
+    private final BinaryRow[] keys;
+
+    public GlobalIndexRequest(String serverEpoch, long servedGeneration, BinaryRow[] keys) {
+        validateServerEpoch(serverEpoch);
+        validateKeyCount(keys == null ? 0 : keys.length);
+        long totalKeyBytes = 0L;
+        BinaryRow[] normalizedKeys = new BinaryRow[keys.length];
+        for (int i = 0; i < keys.length; i++) {
+            BinaryRow key = keys[i];
+            if (key == null) {
+                throw new GlobalIndexQueryException(
+                        INVALID_REQUEST, "Global-index request key is null.");
+            }
+            BinaryRow normalizedKey = GlobalIndexQueryServiceUtils.normalizeKey(key);
+            validateKey(normalizedKey);
+            totalKeyBytes += Integer.BYTES + normalizedKey.getSizeInBytes();
+            validateTotalKeyBytes(totalKeyBytes);
+            normalizedKeys[i] = normalizedKey;
+        }
+        this.serverEpoch = serverEpoch;
+        this.servedGeneration = servedGeneration;
+        this.keys = normalizedKeys;
+    }
+
+    public int protocolVersion() {
+        return PROTOCOL_VERSION;
+    }
+
+    public String serverEpoch() {
+        return serverEpoch;
+    }
+
+    public long servedGeneration() {
+        return servedGeneration;
+    }
+
+    public BinaryRow[] keys() {
+        return keys;
+    }
+
+    @Override
+    public byte[] serialize() {
+        byte[] serverEpochBytes = serverEpoch.getBytes(StandardCharsets.UTF_8);
+        int size =
+                Integer.BYTES
+                        + Integer.BYTES
+                        + serverEpochBytes.length
+                        + Long.BYTES
+                        + Integer.BYTES;
+        List<byte[]> serializedKeys = new ArrayList<>(keys.length);
+        for (BinaryRow key : keys) {
+            byte[] bytes = serializeBinaryRow(key);
+            serializedKeys.add(bytes);
+            size += Integer.BYTES + bytes.length;
+        }
+
+        ByteBuffer buffer =
+                ByteBuffer.allocate(size)
+                        .putInt(PROTOCOL_VERSION)
+                        .putInt(serverEpochBytes.length)
+                        .put(serverEpochBytes)
+                        .putLong(servedGeneration)
+                        .putInt(keys.length);
+        for (byte[] key : serializedKeys) {
+            buffer.putInt(key.length).put(key);
+        }
+        return buffer.array();
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        return this == o
+                || (o instanceof GlobalIndexRequest
+                        && serverEpoch.equals(((GlobalIndexRequest) o).serverEpoch)
+                        && servedGeneration == ((GlobalIndexRequest) o).servedGeneration
+                        && Arrays.equals(keys, ((GlobalIndexRequest) o).keys));
+    }
+
+    @Override
+    public int hashCode() {
+        int result = serverEpoch.hashCode();
+        result = 31 * result + Long.hashCode(servedGeneration);
+        return 31 * result + Arrays.hashCode(keys);
+    }
+
+    /** Deserializer for {@link GlobalIndexRequest}. */
+    public static class Deserializer implements MessageDeserializer<GlobalIndexRequest> {
+
+        @Override
+        public GlobalIndexRequest deserializeMessage(ByteBuf buf) {
+            try {
+                return deserialize(buf);
+            } catch (GlobalIndexQueryException e) {
+                throw e;
+            } catch (RuntimeException e) {
+                throw new GlobalIndexQueryException(
+                        INVALID_REQUEST, "Malformed global-index query request.", e);
+            }
+        }
+
+        private GlobalIndexRequest deserialize(ByteBuf buf) {
+            int protocolVersion = buf.readInt();
+            if (protocolVersion != PROTOCOL_VERSION) {
+                throw new GlobalIndexQueryException(
+                        UNSUPPORTED_PROTOCOL,
+                        String.format(
+                                "Unsupported global-index query protocol version %s; expected %s.",
+                                protocolVersion, PROTOCOL_VERSION));
+            }
+            int serverEpochLength = buf.readInt();
+            if (serverEpochLength <= 0) {
+                throw new GlobalIndexQueryException(
+                        INVALID_REQUEST,
+                        "Global-index request contains an invalid server epoch length.");
+            }
+            if (serverEpochLength > MAX_SERVER_EPOCH_BYTES) {
+                throw new GlobalIndexQueryException(
+                        REQUEST_TOO_LARGE,
+                        String.format(
+                                "Global-index request server epoch is %s bytes; maximum is %s.",
+                                serverEpochLength, MAX_SERVER_EPOCH_BYTES));
+            }
+            String serverEpoch =
+                    new String(readBytes(buf, serverEpochLength), StandardCharsets.UTF_8);
+            validateServerEpoch(serverEpoch);
+            long servedGeneration = buf.readLong();
+            int size = buf.readInt();
+            validateKeyCount(size);
+            List<BinaryRow> keys = new ArrayList<>(size);
+            long totalKeyBytes = 0L;
+            for (int i = 0; i < size; i++) {
+                int keyLength = buf.readInt();
+                if (keyLength <= 0) {
+                    throw new GlobalIndexQueryException(
+                            INVALID_REQUEST,
+                            "Global-index request contains an invalid serialized key length.");
+                }
+                totalKeyBytes += keyLength;
+                validateTotalKeyBytes(totalKeyBytes);
+                byte[] serializedKey = readBytes(buf, keyLength);
+                validateSerializedKey(serializedKey);
+                // The constructor copies this non-zero-offset row and canonicalizes its RowKind.
+                keys.add(deserializeBinaryRow(serializedKey));
+            }
+            if (buf.isReadable()) {
+                throw new GlobalIndexQueryException(
+                        INVALID_REQUEST,
+                        String.format(
+                                "Global-index request contains %s trailing bytes.",
+                                buf.readableBytes()));
+            }
+            return new GlobalIndexRequest(
+                    serverEpoch, servedGeneration, keys.toArray(new BinaryRow[0]));
+        }
+    }
+
+    private static void validateServerEpoch(String serverEpoch) {
+        if (serverEpoch == null || serverEpoch.isEmpty()) {
+            throw new GlobalIndexQueryException(
+                    INVALID_REQUEST, "Global-index request server epoch is empty.");
+        }
+        int bytes = serverEpoch.getBytes(StandardCharsets.UTF_8).length;
+        if (bytes > MAX_SERVER_EPOCH_BYTES) {
+            throw new GlobalIndexQueryException(
+                    REQUEST_TOO_LARGE,
+                    String.format(
+                            "Global-index request server epoch is %s bytes; maximum is %s.",
+                            bytes, MAX_SERVER_EPOCH_BYTES));
+        }
+    }
+
+    private static void validateKeyCount(int keyCount) {
+        if (keyCount <= 0) {
+            throw new GlobalIndexQueryException(
+                    INVALID_REQUEST, "Global-index request keys are empty.");
+        }
+        if (keyCount > MAX_KEYS) {
+            throw new GlobalIndexQueryException(
+                    REQUEST_TOO_LARGE,
+                    String.format(
+                            "Global-index request contains %s keys; maximum is %s.",
+                            keyCount, MAX_KEYS));
+        }
+    }
+
+    private static void validateKey(BinaryRow key) {
+        if (key.getFieldCount() != 1) {
+            throw new GlobalIndexQueryException(
+                    INVALID_REQUEST,
+                    String.format(
+                            "Global-index request key must contain exactly one field, but found %s.",
+                            key.getFieldCount()));
+        }
+        if (key.isNullAt(0)) {
+            throw new GlobalIndexQueryException(
+                    INVALID_REQUEST, "Global-index request key field is null.");
+        }
+    }
+
+    private static void validateSerializedKey(byte[] serializedKey) {
+        if (serializedKey.length < Integer.BYTES) {
+            throw new GlobalIndexQueryException(
+                    INVALID_REQUEST, "Global-index request contains a truncated key.");
+        }
+        int arity = ByteBuffer.wrap(serializedKey).getInt();
+        if (arity != 1) {
+            throw new GlobalIndexQueryException(
+                    INVALID_REQUEST,
+                    String.format(
+                            "Global-index request key must contain exactly one field, but found %s.",
+                            arity));
+        }
+        int rowBytes = serializedKey.length - Integer.BYTES;
+        if (rowBytes < BinaryRow.calculateFixPartSizeInBytes(arity)) {
+            throw new GlobalIndexQueryException(
+                    INVALID_REQUEST, "Global-index request contains a truncated key row.");
+        }
+    }
+
+    private static void validateTotalKeyBytes(long totalKeyBytes) {
+        if (totalKeyBytes > MAX_TOTAL_KEY_BYTES) {
+            throw new GlobalIndexQueryException(
+                    REQUEST_TOO_LARGE,
+                    String.format(
+                            "Global-index request key payload is %s bytes; maximum is %s.",
+                            totalKeyBytes, MAX_TOTAL_KEY_BYTES));
+        }
+    }
+}

--- a/paimon-service/paimon-service-client/src/main/java/org/apache/paimon/service/messages/GlobalIndexResponse.java
+++ b/paimon-service/paimon-service-client/src/main/java/org/apache/paimon/service/messages/GlobalIndexResponse.java
@@ -1,0 +1,491 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.service.messages;
+
+import org.apache.paimon.data.BinaryRow;
+import org.apache.paimon.service.exceptions.GlobalIndexQueryErrorCode;
+import org.apache.paimon.service.exceptions.GlobalIndexQueryException;
+import org.apache.paimon.service.network.messages.MessageBody;
+import org.apache.paimon.service.network.messages.MessageDeserializer;
+import org.apache.paimon.table.query.GlobalIndexQueryServiceUtils;
+
+import org.apache.paimon.shade.netty4.io.netty.buffer.ByteBuf;
+
+import javax.annotation.Nullable;
+
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+
+import static org.apache.paimon.service.exceptions.GlobalIndexQueryErrorCode.INVALID_REQUEST;
+import static org.apache.paimon.service.exceptions.GlobalIndexQueryErrorCode.REQUEST_TOO_LARGE;
+import static org.apache.paimon.service.exceptions.GlobalIndexQueryErrorCode.UNSUPPORTED_PROTOCOL;
+import static org.apache.paimon.service.network.messages.MessageDeserializer.readBytes;
+import static org.apache.paimon.utils.SerializationUtils.deserializeBinaryRow;
+import static org.apache.paimon.utils.SerializationUtils.serializeBinaryRow;
+
+/** Snapshot-fenced response from one global-index query server. */
+public class GlobalIndexResponse extends MessageBody {
+
+    public static final int MAX_TOTAL_VALUE_BYTES =
+            GlobalIndexQueryServiceUtils.MAX_TOTAL_VALUE_BYTES;
+    public static final int MAX_ERROR_MESSAGE_BYTES = 16 * 1024;
+    private static final int MAX_VALUE_FIELDS = 10_000;
+    private static final int SUCCESS_CODE = 0;
+
+    /** Maximum response payload before the network envelope is added. */
+    public static final int MAX_SERIALIZED_PAYLOAD_BYTES =
+            Integer.BYTES
+                    + Integer.BYTES
+                    + GlobalIndexRequest.MAX_SERVER_EPOCH_BYTES
+                    + Long.BYTES
+                    + Long.BYTES
+                    + Integer.BYTES
+                    + 1
+                    + Integer.BYTES
+                    + MAX_ERROR_MESSAGE_BYTES
+                    + Integer.BYTES
+                    + GlobalIndexRequest.MAX_KEYS
+                    + GlobalIndexRequest.MAX_KEYS * Integer.BYTES
+                    + MAX_TOTAL_VALUE_BYTES;
+
+    /** Maximum complete network frame, including length, message header, and request ID fields. */
+    public static final int MAX_NETWORK_FRAME_BYTES =
+            Integer.BYTES + 2 * Integer.BYTES + Long.BYTES + MAX_SERIALIZED_PAYLOAD_BYTES;
+
+    private final String serverEpoch;
+    private final long servedGeneration;
+    private final long servedSnapshotId;
+    @Nullable private final GlobalIndexQueryErrorCode errorCode;
+    private final boolean retryable;
+    private final String errorMessage;
+    private final BinaryRow[] values;
+
+    public GlobalIndexResponse(
+            String serverEpoch, long servedGeneration, long servedSnapshotId, BinaryRow[] values) {
+        this(serverEpoch, servedGeneration, servedSnapshotId, null, false, "", values);
+    }
+
+    private GlobalIndexResponse(
+            String serverEpoch,
+            long servedGeneration,
+            long servedSnapshotId,
+            @Nullable GlobalIndexQueryErrorCode errorCode,
+            boolean retryable,
+            String errorMessage,
+            BinaryRow[] values) {
+        validateServerEpoch(serverEpoch);
+        validateStatus(errorCode, retryable, errorMessage);
+        validateValueCount(values == null ? -1 : values.length);
+        if (errorCode != null && values.length != 0) {
+            throw new GlobalIndexQueryException(
+                    INVALID_REQUEST, "Failed global-index response must not contain values.");
+        }
+        long totalValueBytes = 0L;
+        for (BinaryRow value : values) {
+            if (value != null) {
+                validateValue(value);
+                totalValueBytes += Integer.BYTES + value.getSizeInBytes();
+                validateTotalValueBytes(totalValueBytes);
+            }
+        }
+        this.serverEpoch = serverEpoch;
+        this.servedGeneration = servedGeneration;
+        this.servedSnapshotId = servedSnapshotId;
+        this.errorCode = errorCode;
+        this.retryable = retryable;
+        this.errorMessage = errorMessage;
+        this.values = values;
+    }
+
+    public static GlobalIndexResponse failure(
+            String serverEpoch,
+            long servedGeneration,
+            long servedSnapshotId,
+            GlobalIndexQueryErrorCode errorCode,
+            String message) {
+        return failure(
+                serverEpoch,
+                servedGeneration,
+                servedSnapshotId,
+                errorCode,
+                errorCode.retryable(),
+                message);
+    }
+
+    public static GlobalIndexResponse failure(
+            String serverEpoch,
+            long servedGeneration,
+            long servedSnapshotId,
+            GlobalIndexQueryErrorCode errorCode,
+            boolean retryable,
+            String message) {
+        return new GlobalIndexResponse(
+                serverEpoch,
+                servedGeneration,
+                servedSnapshotId,
+                errorCode,
+                retryable,
+                truncateErrorMessage(message),
+                new BinaryRow[0]);
+    }
+
+    public int protocolVersion() {
+        return GlobalIndexRequest.PROTOCOL_VERSION;
+    }
+
+    public String serverEpoch() {
+        return serverEpoch;
+    }
+
+    public long servedGeneration() {
+        return servedGeneration;
+    }
+
+    public long servedSnapshotId() {
+        return servedSnapshotId;
+    }
+
+    public boolean isSuccess() {
+        return errorCode == null;
+    }
+
+    @Nullable
+    public GlobalIndexQueryErrorCode errorCode() {
+        return errorCode;
+    }
+
+    public boolean retryable() {
+        return retryable;
+    }
+
+    public String errorMessage() {
+        return errorMessage;
+    }
+
+    public GlobalIndexQueryException toException() {
+        if (errorCode == null) {
+            throw new IllegalStateException("Successful global-index response has no error.");
+        }
+        return new GlobalIndexQueryException(errorCode, retryable, errorMessage);
+    }
+
+    public BinaryRow[] values() {
+        return values;
+    }
+
+    @Override
+    public byte[] serialize() {
+        byte[] serverEpochBytes = serverEpoch.getBytes(StandardCharsets.UTF_8);
+        byte[] errorMessageBytes = errorMessage.getBytes(StandardCharsets.UTF_8);
+        byte[][] serializedValues = new byte[values.length][];
+        int size =
+                Integer.BYTES
+                        + Integer.BYTES
+                        + serverEpochBytes.length
+                        + Long.BYTES
+                        + Long.BYTES
+                        + Integer.BYTES
+                        + 1
+                        + Integer.BYTES
+                        + errorMessageBytes.length
+                        + Integer.BYTES;
+        for (int i = 0; i < values.length; i++) {
+            size += 1;
+            if (values[i] != null) {
+                serializedValues[i] = serializeBinaryRow(values[i]);
+                size += Integer.BYTES + serializedValues[i].length;
+            }
+        }
+
+        ByteBuffer buffer =
+                ByteBuffer.allocate(size)
+                        .putInt(GlobalIndexRequest.PROTOCOL_VERSION)
+                        .putInt(serverEpochBytes.length)
+                        .put(serverEpochBytes)
+                        .putLong(servedGeneration)
+                        .putLong(servedSnapshotId)
+                        .putInt(errorCode == null ? SUCCESS_CODE : errorCode.wireCode())
+                        .put((byte) (retryable ? 1 : 0))
+                        .putInt(errorMessageBytes.length)
+                        .put(errorMessageBytes)
+                        .putInt(values.length);
+        for (byte[] serializedValue : serializedValues) {
+            if (serializedValue == null) {
+                buffer.put((byte) 1);
+            } else {
+                buffer.put((byte) 0).putInt(serializedValue.length).put(serializedValue);
+            }
+        }
+        return buffer.array();
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof GlobalIndexResponse)) {
+            return false;
+        }
+        GlobalIndexResponse that = (GlobalIndexResponse) o;
+        return servedGeneration == that.servedGeneration
+                && servedSnapshotId == that.servedSnapshotId
+                && retryable == that.retryable
+                && serverEpoch.equals(that.serverEpoch)
+                && errorCode == that.errorCode
+                && errorMessage.equals(that.errorMessage)
+                && Arrays.equals(values, that.values);
+    }
+
+    @Override
+    public int hashCode() {
+        int result = serverEpoch.hashCode();
+        result = 31 * result + Long.hashCode(servedGeneration);
+        result = 31 * result + Long.hashCode(servedSnapshotId);
+        result = 31 * result + (errorCode == null ? 0 : errorCode.hashCode());
+        result = 31 * result + Boolean.hashCode(retryable);
+        result = 31 * result + errorMessage.hashCode();
+        return 31 * result + Arrays.hashCode(values);
+    }
+
+    /** Deserializer for {@link GlobalIndexResponse}. */
+    public static class Deserializer implements MessageDeserializer<GlobalIndexResponse> {
+
+        @Override
+        public GlobalIndexResponse deserializeMessage(ByteBuf buf) {
+            try {
+                return deserialize(buf);
+            } catch (GlobalIndexQueryException e) {
+                throw e;
+            } catch (RuntimeException e) {
+                throw new GlobalIndexQueryException(
+                        INVALID_REQUEST, "Malformed global-index query response.", e);
+            }
+        }
+
+        private GlobalIndexResponse deserialize(ByteBuf buf) {
+            int protocolVersion = buf.readInt();
+            if (protocolVersion != GlobalIndexRequest.PROTOCOL_VERSION) {
+                throw new GlobalIndexQueryException(
+                        UNSUPPORTED_PROTOCOL,
+                        String.format(
+                                "Unsupported global-index query protocol version %s; expected %s.",
+                                protocolVersion, GlobalIndexRequest.PROTOCOL_VERSION));
+            }
+            int serverEpochLength = buf.readInt();
+            if (serverEpochLength <= 0) {
+                throw new GlobalIndexQueryException(
+                        INVALID_REQUEST,
+                        "Global-index response contains an invalid server epoch length.");
+            }
+            if (serverEpochLength > GlobalIndexRequest.MAX_SERVER_EPOCH_BYTES) {
+                throw new GlobalIndexQueryException(
+                        REQUEST_TOO_LARGE,
+                        String.format(
+                                "Global-index response server epoch is %s bytes; maximum is %s.",
+                                serverEpochLength, GlobalIndexRequest.MAX_SERVER_EPOCH_BYTES));
+            }
+            String serverEpoch =
+                    new String(readBytes(buf, serverEpochLength), StandardCharsets.UTF_8);
+            validateServerEpoch(serverEpoch);
+            long servedGeneration = buf.readLong();
+            long servedSnapshotId = buf.readLong();
+            int wireErrorCode = buf.readInt();
+            GlobalIndexQueryErrorCode errorCode =
+                    wireErrorCode == SUCCESS_CODE
+                            ? null
+                            : GlobalIndexQueryErrorCode.fromWireCode(wireErrorCode);
+            byte retryableMarker = buf.readByte();
+            if (retryableMarker != 0 && retryableMarker != 1) {
+                throw new GlobalIndexQueryException(
+                        INVALID_REQUEST,
+                        "Global-index response contains an invalid retryable marker.");
+            }
+            boolean retryable = retryableMarker == 1;
+            int errorMessageLength = buf.readInt();
+            if (errorMessageLength < 0) {
+                throw new GlobalIndexQueryException(
+                        INVALID_REQUEST,
+                        "Global-index response contains an invalid error message length.");
+            }
+            if (errorMessageLength > MAX_ERROR_MESSAGE_BYTES) {
+                throw new GlobalIndexQueryException(
+                        REQUEST_TOO_LARGE,
+                        String.format(
+                                "Global-index response error message is %s bytes; maximum is %s.",
+                                errorMessageLength, MAX_ERROR_MESSAGE_BYTES));
+            }
+            String errorMessage =
+                    new String(readBytes(buf, errorMessageLength), StandardCharsets.UTF_8);
+            validateStatus(errorCode, retryable, errorMessage);
+            int valueCount = buf.readInt();
+            validateValueCount(valueCount);
+            if (errorCode != null && valueCount != 0) {
+                throw new GlobalIndexQueryException(
+                        INVALID_REQUEST, "Failed global-index response contains values.");
+            }
+
+            BinaryRow[] values = new BinaryRow[valueCount];
+            long totalValueBytes = 0L;
+            for (int i = 0; i < valueCount; i++) {
+                byte nullMarker = buf.readByte();
+                if (nullMarker != 0 && nullMarker != 1) {
+                    throw new GlobalIndexQueryException(
+                            INVALID_REQUEST,
+                            "Global-index response contains an invalid null marker.");
+                }
+                boolean isNull = nullMarker == 1;
+                if (!isNull) {
+                    int valueLength = buf.readInt();
+                    if (valueLength <= 0) {
+                        throw new GlobalIndexQueryException(
+                                INVALID_REQUEST,
+                                "Global-index response contains an invalid value length.");
+                    }
+                    totalValueBytes += valueLength;
+                    validateTotalValueBytes(totalValueBytes);
+                    byte[] serializedValue = readBytes(buf, valueLength);
+                    validateSerializedValue(serializedValue);
+                    // Normalize schemaless rows at the protocol boundary. This gives callers an
+                    // independent offset-zero row and avoids offset-insensitive BinaryRow methods
+                    // reading the serialized arity prefix as row data.
+                    values[i] = deserializeBinaryRow(serializedValue).copy();
+                }
+            }
+            if (buf.isReadable()) {
+                throw new GlobalIndexQueryException(
+                        INVALID_REQUEST,
+                        String.format(
+                                "Global-index response contains %s trailing bytes.",
+                                buf.readableBytes()));
+            }
+            return new GlobalIndexResponse(
+                    serverEpoch,
+                    servedGeneration,
+                    servedSnapshotId,
+                    errorCode,
+                    retryable,
+                    errorMessage,
+                    values);
+        }
+    }
+
+    private static void validateStatus(
+            @Nullable GlobalIndexQueryErrorCode errorCode, boolean retryable, String errorMessage) {
+        if (errorMessage == null) {
+            throw new GlobalIndexQueryException(
+                    INVALID_REQUEST, "Global-index response error message is null.");
+        }
+        int messageBytes = errorMessage.getBytes(StandardCharsets.UTF_8).length;
+        if (messageBytes > MAX_ERROR_MESSAGE_BYTES) {
+            throw new GlobalIndexQueryException(
+                    REQUEST_TOO_LARGE,
+                    String.format(
+                            "Global-index response error message is %s bytes; maximum is %s.",
+                            messageBytes, MAX_ERROR_MESSAGE_BYTES));
+        }
+        if (errorCode == null && (retryable || !errorMessage.isEmpty())) {
+            throw new GlobalIndexQueryException(
+                    INVALID_REQUEST, "Successful global-index response contains failure metadata.");
+        }
+    }
+
+    private static String truncateErrorMessage(String message) {
+        String nonNullMessage = message == null ? "" : message;
+        byte[] bytes = nonNullMessage.getBytes(StandardCharsets.UTF_8);
+        if (bytes.length <= MAX_ERROR_MESSAGE_BYTES) {
+            return nonNullMessage;
+        }
+        int length = MAX_ERROR_MESSAGE_BYTES;
+        while (length > 0 && (bytes[length] & 0xc0) == 0x80) {
+            length--;
+        }
+        return new String(bytes, 0, length, StandardCharsets.UTF_8);
+    }
+
+    private static void validateServerEpoch(String serverEpoch) {
+        if (serverEpoch == null || serverEpoch.isEmpty()) {
+            throw new GlobalIndexQueryException(
+                    INVALID_REQUEST, "Global-index response server epoch is empty.");
+        }
+        int bytes = serverEpoch.getBytes(StandardCharsets.UTF_8).length;
+        if (bytes > GlobalIndexRequest.MAX_SERVER_EPOCH_BYTES) {
+            throw new GlobalIndexQueryException(
+                    REQUEST_TOO_LARGE,
+                    String.format(
+                            "Global-index response server epoch is %s bytes; maximum is %s.",
+                            bytes, GlobalIndexRequest.MAX_SERVER_EPOCH_BYTES));
+        }
+    }
+
+    private static void validateValueCount(int valueCount) {
+        if (valueCount < 0) {
+            throw new GlobalIndexQueryException(
+                    INVALID_REQUEST, "Global-index response values are null.");
+        }
+        if (valueCount > GlobalIndexRequest.MAX_KEYS) {
+            throw new GlobalIndexQueryException(
+                    REQUEST_TOO_LARGE,
+                    String.format(
+                            "Global-index response contains %s values; maximum is %s.",
+                            valueCount, GlobalIndexRequest.MAX_KEYS));
+        }
+    }
+
+    private static void validateValue(BinaryRow value) {
+        if (value.getFieldCount() <= 0 || value.getFieldCount() > MAX_VALUE_FIELDS) {
+            throw new GlobalIndexQueryException(
+                    INVALID_REQUEST,
+                    String.format(
+                            "Global-index response value contains an invalid field count %s.",
+                            value.getFieldCount()));
+        }
+    }
+
+    private static void validateSerializedValue(byte[] serializedValue) {
+        if (serializedValue.length < Integer.BYTES) {
+            throw new GlobalIndexQueryException(
+                    INVALID_REQUEST, "Global-index response contains a truncated value.");
+        }
+        int arity = ByteBuffer.wrap(serializedValue).getInt();
+        if (arity <= 0 || arity > MAX_VALUE_FIELDS) {
+            throw new GlobalIndexQueryException(
+                    INVALID_REQUEST,
+                    String.format(
+                            "Global-index response value contains an invalid field count %s.",
+                            arity));
+        }
+        int rowBytes = serializedValue.length - Integer.BYTES;
+        if (rowBytes < BinaryRow.calculateFixPartSizeInBytes(arity)) {
+            throw new GlobalIndexQueryException(
+                    INVALID_REQUEST, "Global-index response contains a truncated value row.");
+        }
+    }
+
+    public static void validateTotalValueBytes(long totalValueBytes) {
+        if (totalValueBytes > MAX_TOTAL_VALUE_BYTES) {
+            throw new GlobalIndexQueryException(
+                    REQUEST_TOO_LARGE,
+                    String.format(
+                            "Global-index response value payload is %s bytes; maximum is %s.",
+                            totalValueBytes, MAX_TOTAL_VALUE_BYTES));
+        }
+    }
+}

--- a/paimon-service/paimon-service-client/src/main/java/org/apache/paimon/service/network/AbstractServerHandler.java
+++ b/paimon-service/paimon-service-client/src/main/java/org/apache/paimon/service/network/AbstractServerHandler.java
@@ -40,6 +40,7 @@ import java.io.IOException;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
 import java.util.concurrent.ExecutorService;
+import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.TimeUnit;
 
 /**
@@ -68,6 +69,9 @@ public abstract class AbstractServerHandler<REQ extends MessageBody, RESP extend
     /** Exposed server statistics. */
     private final ServiceRequestStats stats;
 
+    /** Whether this protocol permits Java-serialized Throwable failure frames. */
+    private final LegacyFailureFramePolicy legacyFailureFramePolicy;
+
     /**
      * Create the handler.
      *
@@ -78,11 +82,21 @@ public abstract class AbstractServerHandler<REQ extends MessageBody, RESP extend
             final NetworkServer<REQ, RESP> server,
             final MessageSerializer<REQ, RESP> serializer,
             final ServiceRequestStats stats) {
+        this(server, serializer, stats, LegacyFailureFramePolicy.ALLOW_SERIALIZED_THROWABLE);
+    }
+
+    /** Creates a handler with an explicit legacy failure-frame policy. */
+    public AbstractServerHandler(
+            final NetworkServer<REQ, RESP> server,
+            final MessageSerializer<REQ, RESP> serializer,
+            final ServiceRequestStats stats,
+            final LegacyFailureFramePolicy legacyFailureFramePolicy) {
 
         this.server = Preconditions.checkNotNull(server);
         this.serializer = Preconditions.checkNotNull(serializer);
         this.queryExecutor = server.getQueryExecutor();
         this.stats = Preconditions.checkNotNull(stats);
+        this.legacyFailureFramePolicy = Preconditions.checkNotNull(legacyFailureFramePolicy);
     }
 
     protected String getServerName() {
@@ -123,7 +137,19 @@ public abstract class AbstractServerHandler<REQ extends MessageBody, RESP extend
                 // blocking (e.g. file I/O).
                 //
                 // A submission failure is not treated as fatal.
-                queryExecutor.submit(new AsyncRequestTask<>(this, ctx, requestId, request, stats));
+                try {
+                    queryExecutor.submit(
+                            new AsyncRequestTask<>(this, ctx, requestId, request, stats));
+                } catch (RejectedExecutionException e) {
+                    RESP rejectedResponse = rejectedExecutionResponse(requestId, request);
+                    if (rejectedResponse == null) {
+                        throw e;
+                    }
+                    stats.reportFailedRequest();
+                    ctx.writeAndFlush(
+                            MessageSerializer.serializeResponse(
+                                    ctx.alloc(), requestId, rejectedResponse));
+                }
 
             } else {
                 // ------------------------------------------------------------
@@ -136,12 +162,15 @@ public abstract class AbstractServerHandler<REQ extends MessageBody, RESP extend
                                 + ". Expected "
                                 + MessageType.REQUEST
                                 + ".";
-                final ByteBuf failure =
-                        MessageSerializer.serializeServerFailure(
-                                ctx.alloc(), new IllegalArgumentException(errMsg));
-
                 LOG.debug(errMsg);
-                ctx.writeAndFlush(failure);
+                if (allowsSerializedThrowableFailureFrames()) {
+                    final ByteBuf failure =
+                            MessageSerializer.serializeServerFailure(
+                                    ctx.alloc(), new IllegalArgumentException(errMsg));
+                    ctx.writeAndFlush(failure);
+                } else {
+                    ctx.close();
+                }
             }
         } catch (Throwable t) {
             LOG.error(
@@ -149,24 +178,35 @@ public abstract class AbstractServerHandler<REQ extends MessageBody, RESP extend
                     requestId == UNKNOWN_REQUEST_ID ? "unknown" : requestId,
                     t);
 
-            final String stringifiedCause = ExceptionUtils.stringifyException(t);
+            if (allowsSerializedThrowableFailureFrames()) {
+                final String stringifiedCause = ExceptionUtils.stringifyException(t);
 
-            String errMsg;
-            ByteBuf err;
-            if (request != null) {
-                errMsg = "Failed request with ID " + requestId + ". Caused by: " + stringifiedCause;
-                err =
-                        MessageSerializer.serializeRequestFailure(
-                                ctx.alloc(), requestId, new RuntimeException(errMsg));
-                stats.reportFailedRequest();
+                String errMsg;
+                ByteBuf err;
+                if (request != null) {
+                    errMsg =
+                            "Failed request with ID "
+                                    + requestId
+                                    + ". Caused by: "
+                                    + stringifiedCause;
+                    err =
+                            MessageSerializer.serializeRequestFailure(
+                                    ctx.alloc(), requestId, new RuntimeException(errMsg));
+                    stats.reportFailedRequest();
+                } else {
+                    errMsg = "Failed incoming message. Caused by: " + stringifiedCause;
+                    err =
+                            MessageSerializer.serializeServerFailure(
+                                    ctx.alloc(), new RuntimeException(errMsg));
+                }
+
+                ctx.writeAndFlush(err);
             } else {
-                errMsg = "Failed incoming message. Caused by: " + stringifiedCause;
-                err =
-                        MessageSerializer.serializeServerFailure(
-                                ctx.alloc(), new RuntimeException(errMsg));
+                if (request != null) {
+                    stats.reportFailedRequest();
+                }
+                ctx.close();
             }
-
-            ctx.writeAndFlush(err);
 
         } finally {
             // IMPORTANT: We have to always recycle the incoming buffer.
@@ -181,14 +221,24 @@ public abstract class AbstractServerHandler<REQ extends MessageBody, RESP extend
 
     @Override
     public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) throws Exception {
-        final String msg =
-                "Exception in server pipeline. Caused by: "
-                        + ExceptionUtils.stringifyException(cause);
-        final ByteBuf err =
-                MessageSerializer.serializeServerFailure(ctx.alloc(), new RuntimeException(msg));
+        if (allowsSerializedThrowableFailureFrames()) {
+            final String msg =
+                    "Exception in server pipeline. Caused by: "
+                            + ExceptionUtils.stringifyException(cause);
+            final ByteBuf err =
+                    MessageSerializer.serializeServerFailure(
+                            ctx.alloc(), new RuntimeException(msg));
 
-        LOG.debug(msg);
-        ctx.writeAndFlush(err).addListener(ChannelFutureListener.CLOSE);
+            LOG.debug(msg);
+            ctx.writeAndFlush(err).addListener(ChannelFutureListener.CLOSE);
+        } else {
+            LOG.debug("Exception in server pipeline; closing secure protocol connection.", cause);
+            ctx.close();
+        }
+    }
+
+    private boolean allowsSerializedThrowableFailureFrames() {
+        return legacyFailureFramePolicy == LegacyFailureFramePolicy.ALLOW_SERIALIZED_THROWABLE;
     }
 
     /**
@@ -202,6 +252,13 @@ public abstract class AbstractServerHandler<REQ extends MessageBody, RESP extend
      * @return A future with the response to be forwarded to the client.
      */
     public abstract CompletableFuture<RESP> handleRequest(final long requestId, final REQ request);
+
+    /**
+     * Returns a protocol response when the query executor rejects a request, or null for legacy.
+     */
+    protected RESP rejectedExecutionResponse(long requestId, REQ request) {
+        return null;
+    }
 
     /**
      * Shuts down any handler-specific resources, e.g. thread pools etc and returns a {@link
@@ -291,25 +348,13 @@ public abstract class AbstractServerHandler<REQ extends MessageBody, RESP extend
 
                                 } catch (BadRequestException e) {
                                     LOG.debug("Bad request (request ID = {})", requestId, e);
-                                    try {
-                                        stats.reportFailedRequest();
-                                        final ByteBuf err =
-                                                MessageSerializer.serializeRequestFailure(
-                                                        ctx.alloc(), requestId, e);
-                                        ctx.writeAndFlush(err);
-                                    } catch (IOException io) {
-                                        LOG.error(
-                                                "Failed to respond with the error after failed request",
-                                                io);
-                                    }
+                                    respondWithRequestFailure(e);
                                 } catch (Throwable t) {
                                     LOG.error(
                                             "Error while handling request with ID {}",
                                             requestId,
                                             t);
-                                    try {
-                                        stats.reportFailedRequest();
-
+                                    if (handler.allowsSerializedThrowableFailureFrames()) {
                                         final String errMsg =
                                                 "Failed request "
                                                         + requestId
@@ -317,19 +362,28 @@ public abstract class AbstractServerHandler<REQ extends MessageBody, RESP extend
                                                         + System.lineSeparator()
                                                         + " Caused by: "
                                                         + ExceptionUtils.stringifyException(t);
-                                        final ByteBuf err =
-                                                MessageSerializer.serializeRequestFailure(
-                                                        ctx.alloc(),
-                                                        requestId,
-                                                        new RuntimeException(errMsg));
-                                        ctx.writeAndFlush(err);
-                                    } catch (IOException io) {
-                                        LOG.error(
-                                                "Failed to respond with the error after failed request",
-                                                io);
+                                        respondWithRequestFailure(new RuntimeException(errMsg));
+                                    } else {
+                                        respondWithRequestFailure(t);
                                     }
                                 }
                             });
+        }
+
+        private void respondWithRequestFailure(Throwable throwable) {
+            stats.reportFailedRequest();
+            if (!handler.allowsSerializedThrowableFailureFrames()) {
+                ctx.close();
+                return;
+            }
+            try {
+                final ByteBuf err =
+                        MessageSerializer.serializeRequestFailure(
+                                ctx.alloc(), requestId, throwable);
+                ctx.writeAndFlush(err);
+            } catch (IOException io) {
+                LOG.error("Failed to respond with the error after failed request", io);
+            }
         }
 
         @Override

--- a/paimon-service/paimon-service-client/src/main/java/org/apache/paimon/service/network/ClientHandler.java
+++ b/paimon-service/paimon-service-client/src/main/java/org/apache/paimon/service/network/ClientHandler.java
@@ -32,6 +32,7 @@ import org.apache.paimon.shade.netty4.io.netty.util.ReferenceCountUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.io.IOException;
 import java.nio.channels.ClosedChannelException;
 
 /**
@@ -49,6 +50,8 @@ public class ClientHandler<REQ extends MessageBody, RESP extends MessageBody>
 
     private final ClientHandlerCallback<RESP> callback;
 
+    private final LegacyFailureFramePolicy legacyFailureFramePolicy;
+
     /**
      * Creates a handler with the callback.
      *
@@ -58,8 +61,17 @@ public class ClientHandler<REQ extends MessageBody, RESP extends MessageBody>
     public ClientHandler(
             final MessageSerializer<REQ, RESP> serializer,
             final ClientHandlerCallback<RESP> callback) {
+        this(serializer, callback, LegacyFailureFramePolicy.ALLOW_SERIALIZED_THROWABLE);
+    }
+
+    /** Creates a handler with an explicit policy for Java-serialized Throwable failure frames. */
+    public ClientHandler(
+            final MessageSerializer<REQ, RESP> serializer,
+            final ClientHandlerCallback<RESP> callback,
+            final LegacyFailureFramePolicy legacyFailureFramePolicy) {
         this.serializer = Preconditions.checkNotNull(serializer);
         this.callback = Preconditions.checkNotNull(callback);
+        this.legacyFailureFramePolicy = Preconditions.checkNotNull(legacyFailureFramePolicy);
     }
 
     @Override
@@ -73,9 +85,11 @@ public class ClientHandler<REQ extends MessageBody, RESP extends MessageBody>
                 RESP result = serializer.deserializeResponse(buf);
                 callback.onRequestResult(requestId, result);
             } else if (msgType == MessageType.REQUEST_FAILURE) {
+                rejectLegacyFailureFrameIfConfigured(msgType);
                 RequestFailure failure = MessageSerializer.deserializeRequestFailure(buf);
                 callback.onRequestFailure(failure.getRequestId(), failure.getCause());
             } else if (msgType == MessageType.SERVER_FAILURE) {
+                rejectLegacyFailureFrameIfConfigured(msgType);
                 throw MessageSerializer.deserializeServerFailure(buf);
             } else {
                 throw new IllegalStateException("Unexpected response type '" + msgType + "'");
@@ -88,6 +102,15 @@ public class ClientHandler<REQ extends MessageBody, RESP extends MessageBody>
             }
         } finally {
             ReferenceCountUtil.release(msg);
+        }
+    }
+
+    private void rejectLegacyFailureFrameIfConfigured(MessageType messageType) throws IOException {
+        if (legacyFailureFramePolicy == LegacyFailureFramePolicy.REJECT_SERIALIZED_THROWABLE) {
+            throw new IOException(
+                    "Rejected prohibited legacy serialized Throwable failure frame of type "
+                            + messageType
+                            + '.');
         }
     }
 

--- a/paimon-service/paimon-service-client/src/main/java/org/apache/paimon/service/network/LegacyFailureFramePolicy.java
+++ b/paimon-service/paimon-service-client/src/main/java/org/apache/paimon/service/network/LegacyFailureFramePolicy.java
@@ -1,0 +1,25 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.service.network;
+
+/** Policy for legacy failure frames whose payload is a Java-serialized {@link Throwable}. */
+public enum LegacyFailureFramePolicy {
+    ALLOW_SERIALIZED_THROWABLE,
+    REJECT_SERIALIZED_THROWABLE
+}

--- a/paimon-service/paimon-service-client/src/main/java/org/apache/paimon/service/network/NetworkClient.java
+++ b/paimon-service/paimon-service-client/src/main/java/org/apache/paimon/service/network/NetworkClient.java
@@ -77,6 +77,9 @@ public class NetworkClient<REQ extends MessageBody, RESP extends MessageBody> {
     /** Statistics tracker. */
     private final ServiceRequestStats stats;
 
+    /** Policy for legacy Java-serialized Throwable failure frames. */
+    private final LegacyFailureFramePolicy legacyFailureFramePolicy;
+
     private final Map<InetSocketAddress, ServerConnection<REQ, RESP>> connections =
             new ConcurrentHashMap<>();
 
@@ -97,13 +100,45 @@ public class NetworkClient<REQ extends MessageBody, RESP extends MessageBody> {
             final int numEventLoopThreads,
             final MessageSerializer<REQ, RESP> serializer,
             final ServiceRequestStats stats) {
+        this(clientName, numEventLoopThreads, serializer, stats, Integer.MAX_VALUE);
+    }
+
+    /**
+     * Creates a client with a protocol-specific maximum response frame length while keeping the
+     * legacy constructor unbounded for compatibility.
+     */
+    public NetworkClient(
+            final String clientName,
+            final int numEventLoopThreads,
+            final MessageSerializer<REQ, RESP> serializer,
+            final ServiceRequestStats stats,
+            final int maxFrameLength) {
+        this(
+                clientName,
+                numEventLoopThreads,
+                serializer,
+                stats,
+                maxFrameLength,
+                LegacyFailureFramePolicy.ALLOW_SERIALIZED_THROWABLE);
+    }
+
+    /** Creates a client with protocol-specific frame and legacy failure-frame policies. */
+    public NetworkClient(
+            final String clientName,
+            final int numEventLoopThreads,
+            final MessageSerializer<REQ, RESP> serializer,
+            final ServiceRequestStats stats,
+            final int maxFrameLength,
+            final LegacyFailureFramePolicy legacyFailureFramePolicy) {
 
         Preconditions.checkArgument(
                 numEventLoopThreads >= 1, "Non-positive number of event loop threads.");
+        Preconditions.checkArgument(maxFrameLength > 0, "Non-positive maximum frame length.");
 
         this.clientName = Preconditions.checkNotNull(clientName);
         this.messageSerializer = Preconditions.checkNotNull(serializer);
         this.stats = Preconditions.checkNotNull(stats);
+        this.legacyFailureFramePolicy = Preconditions.checkNotNull(legacyFailureFramePolicy);
 
         final ThreadFactory threadFactory =
                 new ThreadFactoryBuilder()
@@ -126,7 +161,7 @@ public class NetworkClient<REQ extends MessageBody, RESP extends MessageBody> {
                                         channel.pipeline()
                                                 .addLast(
                                                         new LengthFieldBasedFrameDecoder(
-                                                                Integer.MAX_VALUE, 0, 4, 0, 4))
+                                                                maxFrameLength, 0, 4, 0, 4))
                                                 .addLast(new ChunkedWriteHandler());
                                     }
                                 });
@@ -149,7 +184,10 @@ public class NetworkClient<REQ extends MessageBody, RESP extends MessageBody> {
                         ignored -> {
                             final ServerConnection<REQ, RESP> newConnection =
                                     ServerConnection.createPendingConnection(
-                                            clientName, messageSerializer, stats);
+                                            clientName,
+                                            messageSerializer,
+                                            stats,
+                                            legacyFailureFramePolicy);
                             bootstrap
                                     .connect(serverAddress.getAddress(), serverAddress.getPort())
                                     .addListener(
@@ -227,5 +265,10 @@ public class NetworkClient<REQ extends MessageBody, RESP extends MessageBody> {
 
     public boolean isEventGroupShutdown() {
         return bootstrap == null || bootstrap.config().group().isTerminated();
+    }
+
+    /** Returns the number of requests currently awaiting a network response. */
+    public int getNumPendingRequests() {
+        return connections.values().stream().mapToInt(ServerConnection::numPendingRequests).sum();
     }
 }

--- a/paimon-service/paimon-service-client/src/main/java/org/apache/paimon/service/network/NetworkServer.java
+++ b/paimon-service/paimon-service-client/src/main/java/org/apache/paimon/service/network/NetworkServer.java
@@ -42,10 +42,12 @@ import java.net.InetSocketAddress;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.Set;
+import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -85,6 +87,12 @@ public abstract class NetworkServer<REQ extends MessageBody, RESP extends Messag
     /** The number of threads to be used for query serving. */
     private final int numQueryThreads;
 
+    /** Maximum number of bytes accepted for one complete network frame. */
+    private final int maxFrameLength;
+
+    /** Maximum number of requests waiting for a query thread. */
+    private final int maxQueuedRequests;
+
     /** Atomic shut down future. */
     private final AtomicReference<CompletableFuture<Void>> serverShutdownFuture =
             new AtomicReference<>(null);
@@ -117,16 +125,61 @@ public abstract class NetworkServer<REQ extends MessageBody, RESP extends Messag
             final Iterator<Integer> bindPortIterator,
             final Integer numEventLoopThreads,
             final Integer numQueryThreads) {
+        this(
+                serverName,
+                bindAddress,
+                bindPortIterator,
+                numEventLoopThreads,
+                numQueryThreads,
+                Integer.MAX_VALUE,
+                Integer.MAX_VALUE);
+    }
+
+    /**
+     * Creates a server with a protocol-specific maximum frame length while keeping the legacy
+     * constructor unbounded for compatibility.
+     */
+    protected NetworkServer(
+            final String serverName,
+            final String bindAddress,
+            final Iterator<Integer> bindPortIterator,
+            final Integer numEventLoopThreads,
+            final Integer numQueryThreads,
+            final int maxFrameLength) {
+        this(
+                serverName,
+                bindAddress,
+                bindPortIterator,
+                numEventLoopThreads,
+                numQueryThreads,
+                maxFrameLength,
+                Integer.MAX_VALUE);
+    }
+
+    /** Creates a server with protocol-specific frame and query-queue bounds. */
+    protected NetworkServer(
+            final String serverName,
+            final String bindAddress,
+            final Iterator<Integer> bindPortIterator,
+            final Integer numEventLoopThreads,
+            final Integer numQueryThreads,
+            final int maxFrameLength,
+            final int maxQueuedRequests) {
 
         Preconditions.checkNotNull(bindPortIterator);
         Preconditions.checkArgument(
                 numEventLoopThreads >= 1, "Non-positive number of event loop threads.");
         Preconditions.checkArgument(numQueryThreads >= 1, "Non-positive number of query threads.");
+        Preconditions.checkArgument(maxFrameLength > 0, "Non-positive maximum frame length.");
+        Preconditions.checkArgument(
+                maxQueuedRequests > 0, "Non-positive maximum queued request count.");
 
         this.serverName = Preconditions.checkNotNull(serverName);
         this.bindAddress = Preconditions.checkNotNull(bindAddress);
         this.numEventLoopThreads = numEventLoopThreads;
         this.numQueryThreads = numQueryThreads;
+        this.maxFrameLength = maxFrameLength;
+        this.maxQueuedRequests = maxQueuedRequests;
 
         this.bindPortRange = new HashSet<>();
         while (bindPortIterator.hasNext()) {
@@ -151,12 +204,27 @@ public abstract class NetworkServer<REQ extends MessageBody, RESP extends Messag
                         .setDaemon(true)
                         .setNameFormat("Paimon " + getServerName() + " Thread %d")
                         .build();
-        return Executors.newFixedThreadPool(numQueryThreads, threadFactory);
+        if (maxQueuedRequests == Integer.MAX_VALUE) {
+            return Executors.newFixedThreadPool(numQueryThreads, threadFactory);
+        }
+        return new ThreadPoolExecutor(
+                numQueryThreads,
+                numQueryThreads,
+                0L,
+                TimeUnit.MILLISECONDS,
+                new ArrayBlockingQueue<>(maxQueuedRequests),
+                threadFactory,
+                new ThreadPoolExecutor.AbortPolicy());
     }
 
     /** Returns the thread-pool responsible for processing incoming requests. */
     protected ExecutorService getQueryExecutor() {
         return queryExecutor;
+    }
+
+    /** Returns the configured maximum complete request-frame length. */
+    protected int getMaxFrameLength() {
+        return maxFrameLength;
     }
 
     /**
@@ -246,7 +314,7 @@ public abstract class NetworkServer<REQ extends MessageBody, RESP extends Messag
                         .channel(NioServerSocketChannel.class)
                         .option(ChannelOption.ALLOCATOR, bufferPool)
                         .childOption(ChannelOption.ALLOCATOR, bufferPool)
-                        .childHandler(new ServerChannelInitializer<>(handler));
+                        .childHandler(new ServerChannelInitializer<>(handler, maxFrameLength));
 
         final int defaultHighWaterMark = 64 * 1024; // from DefaultChannelConfig (not exposed)
         // (ignore warning here to make this flexible in case the configuration values change)
@@ -379,21 +447,26 @@ public abstract class NetworkServer<REQ extends MessageBody, RESP extends Messag
         /** The shared request handler. */
         private final AbstractServerHandler<REQ, RESP> sharedRequestHandler;
 
+        /** Maximum number of bytes accepted for one complete network frame. */
+        private final int maxFrameLength;
+
         /**
          * Creates the channel pipeline initializer with the shared request handler.
          *
          * @param sharedRequestHandler Shared request handler.
          */
-        ServerChannelInitializer(AbstractServerHandler<REQ, RESP> sharedRequestHandler) {
+        ServerChannelInitializer(
+                AbstractServerHandler<REQ, RESP> sharedRequestHandler, int maxFrameLength) {
             this.sharedRequestHandler =
                     Preconditions.checkNotNull(sharedRequestHandler, "MessageBody handler");
+            this.maxFrameLength = maxFrameLength;
         }
 
         @Override
         protected void initChannel(SocketChannel channel) {
             channel.pipeline()
                     .addLast(new ChunkedWriteHandler())
-                    .addLast(new LengthFieldBasedFrameDecoder(Integer.MAX_VALUE, 0, 4, 0, 4))
+                    .addLast(new LengthFieldBasedFrameDecoder(maxFrameLength, 0, 4, 0, 4))
                     .addLast(sharedRequestHandler);
         }
     }

--- a/paimon-service/paimon-service-client/src/main/java/org/apache/paimon/service/network/ServerConnection.java
+++ b/paimon-service/paimon-service-client/src/main/java/org/apache/paimon/service/network/ServerConnection.java
@@ -93,6 +93,12 @@ final class ServerConnection<REQ extends MessageBody, RESP extends MessageBody> 
         }
     }
 
+    int numPendingRequests() {
+        synchronized (connectionLock) {
+            return internalConnection.numPendingRequests();
+        }
+    }
+
     void establishConnection(ChannelFuture future) {
         synchronized (connectionLock) {
             Preconditions.checkState(running, "Connection has already been closed.");
@@ -121,14 +127,30 @@ final class ServerConnection<REQ extends MessageBody, RESP extends MessageBody> 
                     final String clientName,
                     final MessageSerializer<REQ, RESP> serializer,
                     final ServiceRequestStats stats) {
+        return createPendingConnection(
+                clientName, serializer, stats, LegacyFailureFramePolicy.ALLOW_SERIALIZED_THROWABLE);
+    }
+
+    static <REQ extends MessageBody, RESP extends MessageBody>
+            ServerConnection<REQ, RESP> createPendingConnection(
+                    final String clientName,
+                    final MessageSerializer<REQ, RESP> serializer,
+                    final ServiceRequestStats stats,
+                    final LegacyFailureFramePolicy legacyFailureFramePolicy) {
         final Object lock = new Object();
 
         return new ServerConnection<>(
                 lock,
                 new PendingConnection<>(
+                        lock,
                         channel ->
                                 new EstablishedConnection<>(
-                                        lock, clientName, serializer, channel, stats)));
+                                        lock,
+                                        clientName,
+                                        serializer,
+                                        channel,
+                                        stats,
+                                        legacyFailureFramePolicy)));
     }
 
     interface InternalConnection<REQ, RESP> {
@@ -137,6 +159,8 @@ final class ServerConnection<REQ extends MessageBody, RESP extends MessageBody> 
         InternalConnection<REQ, RESP> establishConnection(ChannelFuture future);
 
         boolean isEstablished();
+
+        int numPendingRequests();
 
         CompletableFuture<Void> getCloseFuture();
 
@@ -147,6 +171,7 @@ final class ServerConnection<REQ extends MessageBody, RESP extends MessageBody> 
     private static final class PendingConnection<REQ extends MessageBody, RESP extends MessageBody>
             implements InternalConnection<REQ, RESP> {
 
+        private final Object lock;
         private final Function<Channel, EstablishedConnection<REQ, RESP>> connectionFactory;
         private final CompletableFuture<Void> closeFuture = new CompletableFuture<>();
 
@@ -160,7 +185,9 @@ final class ServerConnection<REQ extends MessageBody, RESP extends MessageBody> 
 
         /** Creates a pending connection to the given server. */
         private PendingConnection(
+                Object lock,
                 Function<Channel, EstablishedConnection<REQ, RESP>> connectionFactory) {
+            this.lock = lock;
             this.connectionFactory = connectionFactory;
         }
 
@@ -182,6 +209,14 @@ final class ServerConnection<REQ extends MessageBody, RESP extends MessageBody> 
                 // Queue this and handle when connected
                 final PendingRequest<REQ, RESP> pending = new PendingRequest<>(request);
                 queuedRequests.add(pending);
+                pending.whenComplete(
+                        (ignored, throwable) -> {
+                            if (pending.isCancelled()) {
+                                synchronized (lock) {
+                                    queuedRequests.remove(pending);
+                                }
+                            }
+                        });
                 return pending;
             }
         }
@@ -199,6 +234,12 @@ final class ServerConnection<REQ extends MessageBody, RESP extends MessageBody> 
         @Override
         public boolean isEstablished() {
             return false;
+        }
+
+        @Override
+        public int numPendingRequests() {
+            queuedRequests.removeIf(CompletableFuture::isCancelled);
+            return queuedRequests.size();
         }
 
         @Override
@@ -224,9 +265,18 @@ final class ServerConnection<REQ extends MessageBody, RESP extends MessageBody> 
 
                 while (!queuedRequests.isEmpty()) {
                     final PendingRequest<REQ, RESP> pending = queuedRequests.poll();
-
-                    FutureUtils.forward(
-                            establishedConnection.sendRequest(pending.getRequest()), pending);
+                    if (pending.isCancelled()) {
+                        continue;
+                    }
+                    CompletableFuture<RESP> forwarded =
+                            establishedConnection.sendRequest(pending.getRequest());
+                    FutureUtils.forward(forwarded, pending);
+                    pending.whenComplete(
+                            (ignored, throwable) -> {
+                                if (pending.isCancelled()) {
+                                    forwarded.cancel(false);
+                                }
+                            });
                 }
 
                 return establishedConnection;
@@ -312,14 +362,17 @@ final class ServerConnection<REQ extends MessageBody, RESP extends MessageBody> 
                 final String clientName,
                 final MessageSerializer<REQ, RESP> serializer,
                 final Channel channel,
-                final ServiceRequestStats stats) {
+                final ServiceRequestStats stats,
+                final LegacyFailureFramePolicy legacyFailureFramePolicy) {
 
             this.lock = lock;
             this.channel = Preconditions.checkNotNull(channel);
 
             // Add the client handler with the callback
             channel.pipeline()
-                    .addLast(clientName + " Handler", new ClientHandler<>(serializer, this));
+                    .addLast(
+                            clientName + " Handler",
+                            new ClientHandler<>(serializer, this, legacyFailureFramePolicy));
 
             this.stats = stats;
             stats.reportActiveConnection();
@@ -390,6 +443,14 @@ final class ServerConnection<REQ extends MessageBody, RESP extends MessageBody> 
                     try {
                         final long requestId = requestCount++;
                         pendingRequests.put(requestId, requestPromiseTs);
+                        requestPromiseTs.whenComplete(
+                                (ignored, throwable) -> {
+                                    if (throwable != null
+                                            && pendingRequests.remove(
+                                                    requestId, requestPromiseTs)) {
+                                        stats.reportFailedRequest();
+                                    }
+                                });
 
                         stats.reportRequest();
 
@@ -431,6 +492,11 @@ final class ServerConnection<REQ extends MessageBody, RESP extends MessageBody> 
         @Override
         public boolean isEstablished() {
             return true;
+        }
+
+        @Override
+        public int numPendingRequests() {
+            return pendingRequests.size();
         }
 
         @Override

--- a/paimon-service/paimon-service-client/src/test/java/org/apache/paimon/service/client/GlobalIndexQueryClientTest.java
+++ b/paimon-service/paimon-service-client/src/test/java/org/apache/paimon/service/client/GlobalIndexQueryClientTest.java
@@ -1,0 +1,738 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.service.client;
+
+import org.apache.paimon.data.BinaryRow;
+import org.apache.paimon.query.GlobalIndexQueryEndpoint;
+import org.apache.paimon.query.GlobalIndexQueryLocation;
+import org.apache.paimon.service.exceptions.GlobalIndexQueryErrorCode;
+import org.apache.paimon.service.exceptions.GlobalIndexQueryException;
+import org.apache.paimon.service.messages.GlobalIndexRequest;
+import org.apache.paimon.service.messages.GlobalIndexResponse;
+import org.apache.paimon.service.network.AbstractServerHandler;
+import org.apache.paimon.service.network.NetworkServer;
+import org.apache.paimon.service.network.messages.MessageSerializer;
+import org.apache.paimon.service.network.messages.MessageType;
+import org.apache.paimon.service.network.stats.DisabledServiceRequestStats;
+import org.apache.paimon.types.RowKind;
+
+import org.apache.paimon.shade.netty4.io.netty.buffer.ByteBuf;
+import org.apache.paimon.shade.netty4.io.netty.channel.ChannelHandlerContext;
+import org.apache.paimon.shade.netty4.io.netty.util.ReferenceCountUtil;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.net.ConnectException;
+import java.net.InetSocketAddress;
+import java.nio.channels.ClosedChannelException;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.apache.paimon.service.exceptions.GlobalIndexQueryErrorCode.DUPLICATE_KEY;
+import static org.apache.paimon.service.exceptions.GlobalIndexQueryErrorCode.INTERNAL_ERROR;
+import static org.apache.paimon.service.exceptions.GlobalIndexQueryErrorCode.INVALID_REQUEST;
+import static org.apache.paimon.service.exceptions.GlobalIndexQueryErrorCode.NOT_READY;
+import static org.apache.paimon.service.exceptions.GlobalIndexQueryErrorCode.OVERLOADED;
+import static org.apache.paimon.service.exceptions.GlobalIndexQueryErrorCode.REQUEST_TIMEOUT;
+import static org.apache.paimon.service.exceptions.GlobalIndexQueryErrorCode.REQUEST_TOO_LARGE;
+import static org.apache.paimon.service.exceptions.GlobalIndexQueryErrorCode.STALE_GENERATION;
+import static org.apache.paimon.service.exceptions.GlobalIndexQueryErrorCode.UNKNOWN_KEY_SHARD;
+import static org.apache.paimon.service.exceptions.GlobalIndexQueryErrorCode.UNSUPPORTED_PROTOCOL;
+import static org.apache.paimon.service.messages.KvRequestTest.row;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/** Tests routing, fencing, and bounded retries of {@link GlobalIndexQueryClient}. */
+class GlobalIndexQueryClientTest {
+
+    private static final InetSocketAddress ADDRESS_0 =
+            InetSocketAddress.createUnresolved("server-0", 10000);
+    private static final InetSocketAddress ADDRESS_1 =
+            InetSocketAddress.createUnresolved("server-1", 10001);
+
+    @Test
+    void testGroupsByEndpointAndRestoresOriginalOrder() throws Exception {
+        List<SentRequest> sentRequests = new ArrayList<>();
+        GlobalIndexQueryLocation location =
+                (key, forceUpdate) ->
+                        key.getInt(0) % 2 == 0
+                                ? endpoint(0, ADDRESS_0, "epoch-0", 7L, 55L)
+                                : endpoint(1, ADDRESS_1, "epoch-1", 7L, 55L);
+        GlobalIndexQueryClient client =
+                new GlobalIndexQueryClient(
+                        location,
+                        (address, request) -> {
+                            sentRequests.add(new SentRequest(address, request));
+                            BinaryRow[] values = new BinaryRow[request.keys().length];
+                            for (int i = 0; i < values.length; i++) {
+                                values[i] = row(request.keys()[i].getInt(0) + 100);
+                            }
+                            return CompletableFuture.completedFuture(
+                                    new GlobalIndexResponse(
+                                            request.serverEpoch(),
+                                            request.servedGeneration(),
+                                            55L,
+                                            values));
+                        });
+
+        BinaryRow callerKey = row(3);
+        callerKey.setRowKind(RowKind.DELETE);
+        GlobalIndexQueryClient.LookupResult lookupResult =
+                client.getValuesWithMetadata(new BinaryRow[] {callerKey, row(2), row(1), row(4)})
+                        .get(10, TimeUnit.SECONDS);
+        BinaryRow[] values = lookupResult.values();
+
+        assertThat(intValues(values)).containsExactly(103, 102, 101, 104);
+        assertThat(lookupResult.servedGeneration()).isEqualTo(7L);
+        assertThat(lookupResult.servedSnapshotId()).isEqualTo(55L);
+        assertThat(lookupResult.snapshotUuid()).isEqualTo("snapshot-55");
+        assertThat(sentRequests).hasSize(2);
+        assertThat(sentRequests)
+                .extracting(request -> request.address)
+                .containsExactly(ADDRESS_1, ADDRESS_0);
+        assertThat(sentRequests.get(0).request.serverEpoch()).isEqualTo("epoch-1");
+        assertThat(sentRequests.get(0).request.servedGeneration()).isEqualTo(7L);
+        assertThat(intValues(sentRequests.get(0).request.keys())).containsExactly(3, 1);
+        assertThat(intValues(sentRequests.get(1).request.keys())).containsExactly(2, 4);
+        assertThat(sentRequests.get(0).request.keys()[0]).isNotSameAs(callerKey);
+        assertThat(sentRequests.get(0).request.keys()[0].getRowKind()).isEqualTo(RowKind.INSERT);
+        assertThat(callerKey.getRowKind()).isEqualTo(RowKind.DELETE);
+    }
+
+    @Test
+    void testSynchronousNestedConnectFailureRefreshesOnce() throws Exception {
+        List<Boolean> forceUpdates = new ArrayList<>();
+        GlobalIndexQueryLocation location =
+                (key, forceUpdate) -> {
+                    forceUpdates.add(forceUpdate);
+                    if (!forceUpdate) {
+                        throw new IOException(new ConnectException("not listening"));
+                    }
+                    return endpoint(0, ADDRESS_0, "new-epoch", 2L, 20L);
+                };
+        GlobalIndexQueryClient client =
+                new GlobalIndexQueryClient(
+                        location,
+                        (address, request) ->
+                                CompletableFuture.completedFuture(
+                                        new GlobalIndexResponse(
+                                                "new-epoch", 2L, 20L, new BinaryRow[] {row(9)})));
+
+        assertThat(intValues(client.getValues(new BinaryRow[] {row(1)}).get())).containsExactly(9);
+        assertThat(forceUpdates).containsExactly(false, true);
+    }
+
+    @Test
+    void testAsynchronousNestedConnectFailureRefreshesOnce() throws Exception {
+        AtomicBoolean refreshed = new AtomicBoolean();
+        List<Boolean> forceUpdates = new ArrayList<>();
+        AtomicInteger sends = new AtomicInteger();
+        GlobalIndexQueryClient client =
+                new GlobalIndexQueryClient(
+                        (key, forceUpdate) -> {
+                            forceUpdates.add(forceUpdate);
+                            if (forceUpdate) {
+                                refreshed.set(true);
+                            }
+                            return refreshed.get()
+                                    ? endpoint(0, ADDRESS_0, "epoch-2", 2L, 20L)
+                                    : endpoint(0, ADDRESS_0, "epoch-1", 1L, 10L);
+                        },
+                        (address, request) -> {
+                            sends.incrementAndGet();
+                            if (request.servedGeneration() == 1L) {
+                                return failedFuture(
+                                        new RuntimeException(
+                                                new IOException(
+                                                        new ConnectException("not listening"))));
+                            }
+                            return CompletableFuture.completedFuture(
+                                    new GlobalIndexResponse(
+                                            "epoch-2", 2L, 20L, new BinaryRow[] {row(9)}));
+                        });
+
+        assertThat(intValues(client.getValues(new BinaryRow[] {row(1)}).get())).containsExactly(9);
+        assertThat(sends).hasValue(2);
+        assertThat(forceUpdates).containsExactly(false, true);
+    }
+
+    @Test
+    void testClosedChannelFailureRefreshesOnce() throws Exception {
+        AtomicBoolean refreshed = new AtomicBoolean();
+        List<Boolean> forceUpdates = new ArrayList<>();
+        AtomicInteger sends = new AtomicInteger();
+        GlobalIndexQueryClient client =
+                new GlobalIndexQueryClient(
+                        (key, forceUpdate) -> {
+                            forceUpdates.add(forceUpdate);
+                            if (forceUpdate) {
+                                refreshed.set(true);
+                            }
+                            return refreshed.get()
+                                    ? endpoint(0, ADDRESS_0, "epoch-2", 2L, 20L)
+                                    : endpoint(0, ADDRESS_0, "epoch-1", 1L, 10L);
+                        },
+                        (address, request) -> {
+                            sends.incrementAndGet();
+                            if (request.servedGeneration() == 1L) {
+                                return failedFuture(new IOException(new ClosedChannelException()));
+                            }
+                            return CompletableFuture.completedFuture(
+                                    new GlobalIndexResponse(
+                                            "epoch-2", 2L, 20L, new BinaryRow[] {row(9)}));
+                        });
+
+        assertThat(intValues(client.getValues(new BinaryRow[] {row(1)}).get())).containsExactly(9);
+        assertThat(sends).hasValue(2);
+        assertThat(forceUpdates).containsExactly(false, true);
+    }
+
+    @Test
+    void testUnknownShardRetriesOnlyOnce() {
+        List<Boolean> forceUpdates = new ArrayList<>();
+        AtomicInteger sends = new AtomicInteger();
+        GlobalIndexQueryClient client =
+                new GlobalIndexQueryClient(
+                        (key, forceUpdate) -> {
+                            forceUpdates.add(forceUpdate);
+                            return endpoint(0, ADDRESS_0, "epoch", 1L, 10L);
+                        },
+                        (address, request) -> {
+                            sends.incrementAndGet();
+                            return CompletableFuture.completedFuture(
+                                    GlobalIndexResponse.failure(
+                                            request.serverEpoch(),
+                                            request.servedGeneration(),
+                                            10L,
+                                            UNKNOWN_KEY_SHARD,
+                                            "wrong shard"));
+                        });
+
+        Throwable failure = failure(client.getValues(new BinaryRow[] {row(1)}));
+
+        assertThat(failure)
+                .isInstanceOfSatisfying(
+                        GlobalIndexQueryException.class,
+                        e -> {
+                            assertThat(e.errorCode()).isEqualTo(UNKNOWN_KEY_SHARD);
+                            assertThat(e.retryable()).isTrue();
+                        });
+        assertThat(sends).hasValue(2);
+        assertThat(forceUpdates).containsExactly(false, true);
+    }
+
+    @Test
+    void testMismatchedResponseFenceRefreshesWholeBatch() throws Exception {
+        AtomicBoolean refreshed = new AtomicBoolean();
+        List<Boolean> forceUpdates = new ArrayList<>();
+        AtomicInteger sends = new AtomicInteger();
+        GlobalIndexQueryClient client =
+                new GlobalIndexQueryClient(
+                        (key, forceUpdate) -> {
+                            forceUpdates.add(forceUpdate);
+                            if (forceUpdate) {
+                                refreshed.set(true);
+                            }
+                            return refreshed.get()
+                                    ? endpoint(0, ADDRESS_0, "epoch-2", 2L, 20L)
+                                    : endpoint(0, ADDRESS_0, "epoch-1", 1L, 10L);
+                        },
+                        (address, request) -> {
+                            sends.incrementAndGet();
+                            long snapshot = request.servedGeneration() == 1L ? 99L : 20L;
+                            return CompletableFuture.completedFuture(
+                                    new GlobalIndexResponse(
+                                            request.serverEpoch(),
+                                            request.servedGeneration(),
+                                            snapshot,
+                                            new BinaryRow[] {row(11), row(12)}));
+                        });
+
+        BinaryRow[] values = client.getValues(new BinaryRow[] {row(1), row(2)}).get();
+
+        assertThat(intValues(values)).containsExactly(11, 12);
+        assertThat(sends).hasValue(2);
+        assertThat(forceUpdates).containsExactly(false, false, true, false);
+    }
+
+    @Test
+    void testMismatchedFailureResponseFenceTakesPrecedenceOverBusinessError() {
+        List<GlobalIndexResponse> mismatchedResponses =
+                Arrays.asList(
+                        GlobalIndexResponse.failure(
+                                "other-epoch", 1L, 10L, DUPLICATE_KEY, "duplicate key"),
+                        GlobalIndexResponse.failure(
+                                "epoch", 2L, 10L, DUPLICATE_KEY, "duplicate key"),
+                        GlobalIndexResponse.failure(
+                                "epoch", 1L, 11L, DUPLICATE_KEY, "duplicate key"));
+
+        for (GlobalIndexResponse response : mismatchedResponses) {
+            List<Boolean> forceUpdates = new ArrayList<>();
+            AtomicInteger sends = new AtomicInteger();
+            GlobalIndexQueryClient client =
+                    new GlobalIndexQueryClient(
+                            (key, forceUpdate) -> {
+                                forceUpdates.add(forceUpdate);
+                                return endpoint(0, ADDRESS_0, "epoch", 1L, 10L);
+                            },
+                            (address, request) -> {
+                                sends.incrementAndGet();
+                                return CompletableFuture.completedFuture(response);
+                            });
+
+            assertThat(failure(client.getValues(new BinaryRow[] {row(1)})))
+                    .isInstanceOfSatisfying(
+                            GlobalIndexQueryException.class,
+                            e -> {
+                                assertThat(e.errorCode()).isEqualTo(STALE_GENERATION);
+                                assertThat(e.retryable()).isTrue();
+                                assertThat(e).hasMessageContaining("does not match expected");
+                            });
+            assertThat(sends).hasValue(2);
+            assertThat(forceUpdates).containsExactly(false, true);
+        }
+    }
+
+    @Test
+    void testMatchingFailureResponseFencePreservesBusinessError() {
+        AtomicInteger sends = new AtomicInteger();
+        GlobalIndexQueryClient client =
+                new GlobalIndexQueryClient(
+                        (key, forceUpdate) -> endpoint(0, ADDRESS_0, "epoch", 1L, 10L),
+                        (address, request) -> {
+                            sends.incrementAndGet();
+                            return CompletableFuture.completedFuture(
+                                    GlobalIndexResponse.failure(
+                                            "epoch",
+                                            1L,
+                                            10L,
+                                            DUPLICATE_KEY,
+                                            "duplicate from server"));
+                        });
+
+        assertThat(failure(client.getValues(new BinaryRow[] {row(1)})))
+                .isInstanceOfSatisfying(
+                        GlobalIndexQueryException.class,
+                        e -> {
+                            assertThat(e.errorCode()).isEqualTo(DUPLICATE_KEY);
+                            assertThat(e.retryable()).isFalse();
+                            assertThat(e).hasMessage("duplicate from server");
+                        });
+        assertThat(sends).hasValue(1);
+    }
+
+    @Test
+    void testMixedDiscoveryFenceIsNeverSentAndRefreshesWholeBatch() throws Exception {
+        AtomicBoolean refreshed = new AtomicBoolean();
+        List<Boolean> forceUpdates = new ArrayList<>();
+        AtomicInteger sends = new AtomicInteger();
+        GlobalIndexQueryClient client =
+                new GlobalIndexQueryClient(
+                        (key, forceUpdate) -> {
+                            forceUpdates.add(forceUpdate);
+                            if (forceUpdate) {
+                                refreshed.set(true);
+                            }
+                            long snapshot = refreshed.get() ? 20L : 10L + key.getInt(0);
+                            return endpoint(
+                                    0,
+                                    ADDRESS_0,
+                                    refreshed.get() ? "epoch-2" : "epoch-1",
+                                    refreshed.get() ? 2L : 1L,
+                                    snapshot);
+                        },
+                        (address, request) -> {
+                            sends.incrementAndGet();
+                            return CompletableFuture.completedFuture(
+                                    new GlobalIndexResponse(
+                                            request.serverEpoch(),
+                                            request.servedGeneration(),
+                                            20L,
+                                            new BinaryRow[] {row(21), row(22)}));
+                        });
+
+        BinaryRow[] values = client.getValues(new BinaryRow[] {row(1), row(2)}).get();
+
+        assertThat(intValues(values)).containsExactly(21, 22);
+        assertThat(sends).hasValue(1);
+        assertThat(forceUpdates).containsExactly(false, false, true, false);
+    }
+
+    @Test
+    void testSemanticFailuresDoNotRetry() {
+        for (GlobalIndexQueryErrorCode errorCode :
+                Arrays.asList(
+                        NOT_READY,
+                        DUPLICATE_KEY,
+                        INTERNAL_ERROR,
+                        UNSUPPORTED_PROTOCOL,
+                        REQUEST_TOO_LARGE,
+                        INVALID_REQUEST)) {
+            AtomicInteger locations = new AtomicInteger();
+            AtomicInteger sends = new AtomicInteger();
+            GlobalIndexQueryClient client =
+                    new GlobalIndexQueryClient(
+                            (key, forceUpdate) -> {
+                                locations.incrementAndGet();
+                                return endpoint(0, ADDRESS_0, "epoch", 1L, 10L);
+                            },
+                            (address, request) -> {
+                                sends.incrementAndGet();
+                                return CompletableFuture.completedFuture(
+                                        GlobalIndexResponse.failure(
+                                                request.serverEpoch(),
+                                                request.servedGeneration(),
+                                                10L,
+                                                errorCode,
+                                                "failure"));
+                            });
+
+            assertThat(failure(client.getValues(new BinaryRow[] {row(1)})))
+                    .isInstanceOfSatisfying(
+                            GlobalIndexQueryException.class,
+                            e -> assertThat(e.errorCode()).isEqualTo(errorCode));
+            assertThat(locations).hasValue(1);
+            assertThat(sends).hasValue(1);
+        }
+    }
+
+    @Test
+    void testOverloadedResponseRefreshesOnlyOnce() {
+        List<Boolean> forceUpdates = new ArrayList<>();
+        AtomicInteger sends = new AtomicInteger();
+        GlobalIndexQueryClient client =
+                new GlobalIndexQueryClient(
+                        (key, forceUpdate) -> {
+                            forceUpdates.add(forceUpdate);
+                            return endpoint(0, ADDRESS_0, "epoch", 1L, 10L);
+                        },
+                        (address, request) -> {
+                            sends.incrementAndGet();
+                            return CompletableFuture.completedFuture(
+                                    GlobalIndexResponse.failure(
+                                            request.serverEpoch(),
+                                            request.servedGeneration(),
+                                            10L,
+                                            OVERLOADED,
+                                            "busy"));
+                        });
+
+        assertThat(failure(client.getValues(new BinaryRow[] {row(1)})))
+                .isInstanceOfSatisfying(
+                        GlobalIndexQueryException.class,
+                        e -> {
+                            assertThat(e.errorCode()).isEqualTo(OVERLOADED);
+                            assertThat(e.retryable()).isTrue();
+                        });
+        assertThat(sends).hasValue(2);
+        assertThat(forceUpdates).containsExactly(false, true);
+    }
+
+    @Test
+    void testBlackHoleRequestTimesOutCancelsAndRefreshesOnlyOnce() throws Exception {
+        List<Boolean> forceUpdates = new ArrayList<>();
+        List<CompletableFuture<GlobalIndexResponse>> blackHoles = new ArrayList<>();
+        GlobalIndexQueryClient client =
+                new GlobalIndexQueryClient(
+                        (key, forceUpdate) -> {
+                            forceUpdates.add(forceUpdate);
+                            return endpoint(0, ADDRESS_0, "epoch", 1L, 10L);
+                        },
+                        (address, request) -> {
+                            CompletableFuture<GlobalIndexResponse> blackHole =
+                                    new CompletableFuture<>();
+                            blackHoles.add(blackHole);
+                            return blackHole;
+                        },
+                        Duration.ofMillis(20));
+
+        assertThat(failure(client.getValues(new BinaryRow[] {row(1)})))
+                .isInstanceOfSatisfying(
+                        GlobalIndexQueryException.class,
+                        e -> {
+                            assertThat(e.errorCode()).isEqualTo(REQUEST_TIMEOUT);
+                            assertThat(e.retryable()).isTrue();
+                        });
+        assertThat(forceUpdates).containsExactly(false, true);
+        assertThat(blackHoles).hasSize(2);
+        awaitAllCancelled(blackHoles);
+    }
+
+    @Test
+    void testRepeatedNetworkTimeoutsReleasePendingRequests() throws Throwable {
+        BlackHoleServer server = new BlackHoleServer();
+        GlobalIndexQueryClient client = null;
+        try {
+            server.start();
+            InetSocketAddress address = server.getServerAddress();
+            client =
+                    new GlobalIndexQueryClient(
+                            (key, forceUpdate) -> endpoint(0, address, "epoch", 1L, 10L),
+                            1,
+                            Duration.ofMillis(50));
+
+            for (int i = 0; i < 5; i++) {
+                assertThat(failure(client.getValues(new BinaryRow[] {row(i)})))
+                        .isInstanceOfSatisfying(
+                                GlobalIndexQueryException.class,
+                                e -> assertThat(e.errorCode()).isEqualTo(REQUEST_TIMEOUT));
+                awaitNoPendingRequests(client);
+            }
+
+            assertThat(server.requestCount()).hasValue(10);
+        } finally {
+            if (client != null) {
+                client.shutdownFuture().get(10L, TimeUnit.SECONDS);
+            }
+            server.shutdownServer().get(10L, TimeUnit.SECONDS);
+        }
+    }
+
+    @Test
+    void testRejectsMaliciousLegacyFailureFrameWithoutDeserializingThrowable() throws Throwable {
+        MaliciousFailureServer server = new MaliciousFailureServer();
+        GlobalIndexQueryClient client = null;
+        DeserializationProbeException.reset();
+        try {
+            server.start();
+            InetSocketAddress address = server.getServerAddress();
+            client =
+                    new GlobalIndexQueryClient(
+                            (key, forceUpdate) -> endpoint(0, address, "epoch", 1L, 10L),
+                            1,
+                            Duration.ofSeconds(5));
+
+            Throwable failure = failure(client.getValues(new BinaryRow[] {row(1)}));
+
+            assertThat(failure)
+                    .isInstanceOf(IOException.class)
+                    .hasMessageContaining("Rejected prohibited legacy serialized Throwable");
+            assertThat(DeserializationProbeException.deserializationCount()).isZero();
+            awaitNoPendingRequests(client);
+        } finally {
+            if (client != null) {
+                client.shutdownFuture().get(10L, TimeUnit.SECONDS);
+            }
+            server.shutdownServer().get(10L, TimeUnit.SECONDS);
+        }
+    }
+
+    @Test
+    void testLogicalBatchLimitIsAppliedBeforeSharding() {
+        GlobalIndexQueryClient client =
+                new GlobalIndexQueryClient(
+                        (key, forceUpdate) -> endpoint(0, ADDRESS_0, "epoch", 1L, 10L),
+                        (address, request) -> {
+                            throw new AssertionError("Oversized logical batch must not be sent.");
+                        });
+        BinaryRow[] keys = new BinaryRow[GlobalIndexRequest.MAX_KEYS + 1];
+        Arrays.fill(keys, row(1));
+
+        assertThatThrownBy(() -> client.getValues(keys))
+                .isInstanceOfSatisfying(
+                        GlobalIndexQueryException.class,
+                        e -> assertThat(e.errorCode()).isEqualTo(REQUEST_TOO_LARGE));
+    }
+
+    private static GlobalIndexQueryEndpoint endpoint(
+            int shard, InetSocketAddress address, String epoch, long generation, long snapshot) {
+        return new GlobalIndexQueryEndpoint(
+                shard, address, epoch, generation, snapshot, "snapshot-" + snapshot);
+    }
+
+    private static CompletableFuture<GlobalIndexResponse> failedFuture(Throwable throwable) {
+        CompletableFuture<GlobalIndexResponse> future = new CompletableFuture<>();
+        future.completeExceptionally(throwable);
+        return future;
+    }
+
+    private static Throwable failure(CompletableFuture<?> future) {
+        try {
+            future.join();
+            throw new AssertionError("Expected global-index query to fail.");
+        } catch (CompletionException e) {
+            return e.getCause();
+        }
+    }
+
+    private static List<Integer> intValues(BinaryRow[] rows) {
+        List<Integer> values = new ArrayList<>(rows.length);
+        for (BinaryRow row : rows) {
+            values.add(row == null ? null : row.getInt(0));
+        }
+        return values;
+    }
+
+    private static void awaitAllCancelled(List<CompletableFuture<GlobalIndexResponse>> futures)
+            throws Exception {
+        for (int attempt = 0; attempt < 100; attempt++) {
+            if (futures.stream().allMatch(CompletableFuture::isCancelled)) {
+                return;
+            }
+            Thread.sleep(10L);
+        }
+        assertThat(futures).allMatch(CompletableFuture::isCancelled);
+    }
+
+    private static void awaitNoPendingRequests(GlobalIndexQueryClient client) throws Exception {
+        for (int attempt = 0; attempt < 100; attempt++) {
+            if (client.numPendingNetworkRequests() == 0) {
+                return;
+            }
+            Thread.sleep(10L);
+        }
+        assertThat(client.numPendingNetworkRequests()).isZero();
+    }
+
+    private static class BlackHoleServer
+            extends NetworkServer<GlobalIndexRequest, GlobalIndexResponse> {
+
+        private final AtomicInteger requestCount = new AtomicInteger();
+
+        private BlackHoleServer() {
+            super(
+                    "Global Index Black Hole Test Server",
+                    "127.0.0.1",
+                    Collections.singletonList(0).iterator(),
+                    1,
+                    1,
+                    GlobalIndexRequest.MAX_NETWORK_FRAME_BYTES);
+        }
+
+        @Override
+        public AbstractServerHandler<GlobalIndexRequest, GlobalIndexResponse> initializeHandler() {
+            return new AbstractServerHandler<GlobalIndexRequest, GlobalIndexResponse>(
+                    this,
+                    new MessageSerializer<>(
+                            new GlobalIndexRequest.Deserializer(),
+                            new GlobalIndexResponse.Deserializer()),
+                    new DisabledServiceRequestStats()) {
+                @Override
+                public CompletableFuture<GlobalIndexResponse> handleRequest(
+                        long requestId, GlobalIndexRequest request) {
+                    requestCount.incrementAndGet();
+                    return new CompletableFuture<>();
+                }
+
+                @Override
+                public CompletableFuture<Void> shutdown() {
+                    return CompletableFuture.completedFuture(null);
+                }
+            };
+        }
+
+        private AtomicInteger requestCount() {
+            return requestCount;
+        }
+    }
+
+    private static class MaliciousFailureServer
+            extends NetworkServer<GlobalIndexRequest, GlobalIndexResponse> {
+
+        private MaliciousFailureServer() {
+            super(
+                    "Malicious Legacy Failure Test Server",
+                    "127.0.0.1",
+                    Collections.singletonList(0).iterator(),
+                    1,
+                    1,
+                    GlobalIndexRequest.MAX_NETWORK_FRAME_BYTES);
+        }
+
+        @Override
+        public AbstractServerHandler<GlobalIndexRequest, GlobalIndexResponse> initializeHandler() {
+            return new AbstractServerHandler<GlobalIndexRequest, GlobalIndexResponse>(
+                    this,
+                    new MessageSerializer<>(
+                            new GlobalIndexRequest.Deserializer(),
+                            new GlobalIndexResponse.Deserializer()),
+                    new DisabledServiceRequestStats()) {
+                @Override
+                public void channelRead(ChannelHandlerContext ctx, Object msg) throws Exception {
+                    try {
+                        ByteBuf frame = (ByteBuf) msg;
+                        MessageType messageType = MessageSerializer.deserializeHeader(frame);
+                        if (messageType != MessageType.REQUEST) {
+                            throw new IOException("Expected a request frame.");
+                        }
+                        long requestId = MessageSerializer.getRequestId(frame);
+                        ctx.writeAndFlush(
+                                MessageSerializer.serializeRequestFailure(
+                                        ctx.alloc(),
+                                        requestId,
+                                        new DeserializationProbeException()));
+                    } finally {
+                        ReferenceCountUtil.release(msg);
+                    }
+                }
+
+                @Override
+                public CompletableFuture<GlobalIndexResponse> handleRequest(
+                        long requestId, GlobalIndexRequest request) {
+                    throw new AssertionError("Raw malicious handler must bypass request handling.");
+                }
+
+                @Override
+                public CompletableFuture<Void> shutdown() {
+                    return CompletableFuture.completedFuture(null);
+                }
+            };
+        }
+    }
+
+    private static class DeserializationProbeException extends RuntimeException {
+
+        private static final long serialVersionUID = 1L;
+        private static final AtomicInteger DESERIALIZATION_COUNT = new AtomicInteger();
+
+        private void readObject(ObjectInputStream input)
+                throws IOException, ClassNotFoundException {
+            input.defaultReadObject();
+            DESERIALIZATION_COUNT.incrementAndGet();
+        }
+
+        private static void reset() {
+            DESERIALIZATION_COUNT.set(0);
+        }
+
+        private static int deserializationCount() {
+            return DESERIALIZATION_COUNT.get();
+        }
+    }
+
+    private static class SentRequest {
+        private final InetSocketAddress address;
+        private final GlobalIndexRequest request;
+
+        private SentRequest(InetSocketAddress address, GlobalIndexRequest request) {
+            this.address = address;
+            this.request = request;
+        }
+    }
+}

--- a/paimon-service/paimon-service-client/src/test/java/org/apache/paimon/service/client/GlobalIndexQueryClientTest.java
+++ b/paimon-service/paimon-service-client/src/test/java/org/apache/paimon/service/client/GlobalIndexQueryClientTest.java
@@ -500,21 +500,41 @@ class GlobalIndexQueryClientTest {
                                 return endpoint(0, address, "epoch", 1L, 10L);
                             },
                             1,
-                            Duration.ofMillis(50));
+                            Duration.ofMillis(100));
 
-            assertThat(failure(client.getValues(new BinaryRow[] {row(0)})))
-                    .isInstanceOfSatisfying(
-                            GlobalIndexQueryException.class,
-                            e -> assertThat(e.errorCode()).isEqualTo(REQUEST_TIMEOUT));
-            awaitNoPendingRequests(client);
-            assertThat(server.awaitFirstRequest()).isTrue();
+            boolean connectionReady = false;
+            for (int attempt = 0; attempt < 100; attempt++) {
+                try {
+                    assertThat(client.getValues(new BinaryRow[] {row(-1)}).join())
+                            .containsExactly((BinaryRow) null);
+                    connectionReady = true;
+                } catch (CompletionException e) {
+                    assertThat(e.getCause())
+                            .isInstanceOfSatisfying(
+                                    GlobalIndexQueryException.class,
+                                    failure ->
+                                            assertThat(failure.errorCode())
+                                                    .isEqualTo(REQUEST_TIMEOUT));
+                }
+                awaitNoPendingRequests(client);
+                if (connectionReady) {
+                    break;
+                }
+            }
+            assertThat(connectionReady).isTrue();
 
-            for (int i = 1; i < 5; i++) {
+            server.enableBlackHole();
+            queryLocationCalls.set(0);
+
+            for (int i = 0; i < 5; i++) {
                 assertThat(failure(client.getValues(new BinaryRow[] {row(i)})))
                         .isInstanceOfSatisfying(
                                 GlobalIndexQueryException.class,
                                 e -> assertThat(e.errorCode()).isEqualTo(REQUEST_TIMEOUT));
                 awaitNoPendingRequests(client);
+                if (i == 0) {
+                    assertThat(server.awaitFirstBlackHoleRequest()).isTrue();
+                }
             }
 
             assertThat(queryLocationCalls).hasValue(10);
@@ -625,7 +645,8 @@ class GlobalIndexQueryClientTest {
     private static class BlackHoleServer
             extends NetworkServer<GlobalIndexRequest, GlobalIndexResponse> {
 
-        private final CountDownLatch firstRequestReceived = new CountDownLatch(1);
+        private final AtomicBoolean blackHoleEnabled = new AtomicBoolean();
+        private final CountDownLatch firstBlackHoleRequestReceived = new CountDownLatch(1);
 
         private BlackHoleServer() {
             super(
@@ -648,7 +669,15 @@ class GlobalIndexQueryClientTest {
                 @Override
                 public CompletableFuture<GlobalIndexResponse> handleRequest(
                         long requestId, GlobalIndexRequest request) {
-                    firstRequestReceived.countDown();
+                    if (!blackHoleEnabled.get()) {
+                        return CompletableFuture.completedFuture(
+                                new GlobalIndexResponse(
+                                        request.serverEpoch(),
+                                        request.servedGeneration(),
+                                        10L,
+                                        new BinaryRow[request.keys().length]));
+                    }
+                    firstBlackHoleRequestReceived.countDown();
                     return new CompletableFuture<>();
                 }
 
@@ -659,8 +688,12 @@ class GlobalIndexQueryClientTest {
             };
         }
 
-        private boolean awaitFirstRequest() throws InterruptedException {
-            return firstRequestReceived.await(10L, TimeUnit.SECONDS);
+        private void enableBlackHole() {
+            blackHoleEnabled.set(true);
+        }
+
+        private boolean awaitFirstBlackHoleRequest() throws InterruptedException {
+            return firstBlackHoleRequestReceived.await(10L, TimeUnit.SECONDS);
         }
     }
 

--- a/paimon-service/paimon-service-client/src/test/java/org/apache/paimon/service/client/GlobalIndexQueryClientTest.java
+++ b/paimon-service/paimon-service-client/src/test/java/org/apache/paimon/service/client/GlobalIndexQueryClientTest.java
@@ -50,6 +50,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
+import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -491,13 +492,24 @@ class GlobalIndexQueryClientTest {
         try {
             server.start();
             InetSocketAddress address = server.getServerAddress();
+            AtomicInteger queryLocationCalls = new AtomicInteger();
             client =
                     new GlobalIndexQueryClient(
-                            (key, forceUpdate) -> endpoint(0, address, "epoch", 1L, 10L),
+                            (key, forceUpdate) -> {
+                                queryLocationCalls.incrementAndGet();
+                                return endpoint(0, address, "epoch", 1L, 10L);
+                            },
                             1,
                             Duration.ofMillis(50));
 
-            for (int i = 0; i < 5; i++) {
+            assertThat(failure(client.getValues(new BinaryRow[] {row(0)})))
+                    .isInstanceOfSatisfying(
+                            GlobalIndexQueryException.class,
+                            e -> assertThat(e.errorCode()).isEqualTo(REQUEST_TIMEOUT));
+            awaitNoPendingRequests(client);
+            assertThat(server.awaitFirstRequest()).isTrue();
+
+            for (int i = 1; i < 5; i++) {
                 assertThat(failure(client.getValues(new BinaryRow[] {row(i)})))
                         .isInstanceOfSatisfying(
                                 GlobalIndexQueryException.class,
@@ -505,7 +517,7 @@ class GlobalIndexQueryClientTest {
                 awaitNoPendingRequests(client);
             }
 
-            assertThat(server.requestCount()).hasValue(10);
+            assertThat(queryLocationCalls).hasValue(10);
         } finally {
             if (client != null) {
                 client.shutdownFuture().get(10L, TimeUnit.SECONDS);
@@ -613,7 +625,7 @@ class GlobalIndexQueryClientTest {
     private static class BlackHoleServer
             extends NetworkServer<GlobalIndexRequest, GlobalIndexResponse> {
 
-        private final AtomicInteger requestCount = new AtomicInteger();
+        private final CountDownLatch firstRequestReceived = new CountDownLatch(1);
 
         private BlackHoleServer() {
             super(
@@ -636,7 +648,7 @@ class GlobalIndexQueryClientTest {
                 @Override
                 public CompletableFuture<GlobalIndexResponse> handleRequest(
                         long requestId, GlobalIndexRequest request) {
-                    requestCount.incrementAndGet();
+                    firstRequestReceived.countDown();
                     return new CompletableFuture<>();
                 }
 
@@ -647,8 +659,8 @@ class GlobalIndexQueryClientTest {
             };
         }
 
-        private AtomicInteger requestCount() {
-            return requestCount;
+        private boolean awaitFirstRequest() throws InterruptedException {
+            return firstRequestReceived.await(10L, TimeUnit.SECONDS);
         }
     }
 

--- a/paimon-service/paimon-service-client/src/test/java/org/apache/paimon/service/messages/GlobalIndexRequestTest.java
+++ b/paimon-service/paimon-service-client/src/test/java/org/apache/paimon/service/messages/GlobalIndexRequestTest.java
@@ -1,0 +1,194 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.service.messages;
+
+import org.apache.paimon.data.BinaryRow;
+import org.apache.paimon.data.BinaryRowWriter;
+import org.apache.paimon.service.exceptions.GlobalIndexQueryException;
+import org.apache.paimon.types.RowKind;
+
+import org.apache.paimon.shade.netty4.io.netty.buffer.Unpooled;
+
+import org.junit.jupiter.api.Test;
+
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+
+import static org.apache.paimon.service.exceptions.GlobalIndexQueryErrorCode.INVALID_REQUEST;
+import static org.apache.paimon.service.exceptions.GlobalIndexQueryErrorCode.REQUEST_TOO_LARGE;
+import static org.apache.paimon.service.exceptions.GlobalIndexQueryErrorCode.UNSUPPORTED_PROTOCOL;
+import static org.apache.paimon.service.messages.KvRequestTest.row;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/** Tests for the versioned and bounded {@link GlobalIndexRequest} wire payload. */
+class GlobalIndexRequestTest {
+
+    @Test
+    void testSerialization() {
+        GlobalIndexRequest request =
+                new GlobalIndexRequest("server-epoch", 17L, new BinaryRow[] {row(1), row(2)});
+
+        GlobalIndexRequest deserialized =
+                new GlobalIndexRequest.Deserializer()
+                        .deserializeMessage(Unpooled.wrappedBuffer(request.serialize()));
+
+        assertThat(deserialized).isEqualTo(request);
+        assertThat(deserialized.protocolVersion()).isEqualTo(GlobalIndexRequest.PROTOCOL_VERSION);
+        assertThat(deserialized.serverEpoch()).isEqualTo("server-epoch");
+        assertThat(deserialized.servedGeneration()).isEqualTo(17L);
+        assertThat(deserialized.keys())
+                .allSatisfy(
+                        key -> {
+                            assertThat(key.getOffset()).isZero();
+                            assertThat(key.anyNull()).isFalse();
+                        });
+    }
+
+    @Test
+    void testCanonicalizesRowKindAndCopiesCallerKeys() {
+        BinaryRow insert = row(7);
+        BinaryRow delete = row(7);
+        delete.setRowKind(RowKind.DELETE);
+        BinaryRow update = row(7);
+        update.setRowKind(RowKind.UPDATE_AFTER);
+
+        GlobalIndexRequest insertRequest =
+                new GlobalIndexRequest("epoch", 1L, new BinaryRow[] {insert});
+        GlobalIndexRequest deleteRequest =
+                new GlobalIndexRequest("epoch", 1L, new BinaryRow[] {delete});
+        GlobalIndexRequest updateRequest =
+                new GlobalIndexRequest("epoch", 1L, new BinaryRow[] {update});
+
+        assertThat(deleteRequest).isEqualTo(insertRequest).isEqualTo(updateRequest);
+        assertThat(deleteRequest.serialize())
+                .containsExactly(insertRequest.serialize())
+                .containsExactly(updateRequest.serialize());
+        assertThat(deleteRequest.keys()[0]).isNotSameAs(delete);
+        assertThat(deleteRequest.keys()[0].getRowKind()).isEqualTo(RowKind.INSERT);
+        assertThat(delete.getRowKind()).isEqualTo(RowKind.DELETE);
+    }
+
+    @Test
+    void testRejectUnsupportedProtocol() {
+        byte[] bytes = new GlobalIndexRequest("epoch", 1L, new BinaryRow[] {row(1)}).serialize();
+        ByteBuffer.wrap(bytes).putInt(GlobalIndexRequest.PROTOCOL_VERSION + 1);
+
+        assertStructuredFailure(bytes, UNSUPPORTED_PROTOCOL);
+    }
+
+    @Test
+    void testRejectTrailingBytes() {
+        byte[] bytes = new GlobalIndexRequest("epoch", 1L, new BinaryRow[] {row(1)}).serialize();
+        assertStructuredFailure(Arrays.copyOf(bytes, bytes.length + 1), INVALID_REQUEST);
+    }
+
+    @Test
+    void testRejectMalformedAndNullKeyRows() {
+        assertStructuredFailure(new byte[] {0}, INVALID_REQUEST);
+
+        byte[] bytes = new GlobalIndexRequest("epoch", 1L, new BinaryRow[] {row(1)}).serialize();
+        int keyArityOffset =
+                Integer.BYTES
+                        + Integer.BYTES
+                        + "epoch".getBytes(StandardCharsets.UTF_8).length
+                        + Long.BYTES
+                        + Integer.BYTES
+                        + Integer.BYTES;
+        ByteBuffer.wrap(bytes).putInt(keyArityOffset, 2);
+        assertStructuredFailure(bytes, INVALID_REQUEST);
+
+        BinaryRow nullKey = new BinaryRow(1);
+        BinaryRowWriter writer = new BinaryRowWriter(nullKey);
+        writer.setNullAt(0);
+        writer.complete();
+        assertThatThrownBy(() -> new GlobalIndexRequest("epoch", 1L, new BinaryRow[] {nullKey}))
+                .isInstanceOfSatisfying(
+                        GlobalIndexQueryException.class,
+                        e -> assertThat(e.errorCode()).isEqualTo(INVALID_REQUEST));
+    }
+
+    @Test
+    void testRejectEmptyAndTooManyKeys() {
+        assertThatThrownBy(() -> new GlobalIndexRequest("epoch", 1L, new BinaryRow[0]))
+                .isInstanceOfSatisfying(
+                        GlobalIndexQueryException.class,
+                        e -> assertThat(e.errorCode()).isEqualTo(INVALID_REQUEST));
+        assertThatThrownBy(() -> new GlobalIndexRequest("epoch", 1L, new BinaryRow[] {null}))
+                .isInstanceOfSatisfying(
+                        GlobalIndexQueryException.class,
+                        e -> assertThat(e.errorCode()).isEqualTo(INVALID_REQUEST));
+
+        BinaryRow[] keys = new BinaryRow[GlobalIndexRequest.MAX_KEYS + 1];
+        Arrays.fill(keys, row(1));
+        assertThatThrownBy(() -> new GlobalIndexRequest("epoch", 1L, keys))
+                .isInstanceOfSatisfying(
+                        GlobalIndexQueryException.class,
+                        e -> assertThat(e.errorCode()).isEqualTo(REQUEST_TOO_LARGE));
+    }
+
+    @Test
+    void testRejectOversizedEpochAndKeyBeforeAllocation() {
+        char[] epochChars = new char[GlobalIndexRequest.MAX_SERVER_EPOCH_BYTES + 1];
+        Arrays.fill(epochChars, 'e');
+        assertThatThrownBy(
+                        () ->
+                                new GlobalIndexRequest(
+                                        new String(epochChars), 1L, new BinaryRow[] {row(1)}))
+                .isInstanceOfSatisfying(
+                        GlobalIndexQueryException.class,
+                        e -> assertThat(e.errorCode()).isEqualTo(REQUEST_TOO_LARGE));
+        assertStructuredFailure(
+                ByteBuffer.allocate(2 * Integer.BYTES)
+                        .putInt(GlobalIndexRequest.PROTOCOL_VERSION)
+                        .putInt(GlobalIndexRequest.MAX_SERVER_EPOCH_BYTES + 1)
+                        .array(),
+                REQUEST_TOO_LARGE);
+
+        byte[] epoch = "epoch".getBytes(StandardCharsets.UTF_8);
+        ByteBuffer payload =
+                ByteBuffer.allocate(
+                                Integer.BYTES
+                                        + Integer.BYTES
+                                        + epoch.length
+                                        + Long.BYTES
+                                        + Integer.BYTES
+                                        + Integer.BYTES)
+                        .putInt(GlobalIndexRequest.PROTOCOL_VERSION)
+                        .putInt(epoch.length)
+                        .put(epoch)
+                        .putLong(1L)
+                        .putInt(1)
+                        .putInt(GlobalIndexRequest.MAX_TOTAL_KEY_BYTES + 1);
+        assertStructuredFailure(payload.array(), REQUEST_TOO_LARGE);
+    }
+
+    private static void assertStructuredFailure(
+            byte[] payload,
+            org.apache.paimon.service.exceptions.GlobalIndexQueryErrorCode expectedCode) {
+        assertThatThrownBy(
+                        () ->
+                                new GlobalIndexRequest.Deserializer()
+                                        .deserializeMessage(Unpooled.wrappedBuffer(payload)))
+                .isInstanceOfSatisfying(
+                        GlobalIndexQueryException.class,
+                        e -> assertThat(e.errorCode()).isEqualTo(expectedCode));
+    }
+}

--- a/paimon-service/paimon-service-client/src/test/java/org/apache/paimon/service/messages/GlobalIndexResponseTest.java
+++ b/paimon-service/paimon-service-client/src/test/java/org/apache/paimon/service/messages/GlobalIndexResponseTest.java
@@ -1,0 +1,144 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.service.messages;
+
+import org.apache.paimon.data.BinaryRow;
+import org.apache.paimon.service.exceptions.GlobalIndexQueryException;
+
+import org.apache.paimon.shade.netty4.io.netty.buffer.Unpooled;
+
+import org.junit.jupiter.api.Test;
+
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+
+import static org.apache.paimon.service.exceptions.GlobalIndexQueryErrorCode.INVALID_REQUEST;
+import static org.apache.paimon.service.exceptions.GlobalIndexQueryErrorCode.OVERLOADED;
+import static org.apache.paimon.service.exceptions.GlobalIndexQueryErrorCode.UNSUPPORTED_PROTOCOL;
+import static org.apache.paimon.service.messages.KvRequestTest.row;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/** Tests for the snapshot-fenced {@link GlobalIndexResponse} wire payload. */
+class GlobalIndexResponseTest {
+
+    @Test
+    void testSerializationWithMiss() {
+        GlobalIndexResponse response =
+                new GlobalIndexResponse(
+                        "server-epoch", 9L, 101L, new BinaryRow[] {row(1), null, row(3)});
+
+        GlobalIndexResponse deserialized =
+                new GlobalIndexResponse.Deserializer()
+                        .deserializeMessage(Unpooled.wrappedBuffer(response.serialize()));
+
+        assertThat(deserialized).isEqualTo(response);
+        assertThat(deserialized.protocolVersion()).isEqualTo(GlobalIndexRequest.PROTOCOL_VERSION);
+        assertThat(deserialized.isSuccess()).isTrue();
+        assertThat(deserialized.serverEpoch()).isEqualTo("server-epoch");
+        assertThat(deserialized.servedGeneration()).isEqualTo(9L);
+        assertThat(deserialized.servedSnapshotId()).isEqualTo(101L);
+        assertThat(deserialized.values()[0].getOffset()).isZero();
+        assertThat(deserialized.values()[0].anyNull()).isFalse();
+        assertThat(deserialized.values()[2].getOffset()).isZero();
+        assertThat(deserialized.values()[2].anyNull()).isFalse();
+    }
+
+    @Test
+    void testStructuredFailureRoundTripAndBoundedMessage() {
+        char[] messageChars = new char[GlobalIndexResponse.MAX_ERROR_MESSAGE_BYTES * 2];
+        Arrays.fill(messageChars, 'x');
+        GlobalIndexResponse response =
+                GlobalIndexResponse.failure(
+                        "server-epoch", 9L, 101L, OVERLOADED, true, new String(messageChars));
+
+        GlobalIndexResponse deserialized =
+                new GlobalIndexResponse.Deserializer()
+                        .deserializeMessage(Unpooled.wrappedBuffer(response.serialize()));
+
+        assertThat(deserialized.isSuccess()).isFalse();
+        assertThat(deserialized.errorCode()).isEqualTo(OVERLOADED);
+        assertThat(deserialized.retryable()).isTrue();
+        assertThat(deserialized.errorMessage().getBytes(StandardCharsets.UTF_8))
+                .hasSize(GlobalIndexResponse.MAX_ERROR_MESSAGE_BYTES);
+        assertThat(deserialized.values()).isEmpty();
+        assertThat(deserialized.toException())
+                .isInstanceOfSatisfying(
+                        GlobalIndexQueryException.class,
+                        failure -> {
+                            assertThat(failure.errorCode()).isEqualTo(OVERLOADED);
+                            assertThat(failure.retryable()).isTrue();
+                        });
+    }
+
+    @Test
+    void testRejectUnsupportedProtocolAndInvalidNullMarker() {
+        byte[] unsupported =
+                new GlobalIndexResponse("epoch", 1L, 2L, new BinaryRow[] {null}).serialize();
+        ByteBuffer.wrap(unsupported).putInt(GlobalIndexRequest.PROTOCOL_VERSION + 1);
+        assertStructuredFailure(unsupported, UNSUPPORTED_PROTOCOL);
+
+        byte[] invalidMarker =
+                new GlobalIndexResponse("epoch", 1L, 2L, new BinaryRow[] {null}).serialize();
+        invalidMarker[invalidMarker.length - 1] = 2;
+        assertStructuredFailure(invalidMarker, INVALID_REQUEST);
+    }
+
+    @Test
+    void testRejectMalformedAndTrailingPayload() {
+        assertStructuredFailure(new byte[] {0}, INVALID_REQUEST);
+
+        byte[] response =
+                new GlobalIndexResponse("epoch", 1L, 2L, new BinaryRow[] {row(1)}).serialize();
+        assertStructuredFailure(Arrays.copyOf(response, response.length + 1), INVALID_REQUEST);
+    }
+
+    @Test
+    void testRejectUnknownErrorCodeAndInvalidRetryableMarker() {
+        byte[] response =
+                GlobalIndexResponse.failure("epoch", 1L, 2L, OVERLOADED, "busy").serialize();
+        int statusOffset =
+                Integer.BYTES
+                        + Integer.BYTES
+                        + "epoch".getBytes(StandardCharsets.UTF_8).length
+                        + Long.BYTES
+                        + Long.BYTES;
+
+        byte[] unknownCode = Arrays.copyOf(response, response.length);
+        ByteBuffer.wrap(unknownCode).putInt(statusOffset, Integer.MAX_VALUE);
+        assertStructuredFailure(unknownCode, INVALID_REQUEST);
+
+        byte[] invalidRetryable = Arrays.copyOf(response, response.length);
+        invalidRetryable[statusOffset + Integer.BYTES] = 2;
+        assertStructuredFailure(invalidRetryable, INVALID_REQUEST);
+    }
+
+    private static void assertStructuredFailure(
+            byte[] payload,
+            org.apache.paimon.service.exceptions.GlobalIndexQueryErrorCode expectedCode) {
+        assertThatThrownBy(
+                        () ->
+                                new GlobalIndexResponse.Deserializer()
+                                        .deserializeMessage(Unpooled.wrappedBuffer(payload)))
+                .isInstanceOfSatisfying(
+                        GlobalIndexQueryException.class,
+                        e -> assertThat(e.errorCode()).isEqualTo(expectedCode));
+    }
+}

--- a/paimon-service/paimon-service-client/src/test/java/org/apache/paimon/service/network/ServerConnectionTest.java
+++ b/paimon-service/paimon-service-client/src/test/java/org/apache/paimon/service/network/ServerConnectionTest.java
@@ -1,0 +1,57 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.service.network;
+
+import org.apache.paimon.data.BinaryRow;
+import org.apache.paimon.service.messages.GlobalIndexRequest;
+import org.apache.paimon.service.messages.GlobalIndexResponse;
+import org.apache.paimon.service.network.messages.MessageSerializer;
+import org.apache.paimon.service.network.stats.DisabledServiceRequestStats;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.CompletableFuture;
+
+import static org.apache.paimon.service.messages.KvRequestTest.row;
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Tests cancellation cleanup while a server connection is still being established. */
+class ServerConnectionTest {
+
+    @Test
+    void testCancelledRequestsAreRemovedFromPendingConnectionQueue() {
+        ServerConnection<GlobalIndexRequest, GlobalIndexResponse> connection =
+                ServerConnection.createPendingConnection(
+                        "Pending Cancellation Test Client",
+                        new MessageSerializer<>(
+                                new GlobalIndexRequest.Deserializer(),
+                                new GlobalIndexResponse.Deserializer()),
+                        new DisabledServiceRequestStats());
+
+        for (int i = 0; i < 100; i++) {
+            CompletableFuture<GlobalIndexResponse> future =
+                    connection.sendRequest(
+                            new GlobalIndexRequest("epoch", 1L, new BinaryRow[] {row(i)}));
+            assertThat(future.cancel(false)).isTrue();
+        }
+
+        assertThat(connection.numPendingRequests()).isZero();
+        connection.close();
+    }
+}

--- a/paimon-service/paimon-service-runtime/src/main/java/org/apache/paimon/service/server/GlobalIndexQueryServer.java
+++ b/paimon-service/paimon-service-runtime/src/main/java/org/apache/paimon/service/server/GlobalIndexQueryServer.java
@@ -1,0 +1,143 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.service.server;
+
+import org.apache.paimon.query.QueryServer;
+import org.apache.paimon.service.messages.GlobalIndexRequest;
+import org.apache.paimon.service.messages.GlobalIndexResponse;
+import org.apache.paimon.service.network.AbstractServerHandler;
+import org.apache.paimon.service.network.NetworkServer;
+import org.apache.paimon.service.network.messages.MessageSerializer;
+import org.apache.paimon.service.network.stats.ServiceRequestStats;
+import org.apache.paimon.table.query.DataEvolutionGlobalIndexTableQuery;
+import org.apache.paimon.utils.Preconditions;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.net.InetSocketAddress;
+import java.util.Iterator;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+
+/** Network server for shard-routed global-index lookups. */
+public class GlobalIndexQueryServer extends NetworkServer<GlobalIndexRequest, GlobalIndexResponse>
+        implements QueryServer {
+
+    private static final Logger LOG = LoggerFactory.getLogger(GlobalIndexQueryServer.class);
+    public static final int DEFAULT_MAX_QUEUED_REQUESTS = 16;
+
+    private final int serverId;
+    private final int numServers;
+    private final String serverEpoch;
+    private final DataEvolutionGlobalIndexTableQuery lookup;
+    private final ServiceRequestStats stats;
+
+    public GlobalIndexQueryServer(
+            int serverId,
+            int numServers,
+            String serverEpoch,
+            String bindAddress,
+            Iterator<Integer> bindPortIterator,
+            int numEventLoopThreads,
+            int numQueryThreads,
+            DataEvolutionGlobalIndexTableQuery lookup,
+            ServiceRequestStats stats) {
+        this(
+                serverId,
+                numServers,
+                serverEpoch,
+                bindAddress,
+                bindPortIterator,
+                numEventLoopThreads,
+                numQueryThreads,
+                DEFAULT_MAX_QUEUED_REQUESTS,
+                lookup,
+                stats);
+    }
+
+    public GlobalIndexQueryServer(
+            int serverId,
+            int numServers,
+            String serverEpoch,
+            String bindAddress,
+            Iterator<Integer> bindPortIterator,
+            int numEventLoopThreads,
+            int numQueryThreads,
+            int maxQueuedRequests,
+            DataEvolutionGlobalIndexTableQuery lookup,
+            ServiceRequestStats stats) {
+        super(
+                "Global Index Query Server",
+                bindAddress,
+                bindPortIterator,
+                numEventLoopThreads,
+                numQueryThreads,
+                GlobalIndexRequest.MAX_NETWORK_FRAME_BYTES,
+                maxQueuedRequests);
+        Preconditions.checkArgument(
+                serverId >= 0 && serverId < numServers,
+                "Server id %s is outside [0, %s).",
+                serverId,
+                numServers);
+        this.serverId = serverId;
+        this.numServers = numServers;
+        this.serverEpoch = Preconditions.checkNotNull(serverEpoch);
+        this.lookup = Preconditions.checkNotNull(lookup);
+        this.stats = Preconditions.checkNotNull(stats);
+    }
+
+    @Override
+    public AbstractServerHandler<GlobalIndexRequest, GlobalIndexResponse> initializeHandler() {
+        MessageSerializer<GlobalIndexRequest, GlobalIndexResponse> serializer =
+                new MessageSerializer<>(
+                        new GlobalIndexRequest.Deserializer(),
+                        new GlobalIndexResponse.Deserializer());
+        return new GlobalIndexServerHandler(
+                this, serverId, numServers, serverEpoch, lookup, serializer, stats);
+    }
+
+    @Override
+    public void start() throws Throwable {
+        super.start();
+    }
+
+    @Override
+    public InetSocketAddress getServerAddress() {
+        return super.getServerAddress();
+    }
+
+    int numQueuedRequests() {
+        return ((ThreadPoolExecutor) getQueryExecutor()).getQueue().size();
+    }
+
+    int maxRequestFrameLength() {
+        return getMaxFrameLength();
+    }
+
+    @Override
+    public void shutdown() {
+        try {
+            shutdownServer().get(10L, TimeUnit.SECONDS);
+            LOG.info("{} was shutdown successfully.", getServerName());
+        } catch (Exception e) {
+            LOG.warn("{} shutdown failed.", getServerName(), e);
+        }
+    }
+}

--- a/paimon-service/paimon-service-runtime/src/main/java/org/apache/paimon/service/server/GlobalIndexServerHandler.java
+++ b/paimon-service/paimon-service-runtime/src/main/java/org/apache/paimon/service/server/GlobalIndexServerHandler.java
@@ -1,0 +1,243 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.service.server;
+
+import org.apache.paimon.data.BinaryRow;
+import org.apache.paimon.data.InternalRow;
+import org.apache.paimon.data.serializer.InternalRowSerializer;
+import org.apache.paimon.service.exceptions.GlobalIndexQueryException;
+import org.apache.paimon.service.messages.GlobalIndexRequest;
+import org.apache.paimon.service.messages.GlobalIndexResponse;
+import org.apache.paimon.service.network.AbstractServerHandler;
+import org.apache.paimon.service.network.LegacyFailureFramePolicy;
+import org.apache.paimon.service.network.messages.MessageSerializer;
+import org.apache.paimon.service.network.stats.ServiceRequestStats;
+import org.apache.paimon.table.BucketMode;
+import org.apache.paimon.table.query.DataEvolutionGlobalIndexTableQuery;
+import org.apache.paimon.table.query.DuplicateLookupKeyException;
+import org.apache.paimon.table.query.GlobalIndexQueryServiceUtils;
+import org.apache.paimon.table.query.QueryServiceNotReadyException;
+import org.apache.paimon.utils.Preconditions;
+
+import org.apache.paimon.shade.netty4.io.netty.channel.ChannelHandler;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+
+import static org.apache.paimon.service.exceptions.GlobalIndexQueryErrorCode.DUPLICATE_KEY;
+import static org.apache.paimon.service.exceptions.GlobalIndexQueryErrorCode.INTERNAL_ERROR;
+import static org.apache.paimon.service.exceptions.GlobalIndexQueryErrorCode.INVALID_REQUEST;
+import static org.apache.paimon.service.exceptions.GlobalIndexQueryErrorCode.NOT_READY;
+import static org.apache.paimon.service.exceptions.GlobalIndexQueryErrorCode.OVERLOADED;
+import static org.apache.paimon.service.exceptions.GlobalIndexQueryErrorCode.STALE_GENERATION;
+import static org.apache.paimon.service.exceptions.GlobalIndexQueryErrorCode.UNKNOWN_KEY_SHARD;
+
+/** Handles requests for one global-index key-hash shard. */
+@ChannelHandler.Sharable
+public class GlobalIndexServerHandler
+        extends AbstractServerHandler<GlobalIndexRequest, GlobalIndexResponse> {
+
+    private static final Logger LOG = LoggerFactory.getLogger(GlobalIndexServerHandler.class);
+
+    private final int serverId;
+    private final int numServers;
+    private final String serverEpoch;
+    private final DataEvolutionGlobalIndexTableQuery lookup;
+    private final InternalRowSerializer valueSerializer;
+
+    public GlobalIndexServerHandler(
+            GlobalIndexQueryServer server,
+            int serverId,
+            int numServers,
+            String serverEpoch,
+            DataEvolutionGlobalIndexTableQuery lookup,
+            MessageSerializer<GlobalIndexRequest, GlobalIndexResponse> serializer,
+            ServiceRequestStats stats) {
+        super(server, serializer, stats, LegacyFailureFramePolicy.REJECT_SERIALIZED_THROWABLE);
+        this.serverId = serverId;
+        this.numServers = numServers;
+        this.serverEpoch = Preconditions.checkNotNull(serverEpoch);
+        this.lookup = Preconditions.checkNotNull(lookup);
+        this.valueSerializer = lookup.createValueSerializer();
+    }
+
+    @Override
+    public CompletableFuture<GlobalIndexResponse> handleRequest(
+            long requestId, GlobalIndexRequest request) {
+        CompletableFuture<GlobalIndexResponse> responseFuture = new CompletableFuture<>();
+
+        try {
+            if (!serverEpoch.equals(request.serverEpoch())) {
+                responseFuture.complete(
+                        failureResponse(
+                                STALE_GENERATION,
+                                String.format(
+                                        "%s : Requested server epoch '%s', but this server uses '%s'.",
+                                        getServerName(), request.serverEpoch(), serverEpoch)));
+                return responseFuture;
+            }
+
+            // Fence cached descriptors against the newest observed generation, not just the last
+            // published generation. The old state is retained during a shadow rebuild, but
+            // accepting it after an append tail was observed could turn a not-yet-indexed key into
+            // a false MISS.
+            long acceptedGeneration = lookup.latestGeneration();
+            if (request.servedGeneration() != acceptedGeneration) {
+                responseFuture.complete(
+                        failureResponse(
+                                STALE_GENERATION,
+                                String.format(
+                                        "%s : Requested global-index generation %s, but this server serves %s.",
+                                        getServerName(),
+                                        request.servedGeneration(),
+                                        acceptedGeneration)));
+                return responseFuture;
+            }
+
+            BinaryRow[] keys = request.keys();
+            for (BinaryRow key : keys) {
+                if (GlobalIndexQueryServiceUtils.route(key, numServers) != serverId) {
+                    responseFuture.complete(
+                            failureResponse(
+                                    UNKNOWN_KEY_SHARD,
+                                    getServerName()
+                                            + " : The server does not own the requested global-index key shard."));
+                    return responseFuture;
+                }
+            }
+
+            BinaryRow[] values = new BinaryRow[keys.length];
+            Map<BinaryRow, BinaryRow> cachedValues = new HashMap<>();
+            long totalValueBytes = 0L;
+            for (int i = 0; i < keys.length; i++) {
+                BinaryRow binaryValue;
+                if (cachedValues.containsKey(keys[i])) {
+                    binaryValue = cachedValues.get(keys[i]);
+                } else {
+                    InternalRow value =
+                            lookup.lookup(BinaryRow.EMPTY_ROW, BucketMode.UNAWARE_BUCKET, keys[i]);
+                    binaryValue = value == null ? null : valueSerializer.toBinaryRow(value);
+                    if (binaryValue != null) {
+                        long candidateBytes =
+                                totalValueBytes + Integer.BYTES + binaryValue.getSizeInBytes();
+                        GlobalIndexResponse.validateTotalValueBytes(candidateBytes);
+                        binaryValue = binaryValue.copy();
+                        totalValueBytes = candidateBytes;
+                    }
+                    cachedValues.put(keys[i], binaryValue);
+                    values[i] = binaryValue;
+                    continue;
+                }
+                if (binaryValue != null) {
+                    totalValueBytes += Integer.BYTES + binaryValue.getSizeInBytes();
+                    GlobalIndexResponse.validateTotalValueBytes(totalValueBytes);
+                }
+                values[i] = binaryValue;
+            }
+            long responseSnapshotId = lookup.servedSnapshotId();
+            long responseGeneration = lookup.servedGeneration();
+            long acceptedResponseGeneration = lookup.latestGeneration();
+            if (responseGeneration != request.servedGeneration()
+                    || acceptedResponseGeneration != request.servedGeneration()) {
+                responseFuture.complete(
+                        failureResponse(
+                                STALE_GENERATION,
+                                String.format(
+                                        "%s : Requested global-index generation %s, but this server serves %s.",
+                                        getServerName(),
+                                        request.servedGeneration(),
+                                        acceptedResponseGeneration)));
+                return responseFuture;
+            }
+            responseFuture.complete(
+                    new GlobalIndexResponse(
+                            serverEpoch, responseGeneration, responseSnapshotId, values));
+        } catch (QueryServiceNotReadyException e) {
+            responseFuture.complete(failureResponse(NOT_READY, e.getMessage()));
+        } catch (DuplicateLookupKeyException e) {
+            responseFuture.complete(failureResponse(DUPLICATE_KEY, e.getMessage()));
+        } catch (IllegalArgumentException e) {
+            responseFuture.complete(failureResponse(INVALID_REQUEST, e.getMessage()));
+        } catch (GlobalIndexQueryException e) {
+            responseFuture.complete(
+                    GlobalIndexResponse.failure(
+                            serverEpoch,
+                            safeLatestGeneration(),
+                            safeServedSnapshotId(),
+                            e.errorCode(),
+                            e.retryable(),
+                            e.getMessage()));
+        } catch (Throwable t) {
+            LOG.error(
+                    "{} : Internal error while processing request {}.",
+                    getServerName(),
+                    requestId,
+                    t);
+            responseFuture.complete(
+                    failureResponse(
+                            INTERNAL_ERROR,
+                            String.format(
+                                    "%s : Internal error while processing request %s.",
+                                    getServerName(), requestId)));
+        }
+        return responseFuture;
+    }
+
+    @Override
+    protected GlobalIndexResponse rejectedExecutionResponse(
+            long requestId, GlobalIndexRequest request) {
+        return failureResponse(
+                OVERLOADED,
+                String.format(
+                        "%s : Query executor is overloaded; rejected request %s.",
+                        getServerName(), requestId));
+    }
+
+    private GlobalIndexResponse failureResponse(
+            org.apache.paimon.service.exceptions.GlobalIndexQueryErrorCode errorCode,
+            String message) {
+        return GlobalIndexResponse.failure(
+                serverEpoch, safeLatestGeneration(), safeServedSnapshotId(), errorCode, message);
+    }
+
+    private long safeLatestGeneration() {
+        try {
+            return lookup.latestGeneration();
+        } catch (Throwable ignored) {
+            return Long.MIN_VALUE;
+        }
+    }
+
+    private long safeServedSnapshotId() {
+        try {
+            return lookup.servedSnapshotId();
+        } catch (Throwable ignored) {
+            return -1L;
+        }
+    }
+
+    @Override
+    public CompletableFuture<Void> shutdown() {
+        return CompletableFuture.completedFuture(null);
+    }
+}

--- a/paimon-service/paimon-service-runtime/src/test/java/org/apache/paimon/service/network/ClientHandlerTest.java
+++ b/paimon-service/paimon-service-runtime/src/test/java/org/apache/paimon/service/network/ClientHandlerTest.java
@@ -29,7 +29,10 @@ import org.apache.paimon.shade.netty4.io.netty.channel.embedded.EmbeddedChannel;
 
 import org.junit.jupiter.api.Test;
 
+import java.io.IOException;
+import java.io.ObjectInputStream;
 import java.nio.channels.ClosedChannelException;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -125,6 +128,69 @@ class ClientHandlerTest {
         channel.pipeline().fireChannelInactive();
         assertThat(callback.onFailureCnt).isEqualTo(1);
         assertThat(callback.onFailureBody).isInstanceOf(ClosedChannelException.class);
+
+        assertSecureModeRejectsLegacyFailureFramesWithoutDeserializingThrowable(serializer);
+    }
+
+    private static void assertSecureModeRejectsLegacyFailureFramesWithoutDeserializingThrowable(
+            MessageSerializer<KvRequest, KvResponse> serializer) throws Exception {
+        final TestingClientHandlerCallback callback = new TestingClientHandlerCallback();
+        @SuppressWarnings({"unchecked", "rawtypes"})
+        final EmbeddedChannel channel =
+                new EmbeddedChannel(
+                        new ClientHandler(
+                                serializer,
+                                callback,
+                                LegacyFailureFramePolicy.REJECT_SERIALIZED_THROWABLE));
+
+        DeserializationProbeException.reset();
+        ByteBuf requestFailure =
+                MessageSerializer.serializeRequestFailure(
+                        channel.alloc(), 42L, new DeserializationProbeException());
+        requestFailure.skipBytes(Integer.BYTES);
+        channel.writeInbound(requestFailure);
+
+        assertRejectedWithoutDeserialization(callback, requestFailure);
+
+        callback.reset();
+        ByteBuf serverFailure =
+                MessageSerializer.serializeServerFailure(
+                        channel.alloc(), new DeserializationProbeException());
+        serverFailure.skipBytes(Integer.BYTES);
+        channel.writeInbound(serverFailure);
+
+        assertRejectedWithoutDeserialization(callback, serverFailure);
+    }
+
+    private static void assertRejectedWithoutDeserialization(
+            TestingClientHandlerCallback callback, ByteBuf frame) {
+        assertThat(callback.onRequestFailureCnt).isZero();
+        assertThat(callback.onFailureCnt).isOne();
+        assertThat(callback.onFailureBody)
+                .isInstanceOf(IOException.class)
+                .hasMessageContaining("Rejected prohibited legacy serialized Throwable");
+        assertThat(DeserializationProbeException.deserializationCount()).isZero();
+        assertThat(frame.refCnt()).isZero();
+    }
+
+    private static class DeserializationProbeException extends RuntimeException {
+
+        private static final long serialVersionUID = 1L;
+        private static final AtomicInteger DESERIALIZATION_COUNT = new AtomicInteger();
+
+        private void readObject(ObjectInputStream input)
+                throws IOException, ClassNotFoundException {
+            input.defaultReadObject();
+            DESERIALIZATION_COUNT.incrementAndGet();
+        }
+
+        private static void reset() {
+            DESERIALIZATION_COUNT.set(0);
+        }
+
+        private static int deserializationCount() {
+            return DESERIALIZATION_COUNT.get();
+        }
     }
 
     @SuppressWarnings("rawtypes")

--- a/paimon-service/paimon-service-runtime/src/test/java/org/apache/paimon/service/server/GlobalIndexQueryServerTest.java
+++ b/paimon-service/paimon-service-runtime/src/test/java/org/apache/paimon/service/server/GlobalIndexQueryServerTest.java
@@ -1,0 +1,649 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.service.server;
+
+import org.apache.paimon.CoreOptions;
+import org.apache.paimon.data.BinaryRow;
+import org.apache.paimon.data.BinaryString;
+import org.apache.paimon.data.GenericRow;
+import org.apache.paimon.data.InternalRow;
+import org.apache.paimon.data.serializer.InternalRowSerializer;
+import org.apache.paimon.data.serializer.InternalSerializers;
+import org.apache.paimon.schema.Schema;
+import org.apache.paimon.service.exceptions.GlobalIndexQueryErrorCode;
+import org.apache.paimon.service.messages.GlobalIndexRequest;
+import org.apache.paimon.service.messages.GlobalIndexResponse;
+import org.apache.paimon.service.network.AbstractServerHandler;
+import org.apache.paimon.service.network.LegacyFailureFramePolicy;
+import org.apache.paimon.service.network.NetworkClient;
+import org.apache.paimon.service.network.NetworkServer;
+import org.apache.paimon.service.network.messages.MessageSerializer;
+import org.apache.paimon.service.network.stats.DisabledServiceRequestStats;
+import org.apache.paimon.table.FileStoreTable;
+import org.apache.paimon.table.TableTestBase;
+import org.apache.paimon.table.query.DataEvolutionGlobalIndexTableQuery;
+import org.apache.paimon.table.query.GlobalIndexQueryServiceUtils;
+import org.apache.paimon.types.DataTypes;
+import org.apache.paimon.types.RowType;
+
+import org.apache.paimon.shade.netty4.io.netty.buffer.Unpooled;
+import org.apache.paimon.shade.netty4.io.netty.channel.embedded.EmbeddedChannel;
+import org.apache.paimon.shade.netty4.io.netty.handler.codec.LengthFieldBasedFrameDecoder;
+import org.apache.paimon.shade.netty4.io.netty.handler.codec.TooLongFrameException;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.channels.ClosedChannelException;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.apache.paimon.service.exceptions.GlobalIndexQueryErrorCode.INTERNAL_ERROR;
+import static org.apache.paimon.service.exceptions.GlobalIndexQueryErrorCode.NOT_READY;
+import static org.apache.paimon.service.exceptions.GlobalIndexQueryErrorCode.OVERLOADED;
+import static org.apache.paimon.service.exceptions.GlobalIndexQueryErrorCode.REQUEST_TOO_LARGE;
+import static org.apache.paimon.service.exceptions.GlobalIndexQueryErrorCode.STALE_GENERATION;
+import static org.apache.paimon.service.exceptions.GlobalIndexQueryErrorCode.UNKNOWN_KEY_SHARD;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/** Network-level tests for the dedicated global-index server protocol and fences. */
+class GlobalIndexQueryServerTest extends TableTestBase {
+
+    private static final String SERVER_EPOCH = "server-epoch";
+    private static final int SERVER_ID = 0;
+    private static final int NUM_SERVERS = 2;
+
+    @Test
+    void testLookupAndStructuredFenceFailures() throws Throwable {
+        FileStoreTable table = createAppendTable();
+        DataEvolutionGlobalIndexTableQuery query =
+                new DataEvolutionGlobalIndexTableQuery(
+                        table,
+                        "url",
+                        Collections.singletonList("descriptor"),
+                        new File(tempPath.toFile(), "server-query-state"));
+        GlobalIndexQueryServer server =
+                new GlobalIndexQueryServer(
+                        SERVER_ID,
+                        NUM_SERVERS,
+                        SERVER_EPOCH,
+                        "127.0.0.1",
+                        Collections.singletonList(0).iterator(),
+                        1,
+                        1,
+                        query,
+                        new DisabledServiceRequestStats());
+        NetworkClient<GlobalIndexRequest, GlobalIndexResponse> client =
+                new NetworkClient<>(
+                        "Global Index Query Server Test Client",
+                        1,
+                        new MessageSerializer<>(
+                                new GlobalIndexRequest.Deserializer(),
+                                new GlobalIndexResponse.Deserializer()),
+                        new DisabledServiceRequestStats(),
+                        GlobalIndexResponse.MAX_NETWORK_FRAME_BYTES);
+        try {
+            assertRequestFrameLimit(server);
+            server.start();
+            BinaryRow ownedKey = keyForShard(SERVER_ID);
+            BinaryRow foreignKey = keyForShard(1);
+
+            GlobalIndexRequest unsupportedRequest =
+                    new GlobalIndexRequest(
+                            SERVER_EPOCH, Long.MIN_VALUE, new BinaryRow[] {ownedKey}) {
+                        @Override
+                        public byte[] serialize() {
+                            byte[] bytes = super.serialize();
+                            ByteBuffer.wrap(bytes).putInt(GlobalIndexRequest.PROTOCOL_VERSION + 1);
+                            return bytes;
+                        }
+                    };
+            assertMalformedFrameClosesConnection(
+                    sendMalformedRequest(server.getServerAddress(), unsupportedRequest),
+                    "Unsupported global-index");
+
+            GlobalIndexRequest trailingBytesRequest =
+                    new GlobalIndexRequest(
+                            SERVER_EPOCH, Long.MIN_VALUE, new BinaryRow[] {ownedKey}) {
+                        @Override
+                        public byte[] serialize() {
+                            byte[] bytes = super.serialize();
+                            return Arrays.copyOf(bytes, bytes.length + 1);
+                        }
+                    };
+            assertMalformedFrameClosesConnection(
+                    sendMalformedRequest(server.getServerAddress(), trailingBytesRequest),
+                    "trailing bytes");
+
+            assertFailureResponse(
+                    client.sendRequest(
+                            server.getServerAddress(),
+                            new GlobalIndexRequest(
+                                    SERVER_EPOCH, Long.MIN_VALUE, new BinaryRow[] {ownedKey})),
+                    NOT_READY,
+                    false);
+
+            query.beginRefresh(5L, 100L);
+            query.put(5L, ownedKey, value("descriptor"));
+            query.finishRefresh(5L);
+
+            GlobalIndexResponse response =
+                    client.sendRequest(
+                                    server.getServerAddress(),
+                                    new GlobalIndexRequest(
+                                            SERVER_EPOCH, 5L, new BinaryRow[] {ownedKey}))
+                            .get(10L, TimeUnit.SECONDS);
+            assertThat(response.serverEpoch()).isEqualTo(SERVER_EPOCH);
+            assertThat(response.servedGeneration()).isEqualTo(5L);
+            assertThat(response.servedSnapshotId()).isEqualTo(100L);
+            assertThat(response.values()).hasSize(1);
+            assertThat(response.values()[0].getString(0).toString()).isEqualTo("descriptor");
+
+            assertFailureResponse(
+                    client.sendRequest(
+                            server.getServerAddress(),
+                            new GlobalIndexRequest("old-epoch", 5L, new BinaryRow[] {ownedKey})),
+                    STALE_GENERATION,
+                    true);
+            assertFailureResponse(
+                    client.sendRequest(
+                            server.getServerAddress(),
+                            new GlobalIndexRequest(SERVER_EPOCH, 4L, new BinaryRow[] {ownedKey})),
+                    STALE_GENERATION,
+                    true);
+            assertFailureResponse(
+                    client.sendRequest(
+                            server.getServerAddress(),
+                            new GlobalIndexRequest(SERVER_EPOCH, 5L, new BinaryRow[] {foreignKey})),
+                    UNKNOWN_KEY_SHARD,
+                    true);
+
+            // Observing a newer generation immediately fences a cached generation-5 descriptor.
+            // The old state stays allocated for shadow refresh, but it must not answer a key from
+            // an uncovered append tail with null.
+            query.beginRefresh(6L, 101L);
+            assertFailureResponse(
+                    client.sendRequest(
+                            server.getServerAddress(),
+                            new GlobalIndexRequest(SERVER_EPOCH, 5L, new BinaryRow[] {ownedKey})),
+                    STALE_GENERATION,
+                    true);
+            assertFailureResponse(
+                    client.sendRequest(
+                            server.getServerAddress(),
+                            new GlobalIndexRequest(SERVER_EPOCH, 6L, new BinaryRow[] {ownedKey})),
+                    NOT_READY,
+                    false);
+
+        } finally {
+            client.shutdown().get(10L, TimeUnit.SECONDS);
+            server.shutdownServer().get(10L, TimeUnit.SECONDS);
+            query.close();
+        }
+    }
+
+    @Test
+    void testBoundedQueryQueueReturnsStructuredOverloadedResponse() throws Throwable {
+        FileStoreTable table = createAppendTable();
+        BinaryRow ownedKey = keyForShard(SERVER_ID);
+        BlockingQuery query =
+                new BlockingQuery(table, new File(tempPath.toFile(), "bounded-query-state"));
+        query.beginRefresh(5L, 100L);
+        query.put(5L, ownedKey, value("descriptor"));
+        query.finishRefresh(5L);
+
+        GlobalIndexQueryServer server =
+                new GlobalIndexQueryServer(
+                        SERVER_ID,
+                        NUM_SERVERS,
+                        SERVER_EPOCH,
+                        "127.0.0.1",
+                        Collections.singletonList(0).iterator(),
+                        1,
+                        1,
+                        1,
+                        query,
+                        new DisabledServiceRequestStats());
+        NetworkClient<GlobalIndexRequest, GlobalIndexResponse> client = boundedClient();
+        try {
+            server.start();
+            GlobalIndexRequest request =
+                    new GlobalIndexRequest(SERVER_EPOCH, 5L, new BinaryRow[] {ownedKey});
+            CompletableFuture<GlobalIndexResponse> running =
+                    client.sendRequest(server.getServerAddress(), request);
+            assertThat(query.awaitBlocked()).isTrue();
+
+            CompletableFuture<GlobalIndexResponse> queued =
+                    client.sendRequest(server.getServerAddress(), request);
+            awaitQueuedRequest(server);
+            GlobalIndexResponse overloaded =
+                    client.sendRequest(server.getServerAddress(), request)
+                            .get(10L, TimeUnit.SECONDS);
+
+            assertFailureResponse(overloaded, OVERLOADED, true);
+            query.release();
+            assertThat(running.get(10L, TimeUnit.SECONDS).isSuccess()).isTrue();
+            assertThat(queued.get(10L, TimeUnit.SECONDS).isSuccess()).isTrue();
+        } finally {
+            query.release();
+            client.shutdown().get(10L, TimeUnit.SECONDS);
+            server.shutdownServer().get(10L, TimeUnit.SECONDS);
+            query.close();
+        }
+    }
+
+    @Test
+    void testRepeatedLargeValueFailsBeforeResponseConstructionAndDeduplicatesLookup()
+            throws Exception {
+        FileStoreTable table = createAppendTable(DataTypes.BYTES());
+        BinaryRow ownedKey = keyForShard(SERVER_ID);
+        BinaryRow largeValue = row(new byte[8 * 1024 * 1024], DataTypes.BYTES());
+        ConstantQuery query =
+                new ConstantQuery(
+                        table, new File(tempPath.toFile(), "large-value-query-state"), largeValue);
+        GlobalIndexQueryServer server =
+                new GlobalIndexQueryServer(
+                        SERVER_ID,
+                        NUM_SERVERS,
+                        SERVER_EPOCH,
+                        "127.0.0.1",
+                        Collections.singletonList(0).iterator(),
+                        1,
+                        1,
+                        query,
+                        new DisabledServiceRequestStats());
+        GlobalIndexServerHandler handler =
+                new GlobalIndexServerHandler(
+                        server,
+                        SERVER_ID,
+                        NUM_SERVERS,
+                        SERVER_EPOCH,
+                        query,
+                        serializer(),
+                        new DisabledServiceRequestStats());
+        BinaryRow[] duplicateKeys = new BinaryRow[9];
+        Arrays.fill(duplicateKeys, ownedKey);
+
+        GlobalIndexResponse response =
+                handler.handleRequest(42L, new GlobalIndexRequest(SERVER_EPOCH, 5L, duplicateKeys))
+                        .join();
+
+        assertFailureResponse(response, REQUEST_TOO_LARGE, false);
+        assertThat(query.lookupCount()).isOne();
+        query.close();
+    }
+
+    @Test
+    void testUnexpectedLookupFailureUsesStructuredInternalErrorResponse() throws Throwable {
+        FileStoreTable table = createAppendTable();
+        BinaryRow ownedKey = keyForShard(SERVER_ID);
+        FailingQuery query =
+                new FailingQuery(table, new File(tempPath.toFile(), "failing-query-state"));
+        GlobalIndexQueryServer server =
+                new GlobalIndexQueryServer(
+                        SERVER_ID,
+                        NUM_SERVERS,
+                        SERVER_EPOCH,
+                        "127.0.0.1",
+                        Collections.singletonList(0).iterator(),
+                        1,
+                        1,
+                        query,
+                        new DisabledServiceRequestStats());
+        NetworkClient<GlobalIndexRequest, GlobalIndexResponse> client = boundedClient();
+        try {
+            server.start();
+            GlobalIndexResponse response =
+                    client.sendRequest(
+                                    server.getServerAddress(),
+                                    new GlobalIndexRequest(
+                                            SERVER_EPOCH, 5L, new BinaryRow[] {ownedKey}))
+                            .get(10L, TimeUnit.SECONDS);
+
+            assertFailureResponse(response, INTERNAL_ERROR, false);
+            assertThat(response.errorMessage()).doesNotContain("secret lookup failure");
+        } finally {
+            client.shutdown().get(10L, TimeUnit.SECONDS);
+            server.shutdownServer().get(10L, TimeUnit.SECONDS);
+            query.close();
+        }
+    }
+
+    @Test
+    void testBoundedClientRejectsOversizedResponseFrame() throws Throwable {
+        OversizedResponseServer server = new OversizedResponseServer();
+        NetworkClient<GlobalIndexRequest, GlobalIndexResponse> client = boundedClient();
+        try {
+            server.start();
+            Throwable failure =
+                    failure(
+                            client.sendRequest(
+                                    server.getServerAddress(),
+                                    new GlobalIndexRequest(
+                                            SERVER_EPOCH,
+                                            1L,
+                                            new BinaryRow[] {keyForShard(SERVER_ID)})));
+            assertThat(containsCause(failure, TooLongFrameException.class)).isTrue();
+        } finally {
+            client.shutdown().get(10L, TimeUnit.SECONDS);
+            server.shutdownServer().get(10L, TimeUnit.SECONDS);
+        }
+    }
+
+    private FileStoreTable createAppendTable() throws Exception {
+        return createAppendTable(DataTypes.STRING());
+    }
+
+    private FileStoreTable createAppendTable(org.apache.paimon.types.DataType valueType)
+            throws Exception {
+        Schema schema =
+                Schema.newBuilder()
+                        .column("url", DataTypes.STRING().notNull())
+                        .column("descriptor", valueType)
+                        .option(CoreOptions.BUCKET.key(), "-1")
+                        .option(CoreOptions.ROW_TRACKING_ENABLED.key(), "true")
+                        .option(CoreOptions.DATA_EVOLUTION_ENABLED.key(), "true")
+                        .option(CoreOptions.CONSUMER_EXPIRATION_TIME.key(), "1 d")
+                        .build();
+        catalog.createTable(identifier(), schema, false);
+        return (FileStoreTable) catalog.getTable(identifier());
+    }
+
+    private static BinaryRow keyForShard(int shard) {
+        for (int i = 0; i < 10_000; i++) {
+            BinaryRow key = row("key-" + i, DataTypes.STRING().notNull());
+            if (GlobalIndexQueryServiceUtils.route(key, NUM_SERVERS) == shard) {
+                return key;
+            }
+        }
+        throw new AssertionError("Could not find a key for shard " + shard);
+    }
+
+    private static BinaryRow value(String value) {
+        return row(value, DataTypes.STRING());
+    }
+
+    private static BinaryRow row(Object value, org.apache.paimon.types.DataType type) {
+        InternalRowSerializer serializer = InternalSerializers.create(RowType.of(type));
+        Object internalValue =
+                value instanceof String ? BinaryString.fromString((String) value) : value;
+        return serializer.toBinaryRow(GenericRow.of(internalValue)).copy();
+    }
+
+    private static MessageSerializer<GlobalIndexRequest, GlobalIndexResponse> serializer() {
+        return new MessageSerializer<>(
+                new GlobalIndexRequest.Deserializer(), new GlobalIndexResponse.Deserializer());
+    }
+
+    private static NetworkClient<GlobalIndexRequest, GlobalIndexResponse> boundedClient() {
+        return new NetworkClient<>(
+                "Bounded Global Index Test Client",
+                1,
+                serializer(),
+                new DisabledServiceRequestStats(),
+                GlobalIndexResponse.MAX_NETWORK_FRAME_BYTES,
+                LegacyFailureFramePolicy.REJECT_SERIALIZED_THROWABLE);
+    }
+
+    private static Throwable sendMalformedRequest(
+            java.net.InetSocketAddress serverAddress, GlobalIndexRequest request) throws Exception {
+        NetworkClient<GlobalIndexRequest, GlobalIndexResponse> client = boundedClient();
+        try {
+            return failure(client.sendRequest(serverAddress, request));
+        } finally {
+            client.shutdown().get(10L, TimeUnit.SECONDS);
+        }
+    }
+
+    private static void assertFailureResponse(
+            CompletableFuture<GlobalIndexResponse> future,
+            GlobalIndexQueryErrorCode errorCode,
+            boolean retryable)
+            throws Exception {
+        assertFailureResponse(future.get(10L, TimeUnit.SECONDS), errorCode, retryable);
+    }
+
+    private static void assertFailureResponse(
+            GlobalIndexResponse response, GlobalIndexQueryErrorCode errorCode, boolean retryable) {
+        assertThat(response.isSuccess()).isFalse();
+        assertThat(response.errorCode()).isEqualTo(errorCode);
+        assertThat(response.retryable()).isEqualTo(retryable);
+        assertThat(response.values()).isEmpty();
+    }
+
+    private static void assertMalformedFrameClosesConnection(
+            Throwable failure, String privateServerDetail) {
+        assertThat(containsCause(failure, ClosedChannelException.class)).isTrue();
+        assertThat(allMessages(failure)).doesNotContain(privateServerDetail);
+    }
+
+    private static String allMessages(Throwable throwable) {
+        StringBuilder messages = new StringBuilder();
+        Throwable current = throwable;
+        while (current != null) {
+            messages.append(current.getMessage()).append('\n');
+            Throwable next = current.getCause();
+            if (next == current) {
+                break;
+            }
+            current = next;
+        }
+        return messages.toString();
+    }
+
+    private static boolean containsCause(
+            Throwable throwable, Class<? extends Throwable> expectedType) {
+        Throwable current = throwable;
+        while (current != null) {
+            if (expectedType.isInstance(current)) {
+                return true;
+            }
+            Throwable next = current.getCause();
+            if (next == current) {
+                return false;
+            }
+            current = next;
+        }
+        return false;
+    }
+
+    private static void awaitQueuedRequest(GlobalIndexQueryServer server) throws Exception {
+        for (int attempt = 0; attempt < 100; attempt++) {
+            if (server.numQueuedRequests() == 1) {
+                return;
+            }
+            Thread.sleep(10L);
+        }
+        assertThat(server.numQueuedRequests()).isOne();
+    }
+
+    private static void assertRequestFrameLimit(GlobalIndexQueryServer server) {
+        int maxFrameLength = server.maxRequestFrameLength();
+        assertThat(maxFrameLength).isEqualTo(GlobalIndexRequest.MAX_NETWORK_FRAME_BYTES);
+        EmbeddedChannel channel =
+                new EmbeddedChannel(new LengthFieldBasedFrameDecoder(maxFrameLength, 0, 4, 0, 4));
+        try {
+            assertThatThrownBy(
+                            () ->
+                                    channel.writeInbound(
+                                            Unpooled.buffer(Integer.BYTES)
+                                                    .writeInt(maxFrameLength - Integer.BYTES + 1)))
+                    .isInstanceOf(TooLongFrameException.class);
+        } finally {
+            channel.finishAndReleaseAll();
+        }
+    }
+
+    private static class BlockingQuery extends DataEvolutionGlobalIndexTableQuery {
+        private final AtomicBoolean blockFirst = new AtomicBoolean(true);
+        private final CountDownLatch blocked = new CountDownLatch(1);
+        private final CountDownLatch release = new CountDownLatch(1);
+
+        private BlockingQuery(FileStoreTable table, File stateRoot) {
+            super(table, "url", Collections.singletonList("descriptor"), stateRoot);
+        }
+
+        @Override
+        public InternalRow lookup(BinaryRow partition, int bucket, InternalRow key)
+                throws IOException {
+            if (blockFirst.compareAndSet(true, false)) {
+                blocked.countDown();
+                try {
+                    if (!release.await(10L, TimeUnit.SECONDS)) {
+                        throw new IOException("Timed out waiting to release blocked query.");
+                    }
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                    throw new IOException(e);
+                }
+            }
+            return super.lookup(partition, bucket, key);
+        }
+
+        private boolean awaitBlocked() throws InterruptedException {
+            return blocked.await(10L, TimeUnit.SECONDS);
+        }
+
+        private void release() {
+            release.countDown();
+        }
+    }
+
+    private static class ConstantQuery extends DataEvolutionGlobalIndexTableQuery {
+        private final BinaryRow value;
+        private final AtomicInteger lookupCount = new AtomicInteger();
+
+        private ConstantQuery(FileStoreTable table, File stateRoot, BinaryRow value) {
+            super(table, "url", Collections.singletonList("descriptor"), stateRoot);
+            this.value = value;
+        }
+
+        @Override
+        public InternalRow lookup(BinaryRow partition, int bucket, InternalRow key) {
+            lookupCount.incrementAndGet();
+            return value;
+        }
+
+        @Override
+        public long latestGeneration() {
+            return 5L;
+        }
+
+        @Override
+        public long servedGeneration() {
+            return 5L;
+        }
+
+        @Override
+        public long servedSnapshotId() {
+            return 100L;
+        }
+
+        private int lookupCount() {
+            return lookupCount.get();
+        }
+    }
+
+    private static class FailingQuery extends DataEvolutionGlobalIndexTableQuery {
+
+        private FailingQuery(FileStoreTable table, File stateRoot) {
+            super(table, "url", Collections.singletonList("descriptor"), stateRoot);
+        }
+
+        @Override
+        public InternalRow lookup(BinaryRow partition, int bucket, InternalRow key) {
+            throw new AssertionError("secret lookup failure");
+        }
+
+        @Override
+        public long latestGeneration() {
+            return 5L;
+        }
+
+        @Override
+        public long servedGeneration() {
+            return 5L;
+        }
+
+        @Override
+        public long servedSnapshotId() {
+            return 100L;
+        }
+    }
+
+    private static class OversizedResponseServer
+            extends NetworkServer<GlobalIndexRequest, GlobalIndexResponse> {
+
+        private OversizedResponseServer() {
+            super(
+                    "Oversized Global Index Response Server",
+                    "127.0.0.1",
+                    Collections.singletonList(0).iterator(),
+                    1,
+                    1,
+                    GlobalIndexRequest.MAX_NETWORK_FRAME_BYTES);
+        }
+
+        @Override
+        public AbstractServerHandler<GlobalIndexRequest, GlobalIndexResponse> initializeHandler() {
+            return new AbstractServerHandler<GlobalIndexRequest, GlobalIndexResponse>(
+                    this, serializer(), new DisabledServiceRequestStats()) {
+                @Override
+                public CompletableFuture<GlobalIndexResponse> handleRequest(
+                        long requestId, GlobalIndexRequest request) {
+                    return CompletableFuture.completedFuture(
+                            new GlobalIndexResponse(
+                                    request.serverEpoch(),
+                                    request.servedGeneration(),
+                                    1L,
+                                    new BinaryRow[] {value("ignored")}) {
+                                @Override
+                                public byte[] serialize() {
+                                    return new byte
+                                            [GlobalIndexResponse.MAX_SERIALIZED_PAYLOAD_BYTES + 1];
+                                }
+                            });
+                }
+
+                @Override
+                public CompletableFuture<Void> shutdown() {
+                    return CompletableFuture.completedFuture(null);
+                }
+            };
+        }
+    }
+
+    private static Throwable failure(CompletableFuture<?> future) {
+        try {
+            future.join();
+            throw new AssertionError("Expected global-index request to fail.");
+        } catch (CompletionException e) {
+            return e.getCause();
+        }
+    }
+}


### PR DESCRIPTION
## Background and motivation

Paimon's existing query service is designed for primary-key, fixed-bucket tables. Data-evolution append tables have no primary key and normally use `bucket = -1`; pretending that a lookup column is a primary key, or routing every request to physical bucket 0, is therefore incorrect.

This change adds an explicit remote exact-key query service for append tables whose application contract makes one non-null column unique. The initial use case is a large append-only image Blob table keyed by a normalized object name. Returning only the Blob descriptor lets an inference service reuse the original append table without maintaining a second descriptor primary-key table.

## Approach

A BTree global index is used as an exact coverage gate for one pinned snapshot. Requests do not point-read the BTree.

1. One monitor selects and leases an exact snapshot.
2. It validates complete BTree coverage and plans that snapshot's splits.
3. Bootstrap subtasks read each split once and project only lookup/value fields.
4. Rows are shuffled with `floorMod(BinaryRow.hashCode(), parallelism)`.
5. Each executor builds shadow local state and starts a bounded query server.
6. Discovery becomes READY only after every shard acknowledges the same generation and snapshot.

## Correctness and consistency

- The feature does not create or emulate a primary key.
- It accepts only unpartitioned, main-branch, bucket-unaware data-evolution append tables.
- Keys are canonicalized to `RowKind.INSERT`.
- Null table keys are skipped; null request keys are rejected.
- A duplicate non-null key invalidates the whole generation. There is no first/last-wins policy.
- An unserveable or oversized individual value invalidates the generation before READY.
- Seeing a new generation immediately raises every executor's accepted fence. A cached old descriptor therefore gets STALE/NOT_READY instead of a false MISS for an unindexed tail.
- The client validates server epoch, generation, snapshot ID and snapshot identity before interpreting values or structured errors.
- `getValuesWithMetadata` exposes the served fence. A MISS is exact for the advertised snapshot; it is not an implicit read-after-write guarantee.

## Blob and compaction semantics

A selected top-level raw Blob field is read with `blob-as-descriptor=true` inside the query-service table copy. State and responses contain `BlobDescriptor.serialize()`, never Blob payload bytes. Nested Blob, inline descriptor and BlobView fields are rejected in this version.

Ordinary and Blob compaction create a new fenced generation. A per-attempt snapshot lease protects active/building snapshots and provides an acknowledged handover grace period so in-flight descriptors remain readable. Disabling Blob compaction is a reasonable first-deployment optimization, but correctness does not depend on it.

## Discovery and protocol

Protocol v2 discovery contains table UUID, branch, schema fingerprint, ordered lookup/value field IDs, generation, snapshot identity, layout/hash version, owner token, readiness and one address/server epoch per shard.

Expected failures use typed, bounded normal response frames. This client never deserializes legacy Java `Throwable` frames. Requests and responses enforce key-count, byte and frame limits; requests have a timeout and one discovery-refresh retry; servers use a bounded queue and return typed OVERLOADED responses.

## Recovery

State is ephemeral and rebuilt after restart. New attempts first publish NOT_READY with new server epochs. Owner-scoped descriptors and tombstones prevent delayed attempts from overwriting, deleting or reviving newer owners.

Consumer leases survive task close until persisted expiration, protecting failover handover. READY and exact all-shard NOT_READY acknowledgements each get independent grace deadlines, so continuous commits cannot permanently pin the oldest snapshot.

## Compatibility

The existing primary-key QueryService, KV protocol and two-argument Procedure remain unchanged. The append path is selected only when lookup/value arguments are present. Flink 1.18 gets a compatible six-position overload. The new remote wrapper is explicit and does not change SQL lookup-join selection.

## Security and operational boundary

The service rejects query-auth-enabled tables and unsafe corrupt/lost-file or consumer options, checking persisted schema options as well as dynamic copies. Consumer IDs are bounded safe path segments.

This transport does not provide end-user authentication or TLS. Executor ports must stay on a trusted network, with an authenticated Gateway for external traffic.

This version performs one full projected scan per fully indexed snapshot and stores one projected value per key on executor-local disk. Parallelism distributes state and requests, but refresh still incurs a full scan and shuffle.

Operational constraints:

- Run only one logical service job for one lookup projection; owner sequence allocation is not a cross-job CAS.
- Service FileIO needs read-after-write visibility and consistent listings.
- The lookup key must be unique for all non-null values.
- New snapshots need complete BTree coverage before READY.
- Persisted `consumer.expiration-time` must exceed lease grace plus recovery margin.

## Tests

- Core query/coverage/location/lease/ServiceManager: 35 tests.
- Service protocol/network/runtime: 34 tests.
- Flink monitor/register/action/procedure: 12 tests.
- MiniCluster global-index E2E: 3 tests covering hit/miss/batch, unindexed tail, refresh, stale fences, Blob descriptor/compaction, public Action/Procedure, remote wrapper, same-job TaskManager failover, cancellation tombstone and P1-to-P2 rescale.
- Existing PK RemoteLookupJoin: 2 tests.
- Flink 1.18 legacy and six-argument positional Procedure tests passed.
- Flink 2.2/JDK11 reactor package and five-module validation passed.

Flink 1.17/VVR8 is intentionally a downstream backport/release gate.

## Suggested review order

The feature is organized in the first three commits:

1. Core query, coverage, lease and discovery contracts.
2. Transport hardening and protocol framing.
3. Flink topology, public entry points, integration tests and documentation.

The remaining commits contain cross-version CI compatibility fixes, deterministic test hardening, and the LocalFileIO atomic-overwrite correction discovered by the full integration matrix; they do not change the query-service feature contract above.
