### PR TITLE
[flink] Avoid redundant HTTP BLOB existence probes

### DIFF
--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/FlinkRowWrapper.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/FlinkRowWrapper.java
@@ -63,6 +63,7 @@ public class FlinkRowWrapper implements InternalRow {
     private final boolean checkBlobDescriptorExists;
     private final boolean writeNullOnFetchFailure;
     private final Set<Integer> blobFields;
+    private final Set<Integer> materializedBlobFields;
 
     public FlinkRowWrapper(org.apache.flink.table.data.RowData row) {
         this(row, null);
@@ -111,7 +112,8 @@ public class FlinkRowWrapper implements InternalRow {
                 new UriReaderFactory(catalogContext),
                 checkBlobDescriptorExists,
                 writeNullOnFetchFailure,
-                blobFields);
+                blobFields,
+                Collections.emptySet());
     }
 
     public static FlinkRowWrapper fromUriReaderFactory(
@@ -120,12 +122,29 @@ public class FlinkRowWrapper implements InternalRow {
             boolean checkBlobDescriptorExists,
             boolean writeNullOnFetchFailure,
             Set<Integer> blobFields) {
+        return fromUriReaderFactory(
+                row,
+                uriReaderFactory,
+                checkBlobDescriptorExists,
+                writeNullOnFetchFailure,
+                blobFields,
+                Collections.emptySet());
+    }
+
+    public static FlinkRowWrapper fromUriReaderFactory(
+            org.apache.flink.table.data.RowData row,
+            UriReaderFactory uriReaderFactory,
+            boolean checkBlobDescriptorExists,
+            boolean writeNullOnFetchFailure,
+            Set<Integer> blobFields,
+            Set<Integer> materializedBlobFields) {
         return new FlinkRowWrapper(
                 row,
                 uriReaderFactory,
                 checkBlobDescriptorExists,
                 writeNullOnFetchFailure,
-                blobFields);
+                blobFields,
+                materializedBlobFields);
     }
 
     private FlinkRowWrapper(
@@ -133,12 +152,14 @@ public class FlinkRowWrapper implements InternalRow {
             UriReaderFactory uriReaderFactory,
             boolean checkBlobDescriptorExists,
             boolean writeNullOnFetchFailure,
-            Set<Integer> blobFields) {
+            Set<Integer> blobFields,
+            Set<Integer> materializedBlobFields) {
         this.row = row;
         this.uriReaderFactory = uriReaderFactory;
         this.checkBlobDescriptorExists = checkBlobDescriptorExists;
         this.writeNullOnFetchFailure = writeNullOnFetchFailure;
         this.blobFields = blobFields;
+        this.materializedBlobFields = materializedBlobFields;
     }
 
     public static Set<Integer> blobFieldIndexes(org.apache.paimon.types.RowType rowType) {
@@ -253,6 +274,14 @@ public class FlinkRowWrapper implements InternalRow {
         }
 
         BlobDescriptor descriptor = BlobDescriptor.deserialize(bytes);
+        // Materialized BLOB fields are copied into managed blob files. Their writer has to open
+        // HTTP resources and already maps HTTP 404 and other open failures to NULL according to
+        // the two write-null options. Avoid a redundant HEAD / range-GET existence check before
+        // that required GET. Inline descriptor and view fields keep the existence check because
+        // they have no later writer fetch.
+        if (materializedBlobFields.contains(pos) && isHttpUri(descriptor.uri())) {
+            return false;
+        }
         return !descriptorFileExists(pos, descriptor);
     }
 
@@ -301,7 +330,8 @@ public class FlinkRowWrapper implements InternalRow {
     }
 
     private static boolean isHttpUri(String uri) {
-        return uri.startsWith("http://") || uri.startsWith("https://");
+        return uri.regionMatches(true, 0, "http://", 0, "http://".length())
+                || uri.regionMatches(true, 0, "https://", 0, "https://".length());
     }
 
     /**

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/FlinkSinkBuilder.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/FlinkSinkBuilder.java
@@ -225,7 +225,9 @@ public class FlinkSinkBuilder {
                         table.rowType(),
                         readerFactoryForDescriptor,
                         table.coreOptions().blobWriteNullOnMissingFile(),
-                        table.coreOptions().blobWriteNullOnFetchFailure());
+                        table.coreOptions().blobWriteNullOnFetchFailure(),
+                        materializedBlobFieldIndexes(
+                                table.rowType(), table.coreOptions().blobInlineField()));
         if (table.coreOptions().localMergeEnabled() && table.schema().primaryKeys().size() > 0) {
             SingleOutputStreamOperator<InternalRow> newInput =
                     input.forward()
@@ -280,7 +282,8 @@ public class FlinkSinkBuilder {
                 rowType,
                 new UriReaderFactory(catalogContext),
                 checkBlobDescriptorExists,
-                writeNullOnFetchFailure);
+                writeNullOnFetchFailure,
+                Collections.emptySet());
     }
 
     private static DataStream<InternalRow> mapToInternalRowWithUriReaderFactory(
@@ -288,7 +291,8 @@ public class FlinkSinkBuilder {
             org.apache.paimon.types.RowType rowType,
             UriReaderFactory uriReaderFactory,
             boolean checkBlobDescriptorExists,
-            boolean writeNullOnFetchFailure) {
+            boolean writeNullOnFetchFailure,
+            Set<Integer> materializedBlobFields) {
         Set<Integer> blobFields =
                 checkBlobDescriptorExists
                         ? FlinkRowWrapper.blobFieldIndexes(rowType)
@@ -302,12 +306,21 @@ public class FlinkSinkBuilder {
                                                         uriReaderFactory,
                                                         checkBlobDescriptorExists,
                                                         writeNullOnFetchFailure,
-                                                        blobFields))
+                                                        blobFields,
+                                                        materializedBlobFields))
                         .returns(
                                 org.apache.paimon.flink.utils.InternalTypeInfo.fromRowType(
                                         rowType));
         forwardParallelism(result, input);
         return result;
+    }
+
+    private static Set<Integer> materializedBlobFieldIndexes(
+            org.apache.paimon.types.RowType rowType, Set<String> inlineBlobFields) {
+        Set<Integer> materializedBlobFields = FlinkRowWrapper.blobFieldIndexes(rowType);
+        materializedBlobFields.removeIf(
+                pos -> inlineBlobFields.contains(rowType.getFields().get(pos).name()));
+        return materializedBlobFields;
     }
 
     protected DataStreamSink<?> buildDynamicBucketSink(

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/FlinkSinkBuilder.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/FlinkSinkBuilder.java
@@ -219,6 +219,13 @@ public class FlinkSinkBuilder {
         UriReaderFactory readerFactoryForDescriptor = BlobDescriptorReaderFactory.create(table);
         blobDescriptorReaderFactory = readerFactoryForDescriptor;
 
+        // Primary-key tables externalize BLOBs after merging records, and that path does not apply
+        // the write-null fallback while fetching descriptors. Retain the existence preflight there.
+        Set<Integer> materializedBlobFields =
+                table.schema().primaryKeys().isEmpty()
+                        ? materializedBlobFieldIndexes(
+                                table.rowType(), table.coreOptions().blobInlineField())
+                        : Collections.emptySet();
         DataStream<InternalRow> input =
                 mapToInternalRowWithUriReaderFactory(
                         this.input,
@@ -226,8 +233,7 @@ public class FlinkSinkBuilder {
                         readerFactoryForDescriptor,
                         table.coreOptions().blobWriteNullOnMissingFile(),
                         table.coreOptions().blobWriteNullOnFetchFailure(),
-                        materializedBlobFieldIndexes(
-                                table.rowType(), table.coreOptions().blobInlineField()));
+                        materializedBlobFields);
         if (table.coreOptions().localMergeEnabled() && table.schema().primaryKeys().size() > 0) {
             SingleOutputStreamOperator<InternalRow> newInput =
                     input.forward()

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/BlobTableITCase.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/BlobTableITCase.java
@@ -1202,6 +1202,46 @@ public class BlobTableITCase extends CatalogITCaseBase {
     }
 
     @Test
+    public void testPrimaryKeyWriteHttpNotFoundWithMissingFileRetainsPreflight() throws Exception {
+        TestHttpWebServer httpServer = new TestHttpWebServer("/missing_pk_blob");
+        httpServer.start();
+        try {
+            String httpUrl = httpServer.getBaseUrl();
+            httpServer.enqueueResponse("", 404);
+            httpServer.enqueueResponse("", 404);
+
+            tEnv.executeSql(
+                    "CREATE TABLE missing_pk_blob_table ("
+                            + "id INT, picture BYTES, PRIMARY KEY (id) NOT ENFORCED)"
+                            + " WITH ('bucket'='1',"
+                            + " 'blob-field'='picture',"
+                            + " 'blob-as-descriptor'='true',"
+                            + " 'blob-write-null-on-missing-file'='true')");
+
+            batchSql(
+                    "INSERT INTO missing_pk_blob_table VALUES"
+                            + " (1, sys.path_to_descriptor('"
+                            + httpUrl
+                            + "'))");
+
+            assertThat(batchSql("SELECT * FROM missing_pk_blob_table"))
+                    .containsExactly(Row.of(1, null));
+
+            RecordedRequest headRequest = httpServer.takeRequest(1, TimeUnit.SECONDS);
+            assertThat(headRequest).isNotNull();
+            assertThat(headRequest.getMethod()).isEqualTo("HEAD");
+
+            RecordedRequest rangeRequest = httpServer.takeRequest(1, TimeUnit.SECONDS);
+            assertThat(rangeRequest).isNotNull();
+            assertThat(rangeRequest.getMethod()).isEqualTo("GET");
+            assertThat(rangeRequest.getHeader("Range")).isEqualTo("bytes=0-0");
+            assertThat(httpServer.takeRequest(100, TimeUnit.MILLISECONDS)).isNull();
+        } finally {
+            httpServer.stop();
+        }
+    }
+
+    @Test
     public void testWriteExistingHttpBlobWithMissingFileUsesSingleGet() throws Exception {
         TestHttpWebServer httpServer = new TestHttpWebServer("/existing_blob");
         httpServer.start();

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/BlobTableITCase.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/BlobTableITCase.java
@@ -37,10 +37,14 @@ import org.apache.paimon.types.RowType;
 import org.apache.paimon.utils.UriReader;
 import org.apache.paimon.utils.UriReaderFactory;
 
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.RecordedRequest;
 import org.apache.flink.table.planner.factories.TestValuesTableFactory;
 import org.apache.flink.types.Row;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 import java.io.OutputStream;
 import java.net.URI;
@@ -50,6 +54,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Random;
+import java.util.concurrent.TimeUnit;
 
 import static org.apache.paimon.flink.LogicalTypeConversion.toLogicalType;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -1167,12 +1172,78 @@ public class BlobTableITCase extends CatalogITCaseBase {
     }
 
     @Test
+    public void testWriteHttpNotFoundWithMissingFileUsesSingleGet() throws Exception {
+        TestHttpWebServer httpServer = new TestHttpWebServer("/missing_blob");
+        httpServer.start();
+        try {
+            String httpUrl = httpServer.getBaseUrl();
+            httpServer.enqueueResponse("", 404);
+
+            tEnv.executeSql(
+                    "CREATE TABLE missing_blob_table (id INT, data STRING, picture BYTES)"
+                            + " WITH ('row-tracking.enabled'='true',"
+                            + " 'data-evolution.enabled'='true',"
+                            + " 'blob-field'='picture',"
+                            + " 'blob-as-descriptor'='true',"
+                            + " 'blob-write-null-on-missing-file'='true')");
+
+            batchSql(
+                    "INSERT INTO missing_blob_table VALUES"
+                            + " (1, 'missing', sys.path_to_descriptor('"
+                            + httpUrl
+                            + "'))");
+
+            List<Row> result = batchSql("SELECT * FROM missing_blob_table");
+            assertThat(result).containsExactly(Row.of(1, "missing", null));
+            assertOnlyFullGetRequests(httpServer, 1);
+        } finally {
+            httpServer.stop();
+        }
+    }
+
+    @Test
+    public void testWriteExistingHttpBlobWithMissingFileUsesSingleGet() throws Exception {
+        TestHttpWebServer httpServer = new TestHttpWebServer("/existing_blob");
+        httpServer.start();
+        try {
+            String blobContent = "hello-http-blob";
+            String httpUrl = httpServer.getBaseUrl();
+            httpServer.enqueueResponse(blobContent, 200);
+
+            tEnv.executeSql(
+                    "CREATE TABLE existing_blob_table (id INT, data STRING, picture BYTES)"
+                            + " WITH ('row-tracking.enabled'='true',"
+                            + " 'data-evolution.enabled'='true',"
+                            + " 'blob-field'='picture',"
+                            + " 'blob-as-descriptor'='true',"
+                            + " 'blob-write-null-on-missing-file'='true')");
+
+            batchSql(
+                    "INSERT INTO existing_blob_table VALUES"
+                            + " (1, 'existing', sys.path_to_descriptor('"
+                            + httpUrl
+                            + "'))");
+
+            batchSql("ALTER TABLE existing_blob_table SET ('blob-as-descriptor'='false')");
+            List<Row> result = batchSql("SELECT * FROM existing_blob_table");
+            assertThat(result)
+                    .containsExactly(
+                            Row.of(
+                                    1,
+                                    "existing",
+                                    blobContent.getBytes(java.nio.charset.StandardCharsets.UTF_8)));
+            assertOnlyFullGetRequests(httpServer, 1);
+        } finally {
+            httpServer.stop();
+        }
+    }
+
+    @Test
     public void testWriteHttpBadRequestWritesNullWithMissingFileAndFetchFailure() throws Exception {
         TestHttpWebServer httpServer = new TestHttpWebServer("/combined_bad_request_blob");
         httpServer.start();
         try {
             String httpUrl = httpServer.getBaseUrl();
-            httpServer.enqueueResponse("", 400);
             httpServer.enqueueResponse("", 400);
 
             tEnv.executeSql(
@@ -1195,9 +1266,107 @@ public class BlobTableITCase extends CatalogITCaseBase {
             assertThat(result.get(0).getField(0)).isEqualTo(1);
             assertThat(result.get(0).getField(1)).isEqualTo("bad-request");
             assertThat(result.get(0).getField(2)).isNull();
+            assertOnlyFullGetRequests(httpServer, 1);
         } finally {
             httpServer.stop();
         }
+    }
+
+    @ParameterizedTest
+    @ValueSource(ints = {429, 503})
+    public void testWriteRetryableHttpStatusUsesOnlyFullGet(int statusCode) throws Exception {
+        TestHttpWebServer httpServer = new TestHttpWebServer("/retryable_" + statusCode + "_blob");
+        httpServer.start();
+        try {
+            String httpUrl = httpServer.getBaseUrl();
+            MockResponse retryableResponse =
+                    httpServer.generateMockResponse("", statusCode).addHeader("Retry-After", "1");
+            httpServer.enqueueResponse(retryableResponse);
+            String blobContent = "retried-http-blob";
+            httpServer.enqueueResponse(blobContent, 200);
+
+            String tableName = "retryable_" + statusCode + "_blob_table";
+            tEnv.executeSql(
+                    "CREATE TABLE "
+                            + tableName
+                            + " (id INT, data STRING, picture BYTES)"
+                            + " WITH ('row-tracking.enabled'='true',"
+                            + " 'data-evolution.enabled'='true',"
+                            + " 'blob-field'='picture',"
+                            + " 'blob-as-descriptor'='true',"
+                            + " 'blob-write-null-on-missing-file'='true',"
+                            + " 'blob-write-null-on-fetch-failure'='true')");
+
+            batchSql(
+                    "INSERT INTO "
+                            + tableName
+                            + " VALUES (1, 'retryable', sys.path_to_descriptor('"
+                            + httpUrl
+                            + "'))");
+
+            batchSql("ALTER TABLE " + tableName + " SET ('blob-as-descriptor'='false')");
+            List<Row> result = batchSql("SELECT * FROM " + tableName);
+            assertThat(result)
+                    .containsExactly(
+                            Row.of(
+                                    1,
+                                    "retryable",
+                                    blobContent.getBytes(java.nio.charset.StandardCharsets.UTF_8)));
+            assertOnlyFullGetRequests(httpServer, 2);
+        } finally {
+            httpServer.stop();
+        }
+    }
+
+    @Test
+    public void testInlineHttpDescriptorRetainsMissingFileCheck() throws Exception {
+        TestHttpWebServer httpServer = new TestHttpWebServer("/missing_inline_blob");
+        httpServer.start();
+        try {
+            String httpUrl = httpServer.getBaseUrl();
+            httpServer.enqueueResponse("", 404);
+            httpServer.enqueueResponse("", 404);
+
+            tEnv.executeSql(
+                    "CREATE TABLE missing_inline_blob_table (id INT, picture BYTES)"
+                            + " WITH ('row-tracking.enabled'='true',"
+                            + " 'data-evolution.enabled'='true',"
+                            + " 'blob-descriptor-field'='picture',"
+                            + " 'blob-as-descriptor'='true',"
+                            + " 'blob-write-null-on-missing-file'='true')");
+
+            batchSql(
+                    "INSERT INTO missing_inline_blob_table VALUES"
+                            + " (1, sys.path_to_descriptor('"
+                            + httpUrl
+                            + "'))");
+
+            List<Row> result = batchSql("SELECT * FROM missing_inline_blob_table");
+            assertThat(result).containsExactly(Row.of(1, null));
+
+            RecordedRequest headRequest = httpServer.takeRequest(1, TimeUnit.SECONDS);
+            assertThat(headRequest).isNotNull();
+            assertThat(headRequest.getMethod()).isEqualTo("HEAD");
+
+            RecordedRequest rangeRequest = httpServer.takeRequest(1, TimeUnit.SECONDS);
+            assertThat(rangeRequest).isNotNull();
+            assertThat(rangeRequest.getMethod()).isEqualTo("GET");
+            assertThat(rangeRequest.getHeader("Range")).isEqualTo("bytes=0-0");
+            assertThat(httpServer.takeRequest(100, TimeUnit.MILLISECONDS)).isNull();
+        } finally {
+            httpServer.stop();
+        }
+    }
+
+    private static void assertOnlyFullGetRequests(
+            TestHttpWebServer httpServer, int expectedRequestCount) throws Exception {
+        for (int i = 0; i < expectedRequestCount; i++) {
+            RecordedRequest request = httpServer.takeRequest(1, TimeUnit.SECONDS);
+            assertThat(request).isNotNull();
+            assertThat(request.getMethod()).isEqualTo("GET");
+            assertThat(request.getHeader("Range")).isNull();
+        }
+        assertThat(httpServer.takeRequest(100, TimeUnit.MILLISECONDS)).isNull();
     }
 
     @Test

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/FlinkRowWrapperTest.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/FlinkRowWrapperTest.java
@@ -39,9 +39,9 @@ import java.net.InetSocketAddress;
 import java.nio.file.Files;
 import java.util.Collections;
 import java.util.Set;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /** Tests for {@link FlinkRowWrapper}. */
 public class FlinkRowWrapperTest {
@@ -50,6 +50,7 @@ public class FlinkRowWrapperTest {
 
     private HttpServer httpServer;
     private int httpPort;
+    private final AtomicInteger httpRequestCount = new AtomicInteger();
 
     @BeforeEach
     public void setUpHttpServer() throws Exception {
@@ -113,10 +114,11 @@ public class FlinkRowWrapperTest {
     }
 
     @Test
-    public void testMissingHttpBlobDescriptorWithNonBlobColumnBefore() throws Exception {
+    public void testHttpBlobDescriptorWithNonBlobColumnBeforeSkipsExistsCheck() throws Exception {
         httpServer.createContext(
                 "/missing.jpg",
                 exchange -> {
+                    httpRequestCount.incrementAndGet();
                     sendResponse(exchange, 404, new byte[0]);
                 });
         GenericRowData row =
@@ -129,29 +131,33 @@ public class FlinkRowWrapperTest {
 
         assertThat(wrapper.isNullAt(0)).isFalse();
         assertThat(wrapper.getInt(0)).isEqualTo(1);
-        assertThat(wrapper.isNullAt(1)).isTrue();
+        assertThat(wrapper.isNullAt(1)).isFalse();
+        assertThat(httpRequestCount).hasValue(0);
     }
 
     @Test
-    public void testMissingHttpBlobDescriptorIsNullWhenCheckingEnabled() throws Exception {
+    public void testMissingHttpBlobDescriptorIsDeferredToWriter() throws Exception {
         httpServer.createContext(
                 "/missing.jpg",
                 exchange -> {
+                    httpRequestCount.incrementAndGet();
                     sendResponse(exchange, 404, new byte[0]);
                 });
         GenericRowData row = descriptorRow("http://127.0.0.1:" + httpPort + "/missing.jpg", 1);
 
         FlinkRowWrapper wrapper = wrapper(row, true);
 
-        assertThat(wrapper.isNullAt(0)).isTrue();
+        assertThat(wrapper.isNullAt(0)).isFalse();
+        assertThat(httpRequestCount).hasValue(0);
     }
 
     @Test
-    public void testExistingHttpBlobDescriptorIsReadableWhenCheckingEnabled() throws Exception {
+    public void testExistingHttpBlobDescriptorSkipsExistsCheck() throws Exception {
         byte[] bytes = new byte[] {1, 2, 3};
         httpServer.createContext(
                 "/ok.jpg",
                 exchange -> {
+                    httpRequestCount.incrementAndGet();
                     sendResponse(exchange, 200, bytes);
                 });
         GenericRowData row =
@@ -160,6 +166,41 @@ public class FlinkRowWrapperTest {
         FlinkRowWrapper wrapper = wrapper(row, true);
 
         assertThat(wrapper.isNullAt(0)).isFalse();
+        assertThat(httpRequestCount).hasValue(0);
+    }
+
+    @Test
+    public void testUppercaseHttpSchemeSkipsExistsCheck() throws Exception {
+        httpServer.createContext(
+                "/missing.jpg",
+                exchange -> {
+                    httpRequestCount.incrementAndGet();
+                    sendResponse(exchange, 404, new byte[0]);
+                });
+        GenericRowData row = descriptorRow("HTTP://127.0.0.1:" + httpPort + "/missing.jpg", 1);
+
+        FlinkRowWrapper wrapper = wrapper(row, true);
+
+        assertThat(wrapper.isNullAt(0)).isFalse();
+        assertThat(httpRequestCount).hasValue(0);
+    }
+
+    @Test
+    public void testInlineHttpBlobDescriptorRetainsExistsCheck() throws Exception {
+        httpServer.createContext(
+                "/missing-inline.jpg",
+                exchange -> {
+                    httpRequestCount.incrementAndGet();
+                    sendResponse(exchange, 404, new byte[0]);
+                });
+        GenericRowData row =
+                descriptorRow("http://127.0.0.1:" + httpPort + "/missing-inline.jpg", 1);
+
+        FlinkRowWrapper wrapper =
+                wrapper(row, true, false, Collections.singleton(0), Collections.emptySet());
+
+        assertThat(wrapper.isNullAt(0)).isTrue();
+        assertThat(httpRequestCount).hasValue(2);
     }
 
     @Test
@@ -185,23 +226,21 @@ public class FlinkRowWrapperTest {
     }
 
     @Test
-    public void testInvalidUriThrowsWhenFetchFailureDisabled() {
+    public void testInvalidHttpUriIsDeferredToWriterWhenFetchFailureDisabled() {
         GenericRowData row =
                 descriptorRow("https://img.alicdn.com/imgextra/##1304008055350781673", 1);
 
         FlinkRowWrapper wrapper = wrapper(row, true, false);
 
-        assertThatThrownBy(() -> wrapper.isNullAt(0))
-                .isInstanceOf(IllegalArgumentException.class)
-                .hasMessageContaining("Invalid URI")
-                .hasMessageNotContaining("1304008055350781673");
+        assertThat(wrapper.isNullAt(0)).isFalse();
     }
 
     @Test
-    public void testHttpBadRequestDefersExistsCheckWhenFetchFailureEnabled() throws Exception {
+    public void testHttpBadRequestSkipsExistsCheckWhenFetchFailureEnabled() throws Exception {
         httpServer.createContext(
                 "/bad.jpg",
                 exchange -> {
+                    httpRequestCount.incrementAndGet();
                     sendResponse(exchange, 400, new byte[0]);
                 });
         GenericRowData row = descriptorRow("http://127.0.0.1:" + httpPort + "/bad.jpg", 1);
@@ -209,24 +248,23 @@ public class FlinkRowWrapperTest {
         FlinkRowWrapper wrapper = wrapper(row, true, true);
 
         assertThat(wrapper.isNullAt(0)).isFalse();
+        assertThat(httpRequestCount).hasValue(0);
     }
 
     @Test
-    public void testHttpBadRequestThrowsWhenFetchFailureDisabled() throws Exception {
+    public void testHttpBadRequestIsDeferredToWriterWhenFetchFailureDisabled() throws Exception {
         httpServer.createContext(
                 "/bad.jpg",
                 exchange -> {
+                    httpRequestCount.incrementAndGet();
                     sendResponse(exchange, 400, new byte[0]);
                 });
         GenericRowData row = descriptorRow("http://127.0.0.1:" + httpPort + "/bad.jpg", 1);
 
         FlinkRowWrapper wrapper = wrapper(row, true, false);
 
-        assertThatThrownBy(() -> wrapper.isNullAt(0))
-                .isInstanceOf(RuntimeException.class)
-                .hasRootCauseInstanceOf(IOException.class)
-                .rootCause()
-                .hasMessageContaining("Unexpected HTTP status code: 400");
+        assertThat(wrapper.isNullAt(0)).isFalse();
+        assertThat(httpRequestCount).hasValue(0);
     }
 
     private GenericRowData descriptorRow(java.nio.file.Path path, long length) {
@@ -273,11 +311,22 @@ public class FlinkRowWrapperTest {
             boolean checkBlobDescriptorExists,
             boolean writeNullOnFetchFailure,
             Set<Integer> blobFields) {
-        return new FlinkRowWrapper(
+        return wrapper(
+                row, checkBlobDescriptorExists, writeNullOnFetchFailure, blobFields, blobFields);
+    }
+
+    private FlinkRowWrapper wrapper(
+            GenericRowData row,
+            boolean checkBlobDescriptorExists,
+            boolean writeNullOnFetchFailure,
+            Set<Integer> blobFields,
+            Set<Integer> materializedBlobFields) {
+        return FlinkRowWrapper.fromUriReaderFactory(
                 row,
-                CatalogContext.create(new Options()),
+                new UriReaderFactory(CatalogContext.create(new Options())),
                 checkBlobDescriptorExists,
                 writeNullOnFetchFailure,
-                blobFields);
+                blobFields,
+                materializedBlobFields);
     }
 }


### PR DESCRIPTION
### Purpose

[#8219](https://github.com/apache/paimon/pull/8219) introduced an HTTP existence preflight for `blob-write-null-on-missing-file`. Its final design performs the check in `FlinkRowWrapper`, because the writer-side fallback considered at that time could not safely turn an open failure into NULL after record bytes had been emitted.

[#8412](https://github.com/apache/paimon/pull/8412) later changed the BLOB writer to open the source before writing record bytes and added safe open-time classification for HTTP 404 and other fetch failures. The Flink preflight remained, so a materialized HTTP descriptor currently performs:

1. `HEAD`
2. if HEAD is not 200, a range `GET`
3. the full `GET` required to copy the payload into a managed blob file

Each operation has its own 429/503 retry loop. This causes redundant requests for successful resources and can amplify load while an HTTP origin is throttling.

### Changes

- Compute which root BLOB fields are actually materialized into managed blob files.
- For HTTP(S) descriptors of those fields, defer existence and open-failure handling directly to the writer's required full GET.
- Preserve the preflight for inline `blob-descriptor-field` / `blob-view-field` values, because those fields have no later writer fetch.
- Preserve the preflight for non-HTTP descriptors.
- Match HTTP schemes case-insensitively, consistent with the URI reader and writer.

The writer remains the single final classifier for materialized HTTP descriptors:

- HTTP 404 becomes NULL only when `blob-write-null-on-missing-file=true`.
- Other open/fetch failures become NULL only when `blob-write-null-on-fetch-failure=true`.
- A body read failure after output has started still fails the write.
- `HttpClientUtils.exists`, retry status codes, retry counts, timeout defaults, and the HTTP 416 zero-length-resource contract are unchanged.

### Request reduction

With both write-null options enabled:

| Final result | Before | After |
| --- | --- | --- |
| Successful HTTP resource | HEAD + full GET | full GET |
| GET-only HTTP resource | HEAD + range GET + full GET | full GET |
| HTTP 404 | HEAD + range GET | full GET |
| Non-retryable HTTP error | up to 3 request chains | 1 request chain |
| Persistent HTTP 429/503 | up to 3 retry chains | 1 retry chain |

This reduces the persistent 429/503 upper bound from 18 attempts to 6 with the current default of five additional retries, without adding configuration or changing final row semantics.

### Implementation

- `FlinkSinkBuilder` derives materialized BLOB positions from the table row type and excludes `CoreOptions.blobInlineField()`.
- The positions are passed to `FlinkRowWrapper`.
- `FlinkRowWrapper` skips only the redundant HTTP(S) preflight for those positions.
- Existing overloads default to an empty materialized set, preserving their previous behavior.

### Tests

Added unit and end-to-end coverage for:

- materialized HTTP 200: one full GET and payload round-trip;
- materialized HTTP 404: one full GET and NULL with the missing-file option;
- materialized HTTP 400: one full GET and NULL with missing-file plus fetch-failure options;
- HTTP 429 and 503 followed by 200: two full GET attempts, no HEAD or range request, and payload round-trip;
- inline descriptor HTTP 404: HEAD plus range GET is retained and NULL is written;
- uppercase HTTP scheme;
- a non-BLOB column before a BLOB column, to verify field-position handling.

Focused verification completed with 19 tests passing (13 wrapper tests and 6 HTTP BLOB integration cases), together with Checkstyle, Spotless, and `git diff --check`.