### PR TITLE
[format] Support delimiter as fallback key of csv.field-delimiter

### DIFF
--- a/paimon-format/src/main/java/org/apache/paimon/format/csv/CsvOptions.java
+++ b/paimon-format/src/main/java/org/apache/paimon/format/csv/CsvOptions.java
@@ -33,7 +33,7 @@ public class CsvOptions {
             ConfigOptions.key("csv.field-delimiter")
                     .stringType()
                     .defaultValue(",")
-                    .withFallbackKeys("field-delimiter", "seq")
+                    .withFallbackKeys("field-delimiter", "seq", "delimiter")
                     .withDescription("The field delimiter for CSV or TXT format");
 
     public static final ConfigOption<String> LINE_DELIMITER =

--- a/paimon-format/src/test/java/org/apache/paimon/format/csv/CsvFileFormatTest.java
+++ b/paimon-format/src/test/java/org/apache/paimon/format/csv/CsvFileFormatTest.java
@@ -204,6 +204,32 @@ public class CsvFileFormatTest extends FormatReadWriteTest {
     }
 
     @Test
+    public void testCsvFieldDelimiterFallbackKeys() throws IOException {
+        RowType rowType = DataTypes.ROW(DataTypes.INT().notNull(), DataTypes.STRING());
+
+        List<InternalRow> testData =
+                Arrays.asList(
+                        GenericRow.of(1, BinaryString.fromString("Alice")),
+                        GenericRow.of(2, BinaryString.fromString("Bob")));
+
+        for (String fallbackKey : new String[] {"field-delimiter", "seq", "delimiter"}) {
+            Options options = new Options();
+            options.set(fallbackKey, ";");
+
+            assertThat(options.get(CsvOptions.FIELD_DELIMITER)).isEqualTo(";");
+
+            List<InternalRow> result =
+                    writeThenRead(options, rowType, rowType, testData, "test_" + fallbackKey);
+
+            assertThat(result).hasSize(2);
+            assertThat(result.get(0).getInt(0)).isEqualTo(1);
+            assertThat(result.get(0).getString(1).toString()).isEqualTo("Alice");
+            assertThat(result.get(1).getInt(0)).isEqualTo(2);
+            assertThat(result.get(1).getString(1).toString()).isEqualTo("Bob");
+        }
+    }
+
+    @Test
     public void testCsvLineDelimiterWriteRead() throws IOException {
         RowType rowType = DataTypes.ROW(DataTypes.INT().notNull(), DataTypes.STRING());
 


### PR DESCRIPTION
### Purpose

`csv.field-delimiter` already accepts `field-delimiter` and `seq` as fallback keys.
Spark's CSV data source names this option `delimiter`, and users carry that name
over when creating Paimon CSV/TXT format tables, where it is silently ignored and
the default `,` is used instead.

This PR adds `delimiter` as another fallback key.

### Tests

`CsvFileFormatTest#testCsvFieldDelimiterFallbackKeys` asserts that
`field-delimiter`, `seq` and `delimiter` all resolve to `FIELD_DELIMITER` and drive
the CSV write/read round trip. Verified that it fails without the change.