### PR TITLE
[common] Fix missing rows for null range bitmap indexes

### DIFF
--- a/paimon-common/src/main/java/org/apache/paimon/fileindex/rangebitmap/RangeBitmap.java
+++ b/paimon-common/src/main/java/org/apache/paimon/fileindex/rangebitmap/RangeBitmap.java
@@ -225,7 +225,7 @@ public class RangeBitmap {
 
     private RoaringBitmap32 isNull(@Nullable RoaringBitmap32 foundSet) {
         if (cardinality <= 0) {
-            return rid > 0 ? RoaringBitmap32.bitmapOf(0, rid - 1) : new RoaringBitmap32();
+            return rid > 0 ? RoaringBitmap32.bitmapOfRange(0, rid) : new RoaringBitmap32();
         }
 
         if (foundSet != null && foundSet.isEmpty()) {
@@ -306,7 +306,7 @@ public class RangeBitmap {
             @Nullable RoaringBitmap32 foundSet,
             BiFunction<Integer, RoaringBitmap32, RoaringBitmap32> function) {
         if (cardinality <= 0) {
-            return rid > 0 ? RoaringBitmap32.bitmapOf(0, rid - 1) : new RoaringBitmap32();
+            return rid > 0 ? RoaringBitmap32.bitmapOfRange(0, rid) : new RoaringBitmap32();
         }
 
         RoaringBitmap32 bitmap;

--- a/paimon-common/src/test/java/org/apache/paimon/fileindex/rangebitmap/RangeBitmapFileIndexTest.java
+++ b/paimon-common/src/test/java/org/apache/paimon/fileindex/rangebitmap/RangeBitmapFileIndexTest.java
@@ -423,8 +423,9 @@ public class RangeBitmapFileIndexTest {
         FieldRef fieldRef = new FieldRef(0, "", intType);
         RangeBitmapFileIndex bitmapFileIndex = new RangeBitmapFileIndex(intType, new Options());
         FileIndexWriter writer = bitmapFileIndex.createWriter();
-        writer.writeRecord(null);
-        writer.writeRecord(null);
+        for (int i = 0; i < 5; i++) {
+            writer.writeRecord(null);
+        }
 
         // build index
         byte[] bytes = writer.serializedBytes();
@@ -433,7 +434,7 @@ public class RangeBitmapFileIndexTest {
 
         // test is null
         assertThat(((BitmapIndexResult) reader.visitIsNull(fieldRef)).get())
-                .isEqualTo(RoaringBitmap32.bitmapOf(0, 1));
+                .isEqualTo(RoaringBitmap32.bitmapOfRange(0, 5));
         // test is not null
         assertThat(((BitmapIndexResult) reader.visitIsNotNull(fieldRef)).get())
                 .isEqualTo(RoaringBitmap32.bitmapOf());
@@ -444,6 +445,10 @@ public class RangeBitmapFileIndexTest {
         // test GT
         assertThat(((BitmapIndexResult) reader.visitGreaterThan(fieldRef, 0)).get())
                 .isEqualTo(RoaringBitmap32.bitmapOf());
+
+        TopN topN = new TopN(fieldRef, ASCENDING, NULLS_FIRST, 1);
+        assertThat(((BitmapIndexResult) reader.visitTopN(topN, null)).get())
+                .isEqualTo(RoaringBitmap32.bitmapOfRange(0, 5));
     }
 
     @Test


### PR DESCRIPTION
### Purpose
- Range bitmap incorrectly uses bitmapOf instead of bitmapOfRange causing 2 positions to be returned instead of the whole range. This causes missing rows returned for null data/potential silent data loss.
- Ensure we can fix it by using the correct `bitmapOfRange(0, rid)` to select all rows.

### Tests
 - UT
