### PR TITLE
[flink] Fix nullable primary key test across Flink versions

### DIFF
--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/NullablePrimaryKeyITCase.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/NullablePrimaryKeyITCase.java
@@ -89,8 +89,9 @@ public class NullablePrimaryKeyITCase extends CatalogITCaseBase {
                         + "(CAST(NULL AS INT), 'null-v2'), "
                         + "(1, 'one')");
 
-        assertThat(sql("SELECT * FROM T"))
-                .containsExactlyInAnyOrder(Row.of(null, "null-v2"), Row.of(1, "one"));
+        // Without a sequence field, either value may win within the same commit.
+        assertThat(sql("SELECT id FROM T"))
+                .containsExactlyInAnyOrder(Row.of((Object) null), Row.of(1));
     }
 
     @Test


### PR DESCRIPTION
### Purpose

`testDuplicateNullablePrimaryKeyWithinSingleCommit` assumed that the second input row always wins without a sequence field. However, Flink 1.x and 2.x may deliver the rows in different orders, making the assertion version-dependent.

Assert only the primary keys so the test continues to verify nullable-key deduplication without relying on an undefined winner.

### Tests

 - `NullablePrimaryKeyITCase#testDuplicateNullablePrimaryKeyWithinSingleCommit` with Flink 1
  - `NullablePrimaryKeyITCase#testDuplicateNullablePrimaryKeyWithinSingleCommit` with Flink 2
  - Checkstyle and Spotless
