### PR TITLE
[core] Fix invalid length when reading spilled data

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/disk/BufferFileChannelReader.java
+++ b/paimon-core/src/main/java/org/apache/paimon/disk/BufferFileChannelReader.java
@@ -20,6 +20,7 @@ package org.apache.paimon.disk;
 
 import org.apache.paimon.memory.Buffer;
 
+import java.io.EOFException;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.channels.FileChannel;
@@ -46,7 +47,7 @@ public class BufferFileChannelReader {
 
         // Read header
         header.clear();
-        fileChannel.read(header);
+        readFully(header);
         header.flip();
 
         int size = header.getInt();
@@ -60,8 +61,16 @@ public class BufferFileChannelReader {
         }
         checkArgument(buffer.getSize() == 0, "Buffer not empty");
 
-        fileChannel.read(buffer.getNioBuffer(0, size));
+        readFully(buffer.getNioBuffer(0, size));
         buffer.setSize(size);
         return fileChannel.size() - fileChannel.position() == 0;
+    }
+
+    private void readFully(ByteBuffer target) throws IOException {
+        while (target.hasRemaining()) {
+            if (fileChannel.read(target) < 0) {
+                throw new EOFException("Premature end of file while reading buffer");
+            }
+        }
     }
 }

--- a/paimon-core/src/main/java/org/apache/paimon/disk/BufferFileChannelReader.java
+++ b/paimon-core/src/main/java/org/apache/paimon/disk/BufferFileChannelReader.java
@@ -20,7 +20,6 @@ package org.apache.paimon.disk;
 
 import org.apache.paimon.memory.Buffer;
 
