### PR TITLE
[core] Spell out what a negative partition statistic means

### DIFF
--- a/paimon-api/src/main/java/org/apache/paimon/partition/PartitionStatistics.java
+++ b/paimon-api/src/main/java/org/apache/paimon/partition/PartitionStatistics.java
@@ -30,14 +30,38 @@ import java.util.Map;
 import java.util.Objects;
 
 /**
- * Statistics of a partition, fields inside may be negative, indicating that some data has been
- * removed.
+ * Statistics of a partition.
+ *
+ * <p>The numeric fields are read on two planes, and a negative value means a different thing on
+ * each. Which plane an instance belongs to follows from where it came from, never from the value:
+ *
+ * <ul>
+ *   <li><b>Delta plane</b> — what a commit changed. A negative value is a decrement, and the server
+ *       adds it to what it already holds. This is what a table snapshot commit reports.
+ *   <li><b>Observation plane</b> — what a partition currently holds, as returned by {@code
+ *       listPartitions}. A negative value ({@link #UNKNOWN}) means nobody ever reported that field,
+ *       and {@code 0} means an exact zero. The two are not interchangeable: a consumer that treats
+ *       unknown as zero plans against an empty partition that may hold a billion rows.
+ * </ul>
+ *
+ * <p>Unknown is per field, not per partition: a reporter that only knows the file count leaves the
+ * record count {@link #UNKNOWN} and fills the rest. Use {@link #isKnown(long)} rather than
+ * comparing against {@code -1}; any negative value on the observation plane is unknown.
  */
 @JsonIgnoreProperties(ignoreUnknown = true)
 @Public
 public class PartitionStatistics implements Serializable {
 
     private static final long serialVersionUID = 1L;
+
+    /**
+     * Canonical encoding of "this field was never reported" on the observation plane. Any negative
+     * value carries the same meaning; this is the one to write.
+     */
+    public static final long UNKNOWN = -1L;
+
+    /** Format tables have no buckets, so their bucket count is always unknown. */
+    public static final int UNKNOWN_TOTAL_BUCKETS = -1;
 
     public static final String FIELD_SPEC = "spec";
     public static final String FIELD_RECORD_COUNT = "recordCount";
@@ -80,6 +104,20 @@ public class PartitionStatistics implements Serializable {
         this.fileCount = fileCount;
         this.lastFileCreationTime = lastFileCreationTime;
         this.totalBuckets = totalBuckets;
+    }
+
+    /** Statistics of a partition nobody ever reported on: every field {@link #UNKNOWN}. */
+    public static PartitionStatistics unknown(Map<String, String> spec) {
+        return new PartitionStatistics(
+                spec, UNKNOWN, UNKNOWN, UNKNOWN, UNKNOWN, UNKNOWN_TOTAL_BUCKETS);
+    }
+
+    /**
+     * Whether an observation-plane field carries a real measurement. Never apply this to a
+     * delta-plane value, where a negative number is a decrement rather than a missing measurement.
+     */
+    public static boolean isKnown(long value) {
+        return value >= 0;
     }
 
     @JsonGetter(FIELD_SPEC)

--- a/paimon-api/src/test/java/org/apache/paimon/partition/PartitionStatisticsTest.java
+++ b/paimon-api/src/test/java/org/apache/paimon/partition/PartitionStatisticsTest.java
@@ -22,6 +22,9 @@ import org.apache.paimon.utils.JsonSerdeUtil;
 
 import org.junit.jupiter.api.Test;
 
+import java.util.Collections;
+import java.util.Map;
+
 import static org.assertj.core.api.Assertions.assertThat;
 
 /** Test for {@link PartitionStatistics}. */
@@ -40,5 +43,34 @@ public class PartitionStatisticsTest {
         assertThat(stats.fileCount()).isEqualTo(2);
         assertThat(stats.lastFileCreationTime()).isEqualTo(123456789L);
         assertThat(stats.totalBuckets()).isEqualTo(0);
+    }
+
+    @Test
+    void testZeroIsAKnownMeasurement() {
+        // The boundary the whole observation-plane contract rests on: an empty partition was
+        // measured, and a consumer that reads its zero as "nobody looked" plans against the wrong
+        // table.
+        assertThat(PartitionStatistics.isKnown(0L)).isTrue();
+        assertThat(PartitionStatistics.isKnown(1L)).isTrue();
+        assertThat(PartitionStatistics.isKnown(Long.MAX_VALUE)).isTrue();
+
+        assertThat(PartitionStatistics.isKnown(PartitionStatistics.UNKNOWN)).isFalse();
+        // Unknown is any negative value, not only the canonical -1.
+        assertThat(PartitionStatistics.isKnown(-2L)).isFalse();
+        assertThat(PartitionStatistics.isKnown(Long.MIN_VALUE)).isFalse();
+    }
+
+    @Test
+    void testUnknownLeavesEveryFieldUnknown() {
+        Map<String, String> spec = Collections.singletonMap("pt", "1");
+
+        PartitionStatistics stats = PartitionStatistics.unknown(spec);
+
+        assertThat(stats.spec()).isEqualTo(spec);
+        assertThat(PartitionStatistics.isKnown(stats.recordCount())).isFalse();
+        assertThat(PartitionStatistics.isKnown(stats.fileSizeInBytes())).isFalse();
+        assertThat(PartitionStatistics.isKnown(stats.fileCount())).isFalse();
+        assertThat(PartitionStatistics.isKnown(stats.lastFileCreationTime())).isFalse();
+        assertThat(PartitionStatistics.isKnown(stats.totalBuckets())).isFalse();
     }
 }

