### PR TITLE
[iceberg] Warn when the Iceberg metadata committer factory is missing from the classpath

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/iceberg/IcebergCommitCallback.java
+++ b/paimon-core/src/main/java/org/apache/paimon/iceberg/IcebergCommitCallback.java
@@ -23,6 +23,7 @@ import org.apache.paimon.Snapshot;
 import org.apache.paimon.data.BinaryRow;
 import org.apache.paimon.data.GenericArray;
 import org.apache.paimon.data.GenericRow;
+import org.apache.paimon.factories.Factory;
 import org.apache.paimon.factories.FactoryException;
 import org.apache.paimon.factories.FactoryUtil;
 import org.apache.paimon.fs.FileStatus;
@@ -165,9 +166,23 @@ public class IcebergCommitCallback implements CommitCallback, TagCallback {
                     FactoryUtil.discoverFactory(
                             IcebergCommitCallback.class.getClassLoader(),
                             IcebergMetadataCommitterFactory.class,
-                            storageType.toString());
-        } catch (FactoryException ignore) {
+                            storageType.committerFactoryIdentifier());
+        } catch (FactoryException e) {
             metadataCommitterFactory = null;
+            // storage types without a committer have no factory by design, so a miss is expected
+            if (storageType.requiresMetadataCommitter()) {
+                LOG.warn(
+                        "No IcebergMetadataCommitterFactory for '{}={}' found on the classpath, so "
+                                + "table {} will not be synced to the external catalog (commits and "
+                                + "metadata files are unaffected). Check that the module providing it "
+                                + "is deployed and that its META-INF/services/{} entry survived "
+                                + "shading. Cause: {}",
+                        IcebergOptions.METADATA_ICEBERG_STORAGE.key(),
+                        storageType,
+                        table.fullName(),
+                        Factory.class.getName(),
+                        e.getMessage());
+            }
         }
         this.metadataCommitter =
                 metadataCommitterFactory == null ? null : metadataCommitterFactory.create(table);

--- a/paimon-core/src/main/java/org/apache/paimon/iceberg/IcebergOptions.java
+++ b/paimon-core/src/main/java/org/apache/paimon/iceberg/IcebergOptions.java
@@ -198,27 +198,46 @@ public class IcebergOptions {
 
     /** Where to store Iceberg metadata. */
     public enum StorageType implements DescribedEnum {
-        DISABLED("disabled", "Disable Iceberg compatibility support."),
-        TABLE_LOCATION("table-location", "Store Iceberg metadata in each table's directory."),
+        DISABLED("disabled", "Disable Iceberg compatibility support.", false),
+        TABLE_LOCATION(
+                "table-location", "Store Iceberg metadata in each table's directory.", false),
         HADOOP_CATALOG(
                 "hadoop-catalog",
                 "Store Iceberg metadata in a separate directory. "
-                        + "This directory can be specified as the warehouse directory of an Iceberg Hadoop catalog."),
+                        + "This directory can be specified as the warehouse directory of an Iceberg Hadoop catalog.",
+                false),
         HIVE_CATALOG(
                 "hive-catalog",
                 "Not only store Iceberg metadata like hadoop-catalog, "
-                        + "but also create Iceberg external table in Hive."),
+                        + "but also create Iceberg external table in Hive.",
+                true),
         REST_CATALOG(
                 "rest-catalog",
                 "Store Iceberg metadata in a REST catalog. "
-                        + "This allows integration with Iceberg REST catalog services.");
+                        + "This allows integration with Iceberg REST catalog services.",
+                true);
 
         private final String value;
         private final String description;
+        private final boolean requiresMetadataCommitter;
 
