### PR TITLE
[flink] Fix flaky Lumina data evolution index refresh IT

### DIFF
--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/LuminaVectorGlobalIndexITCase.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/LuminaVectorGlobalIndexITCase.java
@@ -519,7 +519,7 @@ public class LuminaVectorGlobalIndexITCase extends CatalogITCaseBase {
         sql(
                 "CALL sys.data_evolution_merge_into("
                         + "'default.T_REFRESH', '', '', 'S_REFRESH', "
-                        + "'T_REFRESH._ROW_ID=S_REFRESH.id', 'v=S_REFRESH.v', 2)");
+                        + "'T_REFRESH.id=S_REFRESH.id', 'v=S_REFRESH.v', 2)");
         assertThat(sql("SELECT id FROM T_REFRESH WHERE id = 1 AND v IS NOT NULL")).hasSize(1);
 
         long updatedSnapshotId = table.snapshotManager().latestSnapshot().id();


### PR DESCRIPTION
### Purpose
- This flaky test updates rows via `_ROW_ID = 1` and asserts that the logical row with `id = 1` was updated.
- However row ids are based on physical file order and are not guaranteed to match logical id, this causes the assertion to be mismatch at parallelism = 2. 
- Ensure we use logical id to keep the assertion deterministic.

### Tests
 - UT Fix