-import java.io.EOFException;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.channels.FileChannel;
@@ -69,7 +68,7 @@ public class BufferFileChannelReader {
     private void readFully(ByteBuffer target) throws IOException {
         while (target.hasRemaining()) {
             if (fileChannel.read(target) < 0) {
-                throw new EOFException("Premature end of file while reading buffer");
+                throw new IOException("Premature end of file while reading buffer");
             }
         }
     }

--- a/paimon-core/src/main/java/org/apache/paimon/disk/ChannelWriterOutputView.java
+++ b/paimon-core/src/main/java/org/apache/paimon/disk/ChannelWriterOutputView.java
@@ -65,7 +65,9 @@ public final class ChannelWriterOutputView extends AbstractPagedOutputView imple
     public void close() throws IOException {
         if (!writer.isClosed()) {
             int currentPositionInSegment = getCurrentPositionInSegment();
-            writeCompressed(currentSegment, currentPositionInSegment);
+            if (currentPositionInSegment > 0) {
+                writeCompressed(currentSegment, currentPositionInSegment);
+            }
             clear();
             this.writeBytes = writer.getSize();
             this.writer.close();

--- a/paimon-core/src/test/java/org/apache/paimon/disk/ChannelWriterOutputViewTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/disk/ChannelWriterOutputViewTest.java
@@ -1,0 +1,69 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.disk;
+
+import org.apache.paimon.compression.BlockCompressionFactory;
+import org.apache.paimon.compression.BlockCompressionType;
+import org.apache.paimon.data.serializer.BinaryRowSerializer;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.file.Path;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Tests for {@link ChannelWriterOutputView}. */
+public class ChannelWriterOutputViewTest {
+
+    private static final int BLOCK_SIZE = 64 * 1024;
+
+    @TempDir Path tempDir;
+
+    @Test
+    public void testEmptyOutput() throws Exception {
+        BlockCompressionFactory compressionFactory =
+                BlockCompressionFactory.create(BlockCompressionType.LZ4);
+        try (IOManager ioManager = IOManager.create(tempDir.toString())) {
+            FileIOChannel.ID channel = ioManager.createChannel();
+            ChannelWriterOutputView output =
+                    FileChannelUtil.createOutputView(
+                            ioManager, channel, compressionFactory, BLOCK_SIZE);
+            output.close();
+
+            ChannelReaderInputView input =
+                    new ChannelReaderInputView(
+                            channel,
+                            ioManager,
+                            compressionFactory,
+                            BLOCK_SIZE,
+                            output.getBlockCount());
+            try {
+                assertThat(
+                                new ChannelReaderInputViewIterator(
+                                                input, null, new BinaryRowSerializer(1))
+                                        .next())
+                        .isNull();
+                assertThat(output.getBlockCount()).isZero();
+            } finally {
+                input.getChannel().closeAndDelete();
+            }
+        }
+    }
+}


### PR DESCRIPTION
### Purpose

Currently when reading spilled data, there is a small probability to meet the following exception.

```
Caused by: org.apache.paimon.compression.BufferDecompressionException: Input is corrupted, invalid length.
    at org.apache.paimon.compression.CompressorUtils.validateLength(CompressorUtils.java:49) ~[?:?]
    at org.apache.paimon.compression.Lz4BlockDecompressor.decompress(Lz4BlockDecompressor.java:48) ~[?:?]
    at org.apache.paimon.disk.ChannelReaderInputView.nextSegment(ChannelReaderInputView.java:83) ~[?:?]
    at org.apache.paimon.data.AbstractPagedInputView.doAdvance(AbstractPagedInputView.java:153) ~[?:?]
    at org.apache.paimon.data.AbstractPagedInputView.advance(AbstractPagedInputView.java:147) ~[?:?]
    at org.apache.paimon.data.AbstractPagedInputView.readInt(AbstractPagedInputView.java:322) ~[?:?]
    at org.apache.paimon.data.serializer.BinaryRowSerializer.deserialize(BinaryRowSerializer.java:77) ~[?:?]
    at org.apache.paimon.disk.ChannelReaderInputViewIterator.next(ChannelReaderInputViewIterator.java:63) ~[?:?]
    at org.apache.paimon.mergetree.MergeSorter$ChannelReaderReader$1.next(MergeSorter.java:257) ~[?:?]
    at org.apache.paimon.mergetree.MergeSorter$ChannelReaderReader$1.next(MergeSorter.java:254) ~[?:?]
    at org.apache.paimon.mergetree.compact.LoserTree$LeafIterator.advanceIfAvailable(LoserTree.java:320) ~[?:?]
    at org.apache.paimon.mergetree.compact.LoserTree.initializeIfNeeded(LoserTree.java:87) ~[?:?]
    at org.apache.paimon.mergetree.compact.SortMergeReaderWithLoserTree.readBatch(SortMergeReaderWithLoserTree.java:81) ~[?:?]
    at org.apache.paimon.reader.RecordReaderIterator.<init>(RecordReaderIterator.java:37) ~[?:?]
    at org.apache.paimon.reader.RecordReader.toCloseableIterator(RecordReader.java:210) ~[?:?]
    at org.apache.paimon.mergetree.compact.ChangelogMergeTreeRewriter.rewriteOrProduceChangelog(ChangelogMergeTreeRewriter.java:133) ~[?:?]
    at org.apache.paimon.mergetree.compact.ChangelogMergeTreeRewriter.rewrite(ChangelogMergeTreeRewriter.java:106) ~[?:?]
    at org.apache.paimon.mergetree.compact.MergeTreeCompactTask.rewriteImpl(MergeTreeCompactTask.java:162) ~[?:?]
    at org.apache.paimon.mergetree.compact.MergeTreeCompactTask.rewrite(MergeTreeCompactTask.java:157) ~[?:?]
    at org.apache.paimon.mergetree.compact.MergeTreeCompactTask.doCompact(MergeTreeCompactTask.java:111) ~[?:?]
    at org.apache.paimon.compact.CompactTask.call(CompactTask.java:55) ~[?:?]
    at org.apache.paimon.compact.CompactTask.call(CompactTask.java:34) ~[?:?]
    at java.util.concurrent.FutureTask.run(FutureTask.java:264) ~[?:?]
    at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:304) ~[?:?]
    at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128) ~[?:?]
    at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628) ~[?:?]
    ... 1 more
```

There are two possible causes:

1. `BufferFileChannelReader` does not fully read the byte buffer.
2. Empty spilled block is not recorded correctly. It is possible to produce an empty spilled block if logically there is no data (for example when we delete all records in a bucket without full compaction).

This PR fixes both causes.

### Tests

* `ChannelWriterOutputViewTest`.