### PR TITLE
[python] Keep native planning for Blob descriptor reads

### DIFF
--- a/paimon-python/pypaimon/read/native_plan.py
+++ b/paimon-python/pypaimon/read/native_plan.py
@@ -124,11 +124,17 @@ def _catalog_options(table) -> dict:
 def _read_options(table) -> dict:
     """Effective Rust read options, including FileStoreTable.copy overrides."""
     options = {
+        str(key): _option_value_to_string(value)
+        for key, value in (
+            getattr(table, '_applied_dynamic_options', {}) or {}).items()
+        if value is not None and key != CoreOptions.SCAN_TIMESTAMP.key()
+    }
+    options.update({
         CoreOptions.SOURCE_SPLIT_TARGET_SIZE.key(): str(
             table.options.source_split_target_size()),
         CoreOptions.SOURCE_SPLIT_OPEN_FILE_COST.key(): str(
             table.options.source_split_open_file_cost()),
-    }
+    })
     table_options = table.options.options
     for option in (
             CoreOptions.SCAN_SNAPSHOT_ID,

--- a/paimon-python/pypaimon/read/native_plan.py
+++ b/paimon-python/pypaimon/read/native_plan.py
@@ -124,17 +124,11 @@ def _catalog_options(table) -> dict:
 def _read_options(table) -> dict:
     """Effective Rust read options, including FileStoreTable.copy overrides."""
     options = {
-        str(key): _option_value_to_string(value)
-        for key, value in (
-            getattr(table, '_applied_dynamic_options', {}) or {}).items()
-        if value is not None and key != CoreOptions.SCAN_TIMESTAMP.key()
-    }
-    options.update({
         CoreOptions.SOURCE_SPLIT_TARGET_SIZE.key(): str(
             table.options.source_split_target_size()),
         CoreOptions.SOURCE_SPLIT_OPEN_FILE_COST.key(): str(
             table.options.source_split_open_file_cost()),
-    })
+    }
     table_options = table.options.options
     for option in (
             CoreOptions.SCAN_SNAPSHOT_ID,

--- a/paimon-python/pypaimon/read/table_scan.py
+++ b/paimon-python/pypaimon/read/table_scan.py
@@ -40,16 +40,25 @@ _NATIVE_FAMILY_SEARCH_MODE_OPTIONS = frozenset({
 _NATIVE_SEARCH_MODE_OPTIONS = _NATIVE_FAMILY_SEARCH_MODE_OPTIONS | {
     CoreOptions.GLOBAL_INDEX_SEARCH_MODE.key(),
 }
+_NATIVE_FORWARDED_OPTIONS = frozenset({
+    CoreOptions.SCAN_NATIVE_PLAN_ENABLED.key(),
+    CoreOptions.SOURCE_SPLIT_TARGET_SIZE.key(),
+    CoreOptions.SOURCE_SPLIT_OPEN_FILE_COST.key(),
+    CoreOptions.SCAN_SNAPSHOT_ID.key(),
+    CoreOptions.SCAN_TAG_NAME.key(),
+    CoreOptions.SCAN_TIMESTAMP.key(),
+    CoreOptions.SCAN_TIMESTAMP_MILLIS.key(),
+}) | _NATIVE_SEARCH_MODE_OPTIONS
+_NATIVE_PLAN_INDEPENDENT_OPTIONS = frozenset({
+    CoreOptions.BLOB_AS_DESCRIPTOR.key(),
+    CoreOptions.READ_BATCH_SIZE.key(),
+    CoreOptions.READ_PARALLELISM.key(),
+})
 _NATIVE_TIME_TRAVEL_OPTIONS = frozenset({
     CoreOptions.SCAN_SNAPSHOT_ID.key(),
     CoreOptions.SCAN_TAG_NAME.key(),
     CoreOptions.SCAN_TIMESTAMP.key(),
     CoreOptions.SCAN_TIMESTAMP_MILLIS.key(),
-})
-_NATIVE_SAFE_REMOVED_OPTIONS = frozenset({
-    CoreOptions.SOURCE_SPLIT_TARGET_SIZE.key(),
-    CoreOptions.SOURCE_SPLIT_OPEN_FILE_COST.key(),
-    CoreOptions.BLOB_AS_DESCRIPTOR.key(),
 })
 
 
@@ -170,8 +179,12 @@ class TableScan:
             return False
         # Rust cannot remove an option persisted in the catalog-loaded schema.
         applied_options = getattr(self.table, '_applied_dynamic_options', {}) or {}
-        if any(value is None and key not in _NATIVE_SAFE_REMOVED_OPTIONS
-               for key, value in applied_options.items()):
+        allowed_options = (
+            _NATIVE_FORWARDED_OPTIONS | _NATIVE_PLAN_INDEPENDENT_OPTIONS)
+        if (set(applied_options) - allowed_options
+                or any(key in (_NATIVE_TIME_TRAVEL_OPTIONS
+                               | _NATIVE_SEARCH_MODE_OPTIONS) and value is None
+                       for key, value in applied_options.items())):
             return False
         from pypaimon.snapshot.time_travel_util import SCAN_KEYS
         unsupported_scan_keys = set(SCAN_KEYS) - _NATIVE_TIME_TRAVEL_OPTIONS

--- a/paimon-python/pypaimon/read/table_scan.py
+++ b/paimon-python/pypaimon/read/table_scan.py
@@ -40,21 +40,16 @@ _NATIVE_FAMILY_SEARCH_MODE_OPTIONS = frozenset({
 _NATIVE_SEARCH_MODE_OPTIONS = _NATIVE_FAMILY_SEARCH_MODE_OPTIONS | {
     CoreOptions.GLOBAL_INDEX_SEARCH_MODE.key(),
 }
-# Options native forwards to Rust; any other copy() override is invisible to Rust.
-_NATIVE_FORWARDED_OPTIONS = frozenset({
-    CoreOptions.SCAN_NATIVE_PLAN_ENABLED.key(),
-    CoreOptions.SOURCE_SPLIT_TARGET_SIZE.key(),
-    CoreOptions.SOURCE_SPLIT_OPEN_FILE_COST.key(),
-    CoreOptions.SCAN_SNAPSHOT_ID.key(),
-    CoreOptions.SCAN_TAG_NAME.key(),
-    CoreOptions.SCAN_TIMESTAMP.key(),
-    CoreOptions.SCAN_TIMESTAMP_MILLIS.key(),
-}) | _NATIVE_SEARCH_MODE_OPTIONS
 _NATIVE_TIME_TRAVEL_OPTIONS = frozenset({
     CoreOptions.SCAN_SNAPSHOT_ID.key(),
     CoreOptions.SCAN_TAG_NAME.key(),
     CoreOptions.SCAN_TIMESTAMP.key(),
     CoreOptions.SCAN_TIMESTAMP_MILLIS.key(),
+})
+_NATIVE_SAFE_REMOVED_OPTIONS = frozenset({
+    CoreOptions.SOURCE_SPLIT_TARGET_SIZE.key(),
+    CoreOptions.SOURCE_SPLIT_OPEN_FILE_COST.key(),
+    CoreOptions.BLOB_AS_DESCRIPTOR.key(),
 })
 
 
@@ -109,8 +104,8 @@ class TableScan:
         a primary-key table whose trimmed PK is empty (PK equals the partition
         key; native may mark splits raw-convertible and skip merge), dynamic
         bucket / cross-partition PK tables (unconfirmed Rust parity), a stale
-        schema without time travel, copy() overrides Rust does not see (notably
-        removing a persisted scan option), unsupported time travel selectors,
+        schema without time travel, removed copy() options which Rust cannot
+        represent, unsupported time travel selectors,
         query auth, non-main branch, incremental scans, a missing/old
         pypaimon-rust, or a catalog / identifier Rust cannot reconstruct. Keep
         this capability gate in sync when adding scan features."""
@@ -175,10 +170,8 @@ class TableScan:
             return False
         # Rust cannot remove an option persisted in the catalog-loaded schema.
         applied_options = getattr(self.table, '_applied_dynamic_options', {}) or {}
-        if (set(applied_options) - _NATIVE_FORWARDED_OPTIONS
-                or any(key in (_NATIVE_TIME_TRAVEL_OPTIONS
-                               | _NATIVE_SEARCH_MODE_OPTIONS) and value is None
-                       for key, value in applied_options.items())):
+        if any(value is None and key not in _NATIVE_SAFE_REMOVED_OPTIONS
+               for key, value in applied_options.items()):
             return False
         from pypaimon.snapshot.time_travel_util import SCAN_KEYS
         unsupported_scan_keys = set(SCAN_KEYS) - _NATIVE_TIME_TRAVEL_OPTIONS

--- a/paimon-python/pypaimon/tests/native_plan_integration_test.py
+++ b/paimon-python/pypaimon/tests/native_plan_integration_test.py
@@ -24,6 +24,7 @@ import pyarrow as pa
 from pypaimon import CatalogFactory, Schema
 from pypaimon.globalindex.global_index_result import GlobalIndexResult
 from pypaimon.read.native_plan import native_family_search_modes_available
+from pypaimon.table.row.blob import BlobDescriptor
 from pypaimon.utils.range import Range
 
 
@@ -211,6 +212,21 @@ class NativePlanIntegrationTest(unittest.TestCase):
             for split in blob_plan.splits()
             for data_file in split.files
         ))
+
+        descriptor_table = native_table.copy({'blob-as-descriptor': 'true'})
+        descriptor_builder = (
+            descriptor_table.new_read_builder()
+            .with_projection(['media.camera'])
+            .with_limit(1))
+        descriptor_plan = descriptor_builder.new_scan().plan()
+        descriptor_rows = descriptor_builder.new_read().to_arrow(
+            descriptor_plan.splits()).to_pylist()
+        self.assertEqual(len(descriptor_plan.splits()), 1)
+        self.assertEqual(
+            BlobDescriptor.deserialize(descriptor_rows[0]['media.camera']).length,
+            1,
+        )
+        self.assertTrue(descriptor_builder.explain().native_planned)
 
     @unittest.skipUnless(_has_native_row_ranges(),
                          "pypaimon_rust row-range API not installed")

--- a/paimon-python/pypaimon/tests/native_plan_test.py
+++ b/paimon-python/pypaimon/tests/native_plan_test.py
@@ -373,6 +373,22 @@ class NativePlanTest(unittest.TestCase):
         native.assert_not_called()
         fs.scan.assert_called_once_with()
 
+    def test_dynamic_read_option_uses_native_plan(self):
+        fs = Mock(partition_key_predicate=None)
+        scan = _scan(native_enabled=True, file_scanner=fs)
+        scan.table._applied_dynamic_options = {
+            'blob-as-descriptor': 'true',
+        }
+        split = Mock(partition=Mock(values=[]), snapshot_id=1)
+
+        with patch(
+                'pypaimon.read.native_plan.native_plan',
+                return_value=[split]) as native:
+            self.assertEqual(scan.plan().splits(), [split])
+
+        native.assert_called_once()
+        fs.scan.assert_not_called()
+
     def test_plan_falls_back_when_native_plan_raises(self):
         # A native planning failure (e.g. unsupported scheme) must fall back, not crash.
         fs = Mock(partition_key_predicate=None)
@@ -541,7 +557,13 @@ class NativePlanTest(unittest.TestCase):
             'vector-index.search-mode': 'fast',
             'full-text-index.search-mode': 'fast',
         })
+        table._applied_dynamic_options = {
+            'blob-as-descriptor': True,
+            'read.batch-size': 2048,
+        }
         self.assertEqual(_read_options(table), {
+            'blob-as-descriptor': 'true',
+            'read.batch-size': '2048',
             'source.split.target-size': '1024',
             'source.split.open-file-cost': '128',
             'scan.snapshot-id': '9',
@@ -655,6 +677,7 @@ class NativePlanTest(unittest.TestCase):
         table.options.source_split_target_size.return_value = 1024
         table.options.source_split_open_file_cost.return_value = 128
         table.options.options.contains_key.return_value = False
+        table._applied_dynamic_options = {}
         split = Mock()
         split.serialize.return_value = b'bytes'
         rt = Mock()

--- a/paimon-python/pypaimon/tests/native_plan_test.py
+++ b/paimon-python/pypaimon/tests/native_plan_test.py
@@ -378,6 +378,8 @@ class NativePlanTest(unittest.TestCase):
         scan = _scan(native_enabled=True, file_scanner=fs)
         scan.table._applied_dynamic_options = {
             'blob-as-descriptor': 'true',
+            'read.batch-size': '2048',
+            'read.parallelism': '2',
         }
         split = Mock(partition=Mock(values=[]), snapshot_id=1)
 
@@ -388,6 +390,20 @@ class NativePlanTest(unittest.TestCase):
 
         native.assert_called_once()
         fs.scan.assert_not_called()
+
+    def test_unknown_dynamic_option_falls_back(self):
+        fs = Mock(partition_key_predicate=None)
+        fs.scan.return_value = fallback = object()
+        scan = _scan(native_enabled=True, file_scanner=fs)
+        scan.table._applied_dynamic_options = {
+            'future.scan-option': 'value',
+        }
+
+        with patch('pypaimon.read.native_plan.native_plan') as native:
+            self.assertIs(scan.plan(), fallback)
+
+        native.assert_not_called()
+        fs.scan.assert_called_once_with()
 
     def test_plan_falls_back_when_native_plan_raises(self):
         # A native planning failure (e.g. unsupported scheme) must fall back, not crash.
@@ -557,13 +573,7 @@ class NativePlanTest(unittest.TestCase):
             'vector-index.search-mode': 'fast',
             'full-text-index.search-mode': 'fast',
         })
-        table._applied_dynamic_options = {
-            'blob-as-descriptor': True,
-            'read.batch-size': 2048,
-        }
         self.assertEqual(_read_options(table), {
-            'blob-as-descriptor': 'true',
-            'read.batch-size': '2048',
             'source.split.target-size': '1024',
             'source.split.open-file-cost': '128',
             'scan.snapshot-id': '9',


### PR DESCRIPTION
## Purpose

Keep native scan planning enabled for dynamic reader options which do not affect split planning.

`query.read_blobs()` copies the table with `blob-as-descriptor=true`. The native capability gate treated this reader-only option as unsupported and silently fell back to Python planning.

## Changes

- allow `blob-as-descriptor`, `read.batch-size`, and `read.parallelism` without disabling native planning; these options remain effective in the PyPaimon reader and are not needed by the Rust planner
- continue forwarding only the scan options explicitly supported by the Rust planner
- keep unknown dynamic options on the conservative Python fallback path because Rust 0.4 does not strictly reject every unknown option
- preserve conservative handling for option removal
- cover Blob descriptor planning and decoding, reader-only options, and unknown-option fallback

## Tests

- native plan unit and integration tests: 52 passed, 12 subtests passed
- multimodal `read_blobs` / `stream_blobs` tests: 6 passed
- flake8 on changed files
- compileall
- `git diff --check`
- OSS-backed Data Evolution BLOB table: the high-level `query.read_blobs()` path invoked native planning once, planned one split at the pinned snapshot, and returned the expected row and Blob payload