--- a/paimon-core/src/main/java/org/apache/paimon/table/format/FileSystemSplitEnumerator.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/format/FileSystemSplitEnumerator.java
@@ -25,6 +25,7 @@ import org.apache.paimon.fs.Path;
 import org.apache.paimon.manifest.PartitionEntry;
 import org.apache.paimon.partition.PartitionPredicate;
 import org.apache.paimon.partition.PartitionPredicate.MultiplePartitionPredicate;
+import org.apache.paimon.partition.PartitionStatistics;
 import org.apache.paimon.predicate.Predicate;
 import org.apache.paimon.table.FormatTable;
 import org.apache.paimon.table.source.Split;
@@ -125,7 +126,16 @@ final class FileSystemSplitEnumerator extends SplitEnumerator {
         List<PartitionEntry> partitionEntries = new ArrayList<>();
         for (Pair<LinkedHashMap<String, String>, Path> partition2Path : partition2Paths) {
             BinaryRow row = toPartitionRow(partition2Path.getKey());
-            partitionEntries.add(new PartitionEntry(row, -1L, -1L, -1L, -1L, -1));
+            // Discovering partitions from directories measures nothing about what is inside them,
+            // so every statistic is unknown rather than zero.
+            partitionEntries.add(
+                    new PartitionEntry(
+                            row,
+                            PartitionStatistics.UNKNOWN,
+                            PartitionStatistics.UNKNOWN,
+                            PartitionStatistics.UNKNOWN,
+                            PartitionStatistics.UNKNOWN,
+                            PartitionStatistics.UNKNOWN_TOTAL_BUCKETS));
         }
         return partitionEntries;
     }


### PR DESCRIPTION
### Purpose

`PartitionStatistics` says only that its fields "may be negative, indicating that some data has been
removed". That covers one of the two planes the class is read on, and consumers have been getting the
other one wrong.

- **Delta plane** — what a commit changed. A negative value is a decrement the server adds to what it
  holds. That is the existing meaning and **nothing here changes it**.
- **Observation plane** — what `listPartitions` returns for a partition as it stands. A negative value
  means nobody ever reported that field, and `0` means an exact zero.

Conflating them is not cosmetic. A consumer that reads unknown as zero plans against an empty
partition that may hold a billion rows; one that does arithmetic on it gets a number that is wrong
rather than missing. This has already produced a silent wrong answer in a sibling project, where
`COUNT(*)` was answered from a placeholder row count and returned zero for a partition full of data
(apache/paimon-rust#624).

So: the plane is named in the javadoc, unknown gets a name (`UNKNOWN`, with `isKnown()` to test it
rather than each caller comparing against `-1`), and unknown is documented as **per field** — a
reporter that only knows the file count leaves the record count unknown and fills the rest.

### Why the fields stay primitive

Boxing them to express unknown as `null` would be a breaking change to a `@Public` class, and the
encoding above needs no new type.

### Behaviour

Zero change. `UNKNOWN` is a name for a value already in use. `FileSystemSplitEnumerator` now says
`PartitionStatistics.UNKNOWN` where it said `-1` — the same value under its own name, because
discovering partitions by listing directories measures nothing about what is inside them, which is
what unknown already meant there.

### Context

This is the first of a stack that lets a catalog-managed format table report partition statistics; a
format table has no snapshot, so the channel a table snapshot uses does not exist for it. This PR is
worth having on its own regardless of the rest of that stack: the ambiguity it removes has already
cost one silent wrong answer.

### API and Format

`PartitionStatistics` gains `UNKNOWN`, `UNKNOWN_TOTAL_BUCKETS`, `unknown(spec)` and
`isKnown(long)`. Additive only; no existing signature changes. No format change.

### Documentation

The contract now lives in the class javadoc, which is where a consumer looks.