### PR TITLE
[core] Fix level 1 inflation in universal compaction

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/mergetree/compact/UniversalCompaction.java
+++ b/paimon-core/src/main/java/org/apache/paimon/mergetree/compact/UniversalCompaction.java
@@ -116,18 +116,9 @@ public class UniversalCompaction implements CompactStrategy {
             candidateCount++;
         }
 
-        if (candidateCount == 0) {
-            return Optional.empty();
-        }
-
-        // Level 1 must be compacted with level 0 to avoid producing level 0. Include it in the
-        // initial candidates so that the size-ratio check also considers level 2 based on the
-        // combined size of level 0 and level 1.
-        if (candidateCount < runs.size() && runs.get(candidateCount).level() == 1) {
-            candidateCount++;
-        }
-
-        return Optional.of(pickForSizeRatio(numLevels - 1, runs, candidateCount, true));
+        return candidateCount == 0
+                ? Optional.empty()
+                : Optional.of(pickForSizeRatio(numLevels - 1, runs, candidateCount, true));
     }
 
     @VisibleForTesting
@@ -172,22 +163,22 @@ public class UniversalCompaction implements CompactStrategy {
     public CompactUnit pickForSizeRatio(
             int maxLevel, List<LevelSortedRun> runs, int candidateCount, boolean forcePick) {
         long candidateSize = candidateSize(runs, candidateCount);
+        boolean compactionTriggered = forcePick || candidateCount > 1;
         for (int i = candidateCount; i < runs.size(); i++) {
             LevelSortedRun next = runs.get(i);
             if (candidateSize * (100.0 + sizeRatio + ratioForOffPeak()) / 100.0
                     < next.run().totalSize()) {
-                break;
+                if (!compactionTriggered || next.level() > 1) {
+                    break;
+                }
             }
 
             candidateSize += next.run().totalSize();
             candidateCount++;
+            compactionTriggered = true;
         }
 
-        if (forcePick || candidateCount > 1) {
-            return createUnit(runs, maxLevel, candidateCount);
-        }
-
-        return null;
+        return compactionTriggered ? createUnit(runs, maxLevel, candidateCount) : null;
     }
 
     private int ratioForOffPeak() {

--- a/paimon-core/src/test/java/org/apache/paimon/mergetree/compact/UniversalCompactionTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/mergetree/compact/UniversalCompactionTest.java
@@ -169,6 +169,21 @@ public class UniversalCompactionTest {
     }
 
     @Test
+    public void testFileNumCompactionConsidersLevel2() {
+        UniversalCompaction compaction = ofTesting(200, 1, 3);
+
+        // File count first picks the two level 0 runs. Together with level 1, they are large
+        // enough to pick level 2 as well.
+        Optional<CompactUnit> pick =
+                compaction.pick(
+                        3, Arrays.asList(level(0, 10), level(0, 20), level(1, 97), level(2, 100)));
+
+        assertThat(pick).isPresent();
+        assertThat(pick.get().files()).hasSize(4);
+        assertThat(pick.get().outputLevel()).isEqualTo(2);
+    }
+
+    @Test
     public void testExtremeCaseNoOutputLevel0() {
         UniversalCompaction compaction = ofTesting(200, 1, 5);
 


### PR DESCRIPTION
### Purpose

#8993 fixes level 1 inflation in forced level 0 compaction. However, this problem still exists in normal compaction.

For example when num-levels = 6 and num-sorted-run.compaction-trigger = 8 and there are 4 level 0 files, it is possible that total level 0 size does not exceed level 1 size, so only level 0 is picked and is merged with level 1, causing the level 1 size to increase indefinitely.

### Tests

* `UniversalCompactionTest#testFileNumCompactionConsidersLevel2`.
