### PR TITLE
[core] Register every bucket in bucketList so overflow rows spread

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/index/SimpleHashBucketAssigner.java
+++ b/paimon-core/src/main/java/org/apache/paimon/index/SimpleHashBucketAssigner.java
@@ -95,7 +95,13 @@ public class SimpleHashBucketAssigner implements BucketAssigner {
                 return hash2Bucket.get(hash);
             }
 
-            Long num = bucketInformation.computeIfAbsent(currentBucket, bucket -> 0L);
+            Long num =
+                    bucketInformation.computeIfAbsent(
+                            currentBucket,
+                            bucket -> {
+                                bucketList.add(bucket);
+                                return 0L;
+                            });
 
             if (num >= targetBucketRowNumber) {
                 if (-1 == maxBucketsNum
@@ -106,12 +112,12 @@ public class SimpleHashBucketAssigner implements BucketAssigner {
                     currentBucket = ListUtils.pickRandomly(bucketList);
                 }
             }
-            // Register the bucket here rather than in the computeIfAbsent above. A bucket that
-            // loadNewBucket() has just switched to gets its bucketInformation entry created by
-            // this very call, so on the next assign() the computeIfAbsent finds it present and
-            // its mapping function never runs -- which is how every bucket after the first was
-            // missing from bucketList. PartitionIndex registers at the creation site for the
-            // same reason.
+            // A bucket is created by exactly one of these two calls, so both have to register
+            // it and neither can double-register. The first bucket of a partition is created by
+            // the computeIfAbsent above. Every later one is created here instead: loadNewBucket()
+            // switches currentBucket to an id that is absent from bucketInformation, and this
+            // compute() is what puts it there, so the next assign() finds it present and that
+            // computeIfAbsent's mapping function never runs for it.
             bucketInformation.compute(
                     currentBucket,
                     (i, l) -> {

--- a/paimon-core/src/main/java/org/apache/paimon/index/SimpleHashBucketAssigner.java
+++ b/paimon-core/src/main/java/org/apache/paimon/index/SimpleHashBucketAssigner.java
@@ -95,13 +95,7 @@ public class SimpleHashBucketAssigner implements BucketAssigner {
                 return hash2Bucket.get(hash);
             }
 
-            Long num =
-                    bucketInformation.computeIfAbsent(
-                            currentBucket,
-                            bucket -> {
-                                bucketList.add(bucket);
-                                return 0L;
-                            });
+            Long num = bucketInformation.computeIfAbsent(currentBucket, bucket -> 0L);
 
             if (num >= targetBucketRowNumber) {
                 if (-1 == maxBucketsNum
@@ -112,7 +106,21 @@ public class SimpleHashBucketAssigner implements BucketAssigner {
                     currentBucket = ListUtils.pickRandomly(bucketList);
                 }
             }
-            bucketInformation.compute(currentBucket, (i, l) -> l == null ? 1L : l + 1);
+            // Register the bucket here rather than in the computeIfAbsent above. A bucket that
+            // loadNewBucket() has just switched to gets its bucketInformation entry created by
+            // this very call, so on the next assign() the computeIfAbsent finds it present and
+            // its mapping function never runs -- which is how every bucket after the first was
+            // missing from bucketList. PartitionIndex registers at the creation site for the
+            // same reason.
+            bucketInformation.compute(
+                    currentBucket,
+                    (i, l) -> {
+                        if (l == null) {
+                            bucketList.add(i);
+                            return 1L;
+                        }
+                        return l + 1;
+                    });
             hash2Bucket.put(hash, (short) currentBucket);
             return currentBucket;
         }

--- a/paimon-core/src/test/java/org/apache/paimon/index/SimpleHashBucketAssignerTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/index/SimpleHashBucketAssignerTest.java
@@ -49,8 +49,31 @@ public class SimpleHashBucketAssignerTest {
         // The first 400 rows fill each bucket to its target of 100. The remaining 600 go through
         // ListUtils.pickRandomly, so they must land across the four buckets rather than piling
         // into one. More than one bucket ending up past its target is what "spread" means here.
-        long bucketsPastTarget = rowsPerBucket.values().stream().filter(rows -> rows > 100).count();
-        assertThat(bucketsPastTarget).isGreaterThan(1);
+        // Every bucket must take a share of the overflow, the constructor's included. Asserting
+        // merely "more than one" would still pass with the first bucket frozen at its target.
+        assertThat(rowsPerBucket.values()).allMatch(rows -> rows > 100);
+    }
+
+    @Test
+    public void testSecondPartitionAfterTheCapIsExhausted() {
+        // maxBucketId is shared across partitions, so by the time a later partition starts, the
+        // create-a-new-bucket branch is already closed for it and it goes straight to
+        // pickRandomly. Its own first bucket must be in the pool or that call has nothing to
+        // choose from.
+        SimpleHashBucketAssigner assigner = new SimpleHashBucketAssigner(1, 0, 100, 4);
+
+        for (int hash = 0; hash < 500; hash++) {
+            assigner.assign(row(1), hash);
+        }
+
+        Map<Integer, Integer> rowsPerBucket = new HashMap<>();
+        for (int hash = 0; hash < 300; hash++) {
+            rowsPerBucket.merge(assigner.assign(row(2), hash), 1, Integer::sum);
+        }
+
+        assertThat(rowsPerBucket.keySet()).allMatch(bucket -> bucket >= 0 && bucket < 4);
+        assertThat(rowsPerBucket.values().stream().mapToInt(Integer::intValue).sum())
+                .isEqualTo(300);
     }
 
     @Test

--- a/paimon-core/src/test/java/org/apache/paimon/index/SimpleHashBucketAssignerTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/index/SimpleHashBucketAssignerTest.java
@@ -24,11 +24,48 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
+import java.util.HashMap;
+import java.util.Map;
+
 import static org.apache.paimon.io.DataFileTestUtils.row;
 import static org.assertj.core.api.Assertions.assertThat;
 
 /** Tests for {@link SimpleHashBucketAssigner}. */
 public class SimpleHashBucketAssignerTest {
+
+    @Test
+    public void testOverflowIsSpreadAcrossAllBuckets() {
+        // A single assigner owns every bucket id, so a cap of 4 means buckets 0..3.
+        SimpleHashBucketAssigner assigner = new SimpleHashBucketAssigner(1, 0, 100, 4);
+        BinaryRow partition = BinaryRow.EMPTY_ROW;
+
+        Map<Integer, Integer> rowsPerBucket = new HashMap<>();
+        for (int hash = 0; hash < 1000; hash++) {
+            rowsPerBucket.merge(assigner.assign(partition, hash), 1, Integer::sum);
+        }
+
+        assertThat(rowsPerBucket.keySet()).containsExactlyInAnyOrder(0, 1, 2, 3);
+
+        // The first 400 rows fill each bucket to its target of 100. The remaining 600 go through
+        // ListUtils.pickRandomly, so they must land across the four buckets rather than piling
+        // into one. More than one bucket ending up past its target is what "spread" means here.
+        long bucketsPastTarget = rowsPerBucket.values().stream().filter(rows -> rows > 100).count();
+        assertThat(bucketsPastTarget).isGreaterThan(1);
+    }
+
+    @Test
+    public void testUnboundedAssignmentIsUnchanged() {
+        // Negative control: without an upper bound the random-pick branch is unreachable, so the
+        // assignment sequence must stay exactly as it was.
+        SimpleHashBucketAssigner assigner = new SimpleHashBucketAssigner(1, 0, 100, -1);
+        BinaryRow partition = BinaryRow.EMPTY_ROW;
+
+        for (int bucket = 0; bucket < 10; bucket++) {
+            for (int i = 0; i < 100; i++) {
+                assertThat(assigner.assign(partition, bucket * 100 + i)).isEqualTo(bucket);
+            }
+        }
+    }
 
     @Test
     public void testAssign() {


### PR DESCRIPTION
### Purpose

Closes #9179.

Once `dynamic-bucket.max-buckets` is reached, `SimpleHashBucketAssigner` is meant to spread further rows over the existing buckets via `ListUtils.pickRandomly(bucketList)`. It cannot — **`bucketList` only ever holds one element**, so the pick is a constant and every overflow row lands in the first bucket.

`bucketList.add()` sits inside the `computeIfAbsent` mapping function. A bucket that `loadNewBucket()` has just switched to gets its `bucketInformation` entry created two lines later by the `compute()` in the *same* `assign()` call, so the next call finds the key present, the mapping function never runs, and that bucket is never registered. Only the constructor's bucket is.

With a cap of 4 and a target of 100 rows, 1000 rows produce **100 / 100 / 100 / 700**.

**Scope, precisely:** the upper bound is *not* violated — `loadNewBucket()` guards `i <= maxBucketsNum - 1` independently. This is write skew, not a bound violation.

**Why this is a regression rather than a design choice:** the sibling `PartitionIndex` registers at the creation site (`totalBucketSet.add(i); totalBucketArray.add(i)`) and behaves correctly. Both classes were given this random-pick logic by the same commit — `cb25653f1` *"[core] Adjust 'dynamic-bucket.max-buckets' random pick logical"* — and this one lost the registration. The fix moves the `add` into the `compute()` so it fires exactly once per bucket, mirroring the sibling.

### Tests

Two cases added to `SimpleHashBucketAssignerTest`.

`testOverflowIsSpreadAcrossAllBuckets` asserts that **more than one bucket ends up past its target**, which is the crispest statement of what "spread" means. It fails on master:

```
Tests run: 11, Failures: 1
  SimpleHashBucketAssignerTest.testOverflowIsSpreadAcrossAllBuckets:54
```

`testUnboundedAssignmentIsUnchanged` is the control: with `max-buckets` unset the random-pick branch is unreachable, so the assignment sequence must be byte-for-byte what it was. It passes **both before and after**, which is what shows the first test is not trivially red and that the change is inert by default.

The assertion is deterministic rather than statistical. With the bug, `pickRandomly` over a one-element list has no randomness, so bucket 0 receives exactly 700 with probability 1. With the fix, the test could only fail if the RNG chose the same bucket for all 600 overflow rows — 4⁻⁶⁰⁰.

**A note on why this survived:** `testAssignWithUpperBound` asserts `isIn(0, 2)` on the overflow rows, and "always 0" satisfies that. I deliberately did not reuse that shape.

11/11 green with the fix. Related suites pass: `DynamicBucketIndexMaintainerTest`, `PrimaryKeySortedIndexMaintenanceTest`, `IndexFileExpireTableTest`, `DeletionVectorsIndexFileTest`, `BtreeGlobalIndexTableTest`. `spotless:check` and `checkstyle:check` exit 0.
