### PR TITLE
[spark] Respect blob-compaction.enabled in Spark compact procedure

### DIFF
--- a/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/procedure/CompactProcedure.java
+++ b/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/procedure/CompactProcedure.java
@@ -526,7 +526,11 @@ public class CompactProcedure extends BaseProcedure {
         }
         DataEvolutionCompactCoordinator compactCoordinator =
                 new DataEvolutionCompactCoordinator(
-                        table, partitionPredicate, false, false, snapshot);
+                        table,
+                        partitionPredicate,
+                        table.coreOptions().blobCompactionEnabled(),
+                        false,
+                        snapshot);
         CommitMessageSerializer messageSerializerser = new CommitMessageSerializer();
         String commitUser = createCommitUser(table.coreOptions().toConfiguration());
         try {

--- a/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/sql/BlobTestBase.scala
+++ b/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/sql/BlobTestBase.scala
@@ -704,6 +704,31 @@ class BlobTestBase extends PaimonSparkTestBase {
     }
   }
 
+  test("Blob: test compaction with blob compaction enabled") {
+    withTable("t") {
+      sql(
+        "CREATE TABLE t (id INT, data STRING, picture BINARY) TBLPROPERTIES ('row-tracking.enabled'='true', 'data-evolution.enabled'='true', 'blob-field'='picture', 'blob-compaction.enabled'='true')")
+      for (i <- 1 to 10) {
+        sql("INSERT INTO t VALUES (" + i + ", 'paimon', X'48656C6C6F')")
+      }
+      sql("INSERT INTO t VALUES (1, 'paimon', X'48656C6C6F')")
+
+      checkAnswer(
+        sql("SELECT COUNT(*) FROM `t$files`"),
+        Seq(Row(22))
+      )
+      sql("CALL paimon.sys.compact('t')").collect()
+      checkAnswer(
+        sql("SELECT COUNT(*) FROM `t$files`"),
+        Seq(Row(2))
+      )
+      checkAnswer(
+        sql("SELECT *, _ROW_ID, _SEQUENCE_NUMBER FROM t LIMIT 1"),
+        Seq(Row(1, "paimon", Array[Byte](72, 101, 108, 108, 111), 0, 11))
+      )
+    }
+  }
+
   test("Blob: merge-into updates non-blob column on raw blob table with split blob files") {
     withTable("s", "t") {
       sql(


### PR DESCRIPTION
### Purpose

`compactDataEvolutionTable` hardcodes `compactBlob` to `false`, so `blob-compaction.enabled` is
silently ignored by `sys.compact` and blob files are never compacted from Spark. Flink already
reads the option in `DataEvolutionTableCompactSource`. The flag is only consumed when the
coordinator is constructed, so nothing downstream compensates.

The existing test asserts 22 files become 12 (blob files untouched); the Flink test on a table
with the option enabled asserts 22 become 2.

### Tests

`BlobTestBase`
