### PR TITLE
[python] Fix locale-sensitive Date header and nonce replay on retry

### DIFF
--- a/paimon-python/pypaimon/api/auth/dlf_signer.py
+++ b/paimon-python/pypaimon/api/auth/dlf_signer.py
@@ -24,6 +24,7 @@ import uuid
 from abc import ABC, abstractmethod
 from collections import OrderedDict
 from datetime import datetime, timezone
+from email.utils import format_datetime
 from typing import Dict, Optional
 from urllib.parse import unquote
 
@@ -307,7 +308,6 @@ class DLFOpenApiSigner(DLFRequestSigner):
     X_ACS_SECURITY_TOKEN = "x-acs-security-token"
 
     # Values
-    DATE_FORMAT = "%a, %d %b %Y %H:%M:%S GMT"
     ACCEPT_VALUE = "application/json"
     CONTENT_TYPE_VALUE = "application/json"
     SIGNATURE_METHOD_VALUE = "HMAC-SHA1"
@@ -333,7 +333,9 @@ class DLFOpenApiSigner(DLFRequestSigner):
             gmt_time = now.replace(tzinfo=timezone.utc)
         else:
             gmt_time = now.astimezone(timezone.utc)
-        headers[self.DATE_HEADER] = gmt_time.strftime(self.DATE_FORMAT)
+        # RFC 1123 date in English; email.utils is locale-independent,
+        # unlike strftime whose %a/%b follow LC_TIME
+        headers[self.DATE_HEADER] = format_datetime(gmt_time, usegmt=True)
 
         headers[self.ACCEPT_HEADER] = self.ACCEPT_VALUE
 

--- a/paimon-python/pypaimon/api/auth/dlf_signer.py
+++ b/paimon-python/pypaimon/api/auth/dlf_signer.py
@@ -24,7 +24,6 @@ import uuid
 from abc import ABC, abstractmethod
 from collections import OrderedDict
 from datetime import datetime, timezone
-from email.utils import format_datetime
 from typing import Dict, Optional
 from urllib.parse import unquote
 
@@ -315,6 +314,13 @@ class DLFOpenApiSigner(DLFRequestSigner):
     API_VERSION = "2026-01-18"
     HMAC_SHA1 = "sha1"
 
