### PR TITLE
Fix #9113 Exception when reading Paimon table via Hive proxy user in …

### DIFF
--- a/paimon-hive/paimon-hive-connector-common/src/main/java/org/apache/paimon/hive/PaimonStorageHandler.java
+++ b/paimon-hive/paimon-hive-connector-common/src/main/java/org/apache/paimon/hive/PaimonStorageHandler.java
@@ -81,12 +81,12 @@ public class PaimonStorageHandler implements HiveStoragePredicateHandler, HiveSt
         Properties properties = tableDesc.getProperties();
         String paimonLocation = LocationKeyExtractor.getPaimonLocation(conf, properties);
         map.put(LocationKeyExtractor.INTERNAL_LOCATION, paimonLocation);
-        String dataFieldJsonStr = getDataFieldsJsonStr(properties);
+        String dataFieldJsonStr = getDataFieldsJsonStr(conf, properties);
         tableDesc.getProperties().put(PAIMON_TABLE_FIELDS, dataFieldJsonStr);
     }
 
-    static String getDataFieldsJsonStr(Properties properties) {
-        HiveSchema hiveSchema = HiveSchema.extract(null, properties);
+    static String getDataFieldsJsonStr(Configuration conf, Properties properties) {
+        HiveSchema hiveSchema = HiveSchema.extract(conf, properties);
         return JsonSerdeUtil.toJson(hiveSchema.fields());
     }
 

--- a/paimon-hive/paimon-hive-connector-common/src/test/java/org/apache/paimon/hive/HiveTableSchemaTest.java
+++ b/paimon-hive/paimon-hive-connector-common/src/test/java/org/apache/paimon/hive/HiveTableSchemaTest.java
@@ -29,6 +29,7 @@ import org.apache.paimon.utils.JsonSerdeUtil;
 
 import org.apache.paimon.shade.jackson2.com.fasterxml.jackson.core.type.TypeReference;
 
+import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hive.metastore.api.hive_metastoreConstants;
 import org.apache.hadoop.hive.serde2.typeinfo.TypeInfoFactory;
 import org.junit.jupiter.api.Test;
@@ -403,5 +404,78 @@ public class HiveTableSchemaTest {
                 JsonSerdeUtil.fromJson(dataFieldStr, new TypeReference<List<DataField>>() {});
         HiveSchema newHiveSchema = new HiveSchema(new RowType(dataFieldsDeserialized));
         assertThat(newHiveSchema).usingRecursiveComparison().isEqualTo(hiveSchema);
+    }
+
+    @Test
+    public void testGetDataFieldsJsonStrWithNullConf() throws Exception {
+        createSchema();
+        Properties properties = createTableWithExistsDDL();
+
+        String jsonStr = PaimonStorageHandler.getDataFieldsJsonStr(null, properties);
+
+        List<DataField> deserializedFields =
+                JsonSerdeUtil.fromJson(jsonStr, new TypeReference<List<DataField>>() {});
+        assertThat(deserializedFields).hasSize(3);
+        assertThat(deserializedFields.get(0).name()).isEqualTo("a");
+        assertThat(deserializedFields.get(0).type()).isEqualTo(DataTypes.INT());
+        assertThat(deserializedFields.get(0).description()).isEqualTo("first comment");
+        assertThat(deserializedFields.get(1).name()).isEqualTo("b");
+        assertThat(deserializedFields.get(1).type()).isEqualTo(DataTypes.STRING());
+        assertThat(deserializedFields.get(1).description()).isEqualTo("second comment");
+        assertThat(deserializedFields.get(2).name()).isEqualTo("c");
+        assertThat(deserializedFields.get(2).type()).isEqualTo(DataTypes.DECIMAL(5, 3));
+        assertThat(deserializedFields.get(2).description()).isEqualTo("last comment");
+    }
+
+    @Test
+    public void testGetDataFieldsJsonStrWithConf() throws Exception {
+        createSchema();
+        Properties properties = createTableWithExistsDDL();
+        Configuration conf = new Configuration();
+
+        String jsonStr = PaimonStorageHandler.getDataFieldsJsonStr(conf, properties);
+
+        List<DataField> deserializedFields =
+                JsonSerdeUtil.fromJson(jsonStr, new TypeReference<List<DataField>>() {});
+        assertThat(deserializedFields).hasSize(3);
+        assertThat(deserializedFields.get(0).name()).isEqualTo("a");
+        assertThat(deserializedFields.get(0).type()).isEqualTo(DataTypes.INT());
+        assertThat(deserializedFields.get(1).name()).isEqualTo("b");
+        assertThat(deserializedFields.get(1).type()).isEqualTo(DataTypes.STRING());
+        assertThat(deserializedFields.get(2).name()).isEqualTo("c");
+        assertThat(deserializedFields.get(2).type()).isEqualTo(DataTypes.DECIMAL(5, 3));
+    }
+
+    @Test
+    public void testGetDataFieldsJsonStrWithEmptyDDLAndPaimonTable() throws Exception {
+        createSchema();
+        Properties properties = createTableWithEmptyDDL();
+        Configuration conf = new Configuration();
+
+        String jsonStr = PaimonStorageHandler.getDataFieldsJsonStr(conf, properties);
+
+        List<DataField> deserializedFields =
+                JsonSerdeUtil.fromJson(jsonStr, new TypeReference<List<DataField>>() {});
+        HiveSchema reconstructedSchema = new HiveSchema(new RowType(deserializedFields));
+        HiveSchema originalSchema = HiveSchema.extract(conf, properties);
+        assertThat(reconstructedSchema).usingRecursiveComparison().isEqualTo(originalSchema);
+    }
+
+    @Test
+    public void testGetDataFieldsJsonStrRoundtrip() throws Exception {
+        createSchema();
+        Properties properties = createTableWithExistsDDL();
+        Configuration conf = new Configuration();
+
+        String jsonStr = PaimonStorageHandler.getDataFieldsJsonStr(conf, properties);
+
+        List<DataField> deserializedFields =
+                JsonSerdeUtil.fromJson(jsonStr, new TypeReference<List<DataField>>() {});
+        HiveSchema schemaFromJson = new HiveSchema(new RowType(deserializedFields));
+        HiveSchema schemaDirect = HiveSchema.extract(conf, properties);
+
+        assertThat(schemaFromJson.fieldNames()).isEqualTo(schemaDirect.fieldNames());
+        assertThat(schemaFromJson.fieldTypes()).isEqualTo(schemaDirect.fieldTypes());
+        assertThat(schemaFromJson.fieldComments()).isEqualTo(schemaDirect.fieldComments());
     }
 }


