### PR TITLE
[python] Avoid an extra file-size I/O for Blob reads

### DIFF
--- a/paimon-python/pypaimon/read/reader/format_blob_reader.py
+++ b/paimon-python/pypaimon/read/reader/format_blob_reader.py
@@ -46,7 +46,7 @@ class FormatBlobReader(RecordBatchReader):
     def __init__(self, file_io: FileIO, file_path: str, read_fields: List[str],
                  full_fields: List[DataField], push_down_predicate: Any, blob_as_descriptor: bool,
                  batch_size: int = 1024, row_indices: Optional[Any] = None,
-                 blob_parallelism: int = 1):
+                 blob_parallelism: int = 1, file_size: Optional[int] = None):
         self._file_io = file_io
         self._file_path = file_path
         self._push_down_predicate = push_down_predicate
@@ -63,7 +63,11 @@ class FormatBlobReader(RecordBatchReader):
         self._blob_iterator = None
         self._current_batch = None
         try:
-            self._file_size = file_io.get_file_size(file_path)
+            self._file_size = (
+                file_size
+                if file_size is not None and file_size > 0
+                else file_io.get_file_size(file_path)
+            )
             self._input_stream = file_io.new_input_stream(file_path)
             self._read_index()
             self._apply_row_indices(row_indices)

--- a/paimon-python/pypaimon/read/split_read.py
+++ b/paimon-python/pypaimon/read/split_read.py
@@ -336,7 +336,8 @@ class SplitRead(ABC):
                                              self.read_fields, read_arrow_predicate, blob_as_descriptor,
                                              batch_size=batch_size,
                                              row_indices=row_indices,
-                                             blob_parallelism=blob_parallelism)
+                                             blob_parallelism=blob_parallelism,
+                                             file_size=file.file_size)
         elif file_format == CoreOptions.FILE_FORMAT_LANCE:
             if has_nested:
                 raise NotImplementedError(
@@ -1460,6 +1461,7 @@ class DataEvolutionSplitRead(SplitRead):
             batch_size=self.table.options.read_batch_size(),
             row_indices=row_indices,
             blob_parallelism=blob_parallelism,
+            file_size=file.file_size,
         )
 
     def _split_field_bunches(self, need_merge_files: List[DataFileMeta]) -> List[FieldBunch]:

--- a/paimon-python/pypaimon/tests/blob_test.py
+++ b/paimon-python/pypaimon/tests/blob_test.py
@@ -1587,15 +1587,17 @@ class BlobEndToEndTest(unittest.TestCase):
 
         with patch("pypaimon.read.split_read.FormatBlobReader") as reader_cls:
             raw_read.file_reader_supplier(file, False, [field.name], False)
+            args, kwargs = reader_cls.call_args
             arguments = inspect.signature(FormatBlobReader).bind_partial(
-                *reader_cls.call_args.args, **reader_cls.call_args.kwargs
+                *args, **kwargs
             ).arguments
             self.assertEqual(123, arguments.get("file_size"))
 
             reader_cls.reset_mock()
             evolution_read._create_raw_blob_file_reader(file, [field.name])
+            args, kwargs = reader_cls.call_args
             arguments = inspect.signature(FormatBlobReader).bind_partial(
-                *reader_cls.call_args.args, **reader_cls.call_args.kwargs
+                *args, **kwargs
             ).arguments
             self.assertEqual(123, arguments.get("file_size"))
 

--- a/paimon-python/pypaimon/tests/blob_test.py
+++ b/paimon-python/pypaimon/tests/blob_test.py
@@ -1354,6 +1354,16 @@ class BlobEndToEndTest(unittest.TestCase):
         except OSError:
             pass
 
+    @staticmethod
+    def _write_single_blob(path, field, value):
+        from pypaimon.write.blob_format_writer import BlobFormatWriter
+
+        with open(path, 'wb') as output:
+            writer = BlobFormatWriter(output)
+            writer.add_element(GenericRow(
+                [BlobData(value)], [field], RowKind.INSERT))
+            writer.close()
+
     def test_blob_end_to_end(self):
         # Set up file I/O
         file_io = LocalFileIO(self.temp_dir, Options({}))
@@ -1442,6 +1452,145 @@ class BlobEndToEndTest(unittest.TestCase):
         self.assertEqual(batch.column(0)[1].as_py(), b"world")
         self.assertEqual(counting_file_io.input_stream_count, 1)
         reader.close()
