### PR TITLE
[rest] Do not replay a POST the server cannot absorb twice

### DIFF
--- a/paimon-api/src/main/java/org/apache/paimon/partition/PartitionStatistics.java
+++ b/paimon-api/src/main/java/org/apache/paimon/partition/PartitionStatistics.java
@@ -30,14 +30,38 @@ import java.util.Map;
 import java.util.Objects;
 
 /**
- * Statistics of a partition, fields inside may be negative, indicating that some data has been
- * removed.
+ * Statistics of a partition.
+ *
+ * <p>The numeric fields are read on two planes, and a negative value means a different thing on
+ * each. Which plane an instance belongs to follows from where it came from, never from the value:
+ *
+ * <ul>
+ *   <li><b>Delta plane</b> — what a commit changed. A negative value is a decrement, and the server
+ *       adds it to what it already holds. This is what a table snapshot commit reports.
+ *   <li><b>Observation plane</b> — what a partition currently holds, as returned by {@code
+ *       listPartitions}. A negative value ({@link #UNKNOWN}) means nobody ever reported that field,
+ *       and {@code 0} means an exact zero. The two are not interchangeable: a consumer that treats
+ *       unknown as zero plans against an empty partition that may hold a billion rows.
+ * </ul>
+ *
+ * <p>Unknown is per field, not per partition: a reporter that only knows the file count leaves the
+ * record count {@link #UNKNOWN} and fills the rest. Use {@link #isKnown(long)} rather than
+ * comparing against {@code -1}; any negative value on the observation plane is unknown.
  */
 @JsonIgnoreProperties(ignoreUnknown = true)
 @Public
 public class PartitionStatistics implements Serializable {
 
     private static final long serialVersionUID = 1L;
+
+    /**
+     * Canonical encoding of "this field was never reported" on the observation plane. Any negative
+     * value carries the same meaning; this is the one to write.
+     */
+    public static final long UNKNOWN = -1L;
+
+    /** Format tables have no buckets, so their bucket count is always unknown. */
+    public static final int UNKNOWN_TOTAL_BUCKETS = -1;
 
     public static final String FIELD_SPEC = "spec";
     public static final String FIELD_RECORD_COUNT = "recordCount";
@@ -80,6 +104,20 @@ public class PartitionStatistics implements Serializable {
         this.fileCount = fileCount;
         this.lastFileCreationTime = lastFileCreationTime;
         this.totalBuckets = totalBuckets;
+    }
+
+    /** Statistics of a partition nobody ever reported on: every field {@link #UNKNOWN}. */
+    public static PartitionStatistics unknown(Map<String, String> spec) {
+        return new PartitionStatistics(
+                spec, UNKNOWN, UNKNOWN, UNKNOWN, UNKNOWN, UNKNOWN_TOTAL_BUCKETS);
+    }
+
+    /**
+     * Whether an observation-plane field carries a real measurement. Never apply this to a
+     * delta-plane value, where a negative number is a decrement rather than a missing measurement.
+     */
+    public static boolean isKnown(long value) {
+        return value >= 0;
     }
 
     @JsonGetter(FIELD_SPEC)

--- a/paimon-api/src/main/java/org/apache/paimon/rest/ExponentialHttpRequestRetryStrategy.java
+++ b/paimon-api/src/main/java/org/apache/paimon/rest/ExponentialHttpRequestRetryStrategy.java
@@ -23,6 +23,7 @@ import org.apache.paimon.utils.Preconditions;
 import org.apache.paimon.shade.guava30.com.google.common.collect.ImmutableSet;
 
 import org.apache.hc.client5.http.HttpRequestRetryStrategy;
+import org.apache.hc.client5.http.protocol.HttpClientContext;
 import org.apache.hc.client5.http.utils.DateUtils;
 import org.apache.hc.core5.concurrent.CancellableDependency;
 import org.apache.hc.core5.http.ConnectionClosedException;
@@ -35,6 +36,7 @@ import org.apache.hc.core5.http.Method;
 import org.apache.hc.core5.http.protocol.HttpContext;
 import org.apache.hc.core5.util.TimeValue;
 
+import javax.annotation.Nullable;
 import javax.net.ssl.SSLException;
 
 import java.io.IOException;
@@ -47,6 +49,16 @@ import java.util.Set;
 import java.util.concurrent.ThreadLocalRandom;
 
 class ExponentialHttpRequestRetryStrategy implements HttpRequestRetryStrategy {
+
+    /**
+     * Context attribute marking one exchange as "must not be sent twice". A 429 or a 503 can reach
+     * the client from a proxy after the server already applied the request, so replaying it applies
+     * it again; for a request that is not idempotent by content that is a silent double apply. The
+     * mark travels in the context rather than in the request, so it never reaches the wire and
+     * survives whatever the exec chain does to the request object.
+     */
+    static final String RETRY_UNSAFE_ATTRIBUTE = "paimon.rest.retry-unsafe";
+
     private final int maxRetries;
     private final Set<Class<? extends IOException>> nonRetriableExceptions;
     private final Set<Integer> retriableCodes;
@@ -98,7 +110,24 @@ class ExponentialHttpRequestRetryStrategy implements HttpRequestRetryStrategy {
 
     @Override
     public boolean retryRequest(HttpResponse response, int execCount, HttpContext context) {
+        if (isRetryUnsafe(context)) {
+            // The status says nothing about whether the server applied the request: a 503 from an
+            // intermediary can follow a request that already took effect. Replaying it would apply
+            // it twice with nobody the wiser, so the failure goes back to the caller instead.
+            return false;
+        }
         return execCount <= maxRetries && retriableCodes.contains(response.getCode());
+    }
+
+    /** A context for one exchange that must be sent exactly once. */
+    static HttpClientContext retryUnsafeContext() {
+        HttpClientContext context = HttpClientContext.create();
+        context.setAttribute(RETRY_UNSAFE_ATTRIBUTE, Boolean.TRUE);
+        return context;
+    }
+
+    static boolean isRetryUnsafe(@Nullable HttpContext context) {
+        return context != null && Boolean.TRUE.equals(context.getAttribute(RETRY_UNSAFE_ATTRIBUTE));
     }
 
     @Override

--- a/paimon-api/src/main/java/org/apache/paimon/rest/HttpClient.java
+++ b/paimon-api/src/main/java/org/apache/paimon/rest/HttpClient.java
@@ -36,8 +36,12 @@ import org.apache.hc.client5.http.classic.methods.HttpUriRequestBase;
 import org.apache.hc.core5.http.ClassicHttpResponse;
 import org.apache.hc.core5.http.ContentType;
 import org.apache.hc.core5.http.Header;
+import org.apache.hc.core5.http.io.HttpClientResponseHandler;
 import org.apache.hc.core5.http.io.entity.StringEntity;
 import org.apache.hc.core5.http.message.BasicHeader;
+import org.apache.hc.core5.http.protocol.HttpContext;
+
+import javax.annotation.Nullable;
 
 import java.io.IOException;
 import java.util.Arrays;
@@ -100,7 +104,13 @@ public class HttpClient implements RESTClient {
         }
         Header[] authHeaders = getHeaders(path, "POST", encodedBody, restAuthFunction);
         httpPost.setHeaders(authHeaders);
-        return exec(httpPost, responseType);
+        // A POST the server cannot absorb twice is sent exactly once, whatever the status says.
+        return exec(
+                httpPost,
+                responseType,
+                body != null && !body.isRetrySafe()
+                        ? ExponentialHttpRequestRetryStrategy.retryUnsafeContext()
+                        : null);
     }
 
     @Override
@@ -127,9 +137,13 @@ public class HttpClient implements RESTClient {
     }
 
     private <T extends RESTResponse> T exec(HttpUriRequestBase request, Class<T> responseType) {
+        return exec(request, responseType, null);
+    }
+
+    private <T extends RESTResponse> T exec(
+            HttpUriRequestBase request, Class<T> responseType, @Nullable HttpContext context) {
         try {
-            return DEFAULT_HTTP_CLIENT.execute(
-                    request,
+            HttpClientResponseHandler<T> handler =
                     response -> {
                         String responseBodyStr = RESTUtil.extractResponseBodyAsString(response);
                         if (!RESTUtil.isSuccessful(response)) {
@@ -159,7 +173,10 @@ public class HttpClient implements RESTClient {
                         } else {
                             throw new RESTException("response body is null.");
                         }
-                    });
+                    };
+            return context == null
+                    ? DEFAULT_HTTP_CLIENT.execute(request, handler)
+                    : DEFAULT_HTTP_CLIENT.execute(request, context, handler);
         } catch (IOException e) {
             // No cause: a redirect/protocol error message can echo the target URL (a signed URL).
             throw new RESTException(

--- a/paimon-api/src/main/java/org/apache/paimon/rest/RESTRequest.java
+++ b/paimon-api/src/main/java/org/apache/paimon/rest/RESTRequest.java
@@ -18,5 +18,27 @@
 
 package org.apache.paimon.rest;
 
+import org.apache.paimon.shade.jackson2.com.fasterxml.jackson.annotation.JsonIgnore;
+
 /** Interface to mark a REST request. */
-public interface RESTRequest extends RESTMessage {}
+public interface RESTRequest extends RESTMessage {
+
+    /**
+     * Whether sending this request a second time leaves the server where sending it once does.
+     *
+     * <p>This is how the client treats the request, not something the server is told: it is a
+     * getter on a serialized type and must stay off the wire.
+     *
+     * <p>POST is not idempotent by method, but nearly every request Paimon sends over it is by
+     * content — registering a partition, creating a database, committing a snapshot the server
+     * already holds — so the client retries them after a 429 or a 503, which is the only defence
+     * against a rate limiter or a restarting node. A request that reports an increment is the
+     * exception: a proxy answering 503 after the server already applied it turns an automatic retry
+     * into a double count that no caller can see. Such a request says so here and is sent exactly
+     * once; the failure reaches the caller, which can decide.
+     */
+    @JsonIgnore
+    default boolean isRetrySafe() {
+        return true;
+    }
+}

--- a/paimon-api/src/test/java/org/apache/paimon/partition/PartitionStatisticsTest.java
+++ b/paimon-api/src/test/java/org/apache/paimon/partition/PartitionStatisticsTest.java
@@ -22,6 +22,9 @@ import org.apache.paimon.utils.JsonSerdeUtil;
 
 import org.junit.jupiter.api.Test;
 
+import java.util.Collections;
+import java.util.Map;
+
 import static org.assertj.core.api.Assertions.assertThat;
 
 /** Test for {@link PartitionStatistics}. */
@@ -40,5 +43,34 @@ public class PartitionStatisticsTest {
         assertThat(stats.fileCount()).isEqualTo(2);
         assertThat(stats.lastFileCreationTime()).isEqualTo(123456789L);
         assertThat(stats.totalBuckets()).isEqualTo(0);
+    }
+
+    @Test
+    void testZeroIsAKnownMeasurement() {
+        // The boundary the whole observation-plane contract rests on: an empty partition was
+        // measured, and a consumer that reads its zero as "nobody looked" plans against the wrong
+        // table.
+        assertThat(PartitionStatistics.isKnown(0L)).isTrue();
+        assertThat(PartitionStatistics.isKnown(1L)).isTrue();
+        assertThat(PartitionStatistics.isKnown(Long.MAX_VALUE)).isTrue();
+
+        assertThat(PartitionStatistics.isKnown(PartitionStatistics.UNKNOWN)).isFalse();
+        // Unknown is any negative value, not only the canonical -1.
+        assertThat(PartitionStatistics.isKnown(-2L)).isFalse();
+        assertThat(PartitionStatistics.isKnown(Long.MIN_VALUE)).isFalse();
+    }
+
+    @Test
+    void testUnknownLeavesEveryFieldUnknown() {
+        Map<String, String> spec = Collections.singletonMap("pt", "1");
+
+        PartitionStatistics stats = PartitionStatistics.unknown(spec);
+
+        assertThat(stats.spec()).isEqualTo(spec);
+        assertThat(PartitionStatistics.isKnown(stats.recordCount())).isFalse();
+        assertThat(PartitionStatistics.isKnown(stats.fileSizeInBytes())).isFalse();
+        assertThat(PartitionStatistics.isKnown(stats.fileCount())).isFalse();
+        assertThat(PartitionStatistics.isKnown(stats.lastFileCreationTime())).isFalse();
+        assertThat(PartitionStatistics.isKnown(stats.totalBuckets())).isFalse();
     }
 }

--- a/paimon-api/src/test/java/org/apache/paimon/rest/HttpClientRetrySafetyTest.java
+++ b/paimon-api/src/test/java/org/apache/paimon/rest/HttpClientRetrySafetyTest.java
@@ -1,0 +1,146 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.rest;
+
+import org.apache.paimon.rest.exceptions.ServiceUnavailableException;
+import org.apache.paimon.rest.responses.ListDatabasesResponse;
+
+import org.apache.paimon.shade.jackson2.com.fasterxml.jackson.annotation.JsonGetter;
+
+import com.sun.net.httpserver.HttpExchange;
+import com.sun.net.httpserver.HttpServer;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.net.InetSocketAddress;
+import java.nio.charset.StandardCharsets;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Tests that a POST declaring itself unsafe to replay is sent exactly once, and that every other
+ * POST keeps the 429/503 retry it has always had.
+ *
+ * <p>The server here refuses only the first attempt, so a retried request succeeds on its second
+ * one: the request count separates "sent once" from "sent again" without waiting out five backoffs.
+ */
+public class HttpClientRetrySafetyTest {
+
+    private static final String PATH = "/databases";
+
+    private HttpServer server;
+    private HttpClient client;
+    private final AtomicInteger requests = new AtomicInteger();
+
+    @BeforeEach
+    public void setUp() throws Exception {
+        server = HttpServer.create(new InetSocketAddress(0), 0);
+        server.createContext(
+                PATH,
+                exchange -> {
+                    if (requests.incrementAndGet() == 1) {
+                        // A proxy answering 503 says nothing about whether the server applied the
+                        // request; this is exactly the shape that applies a request twice.
+                        respond(exchange, 503, "{\"message\":\"busy\",\"code\":503}");
+                    } else {
+                        respond(exchange, 200, "{\"databases\":[\"db\"]}");
+                    }
+                });
+        server.start();
+        client = new HttpClient("http://127.0.0.1:" + server.getAddress().getPort());
+    }
+
+    @AfterEach
+    public void tearDown() {
+        if (server != null) {
+            server.stop(0);
+        }
+    }
+
+    @Test
+    public void testARequestThatDeclaresItselfUnsafeIsNotRetried() {
+        assertThatThrownBy(() -> post(new UnsafeToRetry()))
+                .isInstanceOf(ServiceUnavailableException.class);
+
+        // Retrying would apply the same request a second time, and nothing downstream could see it.
+        assertThat(requests.get()).isEqualTo(1);
+    }
+
+    @Test
+    public void testARequestThatNeverHeardOfRetrySafetyKeepsItsRetry() {
+        // The regression this guards against is the global one: every request type implements
+        // RESTRequest and rides the interface default, so the case above would still pass if the
+        // default flipped to false and silently took 429/503 retry away from commits, database
+        // creation and every other POST in the catalog.
+        assertThat(new DefaultRetrySafety().isRetrySafe()).isTrue();
+        assertThat(post(new DefaultRetrySafety())).isNotNull();
+
+        assertThat(requests.get()).isEqualTo(2);
+    }
+
+    @Test
+    public void testRetrySafetyNeverReachesTheWire() {
+        // isRetrySafe is how the client treats the request, not something the server is told. It is
+        // a getter on a serialized type, so without @JsonIgnore it would show up in the body.
+        assertThat(RESTUtil.encodedBody(new UnsafeToRetry())).doesNotContain("retrySafe");
+        assertThat(RESTUtil.encodedBody(new DefaultRetrySafety())).doesNotContain("retrySafe");
+    }
+
+    /** A request that leaves {@link RESTRequest#isRetrySafe()} at its default, as all others do. */
+    private static class DefaultRetrySafety implements RESTRequest {
+
+        @JsonGetter("name")
+        public String getName() {
+            return "db";
+        }
+    }
+
+    /** A request that must reach the server at most once. */
+    private static class UnsafeToRetry implements RESTRequest {
+
+        @JsonGetter("name")
+        public String getName() {
+            return "db";
+        }
+
+        @Override
+        public boolean isRetrySafe() {
+            return false;
+        }
+    }
+
+    private ListDatabasesResponse post(RESTRequest request) {
+        return client.post(PATH, request, ListDatabasesResponse.class, null);
+    }
+
+    private static void respond(HttpExchange exchange, int statusCode, String body)
+            throws IOException {
+        byte[] bytes = body.getBytes(StandardCharsets.UTF_8);
+        exchange.getResponseHeaders().add("Content-Type", "application/json");
+        exchange.sendResponseHeaders(statusCode, bytes.length);
+        try (OutputStream out = exchange.getResponseBody()) {
+            out.write(bytes);
+        }
+    }
+}

--- a/paimon-api/src/test/java/org/apache/paimon/rest/TestExponentialHttpRequestRetryStrategy.java
+++ b/paimon-api/src/test/java/org/apache/paimon/rest/TestExponentialHttpRequestRetryStrategy.java
@@ -20,6 +20,7 @@ package org.apache.paimon.rest;
 
 import org.apache.hc.client5.http.HttpRequestRetryStrategy;
 import org.apache.hc.client5.http.classic.methods.HttpGet;
+import org.apache.hc.client5.http.protocol.HttpClientContext;
 import org.apache.hc.client5.http.utils.DateUtils;
 import org.apache.hc.core5.http.ConnectionClosedException;
 import org.apache.hc.core5.http.HttpHeaders;
@@ -219,5 +220,22 @@ public class TestExponentialHttpRequestRetryStrategy {
     public void testRetryDoesNotHappenOnUnacceptableStatusCodes(int statusCode) {
         BasicHttpResponse response = new BasicHttpResponse(statusCode, String.valueOf(statusCode));
         assertThat(retryStrategy.retryRequest(response, 3, null)).isFalse();
+    }
+
+    @ParameterizedTest
+    @ValueSource(ints = {429, 503})
+    public void testRetryDoesNotHappenOnAnExchangeMarkedUnsafe(int statusCode) {
+        BasicHttpResponse response = new BasicHttpResponse(statusCode, String.valueOf(statusCode));
+
+        // The status says the request failed, not that the server never saw it: a 503 can come
+        // from an intermediary after the request already took effect.
+        assertThat(
+                        retryStrategy.retryRequest(
+                                response,
+                                1,
+                                ExponentialHttpRequestRetryStrategy.retryUnsafeContext()))
+                .isFalse();
+        // Only the marked exchange loses the retry; a plain one keeps it.
+        assertThat(retryStrategy.retryRequest(response, 1, HttpClientContext.create())).isTrue();
     }
 }

--- a/paimon-core/src/main/java/org/apache/paimon/io/FormatTableRollingFileWriter.java
+++ b/paimon-core/src/main/java/org/apache/paimon/io/FormatTableRollingFileWriter.java
@@ -45,7 +45,7 @@ public class FormatTableRollingFileWriter implements AutoCloseable {
     private final long targetFileSize;
     private final long targetFileRowNum;
     private final List<FileWriterAbortExecutor> closedWriters;
-    private final List<TwoPhaseOutputStream.Committer> committers;
+    private final List<FormatTableWrittenFile> writtenFiles;
 
     private FormatTableSingleFileWriter currentWriter = null;
     private long recordCount = 0;
@@ -75,7 +75,7 @@ public class FormatTableRollingFileWriter implements AutoCloseable {
         this.targetFileSize = targetFileSize;
         this.targetFileRowNum = targetFileRowNum;
         this.closedWriters = new ArrayList<>();
-        this.committers = new ArrayList<>();
+        this.writtenFiles = new ArrayList<>();
     }
 
     public long targetFileSize() {
@@ -116,7 +116,14 @@ public class FormatTableRollingFileWriter implements AutoCloseable {
         currentWriter.close();
         closedWriters.add(currentWriter.abortExecutor());
         if (currentWriter.committers() != null) {
-            committers.addAll(currentWriter.committers());
+            // Read the counts off the writer that produced this file: once it is replaced, the
+            // rows it wrote cannot be recovered without reading the file back.
+            long fileRecordCount = currentWriter.recordCount();
+            long fileSizeInBytes = currentWriter.outputBytes();
+            for (TwoPhaseOutputStream.Committer committer : currentWriter.committers()) {
+                writtenFiles.add(
+                        new FormatTableWrittenFile(committer, fileRecordCount, fileSizeInBytes));
+            }
         }
 
         currentWriter = null;
@@ -128,22 +135,24 @@ public class FormatTableRollingFileWriter implements AutoCloseable {
             currentWriter.abort();
             currentWriter = null;
         }
-        for (TwoPhaseOutputStream.Committer committer : committers) {
+        for (FormatTableWrittenFile writtenFile : writtenFiles) {
+            TwoPhaseOutputStream.Committer committer = writtenFile.committer();
             try {
                 committer.discard(fileIO);
             } catch (Throwable e) {
                 LOG.warn("Exception occurs when discarding file {}.", committer.targetPath(), e);
             }
         }
-        committers.clear();
+        writtenFiles.clear();
         for (FileWriterAbortExecutor abortExecutor : closedWriters) {
             abortExecutor.abort();
         }
         closedWriters.clear();
     }
 
-    public List<TwoPhaseOutputStream.Committer> committers() {
-        return committers;
+    /** The files this writer produced, each with the rows and bytes it holds. */
+    public List<FormatTableWrittenFile> writtenFiles() {
+        return writtenFiles;
     }
 
     @Override

--- a/paimon-core/src/main/java/org/apache/paimon/io/FormatTableSingleFileWriter.java
+++ b/paimon-core/src/main/java/org/apache/paimon/io/FormatTableSingleFileWriter.java
@@ -50,6 +50,7 @@ public class FormatTableSingleFileWriter {
     private TwoPhaseOutputStream.Committer committer;
 
     protected long outputBytes;
+    protected long recordCount;
     protected boolean closed;
 
     public FormatTableSingleFileWriter(
@@ -99,6 +100,7 @@ public class FormatTableSingleFileWriter {
 
         try {
             writer.addElement(record);
+            recordCount++;
         } catch (Throwable e) {
             LOG.warn("Exception occurs when writing file {}. Cleaning up.", path, e);
             abort();
@@ -138,6 +140,22 @@ public class FormatTableSingleFileWriter {
             throw new RuntimeException("Writer should be closed before getting committer!");
         }
         return Lists.newArrayList(committer);
+    }
+
+    /** Rows written to this file. Exact, counted as they were written. */
+    public long recordCount() {
+        if (!closed) {
+            throw new RuntimeException("Writer should be closed before getting record count!");
+        }
+        return recordCount;
+    }
+
+    /** Bytes this file holds, taken from the stream position at close. */
+    public long outputBytes() {
+        if (!closed) {
+            throw new RuntimeException("Writer should be closed before getting output bytes!");
+        }
+        return outputBytes;
     }
 
     public FileWriterAbortExecutor abortExecutor() {

--- a/paimon-core/src/main/java/org/apache/paimon/io/FormatTableWrittenFile.java
+++ b/paimon-core/src/main/java/org/apache/paimon/io/FormatTableWrittenFile.java
@@ -16,66 +16,36 @@
  * limitations under the License.
  */
 
-package org.apache.paimon.table.format;
+package org.apache.paimon.io;
 
-import org.apache.paimon.data.BinaryRow;
 import org.apache.paimon.fs.TwoPhaseOutputStream;
-import org.apache.paimon.partition.PartitionStatistics;
-import org.apache.paimon.table.sink.CommitMessage;
-
-import javax.annotation.Nullable;
 
 /**
- * {@link CommitMessage} implementation for format table.
- *
- * <p>Carries the row count and byte size of the one file it commits, counted while writing. The
- * partition is not carried: {@link FormatTableCommit} derives it from the committer's target path,
- * and deriving it once keeps the statistics and the registered partition from ever disagreeing.
+ * One data file a format table writer finished, with what it holds. The row count and byte size are
+ * counted while writing, so carrying them alongside the committer costs no extra IO and is the only
+ * place they can still be had exactly — after the commit the file is just bytes on a path.
  */
-public class TwoPhaseCommitMessage implements CommitMessage {
-
-    private static final long serialVersionUID = 1L;
+public class FormatTableWrittenFile {
 
     private final TwoPhaseOutputStream.Committer committer;
     private final long recordCount;
     private final long fileSizeInBytes;
 
-    public TwoPhaseCommitMessage(TwoPhaseOutputStream.Committer committer) {
-        this(committer, PartitionStatistics.UNKNOWN, PartitionStatistics.UNKNOWN);
-    }
-
-    public TwoPhaseCommitMessage(
+    public FormatTableWrittenFile(
             TwoPhaseOutputStream.Committer committer, long recordCount, long fileSizeInBytes) {
         this.committer = committer;
         this.recordCount = recordCount;
         this.fileSizeInBytes = fileSizeInBytes;
     }
 
-    @Override
-    public BinaryRow partition() {
-        return null;
-    }
-
-    @Override
-    public int bucket() {
-        return 0;
-    }
-
-    @Override
-    public @Nullable Integer totalBuckets() {
-        return 0;
-    }
-
-    public TwoPhaseOutputStream.Committer getCommitter() {
+    public TwoPhaseOutputStream.Committer committer() {
         return committer;
     }
 
-    /** Rows in this file, or {@link PartitionStatistics#UNKNOWN} when nobody counted them. */
     public long recordCount() {
         return recordCount;
     }
 
-    /** Bytes in this file, or {@link PartitionStatistics#UNKNOWN} when nobody measured them. */
     public long fileSizeInBytes() {
         return fileSizeInBytes;
     }

--- a/paimon-core/src/main/java/org/apache/paimon/table/format/FileSystemSplitEnumerator.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/format/FileSystemSplitEnumerator.java
@@ -25,6 +25,7 @@ import org.apache.paimon.fs.Path;
 import org.apache.paimon.manifest.PartitionEntry;
 import org.apache.paimon.partition.PartitionPredicate;
 import org.apache.paimon.partition.PartitionPredicate.MultiplePartitionPredicate;
+import org.apache.paimon.partition.PartitionStatistics;
 import org.apache.paimon.predicate.Predicate;
 import org.apache.paimon.table.FormatTable;
 import org.apache.paimon.table.source.Split;
@@ -125,7 +126,16 @@ final class FileSystemSplitEnumerator extends SplitEnumerator {
         List<PartitionEntry> partitionEntries = new ArrayList<>();
         for (Pair<LinkedHashMap<String, String>, Path> partition2Path : partition2Paths) {
             BinaryRow row = toPartitionRow(partition2Path.getKey());
-            partitionEntries.add(new PartitionEntry(row, -1L, -1L, -1L, -1L, -1));
+            // Discovering partitions from directories measures nothing about what is inside them,
+            // so every statistic is unknown rather than zero.
+            partitionEntries.add(
+                    new PartitionEntry(
+                            row,
+                            PartitionStatistics.UNKNOWN,
+                            PartitionStatistics.UNKNOWN,
+                            PartitionStatistics.UNKNOWN,
+                            PartitionStatistics.UNKNOWN,
+                            PartitionStatistics.UNKNOWN_TOTAL_BUCKETS));
         }
         return partitionEntries;
     }

--- a/paimon-core/src/main/java/org/apache/paimon/table/format/FormatTableFileWriter.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/format/FormatTableFileWriter.java
@@ -24,7 +24,7 @@ import org.apache.paimon.data.InternalRow;
 import org.apache.paimon.format.FileFormat;
 import org.apache.paimon.fs.FileIO;
 import org.apache.paimon.fs.Path;
-import org.apache.paimon.fs.TwoPhaseOutputStream;
+import org.apache.paimon.io.FormatTableWrittenFile;
 import org.apache.paimon.table.sink.CommitMessage;
 import org.apache.paimon.types.RowType;
 import org.apache.paimon.utils.FileStorePathFactory;
@@ -97,15 +97,15 @@ public class FormatTableFileWriter {
     }
 
     public List<CommitMessage> prepareCommit() throws Exception {
-        List<TwoPhaseOutputStream.Committer> committers = new ArrayList<>();
+        List<FormatTableWrittenFile> writtenFiles = new ArrayList<>();
         try {
             for (FormatTableRecordWriter writer : writers.values()) {
-                committers.addAll(writer.closeAndGetCommitters());
+                writtenFiles.addAll(writer.closeAndGetWrittenFiles());
             }
         } catch (Exception e) {
-            for (TwoPhaseOutputStream.Committer committer : committers) {
+            for (FormatTableWrittenFile writtenFile : writtenFiles) {
                 try {
-                    committer.discard(fileIO);
+                    writtenFile.committer().discard(fileIO);
                 } catch (Exception cleanupException) {
                     e.addSuppressed(cleanupException);
                 }
@@ -119,8 +119,12 @@ public class FormatTableFileWriter {
         }
 
         List<CommitMessage> commitMessages = new ArrayList<>();
-        for (TwoPhaseOutputStream.Committer committer : committers) {
-            commitMessages.add(new TwoPhaseCommitMessage(committer));
+        for (FormatTableWrittenFile writtenFile : writtenFiles) {
+            commitMessages.add(
+                    new TwoPhaseCommitMessage(
+                            writtenFile.committer(),
+                            writtenFile.recordCount(),
+                            writtenFile.fileSizeInBytes()));
         }
         return commitMessages;
     }

--- a/paimon-core/src/main/java/org/apache/paimon/table/format/FormatTableRecordWriter.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/format/FormatTableRecordWriter.java
@@ -21,9 +21,9 @@ package org.apache.paimon.table.format;
 import org.apache.paimon.data.InternalRow;
 import org.apache.paimon.format.FileFormat;
 import org.apache.paimon.fs.FileIO;
-import org.apache.paimon.fs.TwoPhaseOutputStream;
 import org.apache.paimon.io.DataFilePathFactory;
 import org.apache.paimon.io.FormatTableRollingFileWriter;
+import org.apache.paimon.io.FormatTableWrittenFile;
 import org.apache.paimon.types.RowType;
 
 import java.util.ArrayList;
@@ -65,14 +65,14 @@ public class FormatTableRecordWriter implements AutoCloseable {
         writer.write(data);
     }
 
-    public List<TwoPhaseOutputStream.Committer> closeAndGetCommitters() throws Exception {
-        List<TwoPhaseOutputStream.Committer> commits = new ArrayList<>();
+    public List<FormatTableWrittenFile> closeAndGetWrittenFiles() throws Exception {
+        List<FormatTableWrittenFile> written = new ArrayList<>();
         if (writer != null) {
             writer.close();
-            commits.addAll(writer.committers());
+            written.addAll(writer.writtenFiles());
             writer = null;
         }
-        return commits;
+        return written;
     }
 
     @Override

--- a/paimon-core/src/test/java/org/apache/paimon/table/format/FormatTableWriteTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/table/format/FormatTableWriteTest.java
@@ -41,8 +41,10 @@ import java.io.IOException;
 import java.io.InputStreamReader;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -80,16 +82,30 @@ class FormatTableWriteTest {
         }
 
         assertThat(messages).hasSize(3);
-        List<Path> dataFiles =
-                messages.stream()
-                        .map(
-                                message ->
-                                        ((TwoPhaseCommitMessage) message)
-                                                .getCommitter()
-                                                .targetPath())
-                        .collect(Collectors.toList());
+        // The rows and bytes of each rolled file are counted while writing and survive to commit,
+        // so they never have to be recovered by reading the file back.
+        assertThat(
+                        messages.stream()
+                                .map(message -> ((TwoPhaseCommitMessage) message).recordCount())
+                                .collect(Collectors.toList()))
+                .containsExactlyInAnyOrder(2L, 2L, 1L);
+        // Each message carries the size of the one file it commits, not of some other file that
+        // happens to be positive too.
+        Map<Path, Long> reportedSizes = new LinkedHashMap<>();
+        for (CommitMessage message : messages) {
+            TwoPhaseCommitMessage twoPhase = (TwoPhaseCommitMessage) message;
+            reportedSizes.put(twoPhase.getCommitter().targetPath(), twoPhase.fileSizeInBytes());
+        }
+        assertThat(reportedSizes).hasSize(messages.size());
+        List<Path> dataFiles = new ArrayList<>(reportedSizes.keySet());
         try (BatchTableCommit commit = writeBuilder.newCommit()) {
             commit.commit(messages);
+        }
+
+        for (Map.Entry<Path, Long> reported : reportedSizes.entrySet()) {
+            assertThat(reported.getValue())
+                    .as("byte count reported for %s", reported.getKey())
+                    .isEqualTo(fileIO.getFileSize(reported.getKey()));
         }
 
         List<Long> rowCounts =
@@ -151,11 +167,13 @@ class FormatTableWriteTest {
         TwoPhaseOutputStream.Committer committer = mock(TwoPhaseOutputStream.Committer.class);
         java.util.concurrent.atomic.AtomicInteger closeCount =
                 new java.util.concurrent.atomic.AtomicInteger();
-        when(recordWriter.closeAndGetCommitters())
+        when(recordWriter.closeAndGetWrittenFiles())
                 .thenAnswer(
                         ignored -> {
                             if (closeCount.getAndIncrement() == 0) {
-                                return Collections.singletonList(committer);
+                                return Collections.singletonList(
+                                        new org.apache.paimon.io.FormatTableWrittenFile(
+                                                committer, 1L, 1L));
                             }
                             throw new IOException("expected close failure");
                         });


### PR DESCRIPTION
> **Stacked on #9120 and the S1 PR** — their commits show up here too until they merge. Review only
> `[rest] Do not replay a POST the server cannot absorb twice`.

### Purpose

The REST client retries a 429 or a 503 on any request, POST included. That is right for nearly
everything it sends: registering a partition, creating a database, committing a snapshot the server
already holds all land on the same state the second time, and the retry is the only defence against a
rate limiter or a restarting node.

It is wrong for a request that reports an increment. A 429 or a 503 can reach the client **from an
intermediary after the server already applied the request**, so replaying it applies it again — and an
increment applied twice is a wrong number that no caller can see. Nothing in the response
distinguishes the two cases, which is why this has to be decided by the request rather than by the
status.

`RESTRequest` gains `isRetrySafe()`, defaulting to `true` so **every existing request keeps the retry
it has today**. A request answering `false` is sent exactly once and the failure reaches the caller,
which knows whether re-sending is safe.

### Two details a reviewer will ask about

- The mark travels in the `HttpClientContext` rather than in the request, so it never reaches the wire
  and survives whatever the exec chain does to the request object.
- `isRetrySafe()` is a getter on a serialized type, so it is `@JsonIgnore`; a test pins that it stays
  out of the body.

### Compatibility

This PR adds **no** request that answers `false`. The first one arrives with the partition-statistics
work for catalog-managed format tables, and the ordering matters: with that in and this out, an
automatic retry double-counts an increment and the server cannot tell a redelivery from a second
genuine increment.

### API and Format

`RESTRequest.isRetrySafe()` is a new `default` method returning `true`; existing implementations need
no change. No format change.

### Documentation

The contract is in the method javadoc.