### PR DESCRIPTION
…Kerberos-enabled environment

### Purpose
When querying Paimon external tables via Hive in a Kerberos-secured cluster with proxy user (e.g., Hue, JDBC through HiveServer2), the query fails with:
org.apache.hadoop.hive.ql.parse.SemanticException: Proxy user is not supported
    at org.apache.hadoop.hive.ql.optimizer.SimpleFetchOptimizer.transform(SimpleFetchOptimizer.java:125)
The root cause is that PaimonStorageHandler#getDataFieldsJsonStr passes null as the Configuration to HiveSchema.extract:
// Before
```
static String getDataFieldsJsonStr(Properties properties) {
    HiveSchema hiveSchema = HiveSchema.extract(null, properties);
    ...
}
```
With a null Configuration:
Kerberos credentials are invisible: HiveUtils.extractCatalogConfig(null) returns an empty Options, so Paimon security settings (e.g., paimon.security.kerberos.login.keytab, paimon.security.kerberos.login.principal) configured in Hadoop Configuration are not loaded.
Filesystem initialization fails silently: FileIO.get() cannot obtain a properly authenticated filesystem under the proxy user's doAs context. The schema file fetch silently fails, causing SimpleFetchOptimizer to fall back to a direct-access code path that rejects proxy users.
The fix passes the actual Configuration instance (which carries Kerberos credentials and proxy user context) through the call chain:
// After
```
static String getDataFieldsJsonStr(Configuration conf, Properties properties) {
    HiveSchema hiveSchema = HiveSchema.extract(conf, properties);
    ...
}
```
This ensures HiveSchema.extract can properly initialize the filesystem with Kerberos authentication under the proxy user's UGI, allowing the schema to be read correctly and the query to proceed via the normal MR/Tez execution path instead of falling back to SimpleFetchOptimizer.
### Tests
Added 4 unit tests in HiveTableSchemaTest:
1. testGetDataFieldsJsonStrWithNullConf: Verifies JSON output correctness when conf is null (backward-compatible, local FS).
2. testGetDataFieldsJsonStrWithConf: Verifies JSON output correctness when conf is a real Configuration instance (the fixed code path).
3. testGetDataFieldsJsonStrWithEmptyDDLAndPaimonTable: Verifies JSON roundtrip with empty DDL and an existing Paimon table schema.
4. testGetDataFieldsJsonStrRoundtrip: Verifies that serializing and deserializing the JSON output preserves field names, types, and comments.