### PR TITLE
[core] Honor query-level search-mode overrides

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/table/source/DataEvolutionVectorScan.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/source/DataEvolutionVectorScan.java
@@ -18,6 +18,7 @@
 
 package org.apache.paimon.table.source;
 
+import org.apache.paimon.CoreOptions;
 import org.apache.paimon.CoreOptions.GlobalIndexSearchMode;
 import org.apache.paimon.Snapshot;
 import org.apache.paimon.globalindex.DataEvolutionGlobalIndexCoverage;
@@ -159,7 +160,8 @@ public class DataEvolutionVectorScan implements VectorScan {
             splits.add(new IndexVectorSearchSplit(range.from, range.to, vectorFiles, scalarFiles));
         }
 
-        GlobalIndexSearchMode vectorSearchMode = table.coreOptions().vectorIndexSearchMode();
+        CoreOptions effectiveOptions = effectiveCoreOptions();
+        GlobalIndexSearchMode vectorSearchMode = effectiveOptions.vectorIndexSearchMode();
         List<Range> rawRowRanges =
                 new DataEvolutionGlobalIndexCoverage(
                                 table,
@@ -175,7 +177,7 @@ public class DataEvolutionVectorScan implements VectorScan {
                                     snapshot,
                                     partitionFilter,
                                     scalarIndexFiles(allIndexFiles),
-                                    table.coreOptions().scalarIndexSearchMode())
+                                    effectiveOptions.scalarIndexSearchMode())
                             .unindexedRanges(table.rowType(), filter);
             if (vectorSearchMode == GlobalIndexSearchMode.FAST) {
                 scalarUnindexedRanges =
@@ -207,6 +209,12 @@ public class DataEvolutionVectorScan implements VectorScan {
                 return planSnapshot;
             }
         };
+    }
+
+    private CoreOptions effectiveCoreOptions() {
+        Map<String, String> merged = new HashMap<>(table.options());
+        merged.putAll(options);
+        return CoreOptions.fromMap(merged);
     }
 
     private static boolean isPrimaryColumn(GlobalIndexMeta meta, int fieldId) {

--- a/paimon-core/src/test/java/org/apache/paimon/table/source/VectorSearchBuilderTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/table/source/VectorSearchBuilderTest.java
@@ -1319,6 +1319,17 @@ public class VectorSearchBuilderTest extends TableTestBase {
         GlobalIndexResult result =
                 searchBuilder.newVectorRead().read(searchBuilder.newVectorScan().scan());
         assertThat(result.results().isEmpty()).isTrue();
+
+        VectorSearchBuilder fullFallback =
+                table.newVectorSearchBuilder()
+                        .withVector(new float[] {0.0f, 0.0f})
+                        .withLimit(1)
+                        .withVectorColumn(VECTOR_FIELD_NAME)
+                        .withFilter(idFilter)
+                        .withOption(CoreOptions.SCALAR_INDEX_SEARCH_MODE.key(), "full");
+        GlobalIndexResult fallbackResult =
+                fullFallback.newVectorRead().read(fullFallback.newVectorScan().scan());
+        assertThat(fallbackResult.results()).containsExactly(8L);
     }
 
     @Test


### PR DESCRIPTION
## What is the purpose of the change?

`DataEvolutionVectorScan` reads search-mode settings directly from table options, so query-level overrides supplied by the query builder are ignored. This prevents callers from overriding vector or scalar index search behavior for an individual query.

## Brief change log

- Build effective options by applying table options first and query options second.
- Use the effective options for both vector-index and scalar-index search modes.
- Add regression coverage proving that a query-level scalar full-search override restores fallback rows when the table default is fast mode.

## Verifying this change

```bash
mvn -pl paimon-core -am -DskipITs -Dfast \
  -Dtest=VectorSearchBuilderTest#testFastScalarModePartialPreFilterOnlyUsesIndexedRows \
  -Dsurefire.failIfNoSpecifiedTests=false test
```

Result: the focused regression test passed. Spotless and Checkstyle also passed.
