### PR TITLE
[core] Remove configurable manifest format

### DIFF
--- a/docs/generated/core_configuration.html
+++ b/docs/generated/core_configuration.html
@@ -1036,12 +1036,6 @@ Mainly to resolve data skew on primary keys. We recommend starting with 64 mb wh
             <td>For DELETE manifest entry in manifest file, drop stats to reduce memory and storage. Default value is false only for compatibility of old reader.</td>
         </tr>
         <tr>
-            <td><h5>manifest.format</h5></td>
-            <td style="word-wrap: break-word;">"avro"</td>
-            <td>String</td>
-            <td>Specify the message format of manifest files.</td>
-        </tr>
-        <tr>
             <td><h5>manifest.full-compaction-threshold-size</h5></td>
             <td style="word-wrap: break-word;">16 mb</td>
             <td>MemorySize</td>

--- a/paimon-api/src/main/java/org/apache/paimon/CoreOptions.java
+++ b/paimon-api/src/main/java/org/apache/paimon/CoreOptions.java
@@ -509,12 +509,6 @@ public class CoreOptions implements Serializable {
                                     + "in the previous file. This must not exceed "
                                     + "'variant.shredding.minFieldCardinalityRatio'.");
 
-    public static final ConfigOption<String> MANIFEST_FORMAT =
-            key("manifest.format")
-                    .stringType()
-                    .defaultValue(CoreOptions.FILE_FORMAT_AVRO)
-                    .withDescription("Specify the message format of manifest files.");
-
     public static final ConfigOption<String> MANIFEST_COMPRESSION =
             key("manifest.compression")
                     .stringType()
