### PR TITLE
[flink] Fix flaky test duplicate nullable PK IT

### DIFF
--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/NullablePrimaryKeyITCase.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/NullablePrimaryKeyITCase.java
@@ -90,7 +90,13 @@ public class NullablePrimaryKeyITCase extends CatalogITCaseBase {
                         + "(1, 'one')");
 
         assertThat(sql("SELECT * FROM T"))
-                .containsExactlyInAnyOrder(Row.of(null, "null-v2"), Row.of(1, "one"));
+                .hasSize(2)
+                .contains(Row.of(1, "one"))
+                .anySatisfy(
+                        row -> {
+                            assertThat(row.getField(0)).isNull();
+                            assertThat(row.getField(1)).isIn("null-v1", "null-v2");
+                        });
     }
 
     @Test

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/NullablePrimaryKeyITCase.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/NullablePrimaryKeyITCase.java
@@ -89,9 +89,14 @@ public class NullablePrimaryKeyITCase extends CatalogITCaseBase {
                         + "(CAST(NULL AS INT), 'null-v2'), "
                         + "(1, 'one')");
 
-        // Without a sequence field, either value may win within the same commit.
-        assertThat(sql("SELECT id FROM T"))
-                .containsExactlyInAnyOrder(Row.of((Object) null), Row.of(1));
+        assertThat(sql("SELECT * FROM T"))
+                .hasSize(2)
+                .contains(Row.of(1, "one"))
+                .anySatisfy(
+                        row -> {
+                            assertThat(row.getField(0)).isNull();
+                            assertThat(row.getField(1)).isIn("null-v1", "null-v2");
+                        });
     }
 
     @Test


### PR DESCRIPTION
### Purpose
 - The test inserts two null pks in one insert and asserts the second one wins.
 - Sequence numbers are assigned on arrival and deduplication keeps the highest, so the surviving row varies depending on the arrival order. (18 of 39 runs failed)
 - Fix the assertion to be compatible with the deduplication. All runs pass post fix.
### Tests
 - UT fix