### PR TITLE
[python] Align IN predicates with SQL null semantics

### DIFF
--- a/paimon-python/pypaimon/common/predicate.py
+++ b/paimon-python/pypaimon/common/predicate.py
@@ -301,24 +301,38 @@ class In(Tester):
         return val in literals
 
     def test_by_stats(self, min_v, max_v, literals) -> bool:
-        return any(min_v <= l <= max_v for l in literals)
+        return any(
+            min_v <= literal <= max_v
+            for literal in literals
+            if literal is not None
+        )
 
     def test_by_arrow(self, val, literals) -> bool:
-        return val.isin(literals)
+        # Arrow treats null as a set member, while SQL IN never returns true
+        # solely because both the field and an IN literal are null.
+        non_null_literals = [literal for literal in literals if literal is not None]
+        if not non_null_literals:
+            return val.is_valid() & val.is_null()
+        return val.isin(non_null_literals) & val.is_valid()
 
 
 class NotIn(Tester):
     name = "notIn"
 
     def test_by_value(self, val, literals) -> bool:
-        if val is None:
+        if val is None or any(literal is None for literal in literals):
             return False
         return val not in literals
 
     def test_by_stats(self, min_v, max_v, literals) -> bool:
+        if any(literal is None for literal in literals):
+            return False
         return not any(min_v == l == max_v for l in literals)
 
     def test_by_arrow(self, val, literals) -> bool:
+        # Any null literal makes SQL NOT IN unknown for every non-matching row.
+        if any(literal is None for literal in literals):
+            return val.is_valid() & val.is_null()
         return (~val.isin(literals)) & val.is_valid()
 
 

--- a/paimon-python/pypaimon/tests/predicates_test.py
+++ b/paimon-python/pypaimon/tests/predicates_test.py
@@ -349,6 +349,18 @@ class PredicateTest(unittest.TestCase):
         predicate = predicate_builder.is_in('f0', [1, 2])
         _check_filtered_result(table.new_read_builder().with_filter(predicate), self.df.loc[0:1])
 
+    def test_is_in_with_null_literal_append(self):
+        table = self.catalog.get_table('default.test_append')
+        predicate_builder = table.new_read_builder().new_predicate_builder()
+
+        predicate = predicate_builder.is_in('f1', [None])
+        _check_filtered_result(
+            table.new_read_builder().with_filter(predicate), self.df.iloc[0:0])
+
+        predicate = predicate_builder.is_in('f1', ['abc', None])
+        _check_filtered_result(
+            table.new_read_builder().with_filter(predicate), self.df.loc[[0]])
+
     def test_is_in_pk(self):
         table = self.catalog.get_table('default.test_pk')
         predicate_builder = table.new_read_builder().new_predicate_builder()
@@ -360,6 +372,13 @@ class PredicateTest(unittest.TestCase):
         predicate_builder = table.new_read_builder().new_predicate_builder()
         predicate = predicate_builder.is_not_in('f0', [1, 2])
         _check_filtered_result(table.new_read_builder().with_filter(predicate), self.df.loc[2:4])
+
+    def test_is_not_in_with_null_literal_append(self):
+        table = self.catalog.get_table('default.test_append')
+        predicate_builder = table.new_read_builder().new_predicate_builder()
+        predicate = predicate_builder.is_not_in('f1', ['abc', None])
+        _check_filtered_result(
+            table.new_read_builder().with_filter(predicate), self.df.iloc[0:0])
 
     def test_is_not_in_pk(self):
         table = self.catalog.get_table('default.test_pk')
@@ -557,6 +576,33 @@ class PredicateTest(unittest.TestCase):
         scanner = ds.InMemoryDataset(table).scanner(filter=predicate.to_arrow())
 
         self.assertEqual(scanner.to_table().to_pydict(), {"val": [3]})
+
+    def test_in_and_not_in_null_literal_semantics(self):
+        table = pa.table({"val": [None, 1, 2]})
+
+        in_predicate = Predicate(
+            method='in', index=0, field='val', literals=[1, None])
+        scanner = ds.InMemoryDataset(table).scanner(
+            filter=in_predicate.to_arrow())
+        self.assertEqual(scanner.to_table().to_pydict(), {"val": [1]})
+
+        not_in_predicate = Predicate(
+            method='notIn', index=0, field='val', literals=[1, None])
+        scanner = ds.InMemoryDataset(table).scanner(
+            filter=not_in_predicate.to_arrow())
+        self.assertEqual(scanner.to_table().to_pydict(), {"val": []})
+        self.assertFalse(not_in_predicate.test(OffsetRow([2], 0, 1)))
+
+        fields = [DataField(0, 'val', 'INT')]
+        stats = SimpleStats(
+            min_values=GenericRow([1], fields),
+            max_values=GenericRow([2], fields),
+            null_counts=[0],
+        )
+        self.assertFalse(Predicate(
+            method='in', index=0, field='val', literals=[None]
+        ).test_by_simple_stats(stats, 2))
+        self.assertFalse(not_in_predicate.test_by_simple_stats(stats, 2))
 
     @pytest.mark.python_plan
     def test_pk_reader_with_filter(self):


### PR DESCRIPTION
## What changed

- remove null literals before building Arrow `IN` expressions and reject null input rows
- make `NOT IN` with a null literal match no rows, following SQL three-valued logic
- align row-value, file-stats, and Arrow predicate evaluation
- add table-read and evaluator-level regression tests for null literals

## Why

Arrow set lookup treats null as a matchable set member by default, so `val.isin([None])` does not have SQL `IN (NULL)` semantics. This caused Python reads to return null rows for `IN` predicates and non-matching rows for `NOT IN` predicates containing null.

## Impact

Python predicate evaluation now matches Java Paimon and the existing JSON predicate evaluator for `IN` and `NOT IN` with null literals.

## Verification

- focused null-literal regression tests
- predicate, reader, JSON predicate, projection, data-evolution stats, and pushdown correctness suites: 173 passed, 1 unrelated local pandas 3 dtype assertion deselected, 32 subtests passed
- Flake8 on the changed source and test files
