### PR TITLE
[python] Cache Blob indexes to avoid repeated footer reads

### DIFF
--- a/docs/docs/pypaimon/pytorch.md
+++ b/docs/docs/pypaimon/pytorch.md
@@ -61,8 +61,8 @@ when it is false, it will read the full amount of data into memory.
 
 ## File Format Metadata Cache
 
-Reusable PyArrow Dataset metadata is cached across reads. Configure its estimated
-size limit in the catalog options:
+Reusable Parquet/ORC metadata and Blob file indexes are cached across reads.
+Configure their estimated size limit in the catalog options:
 
 ```python
 catalog = CatalogFactory.create({
@@ -74,10 +74,9 @@ read_builder = table.new_read_builder()
 ```
 
 The default limit is 50 MB; set it to `0 b` to disable and clear the cache. The
-cache is local to each process and benefits workers reused with
-`DataLoader(..., persistent_workers=True)`. The cache uses a conservative
-per-entry memory estimate and an internal entry-count safeguard; actual native
-PyArrow memory may still be higher. The cache assumes immutable Paimon data files.
+cache is local to each process and benefits long-lived workers. It uses a
+conservative per-entry memory estimate and an internal entry-count safeguard.
+The cache assumes immutable Paimon data files.
 
 ## Shuffle
 

--- a/paimon-python/pypaimon/common/options/config.py
+++ b/paimon-python/pypaimon/common/options/config.py
@@ -84,7 +84,7 @@ class CatalogOptions:
         .memory_type()
         .default_value(MemorySize.of_mebi_bytes(50))
         .with_description(
-            "Maximum estimated size of reusable PyArrow Dataset metadata "
+            "Maximum estimated size of reusable file-format metadata "
             "cached in the current process. Set to 0 to disable and clear "
             "the cache."
         )

--- a/paimon-python/pypaimon/read/reader/format_blob_reader.py
+++ b/paimon-python/pypaimon/read/reader/format_blob_reader.py
@@ -16,6 +16,7 @@
 # under the License.
 
 import struct
+import sys
 from typing import List, Optional, Any, Iterator, BinaryIO
 
 import pyarrow as pa
@@ -26,6 +27,10 @@ from pypaimon.common.delta_varint_compressor import DeltaVarintCompressor
 from pypaimon.common.file_io import FileIO
 from pypaimon.common.map_blob_key_serializer import create_map_blob_key_serializer
 from pypaimon.read.reader.iface.record_batch_reader import RecordBatchReader