+
+    def test_blob_reader_uses_provided_file_size(self):
+        class NoStatFileIO:
+
+            def __init__(self, delegate):
+                self._delegate = delegate
+
+            def __getattr__(self, name):
+                return getattr(self._delegate, name)
+
+            def get_file_size(self, path):
+                raise AssertionError("get_file_size should not be called")
+
+        field = DataField(0, "blob_field", AtomicType("BLOB"))
+        path = os.path.join(self.temp_dir, "provided-size.blob")
+        file_io = LocalFileIO(self.temp_dir, Options({}))
+        self._write_single_blob(path, field, b"value")
+
+        reader = FormatBlobReader(
+            NoStatFileIO(file_io),
+            path,
+            [field.name],
+            [field],
+            None,
+            False,
+            file_size=os.path.getsize(path),
+        )
+        try:
+            self.assertEqual(
+                [b"value"], reader.read_arrow_batch().column(0).to_pylist())
+        finally:
+            reader.close()
+
+    def test_blob_reader_falls_back_to_file_size_lookup(self):
+        class CountingFileIO:
+
+            def __init__(self, delegate):
+                self._delegate = delegate
+                self.size_calls = 0
+
+            def __getattr__(self, name):
+                return getattr(self._delegate, name)
+
+            def get_file_size(self, path):
+                self.size_calls += 1
+                return self._delegate.get_file_size(path)
+
+        field = DataField(0, "blob_field", AtomicType("BLOB"))
+        path = os.path.join(self.temp_dir, "fallback-size.blob")
+        file_io = LocalFileIO(self.temp_dir, Options({}))
+        self._write_single_blob(path, field, b"value")
+
+        for file_size in [None, 0]:
+            with self.subTest(file_size=file_size):
+                counting_file_io = CountingFileIO(file_io)
+                reader = FormatBlobReader(
+                    counting_file_io,
+                    path,
+                    [field.name],
+                    [field],
+                    None,
+                    False,
+                    file_size=file_size,
+                )
+                try:
+                    self.assertEqual(
+                        [b"value"],
+                        reader.read_arrow_batch().column(0).to_pylist())
+                    self.assertEqual(1, counting_file_io.size_calls)
+                finally:
+                    reader.close()
+
+    def test_split_read_passes_blob_file_size(self):
+        from pypaimon.read.split_read import (
+            DataEvolutionSplitRead,
+            RawFileSplitRead,
+        )
+
+        class _Options:
+
+            @staticmethod
+            def read_batch_size():
+                return 128
+
+        class _Table:
+            file_io = object()
+            options = _Options()
+
+        field = DataField(0, "blob_field", AtomicType("BLOB"))
+        table = _Table()
+        table.fields = [field]
+        table.table_schema = type("_Schema", (), {"fields": [field]})()
+        file = DataFileMeta(
+            file_name="data.blob",
+            file_size=123,
+            row_count=1,
+            min_key=None,
+            max_key=None,
+            key_stats=None,
+            value_stats=None,
+            min_sequence_number=0,
+            max_sequence_number=0,
+            schema_id=0,
+            level=0,
+            extra_files=[],
+            first_row_id=0,
+            write_cols=[field.name],
+            file_path="data.blob",
+        )
+
+        raw_read = RawFileSplitRead.__new__(RawFileSplitRead)
+        raw_read.table = table
+        raw_read.read_fields = [field]
+        raw_read.trimmed_primary_key = []
+        raw_read._blob_parallelism = 1
+        raw_read._get_fields_and_predicate = lambda *args: (
+            [field.name], None, None)
+        raw_read._row_sidecar_file_name = lambda _: None
+        raw_read._nested_path_by_name = lambda: None
+        raw_read._file_read_fields = lambda _: [field]
+        raw_read._target_read_fields = lambda: [field]
+        raw_read._read_blob_as_descriptor = lambda _: False
+        raw_read.create_index_mapping = lambda: None
+        raw_read._create_partition_info = lambda: None
+
+        evolution_read = DataEvolutionSplitRead.__new__(DataEvolutionSplitRead)
+        evolution_read.table = table
+        evolution_read.read_fields = [field]
+        evolution_read.row_ranges = None
+        evolution_read._blob_parallelism = 1
+        evolution_read._read_blob_as_descriptor = lambda _: False
+
+        with patch("pypaimon.read.split_read.FormatBlobReader") as reader_cls:
+            raw_read.file_reader_supplier(file, False, [field.name], False)
+            self.assertEqual(123, reader_cls.call_args.kwargs["file_size"])
+
+            reader_cls.reset_mock()
+            evolution_read._create_raw_blob_file_reader(file, [field.name])
+            self.assertEqual(123, reader_cls.call_args.kwargs["file_size"])
 
     def test_blob_reader_row_indices_pushdown(self):
         file_io = LocalFileIO(self.temp_dir, Options({}))

