### PR TITLE
[core] Fix incorrect file indexes table range filtering

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/table/system/FileIndexesTable.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/system/FileIndexesTable.java
@@ -67,7 +67,6 @@ import java.io.UncheckedIOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
@@ -198,8 +197,6 @@ public class FileIndexesTable implements ReadonlyTable {
 
     private static class FileIndexesRead implements InnerTableRead {
 
-        private static final Set<String> SCAN_PUSHDOWN_FIELDS =
-                Collections.unmodifiableSet(new HashSet<>(Arrays.asList("partition", "bucket")));
         private static final Set<String> FILE_PUSHDOWN_FIELDS = Collections.singleton("file_path");
 
         private final FileStoreTable storeTable;
@@ -216,13 +213,7 @@ public class FileIndexesTable implements ReadonlyTable {
 
         @Override
         public InnerTableRead withFilter(Predicate predicate) {
-            List<Predicate> remaining =
-                    PredicateBuilder.splitAnd(predicate).stream()
-                            .filter(
-                                    p ->
-                                            !(p instanceof LeafPredicate)
-                                                    || !onlyContainsFields(p, SCAN_PUSHDOWN_FIELDS))
-                            .collect(Collectors.toList());
+            List<Predicate> remaining = new ArrayList<>(PredicateBuilder.splitAnd(predicate));
             List<Predicate> filePredicates =
                     remaining.stream()
                             .filter(p -> onlyContainsFields(p, FILE_PUSHDOWN_FIELDS))

--- a/paimon-core/src/test/java/org/apache/paimon/table/system/FileIndexesTableTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/table/system/FileIndexesTableTest.java
@@ -157,6 +157,13 @@ public class FileIndexesTableTest extends TableTestBase {
                 readWithFilter(fileIndexesTable, builder.equal(0, BinaryString.fromString("{1}")));
         assertThat(partitionRows).hasSize(2);
 
+        assertThat(
+                        readWithFilter(
+                                fileIndexesTable,
+                                PredicateBuilder.and(
+                                        builder.greaterThan(1, 0), builder.lessThan(1, 1))))
+                .isEmpty();
+
         String filePath = partitionRows.get(0).getString(2).toString();
         List<InternalRow> fileRows =
                 readWithFilter(


### PR DESCRIPTION
### Purpose
- `$file_indexes` returns rows outside the requested range wrongly when multiple predicates filter the same scan pushdown field.
- This is because the scan keeps only one predicate per field while the read layer removes all scan pushdown predicates from remaining filter evaluation.
- Fix by retaining the full predicate for read side evaluation.

### Tests
 - UT