### PR TITLE
[core] Compact adjacent overlapping blob ranges together

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/append/dataevolution/DataEvolutionCompactCoordinator.java
+++ b/paimon-core/src/main/java/org/apache/paimon/append/dataevolution/DataEvolutionCompactCoordinator.java
@@ -570,64 +570,56 @@ public class DataEvolutionCompactCoordinator {
 
             RangeHelper<DataFileMeta> rangeHelper =
                     new RangeHelper<>(DataFileMeta::nonNullRowIdRange);
-            List<DataFileMeta> smallFileCandidates = new ArrayList<>();
+            List<List<DataFileMeta>> continuousOrOverlapFiles = new ArrayList<>();
+            long expectedFirstRowId = -1L;
             for (List<DataFileMeta> rowRangeGroup :
                     rangeHelper.mergeOverlappingRanges(sortedFiles)) {
-                if (rowRangeGroup.size() >= BLOB_COMPACT_MIN_FILE_NUM) {
-                    rowRangeGroup.sort(
-                            comparingLong(DataFileMeta::nonNullFirstRowId)
-                                    .thenComparingLong(DataFileMeta::maxSequenceNumber));
-                    result.add(rowRangeGroup);
-                } else {
-                    smallFileCandidates.add(rowRangeGroup.get(0));
+                List<Range> rowRanges =
+                        rowRangeGroup.stream()
+                                .map(DataFileMeta::nonNullRowIdRange)
+                                .collect(Collectors.toList());
+                Range rowRange = Range.sortAndMergeOverlap(rowRanges).get(0);
+                long firstRowId = rowRange.from;
+                if (!continuousOrOverlapFiles.isEmpty() && firstRowId != expectedFirstRowId) {
+                    addFileGroupsToCompact(result, continuousOrOverlapFiles);
+                    continuousOrOverlapFiles.clear();
                 }
-            }
 
-            result.addAll(smallFileGroupsToCompact(smallFileCandidates));
+                continuousOrOverlapFiles.add(rowRangeGroup);
+                expectedFirstRowId = rowRange.to + 1;
+            }
+            addFileGroupsToCompact(result, continuousOrOverlapFiles);
             result.sort(comparingLong(group -> group.get(0).nonNullFirstRowId()));
             return result;
         }
 