--- a/paimon-python/pypaimon/tests/blob_test.py
+++ b/paimon-python/pypaimon/tests/blob_test.py
@@ -16,6 +16,7 @@
 # under the License.
 
 import datetime
+import inspect
 import io
 import os
 import shutil
@@ -1586,11 +1587,17 @@ class BlobEndToEndTest(unittest.TestCase):
 
         with patch("pypaimon.read.split_read.FormatBlobReader") as reader_cls:
             raw_read.file_reader_supplier(file, False, [field.name], False)
-            self.assertEqual(123, reader_cls.call_args.kwargs["file_size"])
+            arguments = inspect.signature(FormatBlobReader).bind_partial(
+                *reader_cls.call_args.args, **reader_cls.call_args.kwargs
+            ).arguments
+            self.assertEqual(123, arguments.get("file_size"))
 
             reader_cls.reset_mock()
             evolution_read._create_raw_blob_file_reader(file, [field.name])
-            self.assertEqual(123, reader_cls.call_args.kwargs["file_size"])
+            arguments = inspect.signature(FormatBlobReader).bind_partial(
+                *reader_cls.call_args.args, **reader_cls.call_args.kwargs
+            ).arguments
+            self.assertEqual(123, arguments.get("file_size"))
 
     def test_blob_reader_row_indices_pushdown(self):
         file_io = LocalFileIO(self.temp_dir, Options({}))

--- a/paimon-python/pypaimon/tests/blob_test.py
+++ b/paimon-python/pypaimon/tests/blob_test.py
@@ -47,11 +47,16 @@ from pypaimon.table.row.row_kind import RowKind
 class MockFileIO:
     """Mock FileIO for testing."""
 
-    def __init__(self, file_io: FileIO):
+    def __init__(self, file_io: FileIO, fail_on_file_size=False):
         self._file_io = file_io
+        self.fail_on_file_size = fail_on_file_size
+        self.file_size_calls = 0
 
     def get_file_size(self, path: str) -> int:
         """Get file size."""
+        self.file_size_calls += 1
+        if self.fail_on_file_size:
+            raise AssertionError("get_file_size should not be called")
         return self._file_io.get_file_size(path)
 
     def new_input_stream(self, path):
@@ -1455,24 +1460,13 @@ class BlobEndToEndTest(unittest.TestCase):
         reader.close()
 
     def test_blob_reader_uses_provided_file_size(self):