+    # English weekday/month abbreviations for RFC 1123 dates. strftime's
+    # %a/%b follow LC_TIME and get localized under non-English locales,
+    # which would break the Aliyun OpenAPI signature.
+    WEEKDAYS = ("Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun")
+    MONTHS = ("Jan", "Feb", "Mar", "Apr", "May", "Jun",
+              "Jul", "Aug", "Sep", "Oct", "Nov", "Dec")
+
     def sign_headers(
             self,
             body: Optional[str],
@@ -333,9 +339,12 @@ class DLFOpenApiSigner(DLFRequestSigner):
             gmt_time = now.replace(tzinfo=timezone.utc)
         else:
             gmt_time = now.astimezone(timezone.utc)
-        # RFC 1123 date in English; email.utils is locale-independent,
-        # unlike strftime whose %a/%b follow LC_TIME
-        headers[self.DATE_HEADER] = format_datetime(gmt_time, usegmt=True)
+        # RFC 1123 date, e.g. "Wed, 16 Apr 2025 03:44:46 GMT"
+        headers[self.DATE_HEADER] = (
+            f"{self.WEEKDAYS[gmt_time.weekday()]}, {gmt_time.day:02d} "
+            f"{self.MONTHS[gmt_time.month - 1]} {gmt_time.year:04d} "
+            f"{gmt_time.hour:02d}:{gmt_time.minute:02d}:{gmt_time.second:02d} GMT"
+        )
 
         headers[self.ACCEPT_HEADER] = self.ACCEPT_VALUE
 

--- a/paimon-python/pypaimon/api/client.py
+++ b/paimon-python/pypaimon/api/client.py
@@ -20,6 +20,8 @@ import logging
 import time
 import urllib.parse
 from abc import ABC, abstractmethod
+from itertools import takewhile
+from random import uniform
 from typing import Callable, Dict, Optional, Type, TypeVar
 
 import requests
@@ -144,6 +146,24 @@ class DefaultErrorHandler(ErrorHandler):
         raise RESTException("Unable to process: %s", message)
 
 
+class JavaStyleBackoffRetry(Retry):
+    """urllib3 Retry with the backoff schedule of the Java client's
+    ExponentialHttpRequestRetryStrategy: 2^(n-1) seconds capped at 64s,
+    plus up to 10% jitter. The Retry-After header is still honored by
+    the inherited sleep().
+    """
+
+    _MAX_BACKOFF_SECONDS = 64.0
+
+    def get_backoff_time(self):
+        consecutive_errors_len = len(
+            list(takewhile(lambda x: x.redirect_location is None, reversed(self.history))))
+        if consecutive_errors_len < 1:
+            return 0
+        delay = min(2.0 ** (consecutive_errors_len - 1), self._MAX_BACKOFF_SECONDS)
+        return delay + uniform(0, delay * 0.1)
+
+
 class ExponentialRetry:
 
     adapter: HTTPAdapter
@@ -154,26 +174,32 @@ class ExponentialRetry:
 
     @staticmethod
     def __create_retry_strategy(max_retries: int) -> Retry:
-        # Single retry budget shared across read and status (429 / 5xx)
-        # errors. Connect failures are intentionally non-retriable: a
-        # connect error usually means the host is wrong or the listener
-        # is down, and burning the budget on it just delays the failure.
+        # Aligned with the Java client's ExponentialHttpRequestRetryStrategy:
+        # - only 429 / 503 responses are retried; 502 / 504 are not, because
+        #   by then the gateway has consumed the request's signature nonce,
+        #   and retrying with the same signed headers is rejected with
+        #   "Specified signature nonce was used already"
+        # - read errors (including read timeouts) are not retried for the
+        #   same reason: the request has likely reached the server
+        # - connect failures are intentionally non-retriable: a connect
+        #   error usually means the host is wrong or the listener is down,
+        #   and burning the budget on it just delays the failure.
         retry_kwargs = {
             'total': max_retries,
-            'read': max_retries,
+            'read': 0,
             'connect': 0,
-            'backoff_factor': 1,
-            'status_forcelist': [429, 502, 503, 504],
+            'status': max_retries,
+            'status_forcelist': [429, 503],
             'raise_on_status': False,
             'raise_on_redirect': False,
         }
         retry_methods = ["GET", "HEAD", "PUT", "DELETE", "TRACE", "OPTIONS"]
-        retry_instance = Retry()
+        retry_instance = JavaStyleBackoffRetry()
         if hasattr(retry_instance, 'allowed_methods'):
             retry_kwargs['allowed_methods'] = retry_methods
         else:
             retry_kwargs['method_whitelist'] = retry_methods
-        return Retry(**retry_kwargs)
+        return JavaStyleBackoffRetry(**retry_kwargs)
 
 
 class RESTClient(ABC):

--- a/paimon-python/pypaimon/api/client.py
+++ b/paimon-python/pypaimon/api/client.py
@@ -20,8 +20,6 @@ import logging
 import time
 import urllib.parse
 from abc import ABC, abstractmethod
-from itertools import takewhile
-from random import uniform
 from typing import Callable, Dict, Optional, Type, TypeVar
 
 import requests
@@ -146,24 +144,6 @@ class DefaultErrorHandler(ErrorHandler):
         raise RESTException("Unable to process: %s", message)
 
 
-class ExponentialBackoffRetry(Retry):
-    """urllib3 Retry with the backoff schedule of the Java client's
-    ExponentialHttpRequestRetryStrategy: 2^(n-1) seconds capped at 64s,
-    plus up to 10% jitter. The Retry-After header is still honored by
-    the inherited sleep().
-    """
-
-    _MAX_BACKOFF_SECONDS = 64.0
-
-    def get_backoff_time(self):
-        consecutive_errors_len = len(
-            list(takewhile(lambda x: x.redirect_location is None, reversed(self.history))))
-        if consecutive_errors_len < 1:
-            return 0
-        delay = min(2.0 ** (consecutive_errors_len - 1), self._MAX_BACKOFF_SECONDS)
-        return delay + uniform(0, delay * 0.1)
-
-
 class ExponentialRetry:
 
     adapter: HTTPAdapter
@@ -174,11 +154,11 @@ class ExponentialRetry:
 
     @staticmethod
     def __create_retry_strategy(max_retries: int) -> Retry:
-        # Aligned with the Java client's ExponentialHttpRequestRetryStrategy:
-        # - only 429 / 503 responses are retried; 502 / 504 are not, because
-        #   by then the gateway has consumed the request's signature nonce,
-        #   and retrying with the same signed headers is rejected with
-        #   "Specified signature nonce was used already"
+        # Aligned with the Java client's retry triggers:
+        # - only 429 / 503 responses are retried; 502 / 504 are not,
+        #   because by then the gateway has consumed the request's
+        #   signature nonce, and retrying with the same signed headers is
+        #   rejected with "Specified signature nonce was used already"
         # - read errors (including read timeouts) are not retried for the
         #   same reason: the request has likely reached the server
         # - connect failures are intentionally non-retriable: a connect
@@ -189,17 +169,18 @@ class ExponentialRetry:
             'read': 0,
             'connect': 0,
             'status': max_retries,
+            'backoff_factor': 1,
             'status_forcelist': [429, 503],
             'raise_on_status': False,
             'raise_on_redirect': False,
         }
         retry_methods = ["GET", "HEAD", "PUT", "DELETE", "TRACE", "OPTIONS"]