-        private List<List<DataFileMeta>> smallFileGroupsToCompact(List<DataFileMeta> files) {
-            List<List<DataFileMeta>> result = new ArrayList<>();
+        private void addFileGroupsToCompact(
+                List<List<DataFileMeta>> result,
+                List<List<DataFileMeta>> continuousOrOverlapFiles) {
+            int compactFileCount = continuousOrOverlapFiles.stream().mapToInt(List::size).sum();
+            if (compactFileCount < BLOB_COMPACT_MIN_FILE_NUM) {
+                return;
+            }
 
-            List<DataFileMeta> continuousFiles = new ArrayList<>();
-            long expectedFirstRowId = -1;
-            for (DataFileMeta file : files) {
-                if (file.fileSize() >= blobTargetFileSize) {
-                    addFileGroupsToCompact(result, continuousFiles);
-                    continuousFiles.clear();
-                    expectedFirstRowId = -1;
+            List<DataFileMeta> taskFiles = new ArrayList<>();
+            long taskFileSize = 0L;
+            for (List<DataFileMeta> fileGroup : continuousOrOverlapFiles) {
+                if (fileGroup.size() == 1 && fileGroup.get(0).fileSize() >= blobTargetFileSize) {
+                    if (taskFiles.size() >= BLOB_COMPACT_MIN_FILE_NUM) {
+                        result.add(taskFiles);
+                    }
+                    taskFiles = new ArrayList<>();
+                    taskFileSize = 0L;
                     continue;
                 }
 
-                long firstRowId = file.nonNullFirstRowId();
-                if (!continuousFiles.isEmpty() && firstRowId != expectedFirstRowId) {
-                    addFileGroupsToCompact(result, continuousFiles);
-                    continuousFiles.clear();
-                }
-                continuousFiles.add(file);
-                expectedFirstRowId = firstRowId + file.rowCount();
-            }
-            addFileGroupsToCompact(result, continuousFiles);
-            return result;
-        }
-
-        private void addFileGroupsToCompact(
-                List<List<DataFileMeta>> result, List<DataFileMeta> continuousFiles) {
-            if (continuousFiles.size() < BLOB_COMPACT_MIN_FILE_NUM) {
-                return;
-            }
-            List<DataFileMeta> taskFiles = new ArrayList<>();
-            long fileSize = 0L;
-            for (DataFileMeta file : continuousFiles) {
-                taskFiles.add(file);
-                fileSize += file.fileSize();
-                if (fileSize >= blobTargetFileSize
+                taskFiles.addAll(fileGroup);
+                taskFileSize += fileGroup.stream().mapToLong(DataFileMeta::fileSize).sum();
+                if (taskFileSize >= blobTargetFileSize
                         && taskFiles.size() >= BLOB_COMPACT_MIN_FILE_NUM) {
                     result.add(taskFiles);
                     taskFiles = new ArrayList<>();
-                    fileSize = 0L;
+                    taskFileSize = 0L;
                 }
             }
 

--- a/paimon-core/src/test/java/org/apache/paimon/append/dataevolution/DataEvolutionCompactCoordinatorTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/append/dataevolution/DataEvolutionCompactCoordinatorTest.java
@@ -212,6 +212,50 @@ public class DataEvolutionCompactCoordinatorTest {
     }
 
     @Test
+    public void testCompactPlannerMergesAdjacentOverlappingBlobGroups() {
+        List<ManifestEntry> entries = new ArrayList<>();
+        entries.add(makeEntry("file1.parquet", 0L, 2L, 100));
+        entries.add(makeBlobEntry("old-prefix.blob", 0L, 1L, 100, 0, "pic"));
+        entries.add(makeBlobEntry("updated-prefix.blob", 0L, 1L, 100, 1, "pic"));
+        entries.add(makeBlobEntry("old-suffix.blob", 1L, 1L, 100, 0, "pic"));
+        entries.add(makeBlobEntry("updated-suffix.blob", 1L, 1L, 100, 1, "pic"));
+
+        DataEvolutionCompactCoordinator.CompactPlanner planner =
+                blobPlanner(250, 1, 2, rowType(new DataField(1, "pic", DataTypes.BLOB())));
+
+        List<DataEvolutionCompactTask> tasks = planner.compactPlan(entries);
+
+        assertThat(tasks).hasSize(1);
+        assertThat(tasks.get(0).type()).isEqualTo(DataEvolutionCompactTask.TaskType.BLOB);
+        assertThat(tasks.get(0).compactBefore())
+                .containsExactly(
+                        entries.get(1).file(),
+                        entries.get(2).file(),
+                        entries.get(3).file(),
+                        entries.get(4).file());
+    }
+
+    @Test
+    public void testCompactPlannerUsesMergedOverlappingBlobRangeBoundary() {
+        List<ManifestEntry> entries = new ArrayList<>();
+        entries.add(makeEntry("file1.parquet", 0L, 11L, 100));
+        entries.add(makeBlobEntry("prefix.blob", 0L, 5L, 100, 0, "pic"));
+        entries.add(makeBlobEntry("overlap.blob", 3L, 7L, 100, 1, "pic"));
+        entries.add(makeBlobEntry("suffix.blob", 10L, 1L, 100, 0, "pic"));
+
+        DataEvolutionCompactCoordinator.CompactPlanner planner =
+                blobPlanner(1024, 1, 2, rowType(new DataField(1, "pic", DataTypes.BLOB())));
+
+        List<DataEvolutionCompactTask> tasks = planner.compactPlan(entries);
+
+        assertThat(tasks).hasSize(1);
+        assertThat(tasks.get(0).type()).isEqualTo(DataEvolutionCompactTask.TaskType.BLOB);
+        assertThat(tasks.get(0).compactBefore())
+                .containsExactly(
+                        entries.get(1).file(), entries.get(2).file(), entries.get(3).file());
+    }
+
+    @Test
     public void testCompactPlannerDoesNotCompactBlobFilesAcrossDataFiles() {
         List<ManifestEntry> entries = new ArrayList<>();
         entries.add(makeEntry("file1.parquet", 0L, 100L, 100));


### PR DESCRIPTION
### Purpose

The blob compact planner currently schedules every overlapping row-range group as a standalone task. When adjacent ranges both contain original and updated blob files, this produces multiple undersized compacted files instead of grouping them according to the target file size.

This change treats each overlapping group as an atomic unit while accumulating contiguous ranges. It adds the whole group before checking the target size, never splits overlapping files across tasks, and uses the merged row-range boundary when deciding whether the next group is contiguous. Large non-overlapping files keep the existing skip behavior.

### Tests

- `mvn spotless:apply`
- `mvn -pl paimon-core -am -Dtest=DataEvolutionCompactCoordinatorTest -Dsurefire.failIfNoSpecifiedTests=false test` (22 tests passed)
- `mvn -pl paimon-core -am -DskipTests install`
