### PR TITLE
[format] Fix cumulative DELTA_BINARY_PACKED read count

### DIFF
--- a/paimon-format/src/main/java/org/apache/paimon/format/parquet/reader/VectorizedDeltaBinaryPackedReader.java
+++ b/paimon-format/src/main/java/org/apache/paimon/format/parquet/reader/VectorizedDeltaBinaryPackedReader.java
@@ -201,7 +201,7 @@ public class VectorizedDeltaBinaryPackedReader extends VectorizedReaderBase {
             rowId += n;
             remaining -= n;
         }
-        valuesRead = total - remaining;
+        valuesRead += total;
     }
 
     /**

--- a/paimon-format/src/test/java/org/apache/paimon/format/parquet/reader/DeltaEncodingTest.java
+++ b/paimon-format/src/test/java/org/apache/paimon/format/parquet/reader/DeltaEncodingTest.java
@@ -189,6 +189,48 @@ abstract class DeltaEncodingTest<T extends Number, F extends WritableColumnVecto
     }
 
     @Test
+    public void testReadCountAccumulatesAcrossCalls() throws IOException {
+        T[] data = allocDataArray(blockSize + 1);
+        for (int i = 0; i < data.length; i++) {
+            setValue(data, i, i * 32);
+        }
+        writeData(data);
+        reader = new VectorizedDeltaBinaryPackedReader();
+        reader.initFromPage(data.length, writer.getBytes().toInputStream());
+        writableColumnVector = getWritableColumnVector(data.length);
+
+        for (int i = 0; i < data.length; i++) {
+            readData(1, writableColumnVector, i);
+            assertTrue(compareValues(i * 32, readDataFromVector(writableColumnVector, i)));
+        }
+
+        ParquetDecodingException e =
+                assertThrows(
+                        ParquetDecodingException.class,
+                        () -> readData(1, writableColumnVector, data.length));
+        assertTrue(e.getMessage().startsWith("No more values to read."));
+    }
+
+    @Test
+    public void testZeroLengthReadDoesNotResetPosition() throws IOException {
+        T[] data = allocDataArray(3);
+        for (int i = 0; i < data.length; i++) {
+            setValue(data, i, i * 32);
+        }
+        writeData(data);
+        reader = new VectorizedDeltaBinaryPackedReader();
+        reader.initFromPage(data.length, writer.getBytes().toInputStream());
+        writableColumnVector = getWritableColumnVector(data.length);
+
+        readData(1, writableColumnVector, 0);
+        readData(0, writableColumnVector, 1);
+        readData(1, writableColumnVector, 1);
+
+        assertTrue(compareValues(0, readDataFromVector(writableColumnVector, 0)));
+        assertTrue(compareValues(32, readDataFromVector(writableColumnVector, 1)));
+    }
+
+    @Test
     public void testSkip() throws IOException {
         T[] data = allocDataArray(5 * blockSize + 1);
         for (int i = 0; i < data.length; i++) {


### PR DESCRIPTION
## Purpose

Paimon's vectorized Parquet readers were originally copied from Spark in #4982. The original Spark `VectorizedDeltaBinaryPackedReader` assigned:

```java
valuesRead = total - remaining;
```

This replaces the cumulative number of values consumed from the current page with the size of the latest read call. As a result:

- multiple read or skip calls do not maintain the correct page-level read count;
- a zero-length read after partial consumption resets `valuesRead` to `0`;
- the next read can incorrectly replay the separately encoded first value of the DELTA_BINARY_PACKED page.

Spark now accumulates the count with `valuesRead += total` in [apache/spark@1071110](https://github.com/apache/spark/commit/107111001a0b5f5258a463481deb1a039902f511). This PR synchronizes that correction to Paimon.

This is complementary to #9127. That PR prevents an invalid zero-length read at an RLE row-range boundary, while this change makes the DELTA_BINARY_PACKED reader maintain correct cumulative state independently.

## Changes

- Accumulate `valuesRead` across DELTA_BINARY_PACKED read and skip calls.
- Add regression coverage for cumulative bounds checking across multiple calls.
- Add regression coverage ensuring a zero-length read does not reset the current decoding position.
- Cover both INT32 and INT64 DELTA_BINARY_PACKED readers through the shared test suite.

## Testing

```bash
mvn -pl paimon-format -am \
  -DwildcardSuites=none \
  -DfailIfNoTests=false \
  -Dsurefire.failIfNoSpecifiedTests=false \
  -Dtest='DeltaEncodingTest*' test
```

Result: 30 tests passed.