-        retry_instance = ExponentialBackoffRetry()
+        retry_instance = Retry()
         if hasattr(retry_instance, 'allowed_methods'):
             retry_kwargs['allowed_methods'] = retry_methods
         else:
             retry_kwargs['method_whitelist'] = retry_methods
-        return ExponentialBackoffRetry(**retry_kwargs)
+        return Retry(**retry_kwargs)
 
 
 class RESTClient(ABC):

--- a/paimon-python/pypaimon/api/client.py
+++ b/paimon-python/pypaimon/api/client.py
@@ -146,7 +146,7 @@ class DefaultErrorHandler(ErrorHandler):
         raise RESTException("Unable to process: %s", message)
 
 
-class JavaStyleBackoffRetry(Retry):
+class ExponentialBackoffRetry(Retry):
     """urllib3 Retry with the backoff schedule of the Java client's
     ExponentialHttpRequestRetryStrategy: 2^(n-1) seconds capped at 64s,
     plus up to 10% jitter. The Retry-After header is still honored by
@@ -194,12 +194,12 @@ class ExponentialRetry:
             'raise_on_redirect': False,
         }
         retry_methods = ["GET", "HEAD", "PUT", "DELETE", "TRACE", "OPTIONS"]
-        retry_instance = JavaStyleBackoffRetry()
+        retry_instance = ExponentialBackoffRetry()
         if hasattr(retry_instance, 'allowed_methods'):
             retry_kwargs['allowed_methods'] = retry_methods
         else:
             retry_kwargs['method_whitelist'] = retry_methods
-        return JavaStyleBackoffRetry(**retry_kwargs)
+        return ExponentialBackoffRetry(**retry_kwargs)
 
 
 class RESTClient(ABC):

--- a/paimon-python/pypaimon/tests/rest/dlf_signer_test.py
+++ b/paimon-python/pypaimon/tests/rest/dlf_signer_test.py
@@ -16,6 +16,7 @@
 # under the License.
 
 import unittest
+import locale
 import re
 import threading
 from datetime import datetime, timezone
@@ -86,6 +87,39 @@ class DLFSignerTest(unittest.TestCase):
 
         # Test identifier
         self.assertEqual("openapi", signer.identifier())
+
+    def test_openapi_date_format_with_chinese_locale(self):
+        """Date header must stay English RFC 1123 under zh_CN locale."""
+        original = locale.setlocale(locale.LC_TIME, None)
+        try:
+            self._set_lc_time_or_skip(["zh_CN.UTF-8", "zh_CN.utf8", "zh_CN"])
+            self._assert_openapi_date_in_english()
+        finally:
+            locale.setlocale(locale.LC_TIME, original)
+
+    def test_openapi_date_format_with_japanese_locale(self):
+        """Date header must stay English RFC 1123 under ja_JP locale."""
+        original = locale.setlocale(locale.LC_TIME, None)
+        try:
+            self._set_lc_time_or_skip(["ja_JP.UTF-8", "ja_JP.utf8", "ja_JP"])
+            self._assert_openapi_date_in_english()
+        finally:
+            locale.setlocale(locale.LC_TIME, original)
+
+    def _set_lc_time_or_skip(self, candidates):
+        for name in candidates:
+            try:
+                locale.setlocale(locale.LC_TIME, name)
+                return
+            except locale.Error:
+                continue
+        self.skipTest(f"None of the locales {candidates} is available on this system")
+
+    def _assert_openapi_date_in_english(self):
+        signer = DLFOpenApiSigner()
+        now = datetime(2025, 4, 16, 3, 44, 46, tzinfo=timezone.utc)
+        headers = signer.sign_headers(None, now, None, "dlfnext.cn-hangzhou.aliyuncs.com")
+        self.assertEqual("Wed, 16 Apr 2025 03:44:46 GMT", headers.get("Date"))
 
     def test_get_authorization(self):
         """Test exact signature output matches."""

--- a/paimon-python/pypaimon/tests/rest/test_exponential_retry_strategy.py
+++ b/paimon-python/pypaimon/tests/rest/test_exponential_retry_strategy.py
@@ -20,9 +20,8 @@ import unittest
 import requests
 from requests.exceptions import ConnectionError, ConnectTimeout, Timeout
 from urllib3.exceptions import NewConnectionError, MaxRetryError
-from urllib3.util.retry import RequestHistory
 
-from pypaimon.api.client import ExponentialBackoffRetry, ExponentialRetry
+from pypaimon.api.client import ExponentialRetry
 
 
 class TestExponentialRetryStrategy(unittest.TestCase):
@@ -47,31 +46,6 @@ class TestExponentialRetryStrategy(unittest.TestCase):
         self.assertNotIn(404, retry.status_forcelist)
         self.assertNotIn(502, retry.status_forcelist)
         self.assertNotIn(504, retry.status_forcelist)
-
-        self.assertIsInstance(retry, ExponentialBackoffRetry)
-
-    def test_backoff_schedule_matches_java(self):
-        # Java ExponentialHttpRequestRetryStrategy sleeps
-        # 1000 * min(2^(execCount-1), 64) ms plus up to 10% jitter
-        # after each failed attempt.
-        base = ExponentialRetry._ExponentialRetry__create_retry_strategy(5)
-
-        def backoff_after(failures):
-            history = tuple(
-                RequestHistory("GET", "http://host", None, 503, None)
-                for _ in range(failures))
-            return base.new(history=history).get_backoff_time()
-
-        expected = [1.0, 2.0, 4.0, 8.0, 16.0, 32.0, 64.0, 64.0]
-        for failures, base_delay in enumerate(expected, start=1):
-            value = backoff_after(failures)
-            self.assertGreaterEqual(
-                value, base_delay,
-                "backoff after {} failure(s) must be >= {}s".format(failures, base_delay))
-            self.assertLessEqual(
-                value, base_delay * 1.1 + 1e-9,
-                "backoff after {} failure(s) must be <= {}s + 10% jitter".format(
-                    failures, base_delay))
 
     def test_retry_on_connect_error(self):
         # ``connect=0`` means connect errors are not retried — the

--- a/paimon-python/pypaimon/tests/rest/test_exponential_retry_strategy.py
+++ b/paimon-python/pypaimon/tests/rest/test_exponential_retry_strategy.py
@@ -20,8 +20,9 @@ import unittest
 import requests
 from requests.exceptions import ConnectionError, ConnectTimeout, Timeout
 from urllib3.exceptions import NewConnectionError, MaxRetryError
+from urllib3.util.retry import RequestHistory
 
-from pypaimon.api.client import ExponentialRetry
+from pypaimon.api.client import ExponentialRetry, JavaStyleBackoffRetry
 
 
 class TestExponentialRetryStrategy(unittest.TestCase):
@@ -30,14 +31,47 @@ class TestExponentialRetryStrategy(unittest.TestCase):
         retry = ExponentialRetry._ExponentialRetry__create_retry_strategy(5)
 
         self.assertEqual(retry.total, 5)
-        self.assertEqual(retry.read, 5)
+        # Read errors / timeouts are not retried: the request has likely
+        # reached the server and its signature nonce is already consumed,
+        # so a retry with the same signed headers would be rejected with
+        # "Specified signature nonce was used already".
+        self.assertEqual(retry.read, 0)
         # Connect failures are intentionally non-retriable — see the
         # comment on ``ExponentialRetry.__create_retry_strategy``.
         self.assertEqual(retry.connect, 0)
+        self.assertEqual(retry.status, 5)
 
+        # Aligned with the Java client: only 429 / 503 are retried.
         self.assertIn(429, retry.status_forcelist)  # Too Many Requests
         self.assertIn(503, retry.status_forcelist)  # Service Unavailable
         self.assertNotIn(404, retry.status_forcelist)
+        self.assertNotIn(502, retry.status_forcelist)
+        self.assertNotIn(504, retry.status_forcelist)
+
+        self.assertIsInstance(retry, JavaStyleBackoffRetry)
+
+    def test_backoff_schedule_matches_java(self):
+        # Java ExponentialHttpRequestRetryStrategy sleeps
+        # 1000 * min(2^(execCount-1), 64) ms plus up to 10% jitter
+        # after each failed attempt.
+        base = ExponentialRetry._ExponentialRetry__create_retry_strategy(5)
+
+        def backoff_after(failures):
+            history = tuple(
+                RequestHistory("GET", "http://host", None, 503, None)
+                for _ in range(failures))
+            return base.new(history=history).get_backoff_time()
+
+        expected = [1.0, 2.0, 4.0, 8.0, 16.0, 32.0, 64.0, 64.0]
+        for failures, base_delay in enumerate(expected, start=1):
+            value = backoff_after(failures)
+            self.assertGreaterEqual(
+                value, base_delay,
+                "backoff after {} failure(s) must be >= {}s".format(failures, base_delay))
+            self.assertLessEqual(
+                value, base_delay * 1.1 + 1e-9,
+                "backoff after {} failure(s) must be <= {}s + 10% jitter".format(
+                    failures, base_delay))
 
     def test_retry_on_connect_error(self):
         # ``connect=0`` means connect errors are not retried — the

--- a/paimon-python/pypaimon/tests/rest/test_exponential_retry_strategy.py
+++ b/paimon-python/pypaimon/tests/rest/test_exponential_retry_strategy.py
@@ -22,7 +22,7 @@ from requests.exceptions import ConnectionError, ConnectTimeout, Timeout
 from urllib3.exceptions import NewConnectionError, MaxRetryError
 from urllib3.util.retry import RequestHistory
 
-from pypaimon.api.client import ExponentialRetry, JavaStyleBackoffRetry
+from pypaimon.api.client import ExponentialBackoffRetry, ExponentialRetry
 
 
 class TestExponentialRetryStrategy(unittest.TestCase):
@@ -48,7 +48,7 @@ class TestExponentialRetryStrategy(unittest.TestCase):
         self.assertNotIn(502, retry.status_forcelist)
         self.assertNotIn(504, retry.status_forcelist)
 
-        self.assertIsInstance(retry, JavaStyleBackoffRetry)
+        self.assertIsInstance(retry, ExponentialBackoffRetry)
 
     def test_backoff_schedule_matches_java(self):
         # Java ExponentialHttpRequestRetryStrategy sleeps


### PR DESCRIPTION
### Purpose

Two fixes to `pypaimon`'s DLF REST client:

**1. Locale-sensitive date formatting in `DLFOpenApiSigner`** (Python counterpart of #7577)

`sign_headers` built the RFC 1123 `Date` header with `strftime("%a, %d %b %Y %H:%M:%S GMT")`. Python's `%a`/`%b` follow the process `LC_TIME`, so under non-English locales (e.g. zh_CN) the header is localized (e.g. `二, 11 8月 2026 14:30:05 GMT`), breaking the Aliyun OpenAPI signature. The header is now built from explicit English weekday/month tables, so it is locale-independent.

**2. Align HTTP retry triggers with the Java client**

pypaimon's urllib3 `Retry` was more aggressive than Java's `ExponentialHttpRequestRetryStrategy`, and every transport retry reuses the same signed headers (same `x-acs-signature-nonce`). When the first attempt had already consumed the nonce at the gateway, the retry was rejected with `400 "Specified signature nonce was used already"` — observed as a flake in an internal DLF REST protocol CI run against a slow pre-release gateway.

Aligned with Java:
- Retry only on `429`/`503` (dropped `502`/`504` — by the time the gateway returns them the nonce is likely consumed);
- Read errors / read timeouts are no longer retried (`read=0`), matching Java which does not retry `InterruptedIOException`.

The backoff itself keeps urllib3's stock exponential backoff (`backoff_factor=1`); replicating Java's exact schedule was unnecessary.

### Tests

- Add `test_openapi_date_format_with_chinese_locale` / `test_openapi_date_format_with_japanese_locale`, mirroring the Java tests in #7577 (skipped when the locale is unavailable).
- Update `test_exponential_retry_strategy.py`: assert `read=0` and `status_forcelist=[429, 503]`.
- All `dlf_signer_test.py` and retry tests pass; flake8 clean.
