### PR TITLE
[lance] Reject unsupported VARIANT and BLOB types in LanceFileFormat schema validation

### DIFF
--- a/paimon-lance/src/main/java/org/apache/paimon/format/lance/LanceFileFormat.java
+++ b/paimon-lance/src/main/java/org/apache/paimon/format/lance/LanceFileFormat.java
@@ -180,12 +180,13 @@ public class LanceFileFormat extends FileFormat {
 
         @Override
         public Void visit(VariantType variantType) {
-            return null;
+            throw new UnsupportedOperationException(
+                    "Lance file format does not support type VARIANT");
         }
 
         @Override
         public Void visit(BlobType blobType) {
-            return null;
+            throw new UnsupportedOperationException("Lance file format does not support type BLOB");
         }
 
         @Override

--- a/paimon-lance/src/test/java/org/apache/paimon/format/lance/LanceFileFormatTest.java
+++ b/paimon-lance/src/test/java/org/apache/paimon/format/lance/LanceFileFormatTest.java
@@ -101,4 +101,20 @@ public class LanceFileFormatTest {
         // Validate that no exception is thrown for supported types
         assertDoesNotThrow(() -> format.validateDataFields(rowType));
     }
+
+    @Test
+    public void testValidateDataFields_UnsupportedVariantType() {
+        LanceFileFormat format =
+                new LanceFileFormat(new FileFormatFactory.FormatContext(new Options(), 1024, 1024));
+        RowType rowType = RowType.of(DataTypes.VARIANT());
+        assertThrows(UnsupportedOperationException.class, () -> format.validateDataFields(rowType));
+    }
+
+    @Test
+    public void testValidateDataFields_UnsupportedBlobType() {
+        LanceFileFormat format =
+                new LanceFileFormat(new FileFormatFactory.FormatContext(new Options(), 1024, 1024));
+        RowType rowType = RowType.of(DataTypes.BLOB());
+        assertThrows(UnsupportedOperationException.class, () -> format.validateDataFields(rowType));
+    }
 }


### PR DESCRIPTION
### Purpose

fix #9149

- `LanceRowTypeVisitor` accepted VARIANT and BLOB, but the `paimon-arrow` bridge supports neither.
- VARIANT writes succeed today, but `SELECT *` fails with a message-less `UnsupportedOperationException` in `Arrow2PaimonVectorConverter#visit(VariantType)` — the written column can never be read back. Rejecting it blocks silent data loss, not a working path.
- BLOB reaches this visitor only through `blob-descriptor-field` / `blob-view-field`, which require `data-evolution.enabled = true`; those inline BLOBs already fail at INSERT. Managed BLOB columns in dedicated blob files are unaffected.
- Matches `VortexFileFormat` and `MosaicFileFormat`, which reject both types, and follows #8678 (MULTISET).
- Related: #9102 (ARRAY element types, merged) — a different method in the same visitor.

### Tests

- Added `LanceFileFormatTest#testValidateDataFields_UnsupportedVariantType` and `#testValidateDataFields_UnsupportedBlobType`.
- `mvn -pl paimon-lance -DfailIfNoTests=false clean install` (JDK 11) — 89 tests, 0 failures, 0 errors, 6 skipped. checkstyle, spotless and enforcer passed.