-        class NoStatFileIO:
-
-            def __init__(self, delegate):
-                self._delegate = delegate
-
-            def __getattr__(self, name):
-                return getattr(self._delegate, name)
-
-            def get_file_size(self, path):
-                raise AssertionError("get_file_size should not be called")
-
         field = DataField(0, "blob_field", AtomicType("BLOB"))
         path = os.path.join(self.temp_dir, "provided-size.blob")
         file_io = LocalFileIO(self.temp_dir, Options({}))
         self._write_single_blob(path, field, b"value")
 
         reader = FormatBlobReader(
-            NoStatFileIO(file_io),
+            MockFileIO(file_io, fail_on_file_size=True),
             path,
             [field.name],
             [field],
@@ -1487,27 +1481,14 @@ class BlobEndToEndTest(unittest.TestCase):
             reader.close()
 
     def test_blob_reader_falls_back_to_file_size_lookup(self):
-        class CountingFileIO:
-
-            def __init__(self, delegate):
-                self._delegate = delegate
-                self.size_calls = 0
-
-            def __getattr__(self, name):
-                return getattr(self._delegate, name)
-
-            def get_file_size(self, path):
-                self.size_calls += 1
-                return self._delegate.get_file_size(path)
-
         field = DataField(0, "blob_field", AtomicType("BLOB"))
         path = os.path.join(self.temp_dir, "fallback-size.blob")
         file_io = LocalFileIO(self.temp_dir, Options({}))
         self._write_single_blob(path, field, b"value")
 
-        for file_size in [None, 0]:
+        for file_size in [None, 0, -1]:
             with self.subTest(file_size=file_size):
-                counting_file_io = CountingFileIO(file_io)
+                counting_file_io = MockFileIO(file_io)
                 reader = FormatBlobReader(
                     counting_file_io,
                     path,
@@ -1521,30 +1502,32 @@ class BlobEndToEndTest(unittest.TestCase):
                     self.assertEqual(
                         [b"value"],
                         reader.read_arrow_batch().column(0).to_pylist())
-                    self.assertEqual(1, counting_file_io.size_calls)
+                    self.assertEqual(1, counting_file_io.file_size_calls)
                 finally:
                     reader.close()
 
     def test_split_read_passes_blob_file_size(self):
+        from pypaimon.read.split import DataSplit
         from pypaimon.read.split_read import (
             DataEvolutionSplitRead,
             RawFileSplitRead,
         )
 
-        class _Options:
-
-            @staticmethod
-            def read_batch_size():
-                return 128
-
-        class _Table:
-            file_io = object()
-            options = _Options()
-
-        field = DataField(0, "blob_field", AtomicType("BLOB"))
-        table = _Table()
-        table.fields = [field]
-        table.table_schema = type("_Schema", (), {"fields": [field]})()
+        fields = [
+            DataField(0, "id", AtomicType("INT")),
+            DataField(1, "blob_field", AtomicType("BLOB")),
+        ]
+        self.catalog.create_table(
+            "test_db.blob_file_size_forwarding",
+            Schema(fields, options={
+                "blob.file-format": "blob",
+                "data-evolution.enabled": "true",
+                "row-tracking.enabled": "true",
+            }),
+            False,
+        )
+        table = self.catalog.get_table("test_db.blob_file_size_forwarding")
+        field = fields[1]
         file = DataFileMeta(
             file_name="data.blob",
             file_size=123,
@@ -1562,44 +1545,25 @@ class BlobEndToEndTest(unittest.TestCase):
             write_cols=[field.name],
             file_path="data.blob",
         )
-
-        raw_read = RawFileSplitRead.__new__(RawFileSplitRead)
-        raw_read.table = table
-        raw_read.read_fields = [field]
-        raw_read.trimmed_primary_key = []
-        raw_read._blob_parallelism = 1
-        raw_read._get_fields_and_predicate = lambda *args: (
-            [field.name], None, None)
-        raw_read._row_sidecar_file_name = lambda _: None
-        raw_read._nested_path_by_name = lambda: None
-        raw_read._file_read_fields = lambda _: [field]
-        raw_read._target_read_fields = lambda: [field]
-        raw_read._read_blob_as_descriptor = lambda _: False
-        raw_read.create_index_mapping = lambda: None
-        raw_read._create_partition_info = lambda: None
-
-        evolution_read = DataEvolutionSplitRead.__new__(DataEvolutionSplitRead)
-        evolution_read.table = table
-        evolution_read.read_fields = [field]
-        evolution_read.row_ranges = None
-        evolution_read._blob_parallelism = 1
-        evolution_read._read_blob_as_descriptor = lambda _: False
+        split = DataSplit([file], GenericRow([], []), 0)
+        raw_read = RawFileSplitRead(table, None, [field], split, False)
+        evolution_read = DataEvolutionSplitRead(
+            table, None, [field], split, False)
 
         with patch("pypaimon.read.split_read.FormatBlobReader") as reader_cls:
+            def assert_file_size():
+                args, kwargs = reader_cls.call_args
+                arguments = inspect.signature(FormatBlobReader).bind_partial(
+                    *args, **kwargs
+                ).arguments
+                self.assertEqual(123, arguments.get("file_size"))
+
             raw_read.file_reader_supplier(file, False, [field.name], False)
-            args, kwargs = reader_cls.call_args
-            arguments = inspect.signature(FormatBlobReader).bind_partial(
-                *args, **kwargs
-            ).arguments
-            self.assertEqual(123, arguments.get("file_size"))
+            assert_file_size()
 
             reader_cls.reset_mock()
             evolution_read._create_raw_blob_file_reader(file, [field.name])
-            args, kwargs = reader_cls.call_args
-            arguments = inspect.signature(FormatBlobReader).bind_partial(
-                *args, **kwargs
-            ).arguments
-            self.assertEqual(123, arguments.get("file_size"))
+            assert_file_size()
 
     def test_blob_reader_row_indices_pushdown(self):
         file_io = LocalFileIO(self.temp_dir, Options({}))


### PR DESCRIPTION
## Purpose

Avoid the extra file-size lookup performed when `SplitRead` creates a `FormatBlobReader`. `DataFileMeta` already contains the file size, so object-store reads do not need an additional metadata request before reading the Blob footer and index.

## Changes

- Add an optional `file_size` argument to `FormatBlobReader`.
- Reuse `DataFileMeta.file_size` in both normal and Data Evolution raw Blob read paths.
- Preserve the existing lookup when `FormatBlobReader` is constructed without a valid file size.

## Tests

- Provided file size avoids `FileIO.get_file_size`.
- Missing or zero file size falls back to one lookup.
- Both `SplitRead` Blob paths forward `DataFileMeta.file_size`.
- Blob tests: 186 passed, 1 unrelated Ray/pandas compatibility test deselected, 44 subtests passed.
- Deferred Blob tests: 15 passed.
- Flake8 and `git diff --check` passed.