@@ -3042,10 +3036,6 @@ public class CoreOptions implements Serializable {
 
     public String fileFormatString() {
         return normalizeFileFormat(options.get(FILE_FORMAT));
-    }
-
-    public String manifestFormatString() {
-        return normalizeFileFormat(options.get(MANIFEST_FORMAT));
     }
 
     public String manifestCompression() {

--- a/paimon-common/src/main/java/org/apache/paimon/format/FileFormat.java
+++ b/paimon-common/src/main/java/org/apache/paimon/format/FileFormat.java
@@ -117,6 +117,6 @@ public abstract class FileFormat {
     }
 
     public static FileFormat manifestFormat(CoreOptions options) {
-        return FileFormat.fromIdentifier(options.manifestFormatString(), options.toConfiguration());
+        return FileFormat.fromIdentifier(CoreOptions.FILE_FORMAT_AVRO, options.toConfiguration());
     }
 }

--- a/paimon-core/src/test/java/org/apache/paimon/FileFormatTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/FileFormatTest.java
@@ -130,6 +130,16 @@ public class FileFormatTest {
         assertThat(orcFileFormat.readBatchSize()).isEqualTo(1024);
     }
 
+    @Test
+    public void testManifestFormatIsAlwaysAvro() {
+        Options tableOptions = new Options();
+        tableOptions.set(CoreOptions.FILE_FORMAT, "orc");
+
+        FileFormat manifestFormat = FileFormat.manifestFormat(new CoreOptions(tableOptions));
+
+        assertThat(manifestFormat.getFormatIdentifier()).isEqualTo(CoreOptions.FILE_FORMAT_AVRO);
+    }
+
     public FileFormat createFileFormat(String codec) {
         Options tableOptions = new Options();
         tableOptions.set(CoreOptions.FILE_FORMAT, CoreOptions.FILE_FORMAT_AVRO);

--- a/paimon-core/src/test/java/org/apache/paimon/TestFileStore.java
+++ b/paimon-core/src/test/java/org/apache/paimon/TestFileStore.java
@@ -819,7 +819,6 @@ public class TestFileStore extends KeyValueFileStore {
                     MemorySize.parse((ThreadLocalRandom.current().nextInt(16) + 1) + "kb"));
 
             conf.set(CoreOptions.FILE_FORMAT, format);
-            conf.set(CoreOptions.MANIFEST_FORMAT, format);
             conf.set(CoreOptions.PATH, root);
             conf.set(CoreOptions.BUCKET, numBuckets);
 

--- a/paimon-core/src/test/java/org/apache/paimon/append/dataevolution/DataEvolutionRowIdReassignerTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/append/dataevolution/DataEvolutionRowIdReassignerTest.java
@@ -133,7 +133,7 @@ public class DataEvolutionRowIdReassignerTest extends TableTestBase {
 
     @Test
     public void testProjectedPlannerBuildsExpectedPlan() throws Exception {
-        catalog.createTable(identifier(), projectedPlannerSchema(null), true);
+        catalog.createTable(identifier(), projectedPlannerSchema(), true);
         FileStoreTable table = getTableDefault();
         writeOneRow(table, "a", 0);
         writeOneRow(table, "b", 1);
@@ -155,7 +155,7 @@ public class DataEvolutionRowIdReassignerTest extends TableTestBase {
 
     @Test
     public void testProjectedPlannerAppliesPartitionPredicate() throws Exception {
-        catalog.createTable(identifier(), projectedPlannerSchema(null), true);
+        catalog.createTable(identifier(), projectedPlannerSchema(), true);
         FileStoreTable table = getTableDefault();
         writeOneRow(table, "a", 0);
         writeOneRow(table, "b", 1);
@@ -171,23 +171,6 @@ public class DataEvolutionRowIdReassignerTest extends TableTestBase {
         assertThat(result.isEmpty()).isTrue();
         assertThat(result.manifestOrdinals).isEmpty();
         assertThat(result.totalOffset).isZero();
-    }
-
-    @Test
-    public void testProjectedPlannerReadsOrcManifest() throws Exception {
-        catalog.createTable(identifier(), projectedPlannerSchema("orc"), true);
-        FileStoreTable table = getTableDefault();
-        writeOneRow(table, "a", 0);
-        writeOneRow(table, "b", 1);
-        writeOneRow(table, "a", 2);
-
-        DataEvolutionRowIdAssignmentPlanner.Result result = planProjectedState(table, null);
-
-        assertThat(result.rowIdMappings).hasSize(1);
-        RowRangeMappingIndex mapping = result.rowIdMappings.values().iterator().next();
-        assertThat(mapping.map(new Range(0L, 0L))).hasValue(new Range(0L, 0L));
-        assertThat(mapping.map(new Range(2L, 2L))).hasValue(new Range(1L, 1L));
-        assertThat(result.totalOffset).isEqualTo(2L);
     }
 
     @Test
@@ -217,7 +200,7 @@ public class DataEvolutionRowIdReassignerTest extends TableTestBase {
         return state.plan(groups);
     }
 
-    private Schema projectedPlannerSchema(String manifestFormat) {
+    private Schema projectedPlannerSchema() {
         Schema.Builder schemaBuilder = Schema.newBuilder();
         schemaBuilder.column("pt", DataTypes.STRING());
         schemaBuilder.column("id", DataTypes.INT());
@@ -225,9 +208,6 @@ public class DataEvolutionRowIdReassignerTest extends TableTestBase {
         schemaBuilder.partitionKeys("pt");
         schemaBuilder.option(CoreOptions.ROW_TRACKING_ENABLED.key(), "true");
         schemaBuilder.option(CoreOptions.DATA_EVOLUTION_ENABLED.key(), "true");
-        if (manifestFormat != null) {
-            schemaBuilder.option(CoreOptions.MANIFEST_FORMAT.key(), manifestFormat);
-        }
         return schemaBuilder.build();
     }
 
@@ -304,35 +284,6 @@ public class DataEvolutionRowIdReassignerTest extends TableTestBase {
                 compactPlanView(table, metasWithoutPartitionStats, null);
         Optional<AssignmentPlanView> legacyPlan =
                 legacyPlanView(table, metasWithoutPartitionStats, null);
-        assertPlanViewsEqual(compactPlan, legacyPlan);
-        assertThat(compactPlan).isPresent();
-    }
-
-    @Test
-    public void testCompactAndLegacyPlansMatchForOrcManifests() throws Exception {
-        Schema base = schemaDefault();
-        Map<String, String> options = new HashMap<>(base.options());
-        options.put(CoreOptions.MANIFEST_FORMAT.key(), "orc");
-        catalog.createTable(
-                identifier(),
-                new Schema(
-                        base.fields(),
-                        base.partitionKeys(),
-                        base.primaryKeys(),
-                        options,
-                        base.comment()),
-                true);
-        FileStoreTable table = getTableDefault();
-        writeOneRow(table, "a", 0);
-        writeOneRow(table, "b", 1);
-        writeOneRow(table, "a", 2);
-
-        Snapshot snapshot = table.snapshotManager().latestSnapshot();
-        ManifestList manifestList = table.store().manifestListFactory().create();
-        List<ManifestFileMeta> manifestMetas = manifestList.readDataManifests(snapshot);
-
-        Optional<AssignmentPlanView> compactPlan = compactPlanView(table, manifestMetas, null);
-        Optional<AssignmentPlanView> legacyPlan = legacyPlanView(table, manifestMetas, null);
         assertPlanViewsEqual(compactPlan, legacyPlan);
         assertThat(compactPlan).isPresent();
     }

--- a/paimon-core/src/test/java/org/apache/paimon/table/system/ManifestsTableTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/table/system/ManifestsTableTest.java
@@ -90,9 +90,7 @@ public class ManifestsTableTest extends TableTestBase {
         ManifestList.Factory factory =
                 new ManifestList.Factory(
                         fileIO,
-                        FileFormat.fromIdentifier(
-                                CoreOptions.MANIFEST_FORMAT.defaultValue().toString(),
-                                new Options()),
+                        FileFormat.fromIdentifier(CoreOptions.FILE_FORMAT_AVRO, new Options()),
                         "zstd",
                         createNonPartFactory(tablePath),
                         null);

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/CatalogTableITCase.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/CatalogTableITCase.java
@@ -278,7 +278,7 @@ public class CatalogTableITCase extends CatalogITCaseBase {
         sql("ALTER TABLE T SET ('snapshot.time-retained' = '5 h')");
         sql("ALTER TABLE T SET ('snapshot.num-retained.max' = '20')");
         sql("ALTER TABLE T SET ('snapshot.num-retained.min' = '18')");
-        sql("ALTER TABLE T SET ('manifest.format' = 'avro')");
+        sql("ALTER TABLE T SET ('manifest.compression' = 'snappy')");
 
         String actualResult = sql("SHOW CREATE TABLE T$schemas").toString();
         String expectedResult =
@@ -315,8 +315,8 @@ public class CatalogTableITCase extends CatalogITCaseBase {
                                 + "{\"id\":2,\"name\":\"c\",\"type\":\"STRING\"}], [], [\"a\"], "
                                 + "{\"a.aa.aaa\":\"val1\",\"snapshot.time-retained\":\"5 h\",\"b.bb.bbb\":\"val2\",\"snapshot.num-retained.max\":\"20\",\"snapshot.num-retained.min\":\"18\"}, ], "
                                 + "+I[4, [{\"id\":0,\"name\":\"a\",\"type\":\"INT NOT NULL\"},{\"id\":1,\"name\":\"b\",\"type\":\"INT\"},{\"id\":2,\"name\":\"c\",\"type\":\"STRING\"}], [], [\"a\"], "
-                                + "{\"a.aa.aaa\":\"val1\",\"snapshot.time-retained\":\"5 h\",\"b.bb.bbb\":\"val2\",\"snapshot.num-retained.max\":\"20\",\"manifest.format\":\"avro\","
-                                + "\"snapshot.num-retained.min\":\"18\"}, ]]");
+                                + "{\"a.aa.aaa\":\"val1\",\"snapshot.time-retained\":\"5 h\",\"b.bb.bbb\":\"val2\",\"snapshot.num-retained.max\":\"20\",\"snapshot.num-retained.min\":\"18\","
+                                + "\"manifest.compression\":\"snappy\"}, ]]");
 
         result =
                 sql(
@@ -375,8 +375,8 @@ public class CatalogTableITCase extends CatalogITCaseBase {
                                 + "{\"id\":2,\"name\":\"c\",\"type\":\"STRING\"}], [], [\"a\"], "
                                 + "{\"a.aa.aaa\":\"val1\",\"snapshot.time-retained\":\"5 h\",\"b.bb.bbb\":\"val2\",\"snapshot.num-retained.max\":\"20\",\"snapshot.num-retained.min\":\"18\"}, ], "
                                 + "+I[4, [{\"id\":0,\"name\":\"a\",\"type\":\"INT NOT NULL\"},{\"id\":1,\"name\":\"b\",\"type\":\"INT\"},{\"id\":2,\"name\":\"c\",\"type\":\"STRING\"}], [], [\"a\"], "
-                                + "{\"a.aa.aaa\":\"val1\",\"snapshot.time-retained\":\"5 h\",\"b.bb.bbb\":\"val2\",\"snapshot.num-retained.max\":\"20\",\"manifest.format\":\"avro\","
-                                + "\"snapshot.num-retained.min\":\"18\"}, ]]");
+                                + "{\"a.aa.aaa\":\"val1\",\"snapshot.time-retained\":\"5 h\",\"b.bb.bbb\":\"val2\",\"snapshot.num-retained.max\":\"20\",\"snapshot.num-retained.min\":\"18\","
+                                + "\"manifest.compression\":\"snappy\"}, ]]");
 
         // check with not exist schema id
         assertThatThrownBy(


### PR DESCRIPTION
## Purpose

Manifest files are standardized on Avro, and the Python implementation already supports Avro manifests only. Keeping `manifest.format` exposes unsupported alternative formats and can make manifests unreadable across implementations.

## Changes

- Remove the `manifest.format` core option.
- Always create manifest readers and writers with the Avro file format.
- Remove ORC-specific manifest tests and update affected test fixtures.
- Remove the option from the generated configuration documentation.
- Keep `manifest.compression` configurable.

## Tests

- `IndexManifestFileHandlerTest`, `ManifestsTableTest`, and `DataEvolutionRowIdReassignerTest` (69 tests)
- `FileFormatTest#testManifestFormatIsAlwaysAvro`
- `CatalogTableITCase#testSchemasTable`
- `mvn -pl paimon-docs -am -DskipTests package`