-        StorageType(String value, String description) {
+        StorageType(String value, String description, boolean requiresMetadataCommitter) {
             this.value = value;
             this.description = description;
+            this.requiresMetadataCommitter = requiresMetadataCommitter;
+        }
+
+        /** Whether this storage type syncs metadata to an external catalog via a committer. */
+        public boolean requiresMetadataCommitter() {
+            return requiresMetadataCommitter;
+        }
+
+        /**
+         * Identifier this storage type's {@code IcebergMetadataCommitterFactory} is registered
+         * under.
+         */
+        public String committerFactoryIdentifier() {
+            return value;
         }
 
         @Override

--- a/paimon-hive/paimon-hive-catalog/src/main/java/org/apache/paimon/iceberg/IcebergHiveMetadataCommitterFactory.java
+++ b/paimon-hive/paimon-hive-catalog/src/main/java/org/apache/paimon/iceberg/IcebergHiveMetadataCommitterFactory.java
@@ -25,7 +25,7 @@ public class IcebergHiveMetadataCommitterFactory implements IcebergMetadataCommi
 
     @Override
     public String identifier() {
-        return IcebergOptions.StorageType.HIVE_CATALOG.toString();
+        return IcebergOptions.StorageType.HIVE_CATALOG.committerFactoryIdentifier();
     }
 
     @Override

--- a/paimon-iceberg/src/main/java/org/apache/paimon/iceberg/IcebergRESTMetadataCommitterFactory.java
+++ b/paimon-iceberg/src/main/java/org/apache/paimon/iceberg/IcebergRESTMetadataCommitterFactory.java
@@ -24,7 +24,7 @@ import org.apache.paimon.table.FileStoreTable;
 public class IcebergRESTMetadataCommitterFactory implements IcebergMetadataCommitterFactory {
     @Override
     public String identifier() {
-        return IcebergOptions.StorageType.REST_CATALOG.toString();
+        return IcebergOptions.StorageType.REST_CATALOG.committerFactoryIdentifier();
     }
 
     @Override


### PR DESCRIPTION
### Purpose

Closes #9157.

When `metadata.iceberg.storage` requests a sync to an external catalog but the committer factory cannot be discovered, Paimon skipped the sync silently. `IcebergCommitCallback` caught the `FactoryException` and discarded it, leaving `metadataCommitter` null so `commitToExternalCatalog` returned early on every commit. Commits kept succeeding and metadata files kept being written, so the job looked healthy while nothing reached the catalog. In our case a shaded jar had dropped the `META-INF/services` entry for `IcebergRESTMetadataCommitterFactory`.

This logs a `WARN` instead:

```
No IcebergMetadataCommitterFactory for 'metadata.iceberg.storage=rest-catalog' found on
the classpath, so table mydb.t will not be synced to the external catalog (commits and
metadata files are unaffected). Check that the module providing it is deployed and that
its META-INF/services/org.apache.paimon.factories.Factory entry survived shading.
Cause: Could not find any factories that implement
'org.apache.paimon.iceberg.IcebergMetadataCommitterFactory' in the classpath.
```

`disabled`, `table-location` and `hadoop-catalog` have no committer factory by design and must stay quiet. `IcebergOptions.StorageType` now answers that question instead of a switch in the caller:

```java
HIVE_CATALOG("hive-catalog", "...", true),
REST_CATALOG("rest-catalog", "...", true);
```

It is a required constructor argument, so a new storage type cannot be added without stating its own answer. A `committerFactoryIdentifier()` accessor replaces the incidental use of `toString()` as the SPI lookup key. Both factories already derived their identifier from this enum, so this only names the contract.

Still a warning and not a failure, so jobs in this state will not start erroring on upgrade.

### Tests

No new test. Reproducing a missing SPI registration inside a module that has one needs classloader manipulation that would test the harness more than the code. Verified by running it across every `StorageType`:

| `metadata.iceberg.storage` | warns? |
|---|---|
| `table-location` | no |
| `hadoop-catalog` | no |
| `hive-catalog` | yes |
| `rest-catalog` | yes |

Existing suites pass on JDK 11:

- `paimon-core`: `IcebergCommitCallbackTest` 28/28, `IcebergCompatibilityTest` 40/40
- `paimon-iceberg`: 30 unit, 4 IT including `IcebergRestMetadataCommitterITCase`
- `paimon-hive-catalog`: 62 unit, 14 IT

spotless, checkstyle, enforcer and rat are clean.

### API and Format

No format change. `StorageType` gains two public accessors. Constants, values and descriptions are unchanged, so no config or generated-docs change.

### Documentation

None needed.