+from pypaimon.read.reader.format_pyarrow_reader import (
+    _FILE_FORMAT_METADATA_CACHE_MIN_ENTRY_SIZE,
+    _cached_file_format_metadata,
+)
 from pypaimon.schema.data_types import (
     DataField,
     PyarrowFieldParser,
@@ -290,6 +295,26 @@ class FormatBlobReader(RecordBatchReader):
             self._input_stream = None
 
     def _read_index(self) -> None:
+        to_filesystem_path = getattr(
+            self._file_io, 'to_filesystem_path', None)
+        cache_path = (
+            to_filesystem_path(self.file_path)
+            if to_filesystem_path is not None else self.file_path
+        )
+        blob_lengths, blob_offsets = _cached_file_format_metadata(
+            self._file_io,
+            'blob',
+            cache_path,
+            self._load_index,
+            self._estimate_index_size,
+            self._file_size,
+        )
+        # Readers may apply different row selections, so keep cached metadata
+        # immutable and give each reader its own lists.
+        self.blob_lengths = list(blob_lengths)
+        self.blob_offsets = list(blob_offsets)
+
+    def _load_index(self):
         f = self._input_stream
 
         # Seek to header: last 5 bytes
@@ -323,8 +348,21 @@ class FormatBlobReader(RecordBatchReader):
             else:
                 blob_offsets.append(offset)
                 offset += length
-        self.blob_lengths = blob_lengths
-        self.blob_offsets = blob_offsets
+        return tuple(blob_lengths), tuple(blob_offsets)
+
+    @staticmethod
+    def _estimate_index_size(key, index) -> int:
+        blob_lengths, blob_offsets = index
+        int_size = sys.getsizeof(key[-1])
+        size = (
+            sys.getsizeof(key)
+            + sum(sys.getsizeof(item) for item in key)
+            + sys.getsizeof(index)
+            + sys.getsizeof(blob_lengths)
+            + sys.getsizeof(blob_offsets)
+            + (len(blob_lengths) + len(blob_offsets)) * int_size
+        )
+        return max(_FILE_FORMAT_METADATA_CACHE_MIN_ENTRY_SIZE, size)
 
     def _apply_row_indices(self, row_indices: Optional[Any]) -> None:
         if row_indices is None:

--- a/paimon-python/pypaimon/read/reader/format_blob_reader.py
+++ b/paimon-python/pypaimon/read/reader/format_blob_reader.py
@@ -295,16 +295,10 @@ class FormatBlobReader(RecordBatchReader):
             self._input_stream = None
 
     def _read_index(self) -> None:
-        to_filesystem_path = getattr(
-            self._file_io, 'to_filesystem_path', None)
-        cache_path = (
-            to_filesystem_path(self.file_path)
-            if to_filesystem_path is not None else self.file_path
-        )
         blob_lengths, blob_offsets = _cached_file_format_metadata(
             self._file_io,
             'blob',
-            cache_path,
+            self.file_path,
             self._load_index,
             self._estimate_index_size,
             self._file_size,

--- a/paimon-python/pypaimon/read/reader/format_pyarrow_reader.py
+++ b/paimon-python/pypaimon/read/reader/format_pyarrow_reader.py
@@ -80,7 +80,7 @@ class _FileFormatDatasetCache:
         self._loads = {}
         self._lock = threading.Lock()
 
-    def get_or_load(self, key: Tuple[Any, str, str], loader: Callable[[], Any],
+    def get_or_load(self, key: Tuple[Any, ...], loader: Callable[[], Any],
                     size_estimator: Callable[[Any], Optional[int]]):
         with self._lock:
             entry = self._entries.get(key)
@@ -215,6 +215,22 @@ def _file_format_metadata_cache_max_size(file_io: FileIO) -> int:
         CatalogOptions.FILE_FORMAT_METADATA_CACHE_MAX_SIZE).get_bytes()
 
 
+def _cached_file_format_metadata(file_io: FileIO, file_format: str,
+                                 file_path: str, loader, size_estimator,
+                                 cache_identity=None):
+    cache_max_size = _file_format_metadata_cache_max_size(file_io)
+    filesystem = getattr(file_io, 'filesystem', file_io)
+    key = (_FilesystemIdentity(filesystem), file_format, file_path)
+    if cache_identity is not None:
+        key += (cache_identity,)
+    if cache_max_size <= 0:
+        _reset_file_format_dataset_cache()
+        return loader()
+
+    return _file_format_dataset_cache(cache_max_size).get_or_load(
+        key, loader, lambda value: size_estimator(key, value))
+
+
 def _file_format_dataset(file_io: FileIO, file_format: str, file_path: str,
                          cache_max_size: int):
     file_path_for_pyarrow = file_io.to_filesystem_path(file_path)
@@ -224,11 +240,11 @@ def _file_format_dataset(file_io: FileIO, file_format: str, file_path: str,
         return ds.dataset(
             file_path_for_pyarrow, format=file_format, filesystem=filesystem)
 
-    key = (_FilesystemIdentity(filesystem), file_format, file_path_for_pyarrow)
     if cache_max_size <= 0:
         _reset_file_format_dataset_cache()
         return load()
 
+    key = (_FilesystemIdentity(filesystem), file_format, file_path_for_pyarrow)
     return _file_format_dataset_cache(cache_max_size).get_or_load(
         key,
         load,

--- a/paimon-python/pypaimon/tests/blob_test.py
+++ b/paimon-python/pypaimon/tests/blob_test.py
@@ -37,6 +37,7 @@ from pypaimon.common.options import Options
 from pypaimon.filesystem.local_file_io import LocalFileIO
 from pypaimon.manifest.schema.data_file_meta import DataFileMeta
 from pypaimon.read.reader.concat_batch_reader import BlobFallbackBatchReader
+from pypaimon.read.reader import format_pyarrow_reader as reader_module
 from pypaimon.read.reader.format_blob_reader import BlobRecordIterator, FormatBlobReader
 from pypaimon.schema.data_types import ArrayType, AtomicType, DataField, MapType
 from pypaimon.table.row.blob import Blob, BlobData, BlobRef, BlobDescriptor, BlobViewStruct, BlobView
@@ -1505,6 +1506,54 @@ class BlobEndToEndTest(unittest.TestCase):
                     self.assertEqual(1, counting_file_io.file_size_calls)
                 finally:
                     reader.close()
+
+    def test_blob_index_cache(self):
+        class CountingReader(FormatBlobReader):
+            index_loads = 0
+
+            def _load_index(self):
+                CountingReader.index_loads += 1
+                return super()._load_index()
+
+        field = DataField(0, "blob_field", AtomicType("BLOB"))
+        path = os.path.join(self.temp_dir, "cached-index.blob")
+        with open(path, 'wb') as output:
+            from pypaimon.write.blob_format_writer import BlobFormatWriter
+            writer = BlobFormatWriter(output)
+            writer.add_element(GenericRow(
+                [BlobData(b"first")], [field], RowKind.INSERT))
+            writer.add_element(GenericRow(
+                [BlobData(b"second")], [field], RowKind.INSERT))
+            writer.close()
+        reader_module._reset_file_format_dataset_cache()
+
+        try:
+            file_io = LocalFileIO(self.temp_dir, Options({}))
+            for row_index, expected in [(0, b"first"), (1, b"second")]:
+                reader = CountingReader(
+                    file_io, path, [field.name], [field], None, False,
+                    row_indices=[row_index], file_size=os.path.getsize(path),
+                )
+                try:
+                    self.assertEqual(
+                        [expected],
+                        reader.read_arrow_batch().column(0).to_pylist())
+                finally:
+                    reader.close()
+            self.assertEqual(1, CountingReader.index_loads)
+
+            disabled = LocalFileIO(self.temp_dir, Options({
+                "file-format.metadata-cache.max-size": "0 b",
+            }))
+            for _ in range(2):
+                reader = CountingReader(
+                    disabled, path, [field.name], [field], None, False,
+                    file_size=os.path.getsize(path),
+                )
+                reader.close()
+            self.assertEqual(3, CountingReader.index_loads)
+        finally:
+            reader_module._reset_file_format_dataset_cache()
 
     def test_split_read_passes_blob_file_size(self):
         from pypaimon.read.split import DataSplit

--- a/paimon-python/pypaimon/tests/blob_test.py
+++ b/paimon-python/pypaimon/tests/blob_test.py
@@ -1555,6 +1555,47 @@ class BlobEndToEndTest(unittest.TestCase):
         finally:
             reader_module._reset_file_format_dataset_cache()
 
+    def test_blob_index_cache_uses_full_path(self):
+        class NormalizingFileIO(LocalFileIO):
+            def to_filesystem_path(self, path):
+                return os.path.basename(path)
+
+        def write(path, values, field):
+            from pypaimon.write.blob_format_writer import BlobFormatWriter
+
+            os.makedirs(os.path.dirname(path), exist_ok=True)
+            with open(path, 'wb') as output:
+                writer = BlobFormatWriter(output)
+                for value in values:
+                    writer.add_element(GenericRow(
+                        [BlobData(value)], [field], RowKind.INSERT))
+                writer.close()
+
+        def read(file_io, path, field):
+            reader = FormatBlobReader(
+                file_io, path, [field.name], [field], None, False,
+                file_size=os.path.getsize(path),
+            )
+            try:
+                return reader.read_arrow_batch().column(0).to_pylist()
+            finally:
+                reader.close()
+
+        field = DataField(0, "blob_field", AtomicType("BLOB"))
+        first_path = os.path.join(self.temp_dir, "first", "same.blob")
+        second_path = os.path.join(self.temp_dir, "second", "same.blob")
+        write(first_path, [b'a', b'bbb'], field)
+        write(second_path, [b'cc', b'dd'], field)
+        self.assertEqual(os.path.getsize(first_path), os.path.getsize(second_path))
+
+        reader_module._reset_file_format_dataset_cache()
+        try:
+            file_io = NormalizingFileIO(self.temp_dir, Options({}))
+            self.assertEqual([b'a', b'bbb'], read(file_io, first_path, field))
+            self.assertEqual([b'cc', b'dd'], read(file_io, second_path, field))
+        finally:
+            reader_module._reset_file_format_dataset_cache()
+
     def test_split_read_passes_blob_file_size(self):
         from pypaimon.read.split import DataSplit
         from pypaimon.read.split_read import (


### PR DESCRIPTION
### Purpose

Follow up on #9125 by caching decoded Blob file indexes in the existing process-local file-format metadata cache.

When a worker reopens the same Blob file, it can reuse the cached lengths and offsets instead of reading and decoding the footer again. The cache remains bounded by `file-format.metadata-cache.max-size`; setting it to `0 b` disables the cache.

### Tests

- `blob_test.py`
- `blob_table_test.py`
- `parquet_metadata_cache_test.py`
- Python flake8