### PR TITLE
[spark] Fix IndexOutOfBoundsException for vector_search with too few arguments

### DIFF
--- a/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/catalyst/plans/logical/PaimonTableValuedFunctions.scala
+++ b/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/catalyst/plans/logical/PaimonTableValuedFunctions.scala
@@ -596,9 +596,10 @@ case class VectorSearchQuery(override val args: Seq[Expression])
   }
 
   def hasOuterReference(argsWithoutTable: Seq[Expression]): Boolean = {
-    val queryVector = argsWithoutTable(1)
-    (argsWithoutTable.size == 3 || argsWithoutTable.size == 4) &&
-    (queryVector.references.nonEmpty || containsOuterReference(queryVector))
+    (argsWithoutTable.size == 3 || argsWithoutTable.size == 4) && {
+      val queryVector = argsWithoutTable(1)
+      queryVector.references.nonEmpty || containsOuterReference(queryVector)
+    }
   }
 
   private def containsOuterReference(expr: Expression): Boolean = {

--- a/paimon-spark/paimon-spark-common/src/test/scala/org/apache/paimon/spark/catalyst/plans/logical/VectorSearchQueryTest.scala
+++ b/paimon-spark/paimon-spark-common/src/test/scala/org/apache/paimon/spark/catalyst/plans/logical/VectorSearchQueryTest.scala
@@ -319,6 +319,17 @@ class VectorSearchQueryTest extends AnyFunSuite {
     assert(vectorSearch.options().get("hnsw.ef_search") == "64")
   }
 
+  test("reject vector search with too few parameters") {
+    Seq(Seq.empty[Expression], Seq(Literal("v"))).foreach {
+      args =>
+        val exception = intercept[RuntimeException] {
+          VectorSearchQuery(Seq.empty).createVectorSearch(innerTable, args)
+        }
+        assert(exception.getMessage.contains("needs three or four parameters"))
+        assert(!VectorSearchQuery(Seq.empty).hasOuterReference(args))
+    }
+  }
+
   private def createVectorSearch(args: Expression*) =
     VectorSearchQuery(Seq.empty).createVectorSearch(innerTable, args)
 


### PR DESCRIPTION
### Purpose

`hasOuterReference` reads `argsWithoutTable(1)` before checking the argument count, so
`vector_search('T')` and `vector_search('T', 'col')` throw a raw `IndexOutOfBoundsException`
instead of the message `createVectorSearch` already produces. `IndexOutOfBoundsException` is not
rewritten by `QueryExecution.toInternalError`, so it escapes the analyzer rule as-is.

Moving the index inside the size check matches `createVectorSearch`,
`createDynamicVectorSearch`, `createHybridSearch` and `createFullTextSearch`, which all validate
the count first.

### Tests

`VectorSearchQueryTest`
