### PR TITLE
[iceberg] Reject schemas the Iceberg mirror cannot represent before they are persisted

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/AbstractFileStore.java
+++ b/paimon-core/src/main/java/org/apache/paimon/AbstractFileStore.java
@@ -69,6 +69,7 @@ import org.apache.paimon.tag.SuccessFileTagCallback;
 import org.apache.paimon.tag.TagAutoManager;
 import org.apache.paimon.tag.TagPreview;
 import org.apache.paimon.types.RowType;
+import org.apache.paimon.utils.BranchManager;
 import org.apache.paimon.utils.ChainTableUtils;
 import org.apache.paimon.utils.ChangelogManager;
 import org.apache.paimon.utils.FileStorePathFactory;
@@ -311,6 +312,7 @@ abstract class AbstractFileStore<T> implements FileStore<T> {
         if (tableRollback != null) {
             rollback = new CommitRollback(tableRollback);
         }
+        List<CommitCallback> commitCallbacks = createCommitCallbacks(commitUser, table);
         return new FileStoreCommitImpl(
                 snapshotCommit,
                 fileIO,
@@ -327,8 +329,8 @@ abstract class AbstractFileStore<T> implements FileStore<T> {
                 this::newScan,
                 newStatsFileHandler(),
                 bucketMode(),
-                createCommitPreCallbacks(table),
-                createCommitCallbacks(commitUser, table),
+                createCommitPreCallbacks(table, commitCallbacks),
+                commitCallbacks,
                 conflictDetectFactory,
                 rollback);
     }
@@ -392,11 +394,17 @@ abstract class AbstractFileStore<T> implements FileStore<T> {
                 options.legacyPartitionName());
     }
 
-    private List<CommitPreCallback> createCommitPreCallbacks(FileStoreTable table) {
+    private List<CommitPreCallback> createCommitPreCallbacks(
+            FileStoreTable table, List<CommitCallback> commitCallbacks) {
         List<CommitPreCallback> callbacks = new ArrayList<>();
         if (options.isChainTable()) {
             callbacks.add(new ChainTableCommitPreCallback(table));
         }
+        // reuse the same Iceberg callback instance: it validates before the commit too
+        commitCallbacks.stream()
+                .filter(callback -> callback instanceof IcebergCommitCallback)
+                .map(callback -> (IcebergCommitCallback) callback)
+                .forEach(callbacks::add);
         return callbacks;
     }
 
@@ -428,8 +436,7 @@ abstract class AbstractFileStore<T> implements FileStore<T> {
             }
         }
 
-        if (options.toConfiguration().get(IcebergOptions.METADATA_ICEBERG_STORAGE)
-                != IcebergOptions.StorageType.DISABLED) {
+        if (mirrorsToIceberg()) {
             callbacks.add(new IcebergCommitCallback(table, commitUser));
         }
 
@@ -592,11 +599,21 @@ abstract class AbstractFileStore<T> implements FileStore<T> {
         if (options.tagCreateSuccessFile()) {
             callbacks.add(new SuccessFileTagCallback(fileIO, newTagManager().tagDirectory()));
         }
-        if (options.toConfiguration().get(IcebergOptions.METADATA_ICEBERG_STORAGE)
-                != IcebergOptions.StorageType.DISABLED) {
-            callbacks.add(new IcebergCommitCallback(table, ""));
+        if (mirrorsToIceberg()) {
+            callbacks.add(IcebergCommitCallback.forTagCallbacks(table));
         }
         return callbacks;
+    }
+
+    /**
+     * A branch has no Iceberg counterpart: its metadata would land in the table-wide location,
+     * publishing branch-only state as the head every Iceberg reader sees.
+     */
+    private boolean mirrorsToIceberg() {
+        return options.toConfiguration().get(IcebergOptions.METADATA_ICEBERG_STORAGE)
+                        != IcebergOptions.StorageType.DISABLED
+                // a blank branch reads and writes main everywhere else, so it mirrors too
+                && BranchManager.isMainBranch(BranchManager.normalizeBranch(options.branch()));
     }
 
     @Override

--- a/paimon-core/src/main/java/org/apache/paimon/catalog/AbstractCatalog.java
+++ b/paimon-core/src/main/java/org/apache/paimon/catalog/AbstractCatalog.java
@@ -78,6 +78,7 @@ import static org.apache.paimon.catalog.CatalogUtils.checkNotSystemTable;
 import static org.apache.paimon.catalog.CatalogUtils.isSystemDatabase;
 import static org.apache.paimon.catalog.CatalogUtils.listPartitionsFromFileSystem;
 import static org.apache.paimon.catalog.CatalogUtils.validateCreateTable;
+import static org.apache.paimon.catalog.CatalogUtils.validateIcebergMirrorableReplacement;
 import static org.apache.paimon.catalog.Identifier.DEFAULT_MAIN_BRANCH;
 import static org.apache.paimon.options.CatalogOptions.LOCK_ENABLED;
 import static org.apache.paimon.options.CatalogOptions.LOCK_TYPE;
@@ -528,6 +529,8 @@ public abstract class AbstractCatalog implements Catalog {
             }
             throw e;
         }
+        // refuse an unmirrorable schema before the truncate below
+        validateIcebergMirrorableReplacement(existing, newSchema);
 
         TableType targetTableType = Options.fromMap(newSchema.options()).get(TYPE);
         if (!(existing instanceof FileStoreTable) || !targetTableType.equals(TableType.TABLE)) {

--- a/paimon-core/src/main/java/org/apache/paimon/catalog/CatalogUtils.java
+++ b/paimon-core/src/main/java/org/apache/paimon/catalog/CatalogUtils.java
@@ -25,11 +25,13 @@ import org.apache.paimon.format.json.JsonOptions;
 import org.apache.paimon.format.text.TextOptions;
 import org.apache.paimon.fs.FileIO;
 import org.apache.paimon.fs.Path;
+import org.apache.paimon.iceberg.IcebergCommitCallback;
 import org.apache.paimon.manifest.PartitionEntry;
 import org.apache.paimon.options.CatalogOptions;
 import org.apache.paimon.options.Options;
 import org.apache.paimon.partition.Partition;
 import org.apache.paimon.rest.exceptions.NotImplementedException;
+import org.apache.paimon.schema.ColumnDirectiveUtils;
 import org.apache.paimon.schema.Schema;
 import org.apache.paimon.schema.SchemaManager;
 import org.apache.paimon.schema.TableSchema;
@@ -51,6 +53,7 @@ import org.apache.paimon.table.system.AllTablesTable;
 import org.apache.paimon.table.system.CatalogOptionsTable;
 import org.apache.paimon.table.system.SystemTableLoader;
 import org.apache.paimon.types.DataField;
+import org.apache.paimon.types.RowType;
 import org.apache.paimon.utils.InternalRowPartitionComputer;
 import org.apache.paimon.utils.Pair;
 import org.apache.paimon.utils.Preconditions;
@@ -85,6 +88,59 @@ import static org.apache.paimon.utils.Preconditions.checkArgument;
 
 /** Utils for {@link Catalog}. */
 public class CatalogUtils {
+
+    /**
+     * Rejects a schema the Iceberg mirror could not represent. Runs on the effective options, so
+     * catalog defaults are already merged.
+     */
+    public static void validateIcebergMirrorable(Schema schema) {
+        Options options = Options.fromMap(schema.options());
+        TableType tableType = options.get(CoreOptions.TYPE);
+        if (tableType.equals(TableType.TABLE) || tableType.equals(TableType.MATERIALIZED_TABLE)) {
+            // directives (a BYTES field marked __BLOB_FIELD) change the stored types
+            Schema expanded = ColumnDirectiveUtils.applyDirectives(schema);
+            IcebergCommitCallback.checkSchemaMirrorable(options, new RowType(expanded.fields()));
+        }
+    }
+
+    /**
+     * Judges a replacement before {@code replaceTable} truncates: a rule that only exists between
+     * two schemas, such as a format-version downgrade, would otherwise reject it after the data is
+     * gone. Only an in-place replacement is judged against the existing table.
+     */
+    public static void validateIcebergMirrorableReplacement(
+            @Nullable Table existing, Schema newSchema) {
+        Options options = Options.fromMap(newSchema.options());
+        TableType tableType = options.get(CoreOptions.TYPE);
+        if (!tableType.equals(TableType.TABLE) && !tableType.equals(TableType.MATERIALIZED_TABLE)) {
+            return;
+        }
+        // an in-place replacement is staged as written; any other target goes through the create
+        // path, which expands directives first
+        boolean inPlace = existing instanceof FileStoreTable && tableType.equals(TableType.TABLE);
+        List<DataField> fields =
+                inPlace
+                        ? newSchema.fields()
+                        : ColumnDirectiveUtils.applyDirectives(newSchema).fields();
+        IcebergCommitCallback.checkSchemaMirrorable(options, new RowType(fields));
+        if (!inPlace) {
+            return;
+        }
+        FileStoreTable existingTable = (FileStoreTable) existing;
+        TableSchema existingSchema = existingTable.schema();
+        IcebergCommitCallback.checkSchemaChangeMirrorable(
+                Options.fromMap(existingSchema.options()),
+                existingSchema.fields(),
+                options,
+                fields);
+        IcebergCommitCallback.checkNoFormatVersionRegression(
+                options,
+                new SchemaManager(
+                                existingTable.fileIO(),
+                                existingTable.location(),
+                                existingTable.coreOptions().branch())
+                        .listAll());
+    }
 
     public static Path path(String warehouse, String database, String table) {
         return new Path(String.format("%s/%s.db/%s", warehouse, database, table));

--- a/paimon-core/src/main/java/org/apache/paimon/iceberg/IcebergCommitCallback.java
+++ b/paimon-core/src/main/java/org/apache/paimon/iceberg/IcebergCommitCallback.java
@@ -20,6 +20,8 @@ package org.apache.paimon.iceberg;
 
 import org.apache.paimon.CoreOptions;
 import org.apache.paimon.Snapshot;
+import org.apache.paimon.annotation.VisibleForTesting;
+import org.apache.paimon.catalog.CatalogLockFactory;
 import org.apache.paimon.data.BinaryRow;
 import org.apache.paimon.data.GenericArray;
 import org.apache.paimon.data.GenericRow;
@@ -47,16 +49,21 @@ import org.apache.paimon.index.DeletionVectorMeta;
 import org.apache.paimon.index.IndexFileHandler;
 import org.apache.paimon.io.DataFileMeta;
 import org.apache.paimon.io.DataFilePathFactory;
+import org.apache.paimon.manifest.FileKind;
 import org.apache.paimon.manifest.IndexManifestEntry;
 import org.apache.paimon.manifest.ManifestCommittable;
 import org.apache.paimon.manifest.ManifestEntry;
+import org.apache.paimon.manifest.SimpleFileEntry;
+import org.apache.paimon.operation.Lock;
 import org.apache.paimon.options.Options;
 import org.apache.paimon.partition.PartitionPredicate;
 import org.apache.paimon.schema.SchemaManager;
 import org.apache.paimon.schema.SchemaValidation;
 import org.apache.paimon.schema.TableSchema;
+import org.apache.paimon.table.CatalogEnvironment;
 import org.apache.paimon.table.FileStoreTable;
 import org.apache.paimon.table.sink.CommitCallback;
+import org.apache.paimon.table.sink.CommitPreCallback;
 import org.apache.paimon.table.sink.TagCallback;
 import org.apache.paimon.table.source.DataSplit;
 import org.apache.paimon.table.source.DeletionFile;
@@ -67,15 +74,22 @@ import org.apache.paimon.tag.Tag;
 import org.apache.paimon.types.ArrayType;
 import org.apache.paimon.types.DataField;
 import org.apache.paimon.types.DataType;
+import org.apache.paimon.types.DataTypeDefaultVisitor;
+import org.apache.paimon.types.LocalZonedTimestampType;
 import org.apache.paimon.types.MapType;
 import org.apache.paimon.types.MultisetType;
 import org.apache.paimon.types.RowType;
+import org.apache.paimon.types.TimestampType;
+import org.apache.paimon.types.VariantType;
+import org.apache.paimon.types.VectorType;
 import org.apache.paimon.utils.DataFilePathFactories;
 import org.apache.paimon.utils.FileStorePathFactory;
 import org.apache.paimon.utils.ManifestReadThreadPool;
 import org.apache.paimon.utils.Pair;
 import org.apache.paimon.utils.Preconditions;
 import org.apache.paimon.utils.SnapshotManager;
+
+import org.apache.paimon.shade.jackson2.com.fasterxml.jackson.core.JsonProcessingException;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -85,10 +99,12 @@ import javax.annotation.Nullable;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.UncheckedIOException;
+import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Comparator;
+import java.util.Deque;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
@@ -96,12 +112,12 @@ import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
 import java.util.function.Function;
 import java.util.stream.Collectors;
-import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
 import static org.apache.paimon.deletionvectors.DeletionVectorsIndexFile.DELETION_VECTORS_INDEX;
@@ -110,7 +126,7 @@ import static org.apache.paimon.deletionvectors.DeletionVectorsIndexFile.DELETIO
  * A {@link CommitCallback} to create Iceberg compatible metadata, so Iceberg readers can read
  * Paimon's {@link RawFile}.
  */
-public class IcebergCommitCallback implements CommitCallback, TagCallback {
+public class IcebergCommitCallback implements CommitCallback, CommitPreCallback, TagCallback {
 
     private static final Logger LOG = LoggerFactory.getLogger(IcebergCommitCallback.class);
 
@@ -144,6 +160,8 @@ public class IcebergCommitCallback implements CommitCallback, TagCallback {
     private final FileStorePathFactory fileStorePathFactory;
     private final IcebergManifestFile manifestFile;
     private final IcebergManifestList manifestList;
+    // see readManifestListWithFallback
+    private IcebergManifestList legacyManifestList;
     private final int formatVersion;
 
     private final IndexFileHandler indexFileHandler;
@@ -194,14 +212,389 @@ public class IcebergCommitCallback implements CommitCallback, TagCallback {
 
         this.formatVersion =
                 table.coreOptions().toConfiguration().get(IcebergOptions.FORMAT_VERSION);
-        Preconditions.checkArgument(
-                formatVersion == IcebergMetadata.FORMAT_VERSION_V2
-                        || formatVersion == IcebergMetadata.FORMAT_VERSION_V3,
-                "Unsupported iceberg format version! Only version 2 or version 3 is valid, but current version is ",
-                formatVersion);
+        checkSupportedFormatVersion(formatVersion);
+        // schema and manifest-legacy config are checked in preflightSchemas, not here, so abort()
+        // (which emits no Iceberg metadata) is not blocked
 
         this.indexFileHandler = table.store().newIndexFileHandler();
         this.needAddDvToIceberg = needAddDvToIceberg();
+    }
+
+    /** Creates an instance for tag-only use ({@link #notifyCreation} / {@link #notifyDeletion}). */
+    public static IcebergCommitCallback forTagCallbacks(FileStoreTable table) {
+        return new IcebergCommitCallback(table, "");
+    }
+
+    /**
+     * Rejects a schema the Iceberg mirror could not represent. A no-op when compatibility is off.
+     */
+    public static void checkSchemaMirrorable(Options options, RowType rowType) {
+        if (options.get(IcebergOptions.METADATA_ICEBERG_STORAGE)
+                == IcebergOptions.StorageType.DISABLED) {
+            return;
+        }
+        // geospatial has its own rule upstream; the gates here reach paths it does not
+        SchemaValidation.validateIcebergGeospatialTypes(rowType, new CoreOptions(options.toMap()));
+        int formatVersion = options.get(IcebergOptions.FORMAT_VERSION);
+        checkSupportedFormatVersion(formatVersion);
+        Preconditions.checkArgument(
+                formatVersion < IcebergMetadata.FORMAT_VERSION_V3
+                        || !options.get(IcebergOptions.MANIFEST_LEGACY_VERSION),
+                "'%s' cannot be used with Iceberg format version 3: the legacy manifest "
+                        + "schema cannot carry the first_row_id field required by v3 row lineage.",
+                IcebergOptions.MANIFEST_LEGACY_VERSION.key());
+        checkFormatVersionSupportsSchema(formatVersion, rowType);
+        // the version rules say what is accepted; the conversion is the authority on what can be
+        // expressed at all (precisions out of range, blobs, vectors)
+        for (DataField field : rowType.getFields()) {
+            new IcebergDataField(field);
+        }
+    }
+
+    /**
+     * The newest schema this commit can publish: the latest one when it is representable, else the
+     * newest representable one below it. The snapshot is already durable here, so an unsupported
+     * schema that slipped past the pre-commit check degrades instead of failing the commit.
+     */
+    private int publishableSchemaId(SchemaCache schemaCache, long latestSchemaId) {
+        for (long id = latestSchemaId; id >= 0; id--) {
+            try {
+                schemaCache.getValidated(id);
+                return (int) id;
+            } catch (IllegalArgumentException | UnsupportedOperationException notRepresentable) {
+            }
+        }
+        throw new IllegalStateException(
+                "No schema of this table can be represented in Iceberg metadata; "
+                        + "Iceberg compatibility cannot mirror it.");
+    }
+
+    /**
+     * The schema a snapshot entry points at: always its own. Labelling its files with a different
+     * one would make Iceberg read them under fields they were never written with.
+     */
+    /**
+     * Refuses a snapshot whose own schema cannot be emitted, before any manifest is written:
+     * rejecting it after the writes would orphan them on every retry.
+     */
+    private void checkSnapshotSchemaEmittable(
+            SchemaCache schemaCache, long snapshotSchemaId, int emittedUpTo) {
+        boolean emittable = snapshotSchemaId <= emittedUpTo;
+        if (emittable) {
+            try {
+                schemaCache.getValidated(snapshotSchemaId);
+            } catch (IllegalArgumentException | UnsupportedOperationException notRepresentable) {
+                emittable = false;
+            }
+        }
+        Preconditions.checkState(
+                emittable,
+                "Snapshot schema %s cannot be represented in Iceberg metadata, so the snapshot "
+                        + "cannot be mirrored. Remove the unsupported fields, or disable Iceberg "
+                        + "compatibility for this table.",
+                snapshotSchemaId);
+    }
+
+    private static int provenanceSchemaId(List<IcebergSchema> emitted, int snapshotSchemaId) {
+        Preconditions.checkState(
+                emitted.stream().anyMatch(schema -> schema.schemaId() == snapshotSchemaId),
+                "Snapshot schema %s cannot be represented in Iceberg metadata, so the snapshot "
+                        + "cannot be mirrored. Remove the unsupported fields, or disable Iceberg "
+                        + "compatibility for this table.",
+                snapshotSchemaId);
+        return snapshotSchemaId;
+    }
+
+    /**
+     * Rejects a schema change the Iceberg mirror cannot represent before it is persisted. Under
+     * mirroring only what the change introduces is judged, so a table already carrying an
+     * unsupported field can evolve away from it; switching mirroring on judges the whole schema.
+     */
+    public static void checkSchemaChangeMirrorable(TableSchema oldSchema, TableSchema newSchema) {
+        checkSchemaChangeMirrorable(
+                Options.fromMap(oldSchema.options()),
+                oldSchema.fields(),
+                Options.fromMap(newSchema.options()),
+                newSchema.fields());
+    }
+
+    /** As above, for callers that hold the parts rather than a persisted {@link TableSchema}. */
+    public static void checkSchemaChangeMirrorable(
+            Options oldOptions,
+            List<DataField> oldSchemaFields,
+            Options newOptions,
+            List<DataField> newSchemaFields) {
+        if (newOptions.get(IcebergOptions.METADATA_ICEBERG_STORAGE)
+                == IcebergOptions.StorageType.DISABLED) {
+            return;
+        }
+        if (oldOptions.get(IcebergOptions.METADATA_ICEBERG_STORAGE)
+                == IcebergOptions.StorageType.DISABLED) {
+            // switching mirroring on starts mirroring every field, not only what changed
+            checkSchemaMirrorable(newOptions, new RowType(newSchemaFields));
+            return;
+        }
+        int formatVersion = newOptions.get(IcebergOptions.FORMAT_VERSION);
+        if (!Objects.equals(
+                        oldOptions.get(IcebergOptions.FORMAT_VERSION),
+                        newOptions.get(IcebergOptions.FORMAT_VERSION))
+                || !Objects.equals(
+                        oldOptions.get(IcebergOptions.MANIFEST_LEGACY_VERSION),
+                        newOptions.get(IcebergOptions.MANIFEST_LEGACY_VERSION))) {
+            checkSupportedFormatVersion(formatVersion);
+            Preconditions.checkArgument(
+                    formatVersion >= oldOptions.get(IcebergOptions.FORMAT_VERSION),
+                    "Iceberg format version cannot be lowered from %s to %s: metadata already "
+                            + "written at the higher version cannot be extended by a lower one.",
+                    oldOptions.get(IcebergOptions.FORMAT_VERSION),
+                    formatVersion);
+            Preconditions.checkArgument(
+                    formatVersion < IcebergMetadata.FORMAT_VERSION_V3
+                            || !newOptions.get(IcebergOptions.MANIFEST_LEGACY_VERSION),
+                    "'%s' cannot be used with Iceberg format version 3: the legacy manifest "
+                            + "schema cannot carry the first_row_id field required by v3 row lineage.",
+                    IcebergOptions.MANIFEST_LEGACY_VERSION.key());
+        }
+        Map<Integer, DataType> oldFields = new HashMap<>();
+        for (DataField field : oldSchemaFields) {
+            oldFields.put(field.id(), field.type());
+        }
+        List<DataField> introduced = new ArrayList<>();
+        for (DataField field : newSchemaFields) {
+            collectIntroduced(
+                    oldFields.get(field.id()), field.type(), field.name(), field.id(), introduced);
+        }
+        if (introduced.isEmpty()) {
+            return;
+        }
+        checkFormatVersionSupportsSchema(formatVersion, new RowType(introduced));
+        for (DataField field : introduced) {
+            new IcebergDataField(field);
+        }
+    }
+
+    /**
+     * The part of {@code updated} this change actually introduces, or null when it carries nothing
+     * new. Nested types are compared by field id, so adding a supported field next to an
+     * unsupported sibling does not drag the sibling back into validation.
+     */
+    /** As above, collecting into {@code introduced} rather than returning. */
+    private static void collectIntroduced(
+            @Nullable DataType existing,
+            DataType updated,
+            String path,
+            int id,
+            List<DataField> introduced) {
+        if (existing == null) {
+            introduced.add(new DataField(id, path, updated));
+            return;
+        }
+        if (existing.equals(updated)) {
+            return;
+        }
+        if (existing instanceof RowType && updated instanceof RowType) {
+            Map<Integer, DataType> existingFields = new HashMap<>();
+            for (DataField field : ((RowType) existing).getFields()) {
+                existingFields.put(field.id(), field.type());
+            }
+            for (DataField field : ((RowType) updated).getFields()) {
+                collectIntroduced(
+                        existingFields.get(field.id()),
+                        field.type(),
+                        path + "." + field.name(),
+                        field.id(),
+                        introduced);
+            }
+            return;
+        }
+        if (existing instanceof ArrayType && updated instanceof ArrayType) {
+            collectIntroduced(
+                    ((ArrayType) existing).getElementType(),
+                    ((ArrayType) updated).getElementType(),
+                    path + ".element",
+                    id,
+                    introduced);
+            return;
+        }
+        if (existing instanceof MultisetType && updated instanceof MultisetType) {
+            collectIntroduced(
+                    ((MultisetType) existing).getElementType(),
+                    ((MultisetType) updated).getElementType(),
+                    path + ".element",
+                    id,
+                    introduced);
+            return;
+        }
+        if (existing instanceof MapType && updated instanceof MapType) {
+            collectIntroduced(
+                    ((MapType) existing).getKeyType(),
+                    ((MapType) updated).getKeyType(),
+                    path + ".key",
+                    id,
+                    introduced);
+            collectIntroduced(
+                    ((MapType) existing).getValueType(),
+                    ((MapType) updated).getValueType(),
+                    path + ".value",
+                    id,
+                    introduced);
+            return;
+        }
+        introduced.add(new DataField(id, path, updated));
+    }
+
+    /**
+     * Refuses re-enabling mirroring at a format version below one this table already published: the
+     * metadata written back then cannot be extended by a lower version.
+     */
+    public static void checkNoFormatVersionRegression(
+            Options newOptions, List<TableSchema> history) {
+        if (newOptions.get(IcebergOptions.METADATA_ICEBERG_STORAGE)
+                == IcebergOptions.StorageType.DISABLED) {
+            return;
+        }
+        checkNoFormatVersionRegressionOnRestore(newOptions, history);
+    }
+
+    /**
+     * The same rule, applied even when the schema being installed disables mirroring: fast-forward
+     * and rollback delete the history that records what was published, so the evidence has to be
+     * checked before it is gone.
+     */
+    public static void checkNoFormatVersionRegressionOnRestore(
+            Options newOptions, List<TableSchema> history) {
+        int formatVersion = newOptions.get(IcebergOptions.FORMAT_VERSION);
+        for (TableSchema past : history) {
+            Options pastOptions = Options.fromMap(past.options());
+            if (pastOptions.get(IcebergOptions.METADATA_ICEBERG_STORAGE)
+                    == IcebergOptions.StorageType.DISABLED) {
+                continue;
+            }
+            Preconditions.checkArgument(
+                    formatVersion >= pastOptions.get(IcebergOptions.FORMAT_VERSION),
+                    "Iceberg format version cannot be lowered from %s to %s: metadata already "
+                            + "written at the higher version cannot be extended by a lower one.",
+                    pastOptions.get(IcebergOptions.FORMAT_VERSION),
+                    formatVersion);
+        }
+    }
+
+    static void checkSupportedFormatVersion(int formatVersion) {
+        Preconditions.checkArgument(
+                formatVersion == IcebergMetadata.FORMAT_VERSION_V2
+                        || formatVersion == IcebergMetadata.FORMAT_VERSION_V3,
+                "Unsupported iceberg format version! Only version 2 or version 3 is valid, but current version is %s.",
+                formatVersion);
+    }
+
+    static void checkFormatVersionSupportsSchema(int formatVersion, RowType rowType) {
+        RestrictedTypeCollector collector = new RestrictedTypeCollector();
+        rowType.accept(collector);
+        throwOnNanosecondTimestamps(collector.nanosTimestamps);
+        throwOnV3OnlyTypes(collector.v3OnlyTypes, formatVersion);
+    }
+
+    /**
+     * Collects the types the Iceberg mirror cannot emit, with the path of each offending field.
+     * Leaf types not named here are representable, or rejected later by the type conversion itself
+     * ({@link IcebergDataField#toTypeString}).
+     */
+    private static class RestrictedTypeCollector extends DataTypeDefaultVisitor<Void> {
+
+        private final Collection<String> nanosTimestamps = new LinkedHashSet<>();
+        private final Collection<String> v3OnlyTypes = new LinkedHashSet<>();
+        private final Deque<String> path = new ArrayDeque<>();
+
+        private Void descend(String name, DataType type) {
+            path.addLast(name);
+            type.accept(this);
+            path.removeLast();
+            return null;
+        }
+
+        private String currentPath(DataType type) {
+            return String.join(".", path) + ": " + type.asSQLString();
+        }
+
+        @Override
+        public Void visit(VariantType variantType) {
+            v3OnlyTypes.add(currentPath(variantType));
+            return null;
+        }
+
+        @Override
+        public Void visit(TimestampType timestampType) {
+            if (timestampType.getPrecision() >= IcebergDataField.MIN_NANOS_TIMESTAMP_PRECISION) {
+                nanosTimestamps.add(currentPath(timestampType));
+            }
+            return null;
+        }
+
+        @Override
+        public Void visit(LocalZonedTimestampType localZonedTimestampType) {
+            if (localZonedTimestampType.getPrecision()
+                    >= IcebergDataField.MIN_NANOS_TIMESTAMP_PRECISION) {
+                nanosTimestamps.add(currentPath(localZonedTimestampType));
+            }
+            return null;
+        }
+
+        @Override
+        public Void visit(ArrayType arrayType) {
+            return descend("element", arrayType.getElementType());
+        }
+
+        @Override
+        public Void visit(MultisetType multisetType) {
+            return descend("element", multisetType.getElementType());
+        }
+
+        @Override
+        public Void visit(VectorType vectorType) {
+            return descend("element", vectorType.getElementType());
+        }
+
+        @Override
+        public Void visit(MapType mapType) {
+            descend("key", mapType.getKeyType());
+            return descend("value", mapType.getValueType());
+        }
+
+        @Override
+        public Void visit(RowType rowType) {
+            for (DataField field : rowType.getFields()) {
+                descend(field.name(), field.type());
+            }
+            return null;
+        }
+
+        @Override
+        protected Void defaultMethod(DataType dataType) {
+            return null;
+        }
+    }
+
+    private static void throwOnNanosecondTimestamps(Collection<String> nanosTimestamps) {
+        // Paimon writes a nanosecond timestamp as Parquet INT96, which Iceberg reads as a
+        // microsecond zoned timestamp rather than timestamp_ns, so the metadata is unreadable.
+        Preconditions.checkArgument(
+                nanosTimestamps.isEmpty(),
+                "Nanosecond-precision timestamps %s are not supported by Iceberg compatibility "
+                        + "because Paimon writes them as Parquet INT96, which Iceberg cannot read "
+                        + "as timestamp_ns. Use a timestamp precision of 6 or less.",
+                nanosTimestamps);
+    }
+
+    // v3-only types stay rejected on every format version: the metadata emitted for format
+    // version 3 carries no row lineage yet, so such a table would not be a valid v3 table either
+    private static void throwOnV3OnlyTypes(Collection<String> v3OnlyTypes, int formatVersion) {
+        Preconditions.checkArgument(
+                v3OnlyTypes.isEmpty(),
+                "Data types %s are not supported by Iceberg compatibility: they need Iceberg "
+                        + "format version 3, whose row lineage this layer does not emit yet "
+                        + "(format version %s in use).",
+                v3OnlyTypes,
+                formatVersion);
     }
 
     public static Path catalogTableMetadataPath(FileStoreTable table) {
@@ -210,17 +603,24 @@ public class IcebergCommitCallback implements CommitCallback, TagCallback {
     }
 
     public static Path catalogDatabasePath(FileStoreTable table) {
-        Path dbPath = table.location().getParent();
-        final String dbSuffix = ".db";
+        return catalogDatabasePath(table, resolveStorageLocation(table));
+    }
 
+    private static IcebergOptions.StorageLocation resolveStorageLocation(FileStoreTable table) {
         IcebergOptions.StorageType storageType =
                 table.coreOptions().toConfiguration().get(IcebergOptions.METADATA_ICEBERG_STORAGE);
+        return table.coreOptions()
+                .toConfiguration()
+                .getOptional(IcebergOptions.METADATA_ICEBERG_STORAGE_LOCATION)
+                .orElse(inferDefaultMetadataLocation(storageType));
+    }
 
-        IcebergOptions.StorageLocation storageLocation =
-                table.coreOptions()
-                        .toConfiguration()
-                        .getOptional(IcebergOptions.METADATA_ICEBERG_STORAGE_LOCATION)
-                        .orElse(inferDefaultMetadataLocation(storageType));
+    private static Path catalogDatabasePath(
+            FileStoreTable table, IcebergOptions.StorageLocation storageLocation) {
+        Path dbPath = table.location().getParent();
+        final String dbSuffix = ".db";
+        IcebergOptions.StorageType storageType =
+                table.coreOptions().toConfiguration().get(IcebergOptions.METADATA_ICEBERG_STORAGE);
 
         switch (storageLocation) {
             case TABLE_LOCATION:
@@ -279,6 +679,76 @@ public class IcebergCommitCallback implements CommitCallback, TagCallback {
     }
 
     @Override
+    public void call(
+            List<SimpleFileEntry> baseFiles,
+            List<ManifestEntry> deltaFiles,
+            List<IndexManifestEntry> indexFiles,
+            Snapshot snapshot) {
+        preflightSchemas(snapshot, deltaFiles);
+    }
+
+    /**
+     * Validates the schema and partition spec this commit would emit, before the Paimon snapshot is
+     * published: throwing here aborts the commit, unlike the post-commit {@link #call(Context)},
+     * whose snapshot already exists and can only degrade.
+     */
+    private void preflightSchemas(Snapshot snapshot, List<ManifestEntry> deltaFiles) {
+        try {
+            Preconditions.checkArgument(
+                    formatVersion < IcebergMetadata.FORMAT_VERSION_V3
+                            || !table.coreOptions()
+                                    .toConfiguration()
+                                    .get(IcebergOptions.MANIFEST_LEGACY_VERSION),
+                    "'%s' cannot be used with Iceberg format version 3: the legacy manifest "
+                            + "schema cannot carry the first_row_id field required by v3 row lineage.",
+                    IcebergOptions.MANIFEST_LEGACY_VERSION.key());
+            // judge the base the post-commit rebuild mirrors from, not v(id-1)
+            long base = latestMirroredSnapshot(snapshot.id());
+            boolean hasUsableBase = false;
+            Path baseMetadataPath = pathFactory.toMetadataPath(base);
+            if (base >= Snapshot.FIRST_SNAPSHOT_ID && table.fileIO().exists(baseMetadataPath)) {
+                // an unreadable base is rebuilt by the post-commit callback; vetoing the data
+                // commit over mirror-only state would block writes on something else
+                IcebergMetadata baseMetadata = tryReadMetadata(baseMetadataPath);
+                if (baseMetadata != null && isSameFormatVersion(baseMetadata.formatVersion())) {
+                    hasUsableBase = true;
+                }
+            }
+            // gate the schema this commit's data uses: a concurrent ALTER installing an
+            // unsupported one must not veto a commit that does not use it yet
+            SchemaCache schemaCache = new SchemaCache();
+            schemaCache.getValidated(snapshot.schemaId());
+            // a file is mirrored under its own schema, which an ALTER between preparation
+            // and commit can make differ from the snapshot's
+            for (long fileSchemaId : addedFileSchemaIds(deltaFiles)) {
+                schemaCache.getValidated(fileSchemaId);
+            }
+            if (!hasUsableBase) {
+                // without a usable base the partition spec is derived from scratch, where a
+                // VARIANT partition key cannot be represented
+                checkNoVariantPartitionKeys(
+                        table.schema().partitionKeys(), schemaCache.get(snapshot.schemaId()));
+            }
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+
+    private Set<Long> addedFileSchemaIds(List<ManifestEntry> deltaFiles) {
+        // deletions are mirrored by file path and publish no schema, so removing files written
+        // under a since-dropped unsupported schema must not be vetoed
+        Set<Long> schemaIds = new LinkedHashSet<>();
+        for (ManifestEntry entry : deltaFiles) {
+            // only files that will actually be mirrored matter: a primary-key table publishes
+            // just the levels shouldAddFileToIceberg accepts
+            if (entry.kind() == FileKind.ADD && shouldAddFileToIceberg(entry.file())) {
+                schemaIds.add(entry.file().schemaId());
+            }
+        }
+        return schemaIds;
+    }
+
+    @Override
     public void retry(ManifestCommittable committable) {
         SnapshotManager snapshotManager = table.snapshotManager();
         Snapshot snapshot =
@@ -298,6 +768,8 @@ public class IcebergCommitCallback implements CommitCallback, TagCallback {
                                                         + table.name()
                                                         + ". This is unexpected."));
         long snapshotId = snapshot.id();
+        // no veto here: this snapshot is already durable, so an unsupported schema introduced
+        // meanwhile must degrade to the newest publishable one, not fail the repair
         createMetadata(
                 snapshot,
                 (removedFiles, addedFiles) ->
@@ -427,25 +899,52 @@ public class IcebergCommitCallback implements CommitCallback, TagCallback {
                 }
             }
 
-            Path baseMetadataPath = pathFactory.toMetadataPath(snapshotId - 1);
-
-            if (table.fileIO().exists(baseMetadataPath)) {
-                createMetadataWithBase(
-                        fileChangesCollector,
-                        indexFiles.stream()
-                                .filter(
-                                        index ->
-                                                index.indexFile()
-                                                        .indexType()
-                                                        .equals(DELETION_VECTORS_INDEX))
-                                .collect(Collectors.toList()),
+            // mirror in snapshot order from the latest already-mirrored metadata: each vK
+            // derives its row ids from v(K-1), so no callback reads a stale watermark and two
+            // callbacks cannot hand out overlapping ranges
+            long base = latestMirroredSnapshot(snapshotId);
+            if (base >= Snapshot.FIRST_SNAPSHOT_ID) {
+                mirrorFrom(
+                        base,
                         snapshot,
-                        baseMetadataPath,
+                        fileChangesCollector,
+                        indexFiles,
                         abandonedLastColumnId,
                         abandonedNextRowId);
             } else {
-                createMetadataWithoutBase(
-                        snapshotId, abandonedUuid, abandonedLastColumnId, abandonedNextRowId);
+                // no surviving base: regenerating mints a fresh table uuid, so serialize it —
+                // two cold starts would otherwise publish independent chains — and recheck
+                // under the lock, since a base or a twin may have appeared meanwhile. Without
+                // a catalog lock this is best-effort.
+                String inheritUuid = abandonedUuid;
+                int lastColumnIdFloor = abandonedLastColumnId;
+                long nextRowIdFloor = abandonedNextRowId;
+                try (Lock lock = icebergLock()) {
+                    lock.runWithLock(
+                            () -> {
+                                if (table.fileIO().exists(pathFactory.toMetadataPath(snapshotId))
+                                        && metadataMatchesSnapshot(snapshotId, snapshot)) {
+                                    return null;
+                                }
+                                long rechecked = latestMirroredSnapshot(snapshotId);
+                                if (rechecked >= Snapshot.FIRST_SNAPSHOT_ID) {
+                                    mirrorFrom(
+                                            rechecked,
+                                            snapshot,
+                                            fileChangesCollector,
+                                            indexFiles,
+                                            lastColumnIdFloor,
+                                            nextRowIdFloor);
+                                } else if (!higherMirroredSnapshotExists(snapshotId)) {
+                                    createMetadataWithoutBase(
+                                            snapshotId,
+                                            inheritUuid,
+                                            lastColumnIdFloor,
+                                            nextRowIdFloor);
+                                }
+                                return null;
+                            });
+                }
             }
 
             if (retireSuffix) {
@@ -458,7 +957,161 @@ public class IcebergCommitCallback implements CommitCallback, TagCallback {
             }
         } catch (IOException e) {
             throw new UncheckedIOException(e);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
         }
+    }
+
+    private void mirrorFrom(
+            long base,
+            Snapshot snapshot,
+            FileChangesCollector fileChangesCollector,
+            List<IndexManifestEntry> indexFiles,
+            int lastColumnIdFloor,
+            long nextRowIdFloor)
+            throws IOException {
+        long snapshotId = snapshot.id();
+        for (long id = base + 1; id <= snapshotId; id++) {
+            if (table.fileIO().exists(pathFactory.toMetadataPath(id))) {
+                // only a genuine twin of the target may be skipped; an abandoned twin is
+                // replaced at the write site, so readers keep a working file meanwhile
+                if (id == snapshotId
+                        ? metadataMatchesSnapshot(id, snapshot)
+                        : usableMirrorBase(id)) {
+                    continue;
+                }
+                if (id != snapshotId) {
+                    // a dead survivor mid-chain (its list is gone, or it sits on a rolled-back
+                    // timeline) blocks this walk and every future one
+                    table.fileIO().deleteQuietly(pathFactory.toMetadataPath(id));
+                }
+            }
+            long mirrorId = id;
+            Snapshot toMirror = id == snapshotId ? snapshot : table.snapshotManager().snapshot(id);
+            FileChangesCollector collector =
+                    id == snapshotId
+                            ? fileChangesCollector
+                            : (removed, added) -> collectFileChanges(mirrorId, removed, added);
+            // a replayed predecessor may sit past an expired base, so its dv state cannot be
+            // diffed against a predecessor scan; rebuild it from the snapshot's own live state
+            boolean replay = id != snapshotId;
+            createMetadataWithBase(
+                    collector,
+                    replay ? Collections.emptyList() : deletionVectorIndexes(indexFiles),
+                    toMirror,
+                    pathFactory.toMetadataPath(id - 1),
+                    lastColumnIdFloor,
+                    nextRowIdFloor,
+                    replay);
+        }
+    }
+
+    /** A lock serializing base-less regeneration, or an empty lock when the catalog has none. */
+    private Lock icebergLock() {
+        CatalogEnvironment env = table.catalogEnvironment();
+        CatalogLockFactory lockFactory = env.lockFactory();
+        if (lockFactory == null || env.identifier() == null) {
+            return Lock.empty();
+        }
+        return Lock.fromCatalog(lockFactory.createLock(env.lockContext()), env.identifier());
+    }
+
+    /**
+     * Whether a snapshot above {@code target} already has Iceberg metadata (a newer rebuilt chain).
+     */
+    private boolean higherMirroredSnapshotExists(long target) throws IOException {
+        Long latest = table.snapshotManager().latestSnapshotId();
+        if (latest == null) {
+            return false;
+        }
+        for (long k = latest; k > target; k--) {
+            if (table.fileIO().exists(pathFactory.toMetadataPath(k))) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Highest snapshot {@code K < target} whose Iceberg metadata still exists and whose successors
+     * up to {@code target} still have Paimon snapshots to rebuild from, or {@code -1} when no such
+     * base chain survives (cold start, or history expired past what can be reconstructed).
+     */
+    private long latestMirroredSnapshot(long target) throws IOException {
+        SnapshotManager snapshotManager = table.snapshotManager();
+        // target is the snapshot being committed (preflight) or just committed (rebuild); it is
+        // always present, so only the snapshots strictly between the base and target need to exist
+        for (long k = target - 1; k >= Snapshot.FIRST_SNAPSHOT_ID; k--) {
+            if (usableMirrorBase(k)) {
+                for (long id = k + 1; id < target; id++) {
+                    if (!snapshotManager.snapshotExists(id)) {
+                        return -1;
+                    }
+                }
+                return k;
+            }
+            // json retention is separate from list expiry, so the highest survivor may be
+            // unreadable as a base; chaining from it would fail every retry
+            if (!snapshotManager.snapshotExists(k)) {
+                return -1;
+            }
+        }
+        return -1;
+    }
+
+    /**
+     * Whether snapshot {@code k}'s metadata can serve as a mirror base: its json parses and the
+     * manifest list it points at still exists.
+     */
+    private boolean usableMirrorBase(long k) throws IOException {
+        if (!table.fileIO().exists(pathFactory.toMetadataPath(k))) {
+            return false;
+        }
+        IcebergMetadata metadata;
+        try {
+            metadata = IcebergMetadata.fromPath(table.fileIO(), pathFactory.toMetadataPath(k));
+        } catch (Exception e) {
+            // condemning a survivor takes positive evidence (absent, corrupt, wrong timeline);
+            // a transient read failure fails the walk instead of retiring a live base
+            if (transientReadFailure(e)) {
+                throw new IOException(e);
+            }
+            return false;
+        }
+        if (metadata.currentSnapshot() == null
+                || !table.fileIO().exists(new Path(metadata.currentSnapshot().manifestList()))) {
+            return false;
+        }
+        // a survivor from a rolled-back timeline must not seed the chain: while the live
+        // snapshot k is still around, the metadata has to carry its commit identity
+        if (table.snapshotManager().snapshotExists(k)) {
+            return metadataMatchesSnapshot(metadata, table.snapshotManager().snapshot(k));
+        }
+        // once snapshot k expired the identity is uncheckable: a pending-rollback marker means
+        // the survivor may sit on an abandoned timeline, so only a full rebuild is safe
+        return !table.fileIO()
+                .exists(new Path(pathFactory.metadataDirectory(), RETIRE_PENDING_FILENAME));
+    }
+
+    private static boolean transientReadFailure(Exception e) {
+        for (Throwable t = e; t != null; t = t.getCause()) {
+            if (t instanceof FileNotFoundException || t instanceof JsonProcessingException) {
+                return false;
+            }
+        }
+        for (Throwable t = e; t != null; t = t.getCause()) {
+            if (t instanceof IOException) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static List<IndexManifestEntry> deletionVectorIndexes(
+            List<IndexManifestEntry> indexFiles) {
+        return indexFiles.stream()
+                .filter(index -> index.indexFile().indexType().equals(DELETION_VECTORS_INDEX))
+                .collect(Collectors.toList());
     }
 
     // -------------------------------------------------------------------------------------
@@ -482,7 +1135,29 @@ public class IcebergCommitCallback implements CommitCallback, TagCallback {
             throws IOException {
         SnapshotReader snapshotReader = table.newSnapshotReader().withSnapshot(snapshotId);
         Snapshot paimonSnapshot = table.snapshotManager().snapshot(snapshotId);
+        // decide the schema story before any manifest is written: an ALTER between the
+        // preflight and this callback would otherwise orphan everything written meanwhile
         SchemaCache schemaCache = new SchemaCache();
+        int schemaId = publishableSchemaId(schemaCache, schemaCache.getLatestSchemaId());
+        checkSnapshotSchemaEmittable(schemaCache, paimonSnapshot.schemaId(), schemaId);
+        IcebergSchema icebergSchema = schemaCache.get(schemaId);
+        List<IcebergPartitionField> partitionFields =
+                getPartitionFields(table.schema().partitionKeys(), icebergSchema);
+        List<IcebergSchema> allSchemas = new ArrayList<>();
+        for (int id = 0; id <= schemaId; id++) {
+            if (id == schemaId) {
+                allSchemas.add(icebergSchema);
+                continue;
+            }
+            try {
+                allSchemas.add(schemaCache.getValidated(id));
+            } catch (IllegalArgumentException | UnsupportedOperationException notRepresentable) {
+                // only a representability verdict is evidence: any other failure (a missing or
+                // malformed schema file, a flaky read) must not be mistaken for a schema that
+                // was never mirrored, or the snapshot silently loses its schema provenance
+            }
+        }
+        int snapshotSchemaId = provenanceSchemaId(allSchemas, (int) paimonSnapshot.schemaId());
         List<IcebergManifestEntry> dataFileEntries = new ArrayList<>();
         List<IcebergManifestEntry> dvFileEntries = new ArrayList<>();
         SummaryMetrics metrics = new SummaryMetrics();
@@ -552,13 +1227,6 @@ public class IcebergCommitCallback implements CommitCallback, TagCallback {
                         : snapshotFirstRowId + rowIdAssignment.assignedRows;
         String manifestListFileName = manifestList.writeWithoutRolling(allManifestFileMetas);
 
-        // current schema follows the latest; the snapshot entry records its own schema
-        int schemaId = (int) schemaCache.getLatestSchemaId();
-        int snapshotSchemaId = (int) paimonSnapshot.schemaId();
-        IcebergSchema icebergSchema = schemaCache.get(schemaId);
-        List<IcebergPartitionField> partitionFields =
-                getPartitionFields(table.schema().partitionKeys(), icebergSchema);
-
         IcebergSnapshotSummary snapshotSummary =
                 computeSnapshotSummary(
                         IcebergSnapshotSummary.APPEND.operation(), paimonSnapshot, metrics);
@@ -588,10 +1256,6 @@ public class IcebergCommitCallback implements CommitCallback, TagCallback {
         // and external catalogs keep refreshing the same table
         String tableUuid = inheritUuid != null ? inheritUuid : UUID.randomUUID().toString();
 
-        List<IcebergSchema> allSchemas =
-                IntStream.rangeClosed(0, schemaId)
-                        .mapToObj(schemaCache::get)
-                        .collect(Collectors.toList());
         IcebergMetadata metadata =
                 new IcebergMetadata(
                         formatVersion,
@@ -630,9 +1294,17 @@ public class IcebergCommitCallback implements CommitCallback, TagCallback {
             table.fileIO().deleteQuietly(metadataPath);
             written = table.fileIO().tryToWriteAtomic(metadataPath, metadata.toJson());
         }
-        if (!written && !metadataMatchesSnapshot(snapshotId, paimonSnapshot)) {
-            // no twin published this snapshot's metadata; fail so the commit retries
-            throw new IllegalStateException("Failed to replace Iceberg metadata " + metadataPath);
+        if (!written) {
+            // decided on one read, like the with-base path above
+            if (metadataMatchesSnapshot(snapshotId, paimonSnapshot)) {
+                // a concurrent callback published this version first; adopt it rather than hand
+                // a divergent twin to the external catalog, and leave expiry to the winner
+                metadata = IcebergMetadata.fromPath(table.fileIO(), metadataPath);
+            } else {
+                // no twin published this snapshot's metadata; fail so the commit retries
+                throw new IllegalStateException(
+                        "Failed to replace Iceberg metadata " + metadataPath);
+            }
         }
         // a delayed callback may still write its metadata (a newer commit extends it), but
         // only the current head may move the hint and the external catalog
@@ -643,9 +1315,11 @@ public class IcebergCommitCallback implements CommitCallback, TagCallback {
                             new Path(pathFactory.metadataDirectory(), VERSION_HINT_FILENAME),
                             String.valueOf(snapshotId));
             commitToExternalCatalog(metadata, metadataPath, null, null);
-            // cleanup only after the catalog serves the new head: a skipped or failed
-            // publication must not delete files an external pointer still references
-            expireAllBefore(snapshotId);
+            // cleanup only after the catalog serves the new head, and only by the writer: a
+            // skipped or failed publication must not delete files a pointer still references
+            if (written) {
+                expireAllBefore(snapshotId);
+            }
         }
     }
 
@@ -721,6 +1395,8 @@ public class IcebergCommitCallback implements CommitCallback, TagCallback {
 
     private List<IcebergPartitionField> getPartitionFields(
             List<String> partitionKeys, IcebergSchema icebergSchema) {
+        checkNoVariantPartitionKeys(partitionKeys, icebergSchema);
+
         Map<String, IcebergDataField> fields = new HashMap<>();
         for (IcebergDataField field : icebergSchema.fields()) {
             fields.put(field.name(), field);
@@ -735,47 +1411,21 @@ public class IcebergCommitCallback implements CommitCallback, TagCallback {
         return result;
     }
 
-    /** VARIANT needs Iceberg row lineage, which Paimon Iceberg compatibility cannot publish. */
-    static void checkVariantNotPublishable(RowType rowType) {
-        Collection<String> variantFields = new LinkedHashSet<>();
-        for (DataField field : rowType.getFields()) {
-            collectVariantFields(field.name(), field.type(), variantFields);
+    // Iceberg's identity transform (the only transform Paimon partition values use) rejects
+    // VARIANT outright, so a VARIANT partition key can never be represented in Iceberg metadata
+    static void checkNoVariantPartitionKeys(
+            List<String> partitionKeys, IcebergSchema icebergSchema) {
+        Set<String> variantPartitionKeys = new LinkedHashSet<>();
+        for (IcebergDataField field : icebergSchema.fields()) {
+            if (partitionKeys.contains(field.name()) && field.dataType() instanceof VariantType) {
+                variantPartitionKeys.add(field.name());
+            }
         }
         Preconditions.checkArgument(
-                variantFields.isEmpty(),
-                "Columns %s use the VARIANT type, which Paimon Iceberg compatibility cannot "
-                        + "publish: it is an Iceberg format-version-3 type that requires row "
-                        + "lineage.",
-                variantFields);
-    }
-
-    private static void collectVariantFields(
-            String path, DataType type, Collection<String> variantFields) {
-        switch (type.getTypeRoot()) {
-            case VARIANT:
-                variantFields.add(path + ": " + type.asSQLString());
-                break;
-            case ARRAY:
-                collectVariantFields(
-                        path + ".element", ((ArrayType) type).getElementType(), variantFields);
-                break;
-            case MULTISET:
-                collectVariantFields(
-                        path + ".element", ((MultisetType) type).getElementType(), variantFields);
-                break;
-            case MAP:
-                collectVariantFields(path + ".key", ((MapType) type).getKeyType(), variantFields);
-                collectVariantFields(
-                        path + ".value", ((MapType) type).getValueType(), variantFields);
-                break;
-            case ROW:
-                for (DataField field : ((RowType) type).getFields()) {
-                    collectVariantFields(path + "." + field.name(), field.type(), variantFields);
-                }
-                break;
-            default:
-                break;
-        }
+                variantPartitionKeys.isEmpty(),
+                "Partition keys %s have type VARIANT, which Iceberg does not support as a "
+                        + "partition key.",
+                variantPartitionKeys);
     }
 
     // -------------------------------------------------------------------------------------
@@ -828,30 +1478,41 @@ public class IcebergCommitCallback implements CommitCallback, TagCallback {
      * deletes anything, and cleared once a commit has listed and retired the leftovers.
      */
     public static void markRetirePendingForRollback(FileStoreTable table) {
-        if (table.coreOptions().toConfiguration().get(IcebergOptions.METADATA_ICEBERG_STORAGE)
-                == IcebergOptions.StorageType.DISABLED) {
-            return;
-        }
-        try {
-            Path dir = catalogTableMetadataPath(table);
-            if (table.fileIO().exists(dir)) {
-                table.fileIO().overwriteFileUtf8(new Path(dir, RETIRE_PENDING_FILENAME), "");
+        // metadata left by an earlier enablement must learn about the rollback even while
+        // mirroring is off, or a later re-enable would trust an abandoned base
+        for (IcebergOptions.StorageLocation location : IcebergOptions.StorageLocation.values()) {
+            try {
+                Path dir =
+                        new Path(
+                                catalogDatabasePath(table, location),
+                                String.format("%s/metadata", table.location().getName()));
+                if (table.fileIO().exists(dir)) {
+                    table.fileIO().overwriteFileUtf8(new Path(dir, RETIRE_PENDING_FILENAME), "");
+                }
+            } catch (Exception e) {
+                // best-effort: the commit-time suspicion gate still covers the common cases
             }
-        } catch (Exception e) {
-            // best-effort: the commit-time suspicion gate still covers the common cases
         }
     }
 
     /** The version recorded in the hint file, or -1 when absent or unreadable. */
-    private long readVersionHint() {
+    private long readVersionHint() throws IOException {
+        // an absent or corrupt hint reads as -1 and is repaired by the next publication; a
+        // transient read failure must fail the caller instead of authorizing a stale publish
+        String hint;
         try {
-            return Long.parseLong(
+            hint =
                     table.fileIO()
                             .readFileUtf8(
                                     new Path(
-                                            pathFactory.metadataDirectory(), VERSION_HINT_FILENAME))
-                            .trim());
-        } catch (Exception e) {
+                                            pathFactory.metadataDirectory(),
+                                            VERSION_HINT_FILENAME));
+        } catch (FileNotFoundException e) {
+            return -1;
+        }
+        try {
+            return Long.parseLong(hint.trim());
+        } catch (NumberFormatException e) {
             return -1;
         }
     }
@@ -937,7 +1598,8 @@ public class IcebergCommitCallback implements CommitCallback, TagCallback {
             Snapshot snapshot,
             Path baseMetadataPath,
             int lastColumnIdFloor,
-            long nextRowIdFloor)
+            long nextRowIdFloor,
+            boolean rebuildDvFromLiveState)
             throws IOException {
         long snapshotId = snapshot.id();
         IcebergMetadata baseMetadata = IcebergMetadata.fromPath(table.fileIO(), baseMetadataPath);
@@ -986,10 +1648,11 @@ public class IcebergCommitCallback implements CommitCallback, TagCallback {
             return;
         }
 
-        // decide the schema story before any manifest is written
+        // decide the schema story before any manifest is written: rejecting later would
+        // orphan the manifests written meanwhile
         SchemaCache schemaCache = new SchemaCache();
-        int schemaId = (int) schemaCache.getLatestSchemaId();
-        int snapshotSchemaId = (int) snapshot.schemaId();
+        int schemaId = publishableSchemaId(schemaCache, schemaCache.getLatestSchemaId());
+        checkSnapshotSchemaEmittable(schemaCache, snapshot.schemaId(), schemaId);
         IcebergSchema icebergSchema = schemaCache.get(schemaId);
         // re-verified each commit: a rollback re-evolution can redefine an already
         // verified id while this callback only ever sees increasing snapshot ids
@@ -1032,7 +1695,7 @@ public class IcebergCommitCallback implements CommitCallback, TagCallback {
         }
 
         List<IcebergManifestFileMeta> baseManifestFileMetas =
-                manifestList.read(baseMetadata.currentSnapshot().manifestList());
+                readManifestListWithFallback(baseMetadata.currentSnapshot().manifestList());
 
         // base manifest file for data files
         List<IcebergManifestFileMeta> baseDataManifestFileMetas =
@@ -1062,6 +1725,7 @@ public class IcebergCommitCallback implements CommitCallback, TagCallback {
         // duplicate.
         List<IcebergManifestFileMeta> newDataManifestFileMetas;
         String operation;
+
         if (isAddOnly) {
             // Fast case. We don't need to remove files from `baseMetadata`. We only need to append
             // new metadata files.
@@ -1084,16 +1748,16 @@ public class IcebergCommitCallback implements CommitCallback, TagCallback {
 
         List<IcebergManifestFileMeta> newDVManifestFileMetas = new ArrayList<>();
         if (needAddDvToIceberg) {
-            if (!indexFiles.isEmpty()) {
-                // reconstruct the dv index
+            if (rebuildDvFromLiveState || !indexFiles.isEmpty()) {
+                // the dv set changed, or a replay cannot trust an empty incremental delta:
+                // rebuild from live state, which is empty when every dv was removed
                 newDVManifestFileMetas.addAll(createDvManifestFileMetas(snapshot));
             } else {
-                // no new dv index, reuse the old one
+                // unchanged: keep the base delete manifests
                 newDVManifestFileMetas.addAll(baseDVManifestFileMetas);
             }
         }
 
-        // compact data manifest file if needed
         newDataManifestFileMetas = compactMetadataIfNeeded(newDataManifestFileMetas, snapshotId);
 
         SummaryMetrics metrics = new SummaryMetrics();
@@ -1173,14 +1837,33 @@ public class IcebergCommitCallback implements CommitCallback, TagCallback {
             // append only ids the list does not already carry
             Set<Integer> knownSchemaIds =
                     schemas.stream().map(IcebergSchema::schemaId).collect(Collectors.toSet());
-            schemas = new ArrayList<>(schemas);
-            schemas.addAll(
-                    IntStream.rangeClosed(baseMetadata.currentSchemaId() + 1, schemaId)
-                            .filter(id -> !knownSchemaIds.contains(id))
-                            .mapToObj(schemaCache::get)
-                            .collect(Collectors.toList()));
+            List<IcebergSchema> added = new ArrayList<>();
+            for (int id = baseMetadata.currentSchemaId() + 1; id <= schemaId; id++) {
+                if (knownSchemaIds.contains(id)) {
+                    continue;
+                }
+                if (id == schemaId) {
+                    added.add(icebergSchema);
+                    continue;
+                }
+                try {
+                    added.add(schemaCache.getValidated(id));
+                } catch (IllegalArgumentException
+                        | UnsupportedOperationException notRepresentable) {
+                    // a pending schema that was vetoed at its introduction and since remedied
+                    // was never mirrored; leaving it out must not brick every later commit.
+                    // Only a representability verdict counts: a missing or malformed schema
+                    // file must surface instead of silently dropping a valid schema
+                }
+            }
+            if (!added.isEmpty()) {
+                schemas = new ArrayList<>(schemas);
+                schemas.addAll(added);
+            }
         }
         // a schema-pointer rollback (validated above): only the current pointer moves
+
+        int snapshotSchemaId = provenanceSchemaId(schemas, (int) snapshot.schemaId());
 
         List<IcebergSnapshot> snapshots = new ArrayList<>(baseMetadata.snapshots());
         snapshots.add(
@@ -1252,26 +1935,40 @@ public class IcebergCommitCallback implements CommitCallback, TagCallback {
             table.fileIO().deleteQuietly(metadataPath);
             written = table.fileIO().tryToWriteAtomic(metadataPath, metadata.toJson());
         }
-        if (!written && !metadataMatchesSnapshot(snapshotId, snapshot)) {
-            // no twin published this snapshot's metadata; fail so the commit retries
-            throw new IllegalStateException("Failed to replace Iceberg metadata " + metadataPath);
+        if (!written) {
+            // decided on one read: a twin finishing between two reads would otherwise leave
+            // this callback publishing neither the file on disk nor a failure
+            if (metadataMatchesSnapshot(snapshotId, snapshot)) {
+                // a concurrent callback published this version first; later callbacks derive
+                // row ids from what is on disk, so adopt the winner wholesale instead of
+                // handing a divergent twin to the external catalog, and leave expiry to it
+                metadata = IcebergMetadata.fromPath(table.fileIO(), metadataPath);
+            } else {
+                // no twin published this snapshot's metadata; fail so the commit retries
+                throw new IllegalStateException(
+                        "Failed to replace Iceberg metadata " + metadataPath);
+            }
         }
-        // a delayed callback may still write its metadata (a newer commit extends it), but
-        // only the current head may move the hint and the external catalog
+        // the target publishes only as the live head (a rollback legitimately moves the hint
+        // back); a replayed catch-up step publishes only while the hint moves forward, so a
+        // stale callback cannot drag hint or catalog backwards
         Long latestAtPublish = table.snapshotManager().latestSnapshotId();
-        if (latestAtPublish != null && latestAtPublish == snapshotId) {
+        if ((latestAtPublish != null && latestAtPublish == snapshotId)
+                || (rebuildDvFromLiveState && snapshotId >= readVersionHint())) {
             table.fileIO()
                     .overwriteFileUtf8(
                             new Path(pathFactory.metadataDirectory(), VERSION_HINT_FILENAME),
                             String.valueOf(snapshotId));
             commitToExternalCatalog(metadata, metadataPath, baseMetadata, baseMetadataPath);
-            // cleanup only after the catalog serves the new head: a skipped or failed
-            // publication must not delete files an external pointer still references
-            deleteApplicableMetadataFiles(snapshotId);
-            for (int i = 0; i + 1 < toExpireExceptLast.size(); i++) {
-                expireManifestList(
-                        new Path(toExpireExceptLast.get(i).manifestList()).getName(),
-                        new Path(toExpireExceptLast.get(i + 1).manifestList()).getName());
+            // cleanup only after the catalog serves the new head, and only by the writer: a
+            // skipped or failed publication must not delete files a pointer still references
+            if (written) {
+                deleteApplicableMetadataFiles(snapshotId);
+                for (int i = 0; i + 1 < toExpireExceptLast.size(); i++) {
+                    expireManifestList(
+                            new Path(toExpireExceptLast.get(i).manifestList()).getName(),
+                            new Path(toExpireExceptLast.get(i + 1).manifestList()).getName());
+                }
             }
         }
     }
@@ -1576,15 +2273,64 @@ public class IcebergCommitCallback implements CommitCallback, TagCallback {
                         - options.get(CoreOptions.SNAPSHOT_TIME_RETAINED).toMillis();
     }
 
-    private void expireManifestList(String toExpire, String next) {
-        // compare by physical path: a carried-over manifest may be re-listed with different
-        // list-level fields (e.g. an assigned first_row_id) while sharing the same file
-        Set<String> pathsInUse = new HashSet<>();
-        for (IcebergManifestFileMeta meta : manifestList.read(next)) {
-            pathsInUse.add(meta.manifestPath());
+    /**
+     * Reads a historical manifest list, falling back to the legacy (iceberg-1.4) reader for lists
+     * written while {@code manifest.legacy-version} was in effect: a table that upgrades to v3 has
+     * to turn the option off, so its older lists stay in the legacy schema. A genuine read failure
+     * still propagates, because the legacy reader fails too and the original error is rethrown.
+     */
+    private List<IcebergManifestFileMeta> readManifestListWithFallback(String listName) {
+        try {
+            return manifestList.read(listName);
+        } catch (RuntimeException primary) {
+            if (legacyManifestList == null) {
+                legacyManifestList =
+                        IcebergManifestList.create(
+                                table.copy(
+                                        Collections.singletonMap(
+                                                IcebergOptions.MANIFEST_LEGACY_VERSION.key(),
+                                                "true")),
+                                pathFactory);
+            }
+            try {
+                return legacyManifestList.read(listName);
+            } catch (RuntimeException notLegacy) {
+                throw primary;
+            }
         }
-        for (IcebergManifestFileMeta meta : manifestList.read(toExpire)) {
-            if (pathsInUse.contains(meta.manifestPath())) {
+    }
+
+    @VisibleForTesting
+    void expireManifestList(String toExpire, String next) {
+        Set<String> manifestPathsInUse;
+        try {
+            manifestPathsInUse =
+                    readManifestListWithFallback(next).stream()
+                            .map(IcebergManifestFileMeta::manifestPath)
+                            .collect(Collectors.toSet());
+        } catch (RuntimeException e) {
+            // without the surviving side there is no safe in-use set; leave this pair to a
+            // later expiry pass instead of failing a commit that already published
+            return;
+        }
+        List<IcebergManifestFileMeta> expiredMetas;
+        try {
+            expiredMetas = readManifestListWithFallback(toExpire);
+        } catch (RuntimeException e) {
+            if (transientReadFailure(e)) {
+                // deleting the list on a flaky read would orphan every manifest it still
+                // indexes; leave the pair to a later expiry pass
+                return;
+            }
+            // an aged base can retain entries whose list a newer, since-lost metadata already
+            // expired; nothing of such a list remains to expire
+            table.fileIO().deleteQuietly(pathFactory.toManifestListPath(toExpire));
+            return;
+        }
+        // compare by path: a reused manifest can reappear under different meta fields and
+        // must not be deleted
+        for (IcebergManifestFileMeta meta : expiredMetas) {
+            if (manifestPathsInUse.contains(meta.manifestPath())) {
                 continue;
             }
             table.fileIO().deleteQuietly(new Path(meta.manifestPath()));
@@ -1610,14 +2356,25 @@ public class IcebergCommitCallback implements CommitCallback, TagCallback {
                 }
                 expiredManifestLists.add(listName);
 
-                // A retained metadata JSON can reference a list an earlier rebuild already
-                // deleted. Reading it must not fail: we only open it to delete what it
-                // points at, and that earlier pass already did so.
+                // a retained metadata json can reference a list an earlier rebuild deleted
                 if (!table.fileIO().exists(listPath)) {
                     continue;
                 }
-
-                for (IcebergManifestFileMeta meta : manifestList.read(listName)) {
+                List<IcebergManifestFileMeta> expiredMetas;
+                try {
+                    expiredMetas = readManifestListWithFallback(listName);
+                } catch (RuntimeException e) {
+                    if (transientReadFailure(e)) {
+                        // deleting the list on a flaky read would orphan every manifest it
+                        // still indexes; leave it to a later expiry pass
+                        continue;
+                    }
+                    // an aged metadata json can reference lists already expired by a newer,
+                    // since-lost metadata; nothing of such a list remains to expire
+                    table.fileIO().deleteQuietly(listPath);
+                    continue;
+                }
+                for (IcebergManifestFileMeta meta : expiredMetas) {
                     String metaName = new Path(meta.manifestPath()).getName();
                     if (expiredManifestFileMetas.contains(metaName)) {
                         continue;
@@ -2145,12 +2902,21 @@ public class IcebergCommitCallback implements CommitCallback, TagCallback {
                     schemaId,
                     id -> {
                         TableSchema schema = schemaManager.schema(id);
-                        // backstop: reject variant on each schema as it is emitted
-                        checkVariantNotPublishable(schema.logicalRowType());
+                        // the variant backstop that used to sit here is superseded by the type
+                        // gate: it judges the schemas a commit publishes, so history that can no
+                        // longer be represented degrades instead of bricking later commits
                         SchemaValidation.validateIcebergGeospatialTypes(
                                 schema.logicalRowType(), table.coreOptions());
                         return IcebergSchema.create(schema);
                     });
+        }
+
+        private IcebergSchema getValidated(long schemaId) {
+            // only schemas a commit newly publishes are gated; history already published
+            // must not brick later commits (e.g. after the offending column was dropped)
+            checkFormatVersionSupportsSchema(
+                    formatVersion, schemaManager.schema(schemaId).logicalRowType());
+            return get(schemaId);
         }
 
         private long getLatestSchemaId() {

--- a/paimon-core/src/main/java/org/apache/paimon/iceberg/metadata/IcebergDataField.java
+++ b/paimon-core/src/main/java/org/apache/paimon/iceberg/metadata/IcebergDataField.java
@@ -63,6 +63,9 @@ import java.util.stream.Collectors;
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class IcebergDataField {
 
+    /** Minimum precision mapped to the v3-only nanosecond types (timestamp[tz]_ns). */
+    public static final int MIN_NANOS_TIMESTAMP_PRECISION = 7;
+
     private static final String FIELD_ID = "id";
     private static final String FIELD_NAME = "name";
     private static final String FIELD_REQUIRED = "required";
@@ -190,13 +193,17 @@ public class IcebergDataField {
                 Preconditions.checkArgument(
                         timestampPrecision >= 3 && timestampPrecision <= 9,
                         "Paimon Iceberg compatibility only support timestamp type with precision from 3 to 9.");
-                return timestampPrecision >= 7 ? "timestamp_ns" : "timestamp";
+                return timestampPrecision >= MIN_NANOS_TIMESTAMP_PRECISION
+                        ? "timestamp_ns"
+                        : "timestamp";
             case TIMESTAMP_WITH_LOCAL_TIME_ZONE:
                 int timestampLtzPrecision = ((LocalZonedTimestampType) dataType).getPrecision();
                 Preconditions.checkArgument(
                         timestampLtzPrecision >= 3 && timestampLtzPrecision <= 9,
                         "Paimon Iceberg compatibility only support timestamp type with precision from 3 to 9.");
-                return timestampLtzPrecision >= 7 ? "timestamptz_ns" : "timestamptz";
+                return timestampLtzPrecision >= MIN_NANOS_TIMESTAMP_PRECISION
+                        ? "timestamptz_ns"
+                        : "timestamptz";
             case VARIANT:
                 return "variant";
             case GEOMETRY:

--- a/paimon-core/src/main/java/org/apache/paimon/operation/FileStoreCommitImpl.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/FileStoreCommitImpl.java
@@ -1259,9 +1259,21 @@ public class FileStoreCommitImpl implements FileStoreCommit {
         boolean success;
         final List<SimpleFileEntry> finalBaseFiles = baseDataFiles;
         final List<ManifestEntry> finalDeltaFiles = deltaFiles;
-        commitPreCallbacks.forEach(
-                callback ->
-                        callback.call(finalBaseFiles, finalDeltaFiles, indexFiles, newSnapshot));
+        try {
+            commitPreCallbacks.forEach(
+                    callback ->
+                            callback.call(
+                                    finalBaseFiles, finalDeltaFiles, indexFiles, newSnapshot));
+        } catch (RuntimeException e) {
+            // a pre-commit callback vetoed the commit: the manifests prepared above were
+            // never referenced by a published snapshot and must be cleaned up, exactly
+            // like a preparation failure
+            commitCleaner.cleanUpReuseTmpManifests(
+                    deltaManifestList, changelogManifestList, oldIndexManifest, indexManifest);
+            commitCleaner.cleanUpNoReuseTmpManifests(
+                    baseManifestList, mergeBeforeManifests, mergeAfterManifests);
+            throw e;
+        }
         try {
             success = commitSnapshotImpl(latestSnapshot, newSnapshot, deltaStatistics);
         } catch (Exception e) {
@@ -1508,8 +1520,16 @@ public class FileStoreCommitImpl implements FileStoreCommit {
         // They may veto the rollback by throwing (e.g. a chain-table snapshot branch rejects a
         // pure-DELETE overwrite that would drop a snapshot partition still anchoring delta
         // partitions), in which case the rollback snapshot is never created.
-        commitPreCallbacks.forEach(
-                callback -> callback.call(baseFiles, deltaFiles, indexChanges, newSnapshot));
+        try {
+            commitPreCallbacks.forEach(
+                    callback -> callback.call(baseFiles, deltaFiles, indexChanges, newSnapshot));
+        } catch (RuntimeException e) {
+            // the base and delta manifests written above were never referenced by a
+            // published snapshot and must be cleaned up, exactly like a regular commit
+            commitCleaner.cleanUpManifestList(baseManifestList);
+            commitCleaner.cleanUpManifestList(deltaManifestList);
+            throw e;
+        }
 
         boolean success =
                 commitSnapshotImpl(

--- a/paimon-core/src/main/java/org/apache/paimon/operation/commit/CommitCleaner.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/commit/CommitCleaner.java
@@ -24,6 +24,8 @@ import org.apache.paimon.manifest.ManifestFileMeta;
 import org.apache.paimon.manifest.ManifestList;
 import org.apache.paimon.utils.Pair;
 
+import javax.annotation.Nullable;
+
 import java.util.List;
 import java.util.Objects;
 import java.util.Set;
@@ -50,21 +52,19 @@ public class CommitCleaner {
             Pair<String, Long> changelogManifestList,
             String oldIndexManifest,
             String newIndexManifest) {
-        if (deltaManifestList != null) {
-            for (ManifestFileMeta manifest : manifestList.read(deltaManifestList.getKey())) {
-                manifestFile.delete(manifest.fileName());
-            }
-            manifestList.delete(deltaManifestList.getKey());
-        }
-
-        if (changelogManifestList != null) {
-            for (ManifestFileMeta manifest : manifestList.read(changelogManifestList.getKey())) {
-                manifestFile.delete(manifest.fileName());
-            }
-            manifestList.delete(changelogManifestList.getKey());
-        }
-
+        cleanUpManifestList(deltaManifestList);
+        cleanUpManifestList(changelogManifestList);
         cleanIndexManifest(oldIndexManifest, newIndexManifest);
+    }
+
+    /** Deletes a manifest list and every manifest file it references. */
+    public void cleanUpManifestList(@Nullable Pair<String, Long> list) {
+        if (list != null) {
+            for (ManifestFileMeta manifest : manifestList.read(list.getKey())) {
+                manifestFile.delete(manifest.fileName());
+            }
+            manifestList.delete(list.getKey());
+        }
     }
 
     public void cleanUpNoReuseTmpManifests(

--- a/paimon-core/src/main/java/org/apache/paimon/rest/RESTCatalog.java
+++ b/paimon-core/src/main/java/org/apache/paimon/rest/RESTCatalog.java
@@ -592,9 +592,11 @@ public class RESTCatalog implements Catalog {
             // the effective options rather than only the explicit ones.
             validateCatalogManagedFormatTablePartitions(
                     identifier, schema.options(), schema.options().containsKey(PATH.key()));
-            createExternalTablePathIfNotExist(schema);
             Schema newSchema = inferSchemaIfExternalPaimonTable(schema);
             api.createTable(identifier, newSchema);
+            // the schema the server refuses is never stored, so the directory an external table
+            // would live in is created only once the table exists
+            createExternalTablePathIfNotExist(schema);
         } catch (AlreadyExistsException e) {
             if (!ignoreIfExists) {
                 throw new TableAlreadyExistException(identifier);
@@ -605,7 +607,7 @@ public class RESTCatalog implements Catalog {
             throw new DatabaseNotExistException(identifier.getDatabaseName());
         } catch (BadRequestException e) {
             throw new RuntimeException(new IllegalArgumentException(e.getMessage()));
-        } catch (IllegalArgumentException e) {
+        } catch (IllegalArgumentException | TableAlreadyExistException e) {
             throw e;
         } catch (Exception e) {
             throw new RuntimeException(e);

--- a/paimon-core/src/main/java/org/apache/paimon/schema/SchemaManager.java
+++ b/paimon-core/src/main/java/org/apache/paimon/schema/SchemaManager.java
@@ -19,13 +19,16 @@
 package org.apache.paimon.schema;
 
 import org.apache.paimon.CoreOptions;
+import org.apache.paimon.TableType;
 import org.apache.paimon.annotation.VisibleForTesting;
 import org.apache.paimon.casting.CastExecutors;
 import org.apache.paimon.catalog.Catalog;
 import org.apache.paimon.catalog.Identifier;
 import org.apache.paimon.fs.FileIO;
 import org.apache.paimon.fs.Path;
+import org.apache.paimon.iceberg.IcebergCommitCallback;
 import org.apache.paimon.iceberg.IcebergOptions;
+import org.apache.paimon.options.Options;
 import org.apache.paimon.schema.ColumnDirectiveUtils.ConvertedColumn;
 import org.apache.paimon.schema.SchemaChange.AddColumn;
 import org.apache.paimon.schema.SchemaChange.DropColumn;
@@ -197,6 +200,8 @@ public class SchemaManager implements Serializable {
                 TableSchema latestSchema = latest.get();
                 if (externalTable) {
                     checkSchemaForExternalTable(latestSchema.toSchema(), schema);
+                    // registration persists nothing, so a table an older release left with an
+                    // unmirrorable schema stays registrable and readable
                     return latestSchema;
                 } else {
                     throw new IllegalStateException(
@@ -1219,6 +1224,40 @@ public class SchemaManager implements Serializable {
         SchemaValidation.validateTableSchema(newSchema);
         validateHistoricalIcebergGeospatialTypes(newSchema);
         SchemaValidation.validateFallbackBranch(this, newSchema);
+        // whatever produced this schema, it must be representable in Iceberg metadata if this
+        // table is mirrored, or every write that follows would be vetoed. Branches are not
+        // mirrored, so they evolve freely and are judged in fast-forward instead.
+        Options newOptions = Options.fromMap(newSchema.options());
+        TableType tableType = newOptions.get(CoreOptions.TYPE);
+        if (DEFAULT_MAIN_BRANCH.equals(branch)
+                && (tableType.equals(TableType.TABLE)
+                        || tableType.equals(TableType.MATERIALIZED_TABLE))) {
+            Optional<TableSchema> previous = latest();
+            try {
+                if (!previous.isPresent()) {
+                    IcebergCommitCallback.checkSchemaMirrorable(
+                            newOptions, newSchema.logicalRowType());
+                } else if (previous.get().id() < newSchema.id()) {
+                    // a schema id another writer already took is a lost race, reported by the
+                    // atomic write below; judging it here would turn that into a failure
+                    IcebergCommitCallback.checkSchemaChangeMirrorable(previous.get(), newSchema);
+                    if (Options.fromMap(previous.get().options())
+                                    .get(IcebergOptions.METADATA_ICEBERG_STORAGE)
+                            == IcebergOptions.StorageType.DISABLED) {
+                        // mirroring is being switched back on: the version it published before
+                        // the pause still bounds what can be published now
+                        IcebergCommitCallback.checkNoFormatVersionRegression(newOptions, listAll());
+                    }
+                }
+            } catch (RuntimeException notRepresentable) {
+                // this judged a state another writer has already replaced; report the lost race
+                // instead, so the caller retries and judges what is actually there now
+                if (!latest().map(current -> current.id() >= newSchema.id()).orElse(false)) {
+                    throw notRepresentable;
+                }
+                return false;
+            }
+        }
         Path schemaPath = toSchemaPath(newSchema.id());
         return fileIO.tryToWriteAtomic(schemaPath, newSchema.toString());
     }
@@ -1304,6 +1343,15 @@ public class SchemaManager implements Serializable {
             ChangelogManager changelogManager)
             throws IOException {
         checkArgument(schemaExists(targetSchemaId), "Schema %s does not exist.", targetSchemaId);
+
+        // rollback installs an older schema without passing through commit(), so the same rules
+        // apply here: writes stamped with the restored schema would otherwise be vetoed
+        if (DEFAULT_MAIN_BRANCH.equals(branch)) {
+            TableSchema target = schema(targetSchemaId);
+            Options targetOptions = Options.fromMap(target.options());
+            IcebergCommitCallback.checkSchemaMirrorable(targetOptions, target.logicalRowType());
+            IcebergCommitCallback.checkNoFormatVersionRegressionOnRestore(targetOptions, listAll());
+        }
 
         // Collect all schemaIds referenced by snapshots, tags, and changelogs
         Set<Long> usedSchemaIds = new HashSet<>();

--- a/paimon-core/src/main/java/org/apache/paimon/utils/FileSystemBranchManager.java
+++ b/paimon-core/src/main/java/org/apache/paimon/utils/FileSystemBranchManager.java
@@ -22,9 +22,11 @@ import org.apache.paimon.CoreOptions;
 import org.apache.paimon.Snapshot;
 import org.apache.paimon.fs.FileIO;
 import org.apache.paimon.fs.Path;
+import org.apache.paimon.iceberg.IcebergCommitCallback;
 import org.apache.paimon.manifest.FileEntry;
 import org.apache.paimon.manifest.FileKind;
 import org.apache.paimon.manifest.ManifestEntry;
+import org.apache.paimon.options.Options;
 import org.apache.paimon.schema.SchemaManager;
 import org.apache.paimon.schema.TableSchema;
 import org.apache.paimon.tag.Tag;
@@ -37,6 +39,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -183,6 +186,21 @@ public class FileSystemBranchManager implements BranchManager {
         Snapshot earliestSnapshot =
                 snapshotManager.copyWithBranch(branchName).snapshot(earliestSnapshotId);
         long earliestSchemaId = earliestSnapshot.schemaId();
+
+        // the branch's schemas are installed verbatim, without passing through
+        // SchemaManager.commit, so the same rules apply here — judged against the versions this
+        // branch already published, which are about to be deleted. Only the mirrored branch.
+        Optional<TableSchema> branchSchema =
+                BranchManager.isMainBranch(BranchManager.normalizeBranch(snapshotManager.branch()))
+                        ? schemaManager.copyWithBranch(branchName).latest()
+                        : Optional.empty();
+        if (branchSchema.isPresent()) {
+            Options branchOptions = Options.fromMap(branchSchema.get().options());
+            IcebergCommitCallback.checkSchemaMirrorable(
+                    branchOptions, branchSchema.get().logicalRowType());
+            IcebergCommitCallback.checkNoFormatVersionRegressionOnRestore(
+                    branchOptions, schemaManager.listAll());
+        }
 
         try {
             // Delete snapshot, schema, and tag from the main branch which occurs after

--- a/paimon-core/src/test/java/org/apache/paimon/iceberg/IcebergCommitCallbackTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/iceberg/IcebergCommitCallbackTest.java
@@ -20,9 +20,15 @@ package org.apache.paimon.iceberg;
 
 import org.apache.paimon.CoreOptions;
 import org.apache.paimon.fs.Path;
+import org.apache.paimon.iceberg.metadata.IcebergDataField;
+import org.apache.paimon.iceberg.metadata.IcebergMetadata;
+import org.apache.paimon.iceberg.metadata.IcebergSchema;
 import org.apache.paimon.options.Options;
 import org.apache.paimon.table.FileStoreTable;
 import org.apache.paimon.tag.Tag;
+import org.apache.paimon.types.DataField;
+import org.apache.paimon.types.DataTypes;
+import org.apache.paimon.types.RowType;
 import org.apache.paimon.utils.TagManager;
 
 import org.junit.jupiter.api.BeforeEach;
@@ -33,6 +39,8 @@ import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.Answers;
 
 import java.lang.reflect.Field;
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.Optional;
 import java.util.stream.Stream;
 
@@ -101,6 +109,131 @@ public class IcebergCommitCallbackTest {
         Field field = IcebergCommitCallback.class.getDeclaredField(fieldName);
         field.setAccessible(true);
         field.set(target, value);
+    }
+
+    @Test
+    void testFormatVersion2RejectsVariantType() {
+        RowType rowType =
+                RowType.of(
+                        new DataField(0, "id", DataTypes.INT()),
+                        new DataField(1, "payload", DataTypes.VARIANT()));
+
+        assertThatThrownBy(
+                        () ->
+                                IcebergCommitCallback.checkFormatVersionSupportsSchema(
+                                        IcebergMetadata.FORMAT_VERSION_V2, rowType))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("VARIANT")
+                .hasMessageContaining("not supported by Iceberg compatibility");
+    }
+
+    @Test
+    void testFormatVersion2RejectsNestedVariantType() {
+        RowType rowType =
+                RowType.of(
+                        new DataField(
+                                0,
+                                "nested",
+                                DataTypes.ARRAY(
+                                        DataTypes.ROW(
+                                                new DataField(
+                                                        1, "payload", DataTypes.VARIANT())))));
+
+        assertThatThrownBy(
+                        () ->
+                                IcebergCommitCallback.checkFormatVersionSupportsSchema(
+                                        IcebergMetadata.FORMAT_VERSION_V2, rowType))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("nested.element.payload: VARIANT");
+    }
+
+    @Test
+    void testVariantPartitionKeyRejected() {
+        IcebergSchema schema =
+                new IcebergSchema(
+                        0,
+                        Arrays.asList(
+                                new IcebergDataField(1, "k", true, "int", null),
+                                new IcebergDataField(2, "payload", false, "variant", null)));
+
+        assertThatThrownBy(
+                        () ->
+                                IcebergCommitCallback.checkNoVariantPartitionKeys(
+                                        Collections.singletonList("payload"), schema))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("payload")
+                .hasMessageContaining("VARIANT");
+    }
+
+    @Test
+    void testNonVariantPartitionKeyAllowed() {
+        IcebergSchema schema =
+                new IcebergSchema(
+                        0,
+                        Arrays.asList(
+                                new IcebergDataField(1, "k", true, "int", null),
+                                new IcebergDataField(2, "payload", false, "variant", null)));
+
+        assertThatCode(
+                        () ->
+                                IcebergCommitCallback.checkNoVariantPartitionKeys(
+                                        Collections.singletonList("k"), schema))
+                .doesNotThrowAnyException();
+    }
+
+    @Test
+    void testNanosecondTimestampsRejectedOnAllVersions() {
+        for (int formatVersion :
+                new int[] {IcebergMetadata.FORMAT_VERSION_V2, IcebergMetadata.FORMAT_VERSION_V3}) {
+            RowType timestampNs = RowType.of(new DataField(0, "ts", DataTypes.TIMESTAMP(9)));
+            assertThatThrownBy(
+                            () ->
+                                    IcebergCommitCallback.checkFormatVersionSupportsSchema(
+                                            formatVersion, timestampNs))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessageContaining("Nanosecond-precision");
+
+            RowType timestampLtzNs =
+                    RowType.of(new DataField(0, "ts", DataTypes.TIMESTAMP_WITH_LOCAL_TIME_ZONE(7)));
+            assertThatThrownBy(
+                            () ->
+                                    IcebergCommitCallback.checkFormatVersionSupportsSchema(
+                                            formatVersion, timestampLtzNs))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessageContaining("Nanosecond-precision");
+        }
+    }
+
+    @Test
+    void testFormatVersion3AlsoRejectsVariantType() {
+        RowType rowType = RowType.of(new DataField(0, "payload", DataTypes.VARIANT()));
+
+        assertThatThrownBy(
+                        () ->
+                                IcebergCommitCallback.checkFormatVersionSupportsSchema(
+                                        IcebergMetadata.FORMAT_VERSION_V3, rowType))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("payload: VARIANT");
+    }
+
+    @Test
+    void testFormatVersion2AllowsNonV3Types() {
+        RowType rowType =
+                RowType.of(
+                        new DataField(0, "id", DataTypes.INT()),
+                        new DataField(1, "name", DataTypes.STRING()),
+                        new DataField(2, "ts", DataTypes.TIMESTAMP(6)),
+                        new DataField(
+                                3,
+                                "nested",
+                                DataTypes.MAP(
+                                        DataTypes.STRING(), DataTypes.ARRAY(DataTypes.INT()))));
+
+        assertThatCode(
+                        () ->
+                                IcebergCommitCallback.checkFormatVersionSupportsSchema(
+                                        IcebergMetadata.FORMAT_VERSION_V2, rowType))
+                .doesNotThrowAnyException();
     }
 
     @ParameterizedTest(name = "StorageType: {0}")

--- a/paimon-core/src/test/java/org/apache/paimon/iceberg/IcebergCompatibilityTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/iceberg/IcebergCompatibilityTest.java
@@ -38,6 +38,7 @@ import org.apache.paimon.iceberg.manifest.IcebergManifestEntry;
 import org.apache.paimon.iceberg.manifest.IcebergManifestFile;
 import org.apache.paimon.iceberg.manifest.IcebergManifestFileMeta;
 import org.apache.paimon.iceberg.manifest.IcebergManifestList;
+import org.apache.paimon.iceberg.metadata.IcebergDataField;
 import org.apache.paimon.iceberg.metadata.IcebergMetadata;
 import org.apache.paimon.iceberg.metadata.IcebergRef;
 import org.apache.paimon.iceberg.metadata.IcebergSchema;
@@ -103,6 +104,7 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /** Tests for Iceberg compatibility. */
@@ -961,6 +963,432 @@ public class IcebergCompatibilityTest {
 
         write.close();
         commit.close();
+    }
+
+    @Test
+    public void testRollbackToOlderSchemaMirrorsWithoutThrowing() throws Exception {
+        RowType rowType =
+                RowType.of(
+                        new DataType[] {DataTypes.INT(), DataTypes.INT()}, new String[] {"k", "v"});
+        FileStoreTable table =
+                createPaimonTable(
+                        rowType,
+                        Collections.emptyList(),
+                        Collections.emptyList(),
+                        -1,
+                        Collections.singletonMap(IcebergOptions.FORMAT_VERSION.key(), "3"));
+
+        String commitUser = UUID.randomUUID().toString();
+        TableWriteImpl<?> write = table.newWrite(commitUser);
+        TableCommitImpl commit = table.newCommit(commitUser);
+        write.write(GenericRow.of(1, 10));
+        commit.commit(1, write.prepareCommit(false, 1));
+        table.createTag("before-evolution", 1);
+        write.close();
+        commit.close();
+
+        SchemaManager schemaManager = new SchemaManager(table.fileIO(), table.location());
+        schemaManager.commitChanges(SchemaChange.addColumn("w", DataTypes.INT()));
+        table = table.copyWithLatestSchema();
+        write = table.newWrite(commitUser);
+        commit = table.newCommit(commitUser);
+        write.write(GenericRow.of(2, 20, 200));
+        commit.commit(2, write.prepareCommit(false, 2));
+        int evolvedSchemaId = (int) table.snapshotManager().snapshot(2).schemaId();
+        write.close();
+        commit.close();
+
+        TableCommitImpl rollbackCommit = table.newCommit(commitUser);
+        rollbackCommit.rollbackToAsLatest(table.tagManager().getOrThrow("before-evolution"));
+        rollbackCommit.close();
+        long rolledBackId = table.snapshotManager().latestSnapshotId();
+
+        IcebergPathFactory pathFactory =
+                new IcebergPathFactory(new Path(table.location(), "metadata"));
+        IcebergMetadata rebuilt =
+                IcebergMetadata.fromPath(table.fileIO(), pathFactory.toMetadataPath(rolledBackId));
+        assertThat(rebuilt.currentSchemaId()).isEqualTo(evolvedSchemaId);
+        assertThat(rebuilt.currentSnapshot().schemaId()).isLessThan(evolvedSchemaId);
+        assertThat(rebuilt.schemas()).anyMatch(s -> s.schemaId() == evolvedSchemaId);
+    }
+
+    @Test
+    public void testLegacyManifestVersionRejectedOnV3() throws Exception {
+        RowType rowType =
+                RowType.of(
+                        new DataType[] {DataTypes.INT(), DataTypes.INT()}, new String[] {"k", "v"});
+        Map<String, String> legacyOptions = new HashMap<>();
+        legacyOptions.put(IcebergOptions.MANIFEST_LEGACY_VERSION.key(), "true");
+        FileStoreTable table =
+                createPaimonTable(
+                                rowType,
+                                Collections.emptyList(),
+                                Collections.emptyList(),
+                                -1,
+                                legacyOptions)
+                        .copy(Collections.singletonMap(IcebergOptions.FORMAT_VERSION.key(), "3"));
+
+        String commitUser = UUID.randomUUID().toString();
+        TableWriteImpl<?> write = table.newWrite(commitUser);
+        TableCommitImpl commit = table.newCommit(commitUser);
+        write.write(GenericRow.of(1, 10));
+        assertThatThrownBy(() -> commit.commit(1, write.prepareCommit(false, 1)))
+                .hasStackTraceContaining("manifest-legacy-version");
+        write.close();
+        commit.close();
+    }
+
+    @Test
+    public void testLegacyManifestVersionV3AllowsAbort() throws Exception {
+        RowType rowType =
+                RowType.of(
+                        new DataType[] {DataTypes.INT(), DataTypes.INT()}, new String[] {"k", "v"});
+        Map<String, String> legacyOptions = new HashMap<>();
+        legacyOptions.put(IcebergOptions.MANIFEST_LEGACY_VERSION.key(), "true");
+        FileStoreTable table =
+                createPaimonTable(
+                                rowType,
+                                Collections.emptyList(),
+                                Collections.emptyList(),
+                                -1,
+                                legacyOptions)
+                        .copy(Collections.singletonMap(IcebergOptions.FORMAT_VERSION.key(), "3"));
+
+        String commitUser = UUID.randomUUID().toString();
+        TableWriteImpl<?> write = table.newWrite(commitUser);
+        TableCommitImpl commit = table.newCommit(commitUser);
+        write.write(GenericRow.of(1, 10));
+        List<CommitMessage> messages = write.prepareCommit(false, 1);
+        commit.abort(messages);
+        write.close();
+        commit.close();
+    }
+
+    @Test
+    public void testDroppedVariantSchemaDoesNotBlockV2Commits() throws Exception {
+        RowType rowType =
+                RowType.of(
+                        new DataType[] {DataTypes.INT(), DataTypes.INT()}, new String[] {"k", "v"});
+        FileStoreTable table =
+                createPaimonTable(
+                        rowType,
+                        Collections.emptyList(),
+                        Collections.singletonList("k"),
+                        1,
+                        Collections.singletonMap(CoreOptions.FILE_FORMAT.key(), "parquet"));
+
+        String commitUser = UUID.randomUUID().toString();
+        TableWriteImpl<?> write = table.newWrite(commitUser);
+        TableCommitImpl commit = table.newCommit(commitUser);
+        write.write(GenericRow.of(1, 10));
+        commit.commit(1, write.prepareCommit(false, 1));
+        write.close();
+        commit.close();
+
+        SchemaManager schemaManager = new SchemaManager(table.fileIO(), table.location());
+        addUnsupportedColumnWhileMirroringOff(schemaManager, "payload", DataTypes.VARIANT());
+        schemaManager.commitChanges(SchemaChange.dropColumn("payload"));
+        table = table.copyWithLatestSchema();
+
+        TableWriteImpl<?> write2 = table.newWrite(commitUser);
+        TableCommitImpl commit2 = table.newCommit(commitUser);
+        write2.write(GenericRow.of(2, 20));
+        commit2.commit(2, write2.prepareCommit(false, 2));
+        assertThat(table.snapshotManager().latestSnapshotId()).isEqualTo(2L);
+        write2.close();
+        commit2.close();
+
+        IcebergMetadata metadata =
+                IcebergMetadata.fromPath(
+                        table.fileIO(), new Path(table.location(), "metadata/v2.metadata.json"));
+        for (IcebergSchema schema : metadata.schemas()) {
+            for (IcebergDataField field : schema.fields()) {
+                assertThat(String.valueOf(field.type())).doesNotContain("variant");
+            }
+        }
+    }
+
+    @Test
+    public void testLegacyInvalidBaseSchemaRebuiltOnNextCommit() throws Exception {
+        RowType rowType =
+                RowType.of(
+                        new DataType[] {DataTypes.INT(), DataTypes.INT()}, new String[] {"k", "v"});
+        FileStoreTable table =
+                createPaimonTable(
+                        rowType, Collections.emptyList(), Collections.singletonList("k"), 1);
+
+        String commitUser = UUID.randomUUID().toString();
+        TableWriteImpl<?> write = table.newWrite(commitUser);
+        TableCommitImpl commit = table.newCommit(commitUser);
+        write.write(GenericRow.of(1, 10));
+        commit.commit(1, write.prepareCommit(false, 1));
+
+        FileIO fileIO = table.fileIO();
+        Path metadataPath = new Path(table.location(), "metadata/v1.metadata.json");
+        String json = fileIO.readFileUtf8(metadataPath);
+        String doctored = json.replace("\"type\" : \"int\"", "\"type\" : \"variant\"");
+        if (doctored.equals(json)) {
+            doctored = json.replace("\"type\":\"int\"", "\"type\":\"variant\"");
+        }
+        assertThat(doctored).isNotEqualTo(json);
+        fileIO.deleteQuietly(metadataPath);
+        fileIO.overwriteFileUtf8(metadataPath, doctored);
+
+        write.write(GenericRow.of(2, 20));
+        commit.commit(2, write.prepareCommit(false, 2));
+        assertThat(table.snapshotManager().latestSnapshotId()).isEqualTo(2L);
+        write.close();
+        commit.close();
+
+        IcebergMetadata rebuilt =
+                IcebergMetadata.fromPath(
+                        fileIO, new Path(table.location(), "metadata/v2.metadata.json"));
+        assertThat(rebuilt.currentSnapshotId()).isEqualTo(2L);
+        for (IcebergSchema schema : rebuilt.schemas()) {
+            for (IcebergDataField field : schema.fields()) {
+                assertThat(String.valueOf(field.type())).doesNotContain("variant");
+            }
+        }
+    }
+
+    @Test
+    public void testRetryDegradesToPublishableSchemaWithoutOrphans() throws Exception {
+        RowType rowType =
+                RowType.of(
+                        new DataType[] {DataTypes.INT(), DataTypes.INT()}, new String[] {"k", "v"});
+        FileStoreTable table =
+                createPaimonTable(
+                        rowType,
+                        Collections.emptyList(),
+                        Collections.singletonList("k"),
+                        1,
+                        Collections.singletonMap(CoreOptions.FILE_FORMAT.key(), "parquet"));
+
+        String commitUser = UUID.randomUUID().toString();
+        TableWriteImpl<?> write = table.newWrite(commitUser);
+        TableCommitImpl commit = table.newCommit(commitUser);
+        write.write(GenericRow.of(1, 10));
+        commit.commit(1, write.prepareCommit(false, 1));
+        write.write(GenericRow.of(2, 20));
+        List<CommitMessage> messages2 = write.prepareCommit(false, 2);
+        commit.commit(2, messages2);
+        write.close();
+        commit.close();
+
+        SchemaManager schemaManager = new SchemaManager(table.fileIO(), table.location());
+        addUnsupportedColumnWhileMirroringOff(schemaManager, "payload", DataTypes.VARIANT());
+        table = table.copyWithLatestSchema();
+
+        IcebergPathFactory pf = new IcebergPathFactory(new Path(table.location(), "metadata"));
+        table.fileIO().deleteQuietly(pf.toMetadataPath(2));
+
+        TableCommitImpl commit2 = table.newCommit(commitUser);
+        Map<Long, List<CommitMessage>> retryMessages = new HashMap<>();
+        retryMessages.put(2L, messages2);
+        commit2.filterAndCommit(retryMessages);
+        commit2.close();
+
+        IcebergMetadata metadata = IcebergMetadata.fromPath(table.fileIO(), pf.toMetadataPath(2));
+        assertThat(metadata.currentSnapshotId()).isEqualTo(2L);
+        for (IcebergSchema schema : metadata.schemas()) {
+            for (IcebergDataField field : schema.fields()) {
+                assertThat(String.valueOf(field.type())).doesNotContain("variant");
+            }
+        }
+        assertThat(metadata.schemas())
+                .anySatisfy(schema -> assertThat(schema.schemaId()).isEqualTo(0));
+    }
+
+    @Test
+    public void testRejectedCommitDoesNotLeaveOrphanedManifests() throws Exception {
+        RowType rowType =
+                RowType.of(
+                        new DataType[] {DataTypes.INT(), DataTypes.INT()}, new String[] {"k", "v"});
+        Map<String, String> legacyOptions = new HashMap<>();
+        legacyOptions.put(IcebergOptions.MANIFEST_LEGACY_VERSION.key(), "true");
+        FileStoreTable table =
+                createPaimonTable(
+                        rowType,
+                        Collections.emptyList(),
+                        Collections.singletonList("k"),
+                        1,
+                        legacyOptions);
+
+        String commitUser = UUID.randomUUID().toString();
+        TableWriteImpl<?> write = table.newWrite(commitUser);
+        TableCommitImpl commit = table.newCommit(commitUser);
+        write.write(GenericRow.of(1, 10));
+        commit.commit(1, write.prepareCommit(false, 1));
+        write.close();
+        commit.close();
+
+        FileIO fileIO = table.fileIO();
+        Path manifestDir = new Path(table.location(), "manifest");
+        int manifestFileCountBefore = fileIO.listStatus(manifestDir).length;
+
+        FileStoreTable upgraded =
+                table.copy(Collections.singletonMap(IcebergOptions.FORMAT_VERSION.key(), "3"));
+        TableWriteImpl<?> write2 = upgraded.newWrite(commitUser);
+        TableCommitImpl commit2 = upgraded.newCommit(commitUser);
+        write2.write(GenericRow.of(2, 20));
+        assertThatThrownBy(() -> commit2.commit(2, write2.prepareCommit(false, 2)))
+                .hasStackTraceContaining("cannot be used with Iceberg format version 3");
+        assertThat(table.snapshotManager().latestSnapshotId()).isEqualTo(1L);
+
+        int manifestFileCountAfter = fileIO.listStatus(manifestDir).length;
+        assertThat(manifestFileCountAfter).isEqualTo(manifestFileCountBefore);
+
+        write2.close();
+        commit2.close();
+    }
+
+    @Test
+    public void testFormatVersionUpgradeRecoversFromLegacyInvalidBase() throws Exception {
+        RowType rowType =
+                RowType.of(
+                        new DataType[] {DataTypes.INT(), DataTypes.INT()}, new String[] {"k", "v"});
+        FileStoreTable table =
+                createPaimonTable(
+                        rowType, Collections.emptyList(), Collections.singletonList("k"), 1);
+
+        String commitUser = UUID.randomUUID().toString();
+        TableWriteImpl<?> write = table.newWrite(commitUser);
+        TableCommitImpl commit = table.newCommit(commitUser);
+        write.write(GenericRow.of(1, 10));
+        commit.commit(1, write.prepareCommit(false, 1));
+
+        FileIO fileIO = table.fileIO();
+        Path metadataPath = new Path(table.location(), "metadata/v1.metadata.json");
+        String json = fileIO.readFileUtf8(metadataPath);
+        String doctored = json.replace("\"type\" : \"int\"", "\"type\" : \"variant\"");
+        if (doctored.equals(json)) {
+            doctored = json.replace("\"type\":\"int\"", "\"type\":\"variant\"");
+        }
+        assertThat(doctored).isNotEqualTo(json);
+        fileIO.deleteQuietly(metadataPath);
+        fileIO.overwriteFileUtf8(metadataPath, doctored);
+
+        SchemaManager schemaManager = new SchemaManager(table.fileIO(), table.location());
+        schemaManager.commitChanges(
+                SchemaChange.setOption(IcebergOptions.FORMAT_VERSION.key(), "3"));
+        table = table.copy(table.schemaManager().latest().get());
+        write.close();
+        commit.close();
+
+        TableWriteImpl<?> write2 = table.newWrite(commitUser);
+        TableCommitImpl commit2 = table.newCommit(commitUser);
+        write2.write(GenericRow.of(2, 20));
+        commit2.commit(2, write2.prepareCommit(false, 2));
+        write2.close();
+        commit2.close();
+
+        IcebergMetadata metadata =
+                IcebergMetadata.fromPath(
+                        fileIO, new Path(table.location(), "metadata/v2.metadata.json"));
+        assertThat(metadata.formatVersion()).isEqualTo(IcebergMetadata.FORMAT_VERSION_V3);
+    }
+
+    @Test
+    public void testRollbackToAsLatestSkipsDroppedIntermediateVariantSchema() throws Exception {
+        RowType rowType =
+                RowType.of(
+                        new DataType[] {DataTypes.INT(), DataTypes.INT()}, new String[] {"k", "v"});
+        FileStoreTable table =
+                createPaimonTable(
+                        rowType,
+                        Collections.emptyList(),
+                        Collections.singletonList("k"),
+                        1,
+                        Collections.singletonMap(CoreOptions.FILE_FORMAT.key(), "parquet"));
+
+        String commitUser = UUID.randomUUID().toString();
+        TableWriteImpl<?> write = table.newWrite(commitUser);
+        TableCommitImpl commit = table.newCommit(commitUser);
+        write.write(GenericRow.of(1, 10));
+        commit.commit(1, write.prepareCommit(false, 1));
+        table.createTag("target", 1);
+
+        write.write(GenericRow.of(2, 20));
+        commit.commit(2, write.prepareCommit(false, 2));
+        write.close();
+        commit.close();
+
+        SchemaManager schemaManager = new SchemaManager(table.fileIO(), table.location());
+        addUnsupportedColumnWhileMirroringOff(schemaManager, "payload", DataTypes.VARIANT());
+        schemaManager.commitChanges(SchemaChange.dropColumn("payload"));
+        FileStoreTable tableWithEvolvedSchema = table.copyWithLatestSchema();
+
+        TableCommitImpl rollbackCommit = tableWithEvolvedSchema.newCommit(commitUser);
+        rollbackCommit.rollbackToAsLatest(tableWithEvolvedSchema.tagManager().getOrThrow("target"));
+        assertThat(tableWithEvolvedSchema.snapshotManager().latestSnapshotId()).isEqualTo(3L);
+        rollbackCommit.close();
+
+        IcebergMetadata metadata =
+                IcebergMetadata.fromPath(
+                        table.fileIO(), new Path(table.location(), "metadata/v3.metadata.json"));
+        assertThat(metadata.currentSnapshotId()).isEqualTo(3L);
+        for (IcebergSchema schema : metadata.schemas()) {
+            for (IcebergDataField field : schema.fields()) {
+                assertThat(String.valueOf(field.type())).doesNotContain("variant");
+            }
+        }
+    }
+
+    @Test
+    public void testDeleteTagSucceedsAfterUnsafeCurrentSchemaChange() throws Exception {
+        RowType rowType =
+                RowType.of(
+                        new DataType[] {DataTypes.INT(), DataTypes.INT()}, new String[] {"k", "v"});
+        FileStoreTable table =
+                createPaimonTable(
+                        rowType,
+                        Collections.emptyList(),
+                        Collections.singletonList("k"),
+                        1,
+                        Collections.singletonMap(CoreOptions.FILE_FORMAT.key(), "parquet"));
+
+        String commitUser = UUID.randomUUID().toString();
+        TableWriteImpl<?> write = table.newWrite(commitUser);
+        TableCommitImpl commit = table.newCommit(commitUser);
+        write.write(GenericRow.of(1, 10));
+        commit.commit(1, write.prepareCommit(false, 1));
+        write.close();
+        commit.close();
+
+        table.createTag("t1", 1);
+
+        SchemaManager schemaManager = new SchemaManager(table.fileIO(), table.location());
+        addUnsupportedColumnWhileMirroringOff(schemaManager, "payload", DataTypes.VARIANT());
+        FileStoreTable tableWithUnsafeSchema = table.copyWithLatestSchema();
+
+        assertThatCode(() -> tableWithUnsafeSchema.deleteTag("t1")).doesNotThrowAnyException();
+    }
+
+    @Test
+    public void testAbortSucceedsWithUnsafeCurrentSchema() throws Exception {
+        RowType rowType =
+                RowType.of(
+                        new DataType[] {DataTypes.INT(), DataTypes.INT()}, new String[] {"k", "v"});
+        FileStoreTable table =
+                createPaimonTable(
+                        rowType,
+                        Collections.emptyList(),
+                        Collections.singletonList("k"),
+                        1,
+                        Collections.singletonMap(CoreOptions.FILE_FORMAT.key(), "parquet"));
+
+        SchemaManager schemaManager = new SchemaManager(table.fileIO(), table.location());
+        addUnsupportedColumnWhileMirroringOff(schemaManager, "payload", DataTypes.VARIANT());
+        FileStoreTable tableWithUnsafeSchema = table.copyWithLatestSchema();
+
+        String commitUser = UUID.randomUUID().toString();
+        assertThatCode(
+                        () -> {
+                            TableCommitImpl commit = tableWithUnsafeSchema.newCommit(commitUser);
+                            commit.abort(Collections.emptyList());
+                            commit.close();
+                        })
+                .doesNotThrowAnyException();
     }
 
     @Test
@@ -2652,6 +3080,110 @@ public class IcebergCompatibilityTest {
     //  Utils
     // ------------------------------------------------------------------------
 
+    @Test
+    public void testAlterAfterPreflightDoesNotFailDurableCommit() throws Exception {
+        RowType rowType =
+                RowType.of(
+                        new DataType[] {DataTypes.INT(), DataTypes.INT()}, new String[] {"k", "v"});
+        FileStoreTable table =
+                createPaimonTable(
+                        rowType,
+                        Collections.emptyList(),
+                        Collections.emptyList(),
+                        -1,
+                        Collections.singletonMap(CoreOptions.FILE_FORMAT.key(), "parquet"));
+
+        String commitUser = UUID.randomUUID().toString();
+        TableWriteImpl<?> write = table.newWrite(commitUser);
+        TableCommitImpl commit = table.newCommit(commitUser);
+        write.write(GenericRow.of(1, 10));
+        commit.commit(1, write.prepareCommit(false, 1));
+        write.close();
+        commit.close();
+
+        SchemaManager schemaManager = new SchemaManager(table.fileIO(), table.location());
+        addUnsupportedColumnWhileMirroringOff(schemaManager, "ts", DataTypes.TIMESTAMP(9));
+
+        IcebergPathFactory pathFactory =
+                new IcebergPathFactory(new Path(table.location(), "metadata"));
+        IcebergCommitCallback callback = new IcebergCommitCallback(table, commitUser);
+        assertThatCode(() -> callback.retry(new ManifestCommittable(1))).doesNotThrowAnyException();
+
+        IcebergMetadata metadata =
+                IcebergMetadata.fromPath(table.fileIO(), pathFactory.toMetadataPath(1));
+        assertThat(metadata.currentSnapshotId()).isEqualTo(1L);
+        for (IcebergSchema schema : metadata.schemas()) {
+            for (IcebergDataField field : schema.fields()) {
+                assertThat(String.valueOf(field.type())).doesNotContain("timestamp_ns");
+            }
+        }
+    }
+
+    @Test
+    public void testUnsupportedSnapshotSchemaIsRefusedBeforeWritingManifests() throws Exception {
+        RowType rowType =
+                RowType.of(
+                        new DataType[] {DataTypes.INT(), DataTypes.INT()}, new String[] {"k", "v"});
+        FileStoreTable table =
+                createPaimonTable(
+                        rowType,
+                        Collections.emptyList(),
+                        Collections.emptyList(),
+                        -1,
+                        Collections.singletonMap(CoreOptions.FILE_FORMAT.key(), "parquet"));
+
+        String commitUser = UUID.randomUUID().toString();
+        TableWriteImpl<?> write = table.newWrite(commitUser);
+        TableCommitImpl commit = table.newCommit(commitUser);
+        write.write(GenericRow.of(1, 10));
+        commit.commit(1, write.prepareCommit(false, 1));
+        write.close();
+        commit.close();
+
+        SchemaManager schemaManager = new SchemaManager(table.fileIO(), table.location());
+        addUnsupportedColumnWhileMirroringOff(schemaManager, "ts", DataTypes.TIMESTAMP(9));
+        FileStoreTable disabled =
+                table.copy(schemaManager.latest().get())
+                        .copy(
+                                Collections.singletonMap(
+                                        IcebergOptions.METADATA_ICEBERG_STORAGE.key(), "disabled"));
+        TableWriteImpl<?> write2 = disabled.newWrite(commitUser);
+        TableCommitImpl commit2 = disabled.newCommit(commitUser);
+        write2.write(GenericRow.of(2, 20, Timestamp.fromEpochMillis(1000)));
+        commit2.commit(2, write2.prepareCommit(false, 2));
+        write2.close();
+        commit2.close();
+
+        IcebergPathFactory pathFactory =
+                new IcebergPathFactory(new Path(table.location(), "metadata"));
+        int before = table.fileIO().listStatus(pathFactory.metadataDirectory()).length;
+
+        FileStoreTable mirrored =
+                table.copy(schemaManager.latest().get())
+                        .copy(
+                                Collections.singletonMap(
+                                        IcebergOptions.METADATA_ICEBERG_STORAGE.key(),
+                                        "table-location"));
+        IcebergCommitCallback callback = new IcebergCommitCallback(mirrored, commitUser);
+        assertThatThrownBy(() -> callback.retry(new ManifestCommittable(2)))
+                .hasStackTraceContaining("cannot be represented in Iceberg metadata");
+        assertThat(table.fileIO().listStatus(pathFactory.metadataDirectory()).length)
+                .isEqualTo(before);
+    }
+
+    private Set<String> listIcebergMetadataFiles(FileStoreTable table) throws Exception {
+        return Arrays.stream(table.fileIO().listStatus(new Path(table.location(), "metadata")))
+                .map(status -> status.getPath().getName())
+                .collect(Collectors.toSet());
+    }
+
+    private void addUnsupportedColumnWhileMirroringOff(
+            SchemaManager schemaManager, String name, DataType type) throws Exception {
+        schemaManager.commitChanges(
+                SchemaChange.setOption(IcebergOptions.METADATA_ICEBERG_STORAGE.key(), "disabled"));
+        schemaManager.commitChanges(SchemaChange.addColumn(name, type));
+    }
+
     private FileStoreTable createPaimonTable(
             RowType rowType, List<String> partitionKeys, List<String> primaryKeys, int numBuckets)
             throws Exception {
@@ -2672,12 +3204,17 @@ public class IcebergCompatibilityTest {
         options.set(CoreOptions.BUCKET, numBuckets);
         options.set(
                 IcebergOptions.METADATA_ICEBERG_STORAGE, IcebergOptions.StorageType.TABLE_LOCATION);
-        options.set(CoreOptions.FILE_FORMAT, "avro");
+        if (!customOptions.containsKey(CoreOptions.FILE_FORMAT.key())) {
+            options.set(CoreOptions.FILE_FORMAT, "avro");
+        }
         options.set(CoreOptions.TARGET_FILE_SIZE, MemorySize.ofKibiBytes(32));
-        options.set(IcebergOptions.COMPACT_MIN_FILE_NUM, 4);
-        options.set(IcebergOptions.COMPACT_MIN_FILE_NUM, 8);
+        if (!customOptions.containsKey(IcebergOptions.COMPACT_MIN_FILE_NUM.key())) {
+            options.set(IcebergOptions.COMPACT_MIN_FILE_NUM, 8);
+        }
         options.set(IcebergOptions.METADATA_DELETE_AFTER_COMMIT, true);
-        options.set(IcebergOptions.METADATA_PREVIOUS_VERSIONS_MAX, 1);
+        if (!customOptions.containsKey(IcebergOptions.METADATA_PREVIOUS_VERSIONS_MAX.key())) {
+            options.set(IcebergOptions.METADATA_PREVIOUS_VERSIONS_MAX, 1);
+        }
         options.set(CoreOptions.MANIFEST_TARGET_FILE_SIZE, MemorySize.ofKibiBytes(8));
         Schema schema =
                 new Schema(rowType.getFields(), partitionKeys, primaryKeys, options.toMap(), "");
@@ -2778,18 +3315,5 @@ public class IcebergCompatibilityTest {
                 }
             }
         }
-    }
-
-    @Test
-    public void testVariantIsNotPublishableToIceberg() {
-        RowType withVariant =
-                RowType.of(
-                        new DataType[] {DataTypes.INT(), DataTypes.VARIANT()},
-                        new String[] {"k", "payload"});
-        assertThatThrownBy(() -> IcebergCommitCallback.checkVariantNotPublishable(withVariant))
-                .hasMessageContaining("VARIANT type");
-
-        IcebergCommitCallback.checkVariantNotPublishable(
-                RowType.of(new DataType[] {DataTypes.INT()}, new String[] {"k"}));
     }
 }

--- a/paimon-core/src/test/java/org/apache/paimon/iceberg/IcebergMirrorCatchUpTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/iceberg/IcebergMirrorCatchUpTest.java
@@ -1,0 +1,805 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.iceberg;
+
+import org.apache.paimon.CoreOptions;
+import org.apache.paimon.catalog.CatalogLock;
+import org.apache.paimon.catalog.CatalogLockContext;
+import org.apache.paimon.catalog.CatalogLockFactory;
+import org.apache.paimon.catalog.FileSystemCatalog;
+import org.apache.paimon.catalog.Identifier;
+import org.apache.paimon.data.GenericRow;
+import org.apache.paimon.data.Timestamp;
+import org.apache.paimon.fs.FileIO;
+import org.apache.paimon.fs.Path;
+import org.apache.paimon.fs.SeekableInputStream;
+import org.apache.paimon.fs.local.LocalFileIO;
+import org.apache.paimon.iceberg.metadata.IcebergMetadata;
+import org.apache.paimon.options.ExpireConfig;
+import org.apache.paimon.options.MemorySize;
+import org.apache.paimon.options.Options;
+import org.apache.paimon.schema.Schema;
+import org.apache.paimon.schema.SchemaChange;
+import org.apache.paimon.schema.SchemaManager;
+import org.apache.paimon.table.CatalogEnvironment;
+import org.apache.paimon.table.FileStoreTable;
+import org.apache.paimon.table.FileStoreTableFactory;
+import org.apache.paimon.table.sink.CommitMessage;
+import org.apache.paimon.table.sink.TableCommitImpl;
+import org.apache.paimon.table.sink.TableWriteImpl;
+import org.apache.paimon.types.DataType;
+import org.apache.paimon.types.DataTypes;
+import org.apache.paimon.types.RowType;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.iceberg.catalog.TableIdentifier;
+import org.apache.iceberg.data.IcebergGenerics;
+import org.apache.iceberg.data.Record;
+import org.apache.iceberg.hadoop.HadoopCatalog;
+import org.apache.iceberg.io.CloseableIterable;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.Callable;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/** Tests for ordered mirroring and catch-up in the Iceberg compatibility layer. */
+public class IcebergMirrorCatchUpTest {
+
+    @TempDir java.nio.file.Path tempDir;
+
+    @Test
+    public void testMirrorRebuildsMissingBaseInSnapshotOrder() throws Exception {
+        RowType rowType =
+                RowType.of(
+                        new DataType[] {DataTypes.INT(), DataTypes.INT()}, new String[] {"k", "v"});
+        FileStoreTable table = createPaimonTable(rowType);
+
+        String commitUser = UUID.randomUUID().toString();
+        TableWriteImpl<?> write = table.newWrite(commitUser);
+        TableCommitImpl commit = table.newCommit(commitUser);
+        write.write(GenericRow.of(1, 10));
+        write.write(GenericRow.of(2, 20));
+        commit.commit(1, write.prepareCommit(false, 1));
+        write.write(GenericRow.of(3, 30));
+        commit.commit(2, write.prepareCommit(false, 2));
+
+        IcebergPathFactory pathFactory =
+                new IcebergPathFactory(new Path(table.location(), "metadata"));
+        table.fileIO().deleteQuietly(pathFactory.toMetadataPath(2));
+
+        write.write(GenericRow.of(4, 40));
+        commit.commit(3, write.prepareCommit(false, 3));
+        write.close();
+        commit.close();
+
+        IcebergMetadata metadata =
+                IcebergMetadata.fromPath(table.fileIO(), pathFactory.toMetadataPath(3));
+        assertThat(metadata.currentSnapshotId()).isEqualTo(3L);
+        IcebergMetadata rebuiltBase =
+                IcebergMetadata.fromPath(table.fileIO(), pathFactory.toMetadataPath(2));
+        assertThat(rebuiltBase.currentSnapshotId()).isEqualTo(2L);
+        assertThat(getIcebergResult())
+                .containsExactlyInAnyOrder(
+                        "Record(1, 10)", "Record(2, 20)", "Record(3, 30)", "Record(4, 40)");
+    }
+
+    @Test
+    public void testRecommitAfterRollbackReplacesAbandonedTwin() throws Exception {
+        RowType rowType =
+                RowType.of(
+                        new DataType[] {DataTypes.INT(), DataTypes.INT()}, new String[] {"k", "v"});
+        FileStoreTable table = createPaimonTable(rowType);
+
+        String commitUser = UUID.randomUUID().toString();
+        TableWriteImpl<?> write = table.newWrite(commitUser);
+        TableCommitImpl commit = table.newCommit(commitUser);
+        write.write(GenericRow.of(1, 10));
+        write.write(GenericRow.of(2, 20));
+        commit.commit(1, write.prepareCommit(false, 1));
+        write.write(GenericRow.of(3, 30));
+        write.write(GenericRow.of(4, 40));
+        commit.commit(2, write.prepareCommit(false, 2));
+        write.write(GenericRow.of(5, 50));
+        write.write(GenericRow.of(6, 60));
+        commit.commit(3, write.prepareCommit(false, 3));
+        write.close();
+        commit.close();
+
+        table.rollbackTo(2);
+
+        TableWriteImpl<?> write2 = table.newWrite(commitUser);
+        TableCommitImpl commit2 = table.newCommit(commitUser);
+        write2.write(GenericRow.of(7, 70));
+        write2.write(GenericRow.of(8, 80));
+        commit2.commit(4, write2.prepareCommit(false, 4));
+        write2.close();
+        commit2.close();
+
+        IcebergPathFactory pathFactory =
+                new IcebergPathFactory(new Path(table.location(), "metadata"));
+        IcebergMetadata metadata =
+                IcebergMetadata.fromPath(table.fileIO(), pathFactory.toMetadataPath(3));
+        assertThat(metadata.currentSnapshot().summary().get("paimon-commit-identity"))
+                .isEqualTo(table.snapshotManager().snapshot(3).uuid());
+        assertThat(getIcebergResult())
+                .containsExactlyInAnyOrder(
+                        "Record(1, 10)",
+                        "Record(2, 20)",
+                        "Record(3, 30)",
+                        "Record(4, 40)",
+                        "Record(7, 70)",
+                        "Record(8, 80)");
+    }
+
+    @Test
+    public void testCatchUpAfterRollbackSkipsAbandonedMirrorBase() throws Exception {
+        RowType rowType =
+                RowType.of(
+                        new DataType[] {DataTypes.INT(), DataTypes.INT()}, new String[] {"k", "v"});
+        FileStoreTable table = createPaimonTable(rowType);
+
+        String commitUser = UUID.randomUUID().toString();
+        TableWriteImpl<?> write = table.newWrite(commitUser);
+        TableCommitImpl commit = table.newCommit(commitUser);
+        write.write(GenericRow.of(1, 10));
+        write.write(GenericRow.of(2, 20));
+        commit.commit(1, write.prepareCommit(false, 1));
+        write.write(GenericRow.of(3, 30));
+        commit.commit(2, write.prepareCommit(false, 2));
+        write.write(GenericRow.of(4, 40));
+        commit.commit(3, write.prepareCommit(false, 3));
+        write.close();
+        commit.close();
+
+        table.rollbackTo(2);
+
+        FileStoreTable disabled =
+                table.copy(
+                        Collections.singletonMap(
+                                IcebergOptions.METADATA_ICEBERG_STORAGE.key(), "disabled"));
+        TableWriteImpl<?> disabledWrite = disabled.newWrite(commitUser);
+        TableCommitImpl disabledCommit = disabled.newCommit(commitUser);
+        disabledWrite.write(GenericRow.of(5, 50));
+        disabledWrite.write(GenericRow.of(6, 60));
+        disabledCommit.commit(4, disabledWrite.prepareCommit(false, 4));
+        disabledWrite.write(GenericRow.of(7, 70));
+        disabledCommit.commit(5, disabledWrite.prepareCommit(false, 5));
+        disabledWrite.close();
+        disabledCommit.close();
+
+        TableWriteImpl<?> write2 = table.newWrite(commitUser);
+        TableCommitImpl commit2 = table.newCommit(commitUser);
+        write2.write(GenericRow.of(8, 80));
+        commit2.commit(6, write2.prepareCommit(false, 6));
+        write2.close();
+        commit2.close();
+
+        IcebergPathFactory pathFactory =
+                new IcebergPathFactory(new Path(table.location(), "metadata"));
+        IcebergMetadata metadata =
+                IcebergMetadata.fromPath(table.fileIO(), pathFactory.toMetadataPath(5));
+        assertThat(metadata.currentSnapshotId()).isEqualTo(5L);
+        assertThat(getIcebergResult())
+                .containsExactlyInAnyOrder(
+                        "Record(1, 10)",
+                        "Record(2, 20)",
+                        "Record(3, 30)",
+                        "Record(5, 50)",
+                        "Record(6, 60)",
+                        "Record(7, 70)",
+                        "Record(8, 80)");
+    }
+
+    @Test
+    public void testColdStartMintsMetadataUnderCatalogLock() throws Exception {
+        RowType rowType =
+                RowType.of(
+                        new DataType[] {DataTypes.INT(), DataTypes.INT()}, new String[] {"k", "v"});
+        FileStoreTable table = createPaimonTable(rowType);
+        Path coldStartMetadata =
+                new IcebergPathFactory(new Path(table.location(), "metadata")).toMetadataPath(1);
+        ProbingLockFactory.reset(table.fileIO(), coldStartMetadata);
+        FileStoreTable lockedTable =
+                FileStoreTableFactory.create(
+                        table.fileIO(),
+                        table.location(),
+                        table.schema(),
+                        new CatalogEnvironment(
+                                Identifier.create("mydb", "t"),
+                                null,
+                                null,
+                                new ProbingLockFactory(),
+                                null,
+                                null,
+                                false,
+                                false));
+
+        String commitUser = UUID.randomUUID().toString();
+        TableWriteImpl<?> write = lockedTable.newWrite(commitUser);
+        TableCommitImpl commit = lockedTable.newCommit(commitUser);
+        write.write(GenericRow.of(1, 10));
+        commit.commit(1, write.prepareCommit(false, 1));
+        write.close();
+        commit.close();
+
+        assertThat(table.fileIO().exists(coldStartMetadata)).isTrue();
+        assertThat(ProbingLockFactory.acquisitions.get()).isGreaterThan(0);
+        assertThat(ProbingLockFactory.metadataExistedAtLockEntry.get()).isFalse();
+        assertThat(ProbingLockFactory.closes.get()).isEqualTo(ProbingLockFactory.creations.get());
+    }
+
+    @Test
+    public void testTransientHintReadFailureFailsCommit() throws Exception {
+        RowType rowType =
+                RowType.of(
+                        new DataType[] {DataTypes.INT(), DataTypes.INT()}, new String[] {"k", "v"});
+        FileStoreTable table = createPaimonTable(rowType);
+
+        String commitUser = UUID.randomUUID().toString();
+        TableWriteImpl<?> write = table.newWrite(commitUser);
+        TableCommitImpl commit = table.newCommit(commitUser);
+        write.write(GenericRow.of(1, 10));
+        commit.commit(1, write.prepareCommit(false, 1));
+        write.close();
+        commit.close();
+
+        FileStoreTable failing =
+                FileStoreTableFactory.create(
+                        new FailingReadFileIO("version-hint.text"),
+                        table.location(),
+                        table.schema(),
+                        CatalogEnvironment.empty());
+        TableWriteImpl<?> write2 = failing.newWrite(commitUser);
+        TableCommitImpl commit2 = failing.newCommit(commitUser);
+        write2.write(GenericRow.of(2, 20));
+        assertThatThrownBy(() -> commit2.commit(2, write2.prepareCommit(false, 2)))
+                .hasStackTraceContaining("injected read failure");
+        write2.close();
+        commit2.close();
+    }
+
+    @Test
+    public void testTransientBaseReadFailureDoesNotRetireBase() throws Exception {
+        RowType rowType =
+                RowType.of(
+                        new DataType[] {DataTypes.INT(), DataTypes.INT()}, new String[] {"k", "v"});
+        FileStoreTable table =
+                createPaimonTable(
+                        rowType,
+                        Collections.singletonMap(
+                                IcebergOptions.METADATA_PREVIOUS_VERSIONS_MAX.key(), "3"));
+
+        String commitUser = UUID.randomUUID().toString();
+        TableWriteImpl<?> write = table.newWrite(commitUser);
+        TableCommitImpl commit = table.newCommit(commitUser);
+        write.write(GenericRow.of(1, 10));
+        commit.commit(1, write.prepareCommit(false, 1));
+        write.write(GenericRow.of(2, 20));
+        commit.commit(2, write.prepareCommit(false, 2));
+        write.close();
+        commit.close();
+
+        IcebergPathFactory pathFactory =
+                new IcebergPathFactory(new Path(table.location(), "metadata"));
+        String v2Before = table.fileIO().readFileUtf8(pathFactory.toMetadataPath(2));
+
+        FileStoreTable disabled =
+                table.copy(
+                        Collections.singletonMap(
+                                IcebergOptions.METADATA_ICEBERG_STORAGE.key(), "disabled"));
+        TableWriteImpl<?> disabledWrite = disabled.newWrite(commitUser);
+        TableCommitImpl disabledCommit = disabled.newCommit(commitUser);
+        disabledWrite.write(GenericRow.of(3, 30));
+        disabledCommit.commit(3, disabledWrite.prepareCommit(false, 3));
+        disabledWrite.close();
+        disabledCommit.close();
+
+        FileStoreTable failing =
+                FileStoreTableFactory.create(
+                        new FailingReadFileIO("v2.metadata.json"),
+                        table.location(),
+                        table.schema(),
+                        CatalogEnvironment.empty());
+        TableWriteImpl<?> write2 = failing.newWrite(commitUser);
+        TableCommitImpl commit2 = failing.newCommit(commitUser);
+        write2.write(GenericRow.of(4, 40));
+        assertThatThrownBy(() -> commit2.commit(4, write2.prepareCommit(false, 4)))
+                .hasStackTraceContaining("injected read failure");
+        write2.close();
+        commit2.close();
+
+        assertThat(table.fileIO().readFileUtf8(pathFactory.toMetadataPath(2))).isEqualTo(v2Before);
+
+        TableWriteImpl<?> write3 = table.newWrite(commitUser);
+        TableCommitImpl commit3 = table.newCommit(commitUser);
+        write3.write(GenericRow.of(5, 50));
+        commit3.commit(5, write3.prepareCommit(false, 5));
+        write3.close();
+        commit3.close();
+
+        long latest = table.snapshotManager().latestSnapshotId();
+        IcebergMetadata metadata =
+                IcebergMetadata.fromPath(table.fileIO(), pathFactory.toMetadataPath(latest));
+        assertThat(metadata.currentSnapshotId()).isEqualTo(latest);
+        assertThat(getIcebergResult())
+                .containsExactlyInAnyOrder(
+                        "Record(1, 10)", "Record(2, 20)", "Record(3, 30)", "Record(5, 50)");
+    }
+
+    @Test
+    public void testDroppedUnsupportedColumnDoesNotBlockCommits() throws Exception {
+        RowType rowType = RowType.of(new DataType[] {DataTypes.INT()}, new String[] {"k"});
+        FileStoreTable table =
+                createPaimonTable(
+                        rowType,
+                        Collections.singletonMap(CoreOptions.FILE_FORMAT.key(), "parquet"));
+        SchemaManager schemaManager = new SchemaManager(table.fileIO(), table.location());
+        schemaManager.commitChanges(
+                SchemaChange.setOption(IcebergOptions.METADATA_ICEBERG_STORAGE.key(), "disabled"));
+        schemaManager.commitChanges(SchemaChange.addColumn("ts", DataTypes.TIMESTAMP(9)));
+        FileStoreTable disabled = table.copy(schemaManager.latest().get());
+
+        String commitUser = UUID.randomUUID().toString();
+        TableWriteImpl<?> write = disabled.newWrite(commitUser);
+        TableCommitImpl commit = disabled.newCommit(commitUser);
+        write.write(GenericRow.of(1, Timestamp.fromEpochMillis(1000)));
+        commit.commit(1, write.prepareCommit(false, 1));
+        write.close();
+        commit.close();
+
+        schemaManager.commitChanges(SchemaChange.dropColumn("ts"));
+        schemaManager.commitChanges(
+                SchemaChange.setOption(
+                        IcebergOptions.METADATA_ICEBERG_STORAGE.key(), "table-location"));
+        FileStoreTable evolved = table.copy(schemaManager.latest().get());
+
+        TableWriteImpl<?> write2 = evolved.newWrite(commitUser);
+        TableCommitImpl commit2 = evolved.newCommit(commitUser);
+        write2.write(GenericRow.of(2));
+        commit2.commit(2, write2.prepareCommit(false, 2));
+        write2.close();
+        commit2.close();
+
+        IcebergPathFactory pathFactory =
+                new IcebergPathFactory(new Path(table.location(), "metadata"));
+        IcebergMetadata metadata =
+                IcebergMetadata.fromPath(table.fileIO(), pathFactory.toMetadataPath(2));
+        assertThat(metadata.currentSnapshotId()).isEqualTo(2L);
+        assertThat(metadata.schemas())
+                .isNotEmpty()
+                .allSatisfy(
+                        schema ->
+                                assertThat(schema.fields())
+                                        .noneMatch(
+                                                f ->
+                                                        String.valueOf(f.type())
+                                                                .contains("timestamp_ns")));
+        assertThat(
+                        metadata.schemas().stream()
+                                .filter(s -> s.schemaId() == metadata.currentSchemaId())
+                                .findFirst()
+                                .get()
+                                .fields())
+                .hasSize(1);
+    }
+
+    @Test
+    public void testDroppedPendingUnsupportedColumnDoesNotBlockMirroredTable() throws Exception {
+        RowType rowType =
+                RowType.of(
+                        new DataType[] {DataTypes.INT(), DataTypes.INT()}, new String[] {"k", "v"});
+        FileStoreTable table =
+                createPaimonTable(
+                        rowType,
+                        Collections.singletonMap(CoreOptions.FILE_FORMAT.key(), "parquet"));
+
+        String commitUser = UUID.randomUUID().toString();
+        TableWriteImpl<?> write = table.newWrite(commitUser);
+        TableCommitImpl commit = table.newCommit(commitUser);
+        write.write(GenericRow.of(1, 10));
+        commit.commit(1, write.prepareCommit(false, 1));
+        write.close();
+        commit.close();
+
+        SchemaManager schemaManager = new SchemaManager(table.fileIO(), table.location());
+        schemaManager.commitChanges(
+                SchemaChange.setOption(IcebergOptions.METADATA_ICEBERG_STORAGE.key(), "disabled"));
+        schemaManager.commitChanges(SchemaChange.addColumn("ts", DataTypes.TIMESTAMP(9)));
+        FileStoreTable withNanos =
+                table.copy(schemaManager.latest().get())
+                        .copy(
+                                Collections.singletonMap(
+                                        IcebergOptions.METADATA_ICEBERG_STORAGE.key(),
+                                        "table-location"));
+        TableWriteImpl<?> write2 = withNanos.newWrite(commitUser);
+        TableCommitImpl commit2 = withNanos.newCommit(commitUser);
+        write2.write(GenericRow.of(2, 20, Timestamp.fromEpochMillis(1000)));
+        assertThatThrownBy(() -> commit2.commit(2, write2.prepareCommit(false, 2)))
+                .hasStackTraceContaining("precision");
+        write2.close();
+        commit2.close();
+
+        schemaManager.commitChanges(SchemaChange.dropColumn("ts"));
+        schemaManager.commitChanges(
+                SchemaChange.setOption(
+                        IcebergOptions.METADATA_ICEBERG_STORAGE.key(), "table-location"));
+        FileStoreTable healed = table.copy(schemaManager.latest().get());
+        TableWriteImpl<?> write3 = healed.newWrite(commitUser);
+        TableCommitImpl commit3 = healed.newCommit(commitUser);
+        write3.write(GenericRow.of(3, 30));
+        commit3.commit(3, write3.prepareCommit(false, 3));
+        write3.close();
+        commit3.close();
+
+        IcebergPathFactory pathFactory =
+                new IcebergPathFactory(new Path(table.location(), "metadata"));
+        long latest = table.snapshotManager().latestSnapshotId();
+        IcebergMetadata metadata =
+                IcebergMetadata.fromPath(table.fileIO(), pathFactory.toMetadataPath(latest));
+        assertThat(metadata.currentSnapshotId()).isEqualTo(latest);
+        assertThat(metadata.schemas())
+                .isNotEmpty()
+                .allSatisfy(
+                        schema ->
+                                assertThat(schema.fields())
+                                        .noneMatch(
+                                                f ->
+                                                        String.valueOf(f.type())
+                                                                .contains("timestamp_ns")));
+    }
+
+    @Test
+    public void testDelayedRetryDoesNotPublishBehindHead() throws Exception {
+        RowType rowType =
+                RowType.of(
+                        new DataType[] {DataTypes.INT(), DataTypes.INT()}, new String[] {"k", "v"});
+        FileStoreTable table =
+                createPaimonTable(
+                        rowType,
+                        Collections.singletonMap(
+                                IcebergOptions.METADATA_PREVIOUS_VERSIONS_MAX.key(), "3"));
+
+        String commitUser = UUID.randomUUID().toString();
+        TableWriteImpl<?> write = table.newWrite(commitUser);
+        TableCommitImpl commit = table.newCommit(commitUser);
+        write.write(GenericRow.of(1, 10));
+        commit.commit(1, write.prepareCommit(false, 1));
+        write.write(GenericRow.of(2, 20));
+        List<CommitMessage> secondCommitMessages = write.prepareCommit(false, 2);
+        commit.commit(2, secondCommitMessages);
+        write.write(GenericRow.of(3, 30));
+        commit.commit(3, write.prepareCommit(false, 3));
+        write.close();
+        commit.close();
+
+        IcebergPathFactory pathFactory =
+                new IcebergPathFactory(new Path(table.location(), "metadata"));
+        Path hintPath = new Path(pathFactory.metadataDirectory(), "version-hint.text");
+        table.fileIO().deleteQuietly(pathFactory.toMetadataPath(2));
+        table.fileIO().deleteQuietly(hintPath);
+
+        TableCommitImpl commit2 = table.newCommit(commitUser);
+        commit2.filterAndCommit(Collections.singletonMap(2L, secondCommitMessages));
+        commit2.close();
+
+        assertThat(table.fileIO().exists(pathFactory.toMetadataPath(2))).isTrue();
+        assertThat(table.fileIO().exists(hintPath)).isFalse();
+    }
+
+    @Test
+    public void testExpiryToleratesAlreadyExpiredLists() throws Exception {
+        RowType rowType =
+                RowType.of(
+                        new DataType[] {DataTypes.INT(), DataTypes.INT()}, new String[] {"k", "v"});
+        FileStoreTable table = createPaimonTable(rowType);
+
+        String commitUser = UUID.randomUUID().toString();
+        TableWriteImpl<?> write = table.newWrite(commitUser);
+        TableCommitImpl commit = table.newCommit(commitUser);
+        write.write(GenericRow.of(1, 10));
+        commit.commit(1, write.prepareCommit(false, 1));
+        write.write(GenericRow.of(2, 20));
+        commit.commit(2, write.prepareCommit(false, 2));
+        write.close();
+        commit.close();
+
+        IcebergPathFactory pathFactory =
+                new IcebergPathFactory(new Path(table.location(), "metadata"));
+        IcebergMetadata v1 =
+                IcebergMetadata.fromPath(table.fileIO(), pathFactory.toMetadataPath(1));
+        IcebergMetadata v2 =
+                IcebergMetadata.fromPath(table.fileIO(), pathFactory.toMetadataPath(2));
+        String firstList = new Path(v1.currentSnapshot().manifestList()).getName();
+        String secondList = new Path(v2.currentSnapshot().manifestList()).getName();
+        table.fileIO().deleteQuietly(new Path(pathFactory.metadataDirectory(), firstList));
+
+        IcebergCommitCallback callback = new IcebergCommitCallback(table, commitUser);
+        assertThatCode(() -> callback.expireManifestList(firstList, secondList))
+                .doesNotThrowAnyException();
+        assertThatCode(() -> callback.expireManifestList(secondList, "snap-0-missing.avro"))
+                .doesNotThrowAnyException();
+        assertThat(table.fileIO().exists(new Path(pathFactory.metadataDirectory(), secondList)))
+                .isTrue();
+        assertThat(getIcebergResult()).containsExactlyInAnyOrder("Record(1, 10)", "Record(2, 20)");
+    }
+
+    @Test
+    public void testTransientSchemaReadFailureFailsCommitInsteadOfDroppingSchema()
+            throws Exception {
+        RowType rowType =
+                RowType.of(
+                        new DataType[] {DataTypes.INT(), DataTypes.INT()}, new String[] {"k", "v"});
+        FileStoreTable table = createPaimonTable(rowType);
+
+        String commitUser = UUID.randomUUID().toString();
+        TableWriteImpl<?> write = table.newWrite(commitUser);
+        TableCommitImpl commit = table.newCommit(commitUser);
+        write.write(GenericRow.of(1, 10));
+        commit.commit(1, write.prepareCommit(false, 1));
+        write.close();
+        commit.close();
+
+        SchemaManager schemaManager = new SchemaManager(table.fileIO(), table.location());
+        schemaManager.commitChanges(SchemaChange.addColumn("w", DataTypes.INT()));
+        schemaManager.commitChanges(SchemaChange.addColumn("x", DataTypes.INT()));
+        FileStoreTable evolved = table.copy(schemaManager.latest().get());
+
+        TableWriteImpl<?> write2 = evolved.newWrite(commitUser);
+        List<CommitMessage> messages;
+        write2.write(GenericRow.of(2, 20, 21, 22));
+        messages = write2.prepareCommit(false, 2);
+        write2.close();
+
+        FileStoreTable failing =
+                FileStoreTableFactory.create(
+                        new FailingReadFileIO("schema-1"),
+                        table.location(),
+                        schemaManager.latest().get(),
+                        CatalogEnvironment.empty());
+        TableCommitImpl commit2 = failing.newCommit(commitUser);
+        assertThatThrownBy(() -> commit2.commit(2, messages))
+                .hasStackTraceContaining("injected read failure");
+        commit2.close();
+    }
+
+    @Test
+    public void testExpiryKeepsListOnTransientReadFailure() throws Exception {
+        RowType rowType =
+                RowType.of(
+                        new DataType[] {DataTypes.INT(), DataTypes.INT()}, new String[] {"k", "v"});
+        FileStoreTable table = createPaimonTable(rowType);
+
+        String commitUser = UUID.randomUUID().toString();
+        TableWriteImpl<?> write = table.newWrite(commitUser);
+        TableCommitImpl commit = table.newCommit(commitUser);
+        write.write(GenericRow.of(1, 10));
+        commit.commit(1, write.prepareCommit(false, 1));
+        write.write(GenericRow.of(2, 20));
+        commit.commit(2, write.prepareCommit(false, 2));
+        write.close();
+        commit.close();
+
+        IcebergPathFactory pathFactory =
+                new IcebergPathFactory(new Path(table.location(), "metadata"));
+        IcebergMetadata v1 =
+                IcebergMetadata.fromPath(table.fileIO(), pathFactory.toMetadataPath(1));
+        IcebergMetadata v2 =
+                IcebergMetadata.fromPath(table.fileIO(), pathFactory.toMetadataPath(2));
+        String firstList = new Path(v1.currentSnapshot().manifestList()).getName();
+        String secondList = new Path(v2.currentSnapshot().manifestList()).getName();
+
+        FileStoreTable failing =
+                FileStoreTableFactory.create(
+                        new FailingReadFileIO(firstList),
+                        table.location(),
+                        table.schema(),
+                        CatalogEnvironment.empty());
+        IcebergCommitCallback callback = new IcebergCommitCallback(failing, commitUser);
+        assertThatCode(() -> callback.expireManifestList(firstList, secondList))
+                .doesNotThrowAnyException();
+        assertThat(table.fileIO().exists(new Path(pathFactory.metadataDirectory(), firstList)))
+                .isTrue();
+    }
+
+    @Test
+    public void testReenableAfterRollbackAndExpiryRebuildsInsteadOfTrustingAbandonedBase()
+            throws Exception {
+        RowType rowType =
+                RowType.of(
+                        new DataType[] {DataTypes.INT(), DataTypes.INT()}, new String[] {"k", "v"});
+        FileStoreTable table = createPaimonTable(rowType);
+
+        String commitUser = UUID.randomUUID().toString();
+        TableWriteImpl<?> write = table.newWrite(commitUser);
+        TableCommitImpl commit = table.newCommit(commitUser);
+        write.write(GenericRow.of(1, 10));
+        commit.commit(1, write.prepareCommit(false, 1));
+        write.write(GenericRow.of(2, 20));
+        commit.commit(2, write.prepareCommit(false, 2));
+        write.write(GenericRow.of(3, 30));
+        commit.commit(3, write.prepareCommit(false, 3));
+        write.close();
+        commit.close();
+
+        FileStoreTable disabled =
+                table.copy(
+                        Collections.singletonMap(
+                                IcebergOptions.METADATA_ICEBERG_STORAGE.key(), "disabled"));
+        disabled.rollbackTo(2);
+        TableWriteImpl<?> disabledWrite = disabled.newWrite(commitUser);
+        TableCommitImpl disabledCommit = disabled.newCommit(commitUser);
+        disabledWrite.write(GenericRow.of(4, 40));
+        disabledCommit.commit(4, disabledWrite.prepareCommit(false, 4));
+        disabledWrite.write(GenericRow.of(5, 50));
+        disabledCommit.commit(5, disabledWrite.prepareCommit(false, 5));
+        disabledWrite.close();
+        disabledCommit.close();
+
+        disabled.newExpireSnapshots()
+                .config(ExpireConfig.builder().snapshotRetainMax(1).snapshotRetainMin(1).build())
+                .expire();
+        assertThat(table.snapshotManager().snapshotExists(3)).isFalse();
+
+        TableWriteImpl<?> write2 = table.newWrite(commitUser);
+        TableCommitImpl commit2 = table.newCommit(commitUser);
+        write2.write(GenericRow.of(6, 60));
+        commit2.commit(6, write2.prepareCommit(false, 6));
+        write2.close();
+        commit2.close();
+
+        IcebergPathFactory pathFactory =
+                new IcebergPathFactory(new Path(table.location(), "metadata"));
+        IcebergMetadata metadata =
+                IcebergMetadata.fromPath(table.fileIO(), pathFactory.toMetadataPath(5));
+        assertThat(metadata.currentSnapshotId()).isEqualTo(5L);
+        assertThat(getIcebergResult())
+                .containsExactlyInAnyOrder(
+                        "Record(1, 10)",
+                        "Record(2, 20)",
+                        "Record(4, 40)",
+                        "Record(5, 50)",
+                        "Record(6, 60)");
+    }
+
+    private FileStoreTable createPaimonTable(RowType rowType) throws Exception {
+        return createPaimonTable(rowType, Collections.emptyMap());
+    }
+
+    private FileStoreTable createPaimonTable(RowType rowType, Map<String, String> customOptions)
+            throws Exception {
+        LocalFileIO fileIO = LocalFileIO.create();
+        Path path = new Path(tempDir.toString());
+
+        Options options = new Options(customOptions);
+        options.set(CoreOptions.BUCKET, -1);
+        options.set(
+                IcebergOptions.METADATA_ICEBERG_STORAGE, IcebergOptions.StorageType.TABLE_LOCATION);
+        if (!customOptions.containsKey(CoreOptions.FILE_FORMAT.key())) {
+            options.set(CoreOptions.FILE_FORMAT, "avro");
+        }
+        options.set(CoreOptions.TARGET_FILE_SIZE, MemorySize.ofKibiBytes(32));
+        options.set(IcebergOptions.COMPACT_MIN_FILE_NUM, 8);
+        options.set(IcebergOptions.METADATA_DELETE_AFTER_COMMIT, true);
+        if (!customOptions.containsKey(IcebergOptions.METADATA_PREVIOUS_VERSIONS_MAX.key())) {
+            options.set(IcebergOptions.METADATA_PREVIOUS_VERSIONS_MAX, 1);
+        }
+        options.set(CoreOptions.MANIFEST_TARGET_FILE_SIZE, MemorySize.ofKibiBytes(8));
+        Schema schema =
+                new Schema(
+                        rowType.getFields(),
+                        Collections.emptyList(),
+                        Collections.emptyList(),
+                        options.toMap(),
+                        "");
+
+        try (FileSystemCatalog paimonCatalog = new FileSystemCatalog(fileIO, path)) {
+            paimonCatalog.createDatabase("mydb", false);
+            Identifier paimonIdentifier = Identifier.create("mydb", "t");
+            paimonCatalog.createTable(paimonIdentifier, schema, false);
+            return (FileStoreTable) paimonCatalog.getTable(paimonIdentifier);
+        }
+    }
+
+    private List<String> getIcebergResult() throws Exception {
+        HadoopCatalog icebergCatalog = new HadoopCatalog(new Configuration(), tempDir.toString());
+        TableIdentifier icebergIdentifier = TableIdentifier.of("mydb.db", "t");
+        org.apache.iceberg.Table icebergTable = icebergCatalog.loadTable(icebergIdentifier);
+        CloseableIterable<Record> result = IcebergGenerics.read(icebergTable).build();
+        List<String> actual = new ArrayList<>();
+        for (Record record : result) {
+            actual.add(record.toString());
+        }
+        result.close();
+        return actual;
+    }
+
+    private static class FailingReadFileIO extends LocalFileIO {
+
+        private final String failingName;
+
+        private FailingReadFileIO(String failingName) {
+            this.failingName = failingName;
+        }
+
+        @Override
+        public SeekableInputStream newInputStream(Path path) throws IOException {
+            if (path.getName().equals(failingName)) {
+                throw new IOException("injected read failure for " + failingName);
+            }
+            return super.newInputStream(path);
+        }
+    }
+
+    private static class ProbingLockFactory implements CatalogLockFactory {
+
+        private static final AtomicInteger acquisitions = new AtomicInteger();
+        private static final AtomicInteger creations = new AtomicInteger();
+        private static final AtomicInteger closes = new AtomicInteger();
+        private static final AtomicBoolean metadataExistedAtLockEntry = new AtomicBoolean();
+        private static FileIO probeFileIO;
+        private static Path probePath;
+
+        private static void reset(FileIO fileIO, Path path) {
+            acquisitions.set(0);
+            creations.set(0);
+            closes.set(0);
+            metadataExistedAtLockEntry.set(false);
+            probeFileIO = fileIO;
+            probePath = path;
+        }
+
+        @Override
+        public CatalogLock createLock(CatalogLockContext context) {
+            creations.incrementAndGet();
+            return new CatalogLock() {
+                @Override
+                public <T> T runWithLock(String database, String tableName, Callable<T> callable)
+                        throws Exception {
+                    acquisitions.incrementAndGet();
+                    if (probeFileIO.exists(probePath)) {
+                        metadataExistedAtLockEntry.set(true);
+                    }
+                    return callable.call();
+                }
+
+                @Override
+                public void close() {
+                    closes.incrementAndGet();
+                }
+            };
+        }
+
+        @Override
+        public String identifier() {
+            return "probing";
+        }
+    }
+}

--- a/paimon-core/src/test/java/org/apache/paimon/iceberg/IcebergMirrorReplayTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/iceberg/IcebergMirrorReplayTest.java
@@ -1,0 +1,339 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.iceberg;
+
+import org.apache.paimon.CoreOptions;
+import org.apache.paimon.catalog.FileSystemCatalog;
+import org.apache.paimon.catalog.Identifier;
+import org.apache.paimon.data.BinaryRow;
+import org.apache.paimon.data.GenericRow;
+import org.apache.paimon.disk.IOManagerImpl;
+import org.apache.paimon.fs.Path;
+import org.apache.paimon.fs.local.LocalFileIO;
+import org.apache.paimon.iceberg.manifest.IcebergManifestFileMeta;
+import org.apache.paimon.iceberg.manifest.IcebergManifestList;
+import org.apache.paimon.iceberg.metadata.IcebergMetadata;
+import org.apache.paimon.options.MemorySize;
+import org.apache.paimon.options.Options;
+import org.apache.paimon.schema.Schema;
+import org.apache.paimon.schema.SchemaChange;
+import org.apache.paimon.schema.SchemaManager;
+import org.apache.paimon.table.FileStoreTable;
+import org.apache.paimon.table.sink.TableCommitImpl;
+import org.apache.paimon.table.sink.TableWriteImpl;
+import org.apache.paimon.types.DataType;
+import org.apache.paimon.types.DataTypes;
+import org.apache.paimon.types.RowKind;
+import org.apache.paimon.types.RowType;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.iceberg.catalog.TableIdentifier;
+import org.apache.iceberg.data.IcebergGenerics;
+import org.apache.iceberg.data.Record;
+import org.apache.iceberg.hadoop.HadoopCatalog;
+import org.apache.iceberg.io.CloseableIterable;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.function.Function;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Tests for replaying the Iceberg metadata a mirror gap left behind. */
+public class IcebergMirrorReplayTest {
+
+    @TempDir java.nio.file.Path tempDir;
+
+    @Test
+    public void testMirrorWalksPastBaseWithExpiredManifestList() throws Exception {
+        RowType rowType =
+                RowType.of(
+                        new DataType[] {DataTypes.INT(), DataTypes.INT()}, new String[] {"k", "v"});
+        Map<String, String> options = new HashMap<>();
+        options.put(IcebergOptions.METADATA_PREVIOUS_VERSIONS_MAX.key(), "10");
+        FileStoreTable table =
+                createPaimonTable(
+                        rowType, Collections.emptyList(), Collections.emptyList(), -1, options);
+
+        String commitUser = UUID.randomUUID().toString();
+        TableWriteImpl<?> write = table.newWrite(commitUser);
+        TableCommitImpl commit = table.newCommit(commitUser);
+        write.write(GenericRow.of(1, 10));
+        commit.commit(1, write.prepareCommit(false, 1));
+        write.write(GenericRow.of(2, 20));
+        commit.commit(2, write.prepareCommit(false, 2));
+        write.write(GenericRow.of(3, 30));
+        commit.commit(3, write.prepareCommit(false, 3));
+
+        IcebergPathFactory pathFactory =
+                new IcebergPathFactory(new Path(table.location(), "metadata"));
+
+        IcebergMetadata v2 =
+                IcebergMetadata.fromPath(table.fileIO(), pathFactory.toMetadataPath(2));
+        table.fileIO().deleteQuietly(new Path(v2.currentSnapshot().manifestList()));
+        table.fileIO().deleteQuietly(pathFactory.toMetadataPath(3));
+
+        write.write(GenericRow.of(4, 40));
+        commit.commit(4, write.prepareCommit(false, 4));
+        write.close();
+        commit.close();
+
+        IcebergMetadata rebuilt =
+                IcebergMetadata.fromPath(table.fileIO(), pathFactory.toMetadataPath(4));
+        assertThat(rebuilt.currentSnapshotId()).isEqualTo(4L);
+        assertThat(getIcebergResult())
+                .containsExactlyInAnyOrder(
+                        "Record(1, 10)", "Record(2, 20)", "Record(3, 30)", "Record(4, 40)");
+    }
+
+    @Test
+    public void testReplayedSnapshotKeepsCommitTime() throws Exception {
+        RowType rowType =
+                RowType.of(
+                        new DataType[] {DataTypes.INT(), DataTypes.INT()}, new String[] {"k", "v"});
+        FileStoreTable table =
+                createPaimonTable(
+                        rowType,
+                        Collections.emptyList(),
+                        Collections.emptyList(),
+                        -1,
+                        Collections.singletonMap(IcebergOptions.FORMAT_VERSION.key(), "3"));
+
+        String commitUser = UUID.randomUUID().toString();
+        TableWriteImpl<?> write = table.newWrite(commitUser);
+        TableCommitImpl commit = table.newCommit(commitUser);
+        write.write(GenericRow.of(1, 10));
+        commit.commit(1, write.prepareCommit(false, 1));
+        write.write(GenericRow.of(2, 20));
+        commit.commit(2, write.prepareCommit(false, 2));
+
+        long paimonSnapshot2Time = table.snapshotManager().snapshot(2).timeMillis();
+
+        IcebergPathFactory pathFactory =
+                new IcebergPathFactory(new Path(table.location(), "metadata"));
+        table.fileIO().deleteQuietly(pathFactory.toMetadataPath(2));
+
+        write.write(GenericRow.of(3, 30));
+        commit.commit(3, write.prepareCommit(false, 3));
+        write.close();
+        commit.close();
+
+        IcebergMetadata rebuiltV2 =
+                IcebergMetadata.fromPath(table.fileIO(), pathFactory.toMetadataPath(2));
+        assertThat(rebuiltV2.currentSnapshot().timestampMs()).isEqualTo(paimonSnapshot2Time);
+    }
+
+    @Test
+    public void testReplayedSnapshotWithoutDeletionVectorsDropsDeleteManifests() throws Exception {
+        RowType rowType =
+                RowType.of(
+                        new DataType[] {DataTypes.INT(), DataTypes.INT()}, new String[] {"k", "v"});
+        Map<String, String> customOptions = new HashMap<>();
+        customOptions.put(IcebergOptions.FORMAT_VERSION.key(), "3");
+        customOptions.put(CoreOptions.DELETION_VECTORS_ENABLED.key(), "true");
+        customOptions.put(CoreOptions.DELETION_VECTOR_BITMAP64.key(), "true");
+        customOptions.put(CoreOptions.SNAPSHOT_NUM_RETAINED_MIN.key(), "100");
+        customOptions.put(CoreOptions.SNAPSHOT_NUM_RETAINED_MAX.key(), "100");
+        FileStoreTable table =
+                createPaimonTable(
+                        rowType,
+                        Collections.emptyList(),
+                        Collections.singletonList("k"),
+                        1,
+                        customOptions);
+
+        String commitUser = UUID.randomUUID().toString();
+        TableWriteImpl<?> write =
+                table.newWrite(commitUser)
+                        .withIOManager(new IOManagerImpl(tempDir.toString() + "/tmp"));
+        TableCommitImpl commit = table.newCommit(commitUser);
+
+        write.write(GenericRow.of(1, 10));
+        write.write(GenericRow.of(2, 20));
+        commit.commit(1, write.prepareCommit(false, 1));
+        table.createTag("predelete", 1);
+        write.write(GenericRow.ofKind(RowKind.DELETE, 2, 20));
+        commit.commit(2, write.prepareCommit(false, 2));
+        write.compact(BinaryRow.EMPTY_ROW, 0, false);
+        commit.commit(3, write.prepareCommit(true, 3));
+        long dvSnapshotId = table.snapshotManager().latestSnapshotId();
+        write.close();
+        commit.close();
+
+        TableCommitImpl rollbackCommit = table.newCommit(commitUser);
+        rollbackCommit.rollbackToAsLatest(table.tagManager().getOrThrow("predelete"));
+        rollbackCommit.close();
+        long rolledBackSnapshotId = table.snapshotManager().latestSnapshotId();
+
+        IcebergPathFactory pathFactory =
+                new IcebergPathFactory(new Path(table.location(), "metadata"));
+        assertThat(countDeleteManifests(table, pathFactory, dvSnapshotId)).isGreaterThan(0L);
+        assertThat(countDeleteManifests(table, pathFactory, rolledBackSnapshotId)).isEqualTo(0L);
+
+        table.fileIO().deleteQuietly(pathFactory.toMetadataPath(rolledBackSnapshotId));
+
+        TableWriteImpl<?> write2 =
+                table.newWrite(commitUser)
+                        .withIOManager(new IOManagerImpl(tempDir.toString() + "/tmp"));
+        TableCommitImpl commit2 = table.newCommit(commitUser);
+        write2.write(GenericRow.of(3, 30));
+        commit2.commit(4, write2.prepareCommit(false, 4));
+        write2.close();
+        commit2.close();
+
+        assertThat(countDeleteManifests(table, pathFactory, rolledBackSnapshotId)).isEqualTo(0L);
+    }
+
+    @Test
+    public void testReplayedSnapshotKeepsHistoricalSchema() throws Exception {
+        RowType rowType =
+                RowType.of(
+                        new DataType[] {DataTypes.INT(), DataTypes.INT()}, new String[] {"k", "v"});
+        FileStoreTable table =
+                createPaimonTable(
+                        rowType,
+                        Collections.emptyList(),
+                        Collections.emptyList(),
+                        -1,
+                        Collections.singletonMap(IcebergOptions.FORMAT_VERSION.key(), "3"));
+
+        String commitUser = UUID.randomUUID().toString();
+        TableWriteImpl<?> write = table.newWrite(commitUser);
+        TableCommitImpl commit = table.newCommit(commitUser);
+        write.write(GenericRow.of(1, 10));
+        commit.commit(1, write.prepareCommit(false, 1));
+        write.close();
+        commit.close();
+
+        SchemaManager schemaManager = new SchemaManager(table.fileIO(), table.location());
+        schemaManager.commitChanges(SchemaChange.addColumn("w", DataTypes.INT()));
+        table = table.copyWithLatestSchema();
+        write = table.newWrite(commitUser);
+        commit = table.newCommit(commitUser);
+        write.write(GenericRow.of(2, 20, 200));
+        commit.commit(2, write.prepareCommit(false, 2));
+        write.close();
+        commit.close();
+        long schema2 = table.snapshotManager().snapshot(2).schemaId();
+
+        IcebergPathFactory pathFactory =
+                new IcebergPathFactory(new Path(table.location(), "metadata"));
+        table.fileIO().deleteQuietly(pathFactory.toMetadataPath(2));
+
+        schemaManager.commitChanges(SchemaChange.addColumn("x", DataTypes.INT()));
+        table = table.copyWithLatestSchema();
+        write = table.newWrite(commitUser);
+        commit = table.newCommit(commitUser);
+        write.write(GenericRow.of(3, 30, 300, 3000));
+        commit.commit(3, write.prepareCommit(false, 3));
+        write.close();
+        commit.close();
+
+        IcebergMetadata rebuiltV2 =
+                IcebergMetadata.fromPath(table.fileIO(), pathFactory.toMetadataPath(2));
+        assertThat(rebuiltV2.currentSnapshot().schemaId()).isEqualTo((int) schema2);
+    }
+
+    private FileStoreTable createPaimonTable(
+            RowType rowType, List<String> partitionKeys, List<String> primaryKeys, int numBuckets)
+            throws Exception {
+        return createPaimonTable(rowType, partitionKeys, primaryKeys, numBuckets, new HashMap<>());
+    }
+
+    private FileStoreTable createPaimonTable(
+            RowType rowType,
+            List<String> partitionKeys,
+            List<String> primaryKeys,
+            int numBuckets,
+            Map<String, String> customOptions)
+            throws Exception {
+        LocalFileIO fileIO = LocalFileIO.create();
+        Path path = new Path(tempDir.toString());
+
+        Options options = new Options(customOptions);
+        options.set(CoreOptions.BUCKET, numBuckets);
+        options.set(
+                IcebergOptions.METADATA_ICEBERG_STORAGE, IcebergOptions.StorageType.TABLE_LOCATION);
+        if (!customOptions.containsKey(CoreOptions.FILE_FORMAT.key())) {
+            options.set(CoreOptions.FILE_FORMAT, "avro");
+        }
+        options.set(CoreOptions.TARGET_FILE_SIZE, MemorySize.ofKibiBytes(32));
+        if (!customOptions.containsKey(IcebergOptions.COMPACT_MIN_FILE_NUM.key())) {
+            options.set(IcebergOptions.COMPACT_MIN_FILE_NUM, 8);
+        }
+        options.set(IcebergOptions.METADATA_DELETE_AFTER_COMMIT, true);
+        if (!customOptions.containsKey(IcebergOptions.METADATA_PREVIOUS_VERSIONS_MAX.key())) {
+            options.set(IcebergOptions.METADATA_PREVIOUS_VERSIONS_MAX, 1);
+        }
+        options.set(CoreOptions.MANIFEST_TARGET_FILE_SIZE, MemorySize.ofKibiBytes(8));
+        Schema schema =
+                new Schema(rowType.getFields(), partitionKeys, primaryKeys, options.toMap(), "");
+
+        try (FileSystemCatalog paimonCatalog = new FileSystemCatalog(fileIO, path)) {
+            paimonCatalog.createDatabase("mydb", false);
+            Identifier paimonIdentifier = Identifier.create("mydb", "t");
+            paimonCatalog.createTable(paimonIdentifier, schema, false);
+            return (FileStoreTable) paimonCatalog.getTable(paimonIdentifier);
+        }
+    }
+
+    private org.apache.iceberg.Table getIcebergTable() {
+        HadoopCatalog icebergCatalog = new HadoopCatalog(new Configuration(), tempDir.toString());
+        TableIdentifier icebergIdentifier = TableIdentifier.of("mydb.db", "t");
+        return icebergCatalog.loadTable(icebergIdentifier);
+    }
+
+    private List<String> getIcebergResult() throws Exception {
+        return getIcebergResult(
+                icebergTable -> IcebergGenerics.read(icebergTable).build(), Record::toString);
+    }
+
+    private List<String> getIcebergResult(
+            Function<org.apache.iceberg.Table, CloseableIterable<Record>> query,
+            Function<Record, String> icebergRecordToString)
+            throws Exception {
+        org.apache.iceberg.Table icebergTable = getIcebergTable();
+        CloseableIterable<Record> result = query.apply(icebergTable);
+        List<String> actual = new ArrayList<>();
+        for (Record record : result) {
+            actual.add(icebergRecordToString.apply(record));
+        }
+        result.close();
+        return actual;
+    }
+
+    private static long countDeleteManifests(
+            FileStoreTable table, IcebergPathFactory pathFactory, long snapshotId)
+            throws IOException {
+        IcebergMetadata metadata =
+                IcebergMetadata.fromPath(table.fileIO(), pathFactory.toMetadataPath(snapshotId));
+        IcebergManifestList manifestList = IcebergManifestList.create(table, pathFactory);
+        return manifestList.read(new Path(metadata.currentSnapshot().manifestList()).getName())
+                .stream()
+                .filter(m -> m.content() == IcebergManifestFileMeta.Content.DELETES)
+                .count();
+    }
+}

--- a/paimon-core/src/test/java/org/apache/paimon/iceberg/IcebergSchemaGatingTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/iceberg/IcebergSchemaGatingTest.java
@@ -1,0 +1,794 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.iceberg;
+
+import org.apache.paimon.CoreOptions;
+import org.apache.paimon.catalog.FileSystemCatalog;
+import org.apache.paimon.catalog.Identifier;
+import org.apache.paimon.data.GenericRow;
+import org.apache.paimon.fs.Path;
+import org.apache.paimon.fs.local.LocalFileIO;
+import org.apache.paimon.options.MemorySize;
+import org.apache.paimon.options.Options;
+import org.apache.paimon.schema.Schema;
+import org.apache.paimon.schema.SchemaChange;
+import org.apache.paimon.schema.SchemaManager;
+import org.apache.paimon.schema.TableSchema;
+import org.apache.paimon.table.FileStoreTable;
+import org.apache.paimon.table.sink.TableCommitImpl;
+import org.apache.paimon.table.sink.TableWriteImpl;
+import org.apache.paimon.types.DataField;
+import org.apache.paimon.types.DataType;
+import org.apache.paimon.types.DataTypes;
+import org.apache.paimon.types.RowType;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.iceberg.catalog.TableIdentifier;
+import org.apache.iceberg.data.IcebergGenerics;
+import org.apache.iceberg.data.Record;
+import org.apache.iceberg.hadoop.HadoopCatalog;
+import org.apache.iceberg.io.CloseableIterable;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/** Tests for refusing schemas the Iceberg mirror cannot represent. */
+public class IcebergSchemaGatingTest {
+
+    @TempDir java.nio.file.Path tempDir;
+
+    @Test
+    public void testCreateTableWithUnsupportedSchemaIsRejected() throws Exception {
+        RowType rowType =
+                RowType.of(
+                        new DataType[] {DataTypes.INT(), DataTypes.TIMESTAMP(9)},
+                        new String[] {"k", "ts"});
+        Map<String, String> options = new HashMap<>();
+        options.put(CoreOptions.FILE_FORMAT.key(), "parquet");
+        assertThatThrownBy(
+                        () ->
+                                createPaimonTable(
+                                        rowType,
+                                        Collections.emptyList(),
+                                        Collections.emptyList(),
+                                        -1,
+                                        options))
+                .hasStackTraceContaining("precision");
+    }
+
+    @Test
+    public void testVariantColumnRejectedOnCreate() throws Exception {
+        RowType rowType =
+                RowType.of(
+                        new DataType[] {DataTypes.INT(), DataTypes.VARIANT()},
+                        new String[] {"k", "payload"});
+        Map<String, String> options = new HashMap<>();
+        options.put(CoreOptions.FILE_FORMAT.key(), "parquet");
+        options.put(IcebergOptions.FORMAT_VERSION.key(), "3");
+        assertThatThrownBy(
+                        () ->
+                                createPaimonTable(
+                                        rowType,
+                                        Collections.emptyList(),
+                                        Collections.emptyList(),
+                                        -1,
+                                        options))
+                .hasStackTraceContaining("payload: VARIANT");
+    }
+
+    @Test
+    public void testReplacementWithGeospatialBelowV3KeepsData() throws Exception {
+        RowType rowType =
+                RowType.of(
+                        new DataType[] {DataTypes.INT(), DataTypes.INT()}, new String[] {"k", "v"});
+        FileStoreTable table =
+                createPaimonTable(
+                        rowType,
+                        Collections.emptyList(),
+                        Collections.singletonList("k"),
+                        1,
+                        Collections.singletonMap(CoreOptions.FILE_FORMAT.key(), "parquet"));
+
+        String commitUser = UUID.randomUUID().toString();
+        TableWriteImpl<?> write = table.newWrite(commitUser);
+        TableCommitImpl commit = table.newCommit(commitUser);
+        write.write(GenericRow.of(1, 10));
+        commit.commit(1, write.prepareCommit(false, 1));
+        write.close();
+        commit.close();
+
+        Map<String, String> options = new HashMap<>(table.options());
+        options.remove(CoreOptions.PATH.key());
+        Schema replacement =
+                new Schema(
+                        RowType.of(
+                                        new DataType[] {DataTypes.INT(), DataTypes.GEOMETRY()},
+                                        new String[] {"k", "geom"})
+                                .getFields(),
+                        Collections.emptyList(),
+                        Collections.singletonList("k"),
+                        options,
+                        "");
+
+        try (FileSystemCatalog catalog =
+                new FileSystemCatalog(table.fileIO(), new Path(tempDir.toString()))) {
+            Identifier identifier = Identifier.create("mydb", "t");
+            assertThatThrownBy(() -> catalog.replaceTable(identifier, replacement, false))
+                    .hasStackTraceContaining("format-version");
+        }
+
+        assertThat(table.snapshotManager().latestSnapshotId()).isEqualTo(1L);
+    }
+
+    @Test
+    public void testReplaceTableWithUnsupportedSchemaKeepsData() throws Exception {
+        RowType rowType =
+                RowType.of(
+                        new DataType[] {DataTypes.INT(), DataTypes.INT()}, new String[] {"k", "v"});
+        FileStoreTable table =
+                createPaimonTable(
+                        rowType, Collections.emptyList(), Collections.singletonList("k"), 1);
+
+        String commitUser = UUID.randomUUID().toString();
+        TableWriteImpl<?> write = table.newWrite(commitUser);
+        TableCommitImpl commit = table.newCommit(commitUser);
+        write.write(GenericRow.of(1, 10));
+        commit.commit(1, write.prepareCommit(false, 1));
+        write.close();
+        commit.close();
+
+        Map<String, String> options = new HashMap<>(table.options());
+        options.remove(CoreOptions.PATH.key());
+        Schema replacement =
+                new Schema(
+                        RowType.of(
+                                        new DataType[] {DataTypes.INT(), DataTypes.VARIANT()},
+                                        new String[] {"k", "payload"})
+                                .getFields(),
+                        Collections.emptyList(),
+                        Collections.singletonList("k"),
+                        options,
+                        "");
+
+        try (FileSystemCatalog catalog =
+                new FileSystemCatalog(table.fileIO(), new Path(tempDir.toString()))) {
+            Identifier identifier = Identifier.create("mydb", "t");
+            assertThatThrownBy(() -> catalog.replaceTable(identifier, replacement, false))
+                    .hasStackTraceContaining("not supported by Iceberg compatibility");
+        }
+
+        assertThat(getIcebergResult()).containsExactlyInAnyOrder("Record(1, 10)");
+    }
+
+    @Test
+    public void testReplaceTableDowngradingFormatVersionKeepsData() throws Exception {
+        RowType rowType =
+                RowType.of(
+                        new DataType[] {DataTypes.INT(), DataTypes.INT()}, new String[] {"k", "v"});
+        Map<String, String> v3Options = new HashMap<>();
+        v3Options.put(IcebergOptions.FORMAT_VERSION.key(), "3");
+        FileStoreTable table =
+                createPaimonTable(
+                        rowType,
+                        Collections.emptyList(),
+                        Collections.singletonList("k"),
+                        1,
+                        v3Options);
+
+        String commitUser = UUID.randomUUID().toString();
+        TableWriteImpl<?> write = table.newWrite(commitUser);
+        TableCommitImpl commit = table.newCommit(commitUser);
+        write.write(GenericRow.of(1, 10));
+        commit.commit(1, write.prepareCommit(false, 1));
+        write.close();
+        commit.close();
+
+        Map<String, String> options = new HashMap<>(table.options());
+        options.remove(CoreOptions.PATH.key());
+        options.put(IcebergOptions.FORMAT_VERSION.key(), "2");
+        Schema downgrade =
+                new Schema(
+                        rowType.getFields(),
+                        Collections.emptyList(),
+                        Collections.singletonList("k"),
+                        options,
+                        "");
+
+        try (FileSystemCatalog catalog =
+                new FileSystemCatalog(table.fileIO(), new Path(tempDir.toString()))) {
+            assertThatThrownBy(
+                            () ->
+                                    catalog.replaceTable(
+                                            Identifier.create("mydb", "t"), downgrade, false))
+                    .hasStackTraceContaining("cannot be lowered");
+        }
+
+        assertThat(table.snapshotManager().latestSnapshotId()).isEqualTo(1L);
+    }
+
+    @Test
+    public void testDropAndCreateReplacementIsRefusedBeforeTheDrop() throws Exception {
+        RowType rowType =
+                RowType.of(
+                        new DataType[] {DataTypes.INT(), DataTypes.INT()}, new String[] {"k", "v"});
+        FileStoreTable table =
+                createPaimonTable(
+                        rowType, Collections.emptyList(), Collections.singletonList("k"), 1);
+
+        String commitUser = UUID.randomUUID().toString();
+        TableWriteImpl<?> write = table.newWrite(commitUser);
+        TableCommitImpl commit = table.newCommit(commitUser);
+        write.write(GenericRow.of(1, 10));
+        commit.commit(1, write.prepareCommit(false, 1));
+        write.close();
+        commit.close();
+
+        Map<String, String> options = new HashMap<>(table.options());
+        options.remove(CoreOptions.PATH.key());
+        options.put(CoreOptions.TYPE.key(), "materialized-table");
+        Schema replacement =
+                new Schema(
+                        Arrays.asList(
+                                new DataField(0, "k", DataTypes.INT()),
+                                new DataField(1, "payload", DataTypes.BYTES(), "__BLOB_FIELD")),
+                        Collections.emptyList(),
+                        Collections.singletonList("k"),
+                        options,
+                        "");
+
+        try (FileSystemCatalog catalog =
+                new FileSystemCatalog(table.fileIO(), new Path(tempDir.toString()))) {
+            Identifier identifier = Identifier.create("mydb", "t");
+            assertThatThrownBy(() -> catalog.replaceTable(identifier, replacement, false))
+                    .hasStackTraceContaining("BLOB");
+        }
+
+        assertThat(getIcebergResult()).containsExactlyInAnyOrder("Record(1, 10)");
+    }
+
+    @Test
+    public void testReplacementKeepsUnexpandedColumnDirective() throws Exception {
+        RowType rowType =
+                RowType.of(
+                        new DataType[] {DataTypes.INT(), DataTypes.INT()}, new String[] {"k", "v"});
+        FileStoreTable table =
+                createPaimonTable(
+                        rowType, Collections.emptyList(), Collections.singletonList("k"), 1);
+
+        String commitUser = UUID.randomUUID().toString();
+        TableWriteImpl<?> write = table.newWrite(commitUser);
+        TableCommitImpl commit = table.newCommit(commitUser);
+        write.write(GenericRow.of(1, 10));
+        commit.commit(1, write.prepareCommit(false, 1));
+        write.close();
+        commit.close();
+
+        Map<String, String> options = new HashMap<>(table.options());
+        options.remove(CoreOptions.PATH.key());
+        Schema replacement =
+                new Schema(
+                        Arrays.asList(
+                                new DataField(0, "k", DataTypes.INT()),
+                                new DataField(1, "payload", DataTypes.BYTES(), "__BLOB_FIELD")),
+                        Collections.emptyList(),
+                        Collections.singletonList("k"),
+                        options,
+                        "");
+
+        try (FileSystemCatalog catalog =
+                new FileSystemCatalog(table.fileIO(), new Path(tempDir.toString()))) {
+            Identifier identifier = Identifier.create("mydb", "t");
+            assertThatCode(() -> catalog.replaceTable(identifier, replacement, false))
+                    .doesNotThrowAnyException();
+        }
+    }
+
+    @Test
+    public void testEnablingMirroringIsRejectedUntilUnsupportedColumnIsGone() throws Exception {
+        RowType rowType =
+                RowType.of(
+                        new DataType[] {DataTypes.INT(), DataTypes.INT()}, new String[] {"k", "v"});
+        FileStoreTable table =
+                createPaimonTable(
+                        rowType,
+                        Collections.emptyList(),
+                        Collections.emptyList(),
+                        -1,
+                        Collections.singletonMap(CoreOptions.FILE_FORMAT.key(), "parquet"));
+        SchemaManager schemaManager = new SchemaManager(table.fileIO(), table.location());
+        addUnsupportedColumnWhileMirroringOff(schemaManager, "payload", DataTypes.VARIANT());
+
+        assertThatThrownBy(
+                        () ->
+                                schemaManager.commitChanges(
+                                        SchemaChange.setOption(
+                                                IcebergOptions.METADATA_ICEBERG_STORAGE.key(),
+                                                "table-location")))
+                .hasStackTraceContaining("VARIANT");
+
+        schemaManager.commitChanges(SchemaChange.dropColumn("payload"));
+        assertThatCode(
+                        () ->
+                                schemaManager.commitChanges(
+                                        SchemaChange.setOption(
+                                                IcebergOptions.METADATA_ICEBERG_STORAGE.key(),
+                                                "table-location")))
+                .doesNotThrowAnyException();
+    }
+
+    @Test
+    public void testSchemaIdAlreadyTakenIsReportedAsLostRace() throws Exception {
+        RowType rowType =
+                RowType.of(
+                        new DataType[] {DataTypes.INT(), DataTypes.INT()}, new String[] {"k", "v"});
+        FileStoreTable table =
+                createPaimonTable(
+                        rowType,
+                        Collections.emptyList(),
+                        Collections.emptyList(),
+                        -1,
+                        Collections.singletonMap(CoreOptions.FILE_FORMAT.key(), "parquet"));
+        SchemaManager schemaManager = new SchemaManager(table.fileIO(), table.location());
+        addUnsupportedColumnWhileMirroringOff(schemaManager, "payload", DataTypes.VARIANT());
+
+        TableSchema latest = schemaManager.latest().get();
+        List<DataField> staged = new ArrayList<>(latest.fields());
+        staged.add(new DataField(latest.highestFieldId() + 1, "w", DataTypes.INT()));
+        Map<String, String> mirrored = new HashMap<>(latest.options());
+        mirrored.put(IcebergOptions.METADATA_ICEBERG_STORAGE.key(), "table-location");
+
+        assertThat(
+                        schemaManager.commit(
+                                new TableSchema(
+                                        latest.id(),
+                                        staged,
+                                        latest.highestFieldId() + 1,
+                                        latest.partitionKeys(),
+                                        latest.primaryKeys(),
+                                        mirrored,
+                                        latest.comment())))
+                .isFalse();
+    }
+
+    @Test
+    public void testSchemaRollbackIsRefusedWhenItLowersFormatVersion() throws Exception {
+        RowType rowType =
+                RowType.of(
+                        new DataType[] {DataTypes.INT(), DataTypes.INT()}, new String[] {"k", "v"});
+        FileStoreTable table =
+                createPaimonTable(
+                        rowType,
+                        Collections.emptyList(),
+                        Collections.emptyList(),
+                        -1,
+                        Collections.singletonMap(CoreOptions.FILE_FORMAT.key(), "parquet"));
+
+        String commitUser = UUID.randomUUID().toString();
+        TableWriteImpl<?> write = table.newWrite(commitUser);
+        TableCommitImpl commit = table.newCommit(commitUser);
+        write.write(GenericRow.of(1, 10));
+        commit.commit(1, write.prepareCommit(false, 1));
+        write.close();
+        commit.close();
+
+        SchemaManager schemaManager = new SchemaManager(table.fileIO(), table.location());
+        schemaManager.commitChanges(
+                SchemaChange.setOption(IcebergOptions.FORMAT_VERSION.key(), "3"));
+
+        assertThatThrownBy(() -> table.copyWithLatestSchema().rollbackSchema(0))
+                .hasStackTraceContaining("cannot be lowered");
+        assertThat(schemaManager.latest().get().id()).isEqualTo(1L);
+    }
+
+    @Test
+    public void testBlankBranchOptionStillMirrors() throws Exception {
+        RowType rowType =
+                RowType.of(
+                        new DataType[] {DataTypes.INT(), DataTypes.INT()}, new String[] {"k", "v"});
+        FileStoreTable table =
+                createPaimonTable(rowType, Collections.emptyList(), Collections.emptyList(), -1);
+
+        FileStoreTable blankBranch =
+                table.copy(Collections.singletonMap(CoreOptions.BRANCH.key(), ""));
+        String commitUser = UUID.randomUUID().toString();
+        TableWriteImpl<?> write = blankBranch.newWrite(commitUser);
+        TableCommitImpl commit = blankBranch.newCommit(commitUser);
+        write.write(GenericRow.of(1, 10));
+        commit.commit(1, write.prepareCommit(false, 1));
+        write.close();
+        commit.close();
+
+        assertThat(table.snapshotManager().latestSnapshotId()).isEqualTo(1L);
+        assertThat(listIcebergMetadataFiles(table)).contains("v1.metadata.json");
+    }
+
+    @Test
+    public void testBranchWritesAreNotVetoedAndLeaveIcebergMetadataAlone() throws Exception {
+        RowType rowType =
+                RowType.of(
+                        new DataType[] {DataTypes.INT(), DataTypes.INT()}, new String[] {"k", "v"});
+        FileStoreTable table =
+                createPaimonTable(rowType, Collections.emptyList(), Collections.emptyList(), -1);
+
+        String commitUser = UUID.randomUUID().toString();
+        TableWriteImpl<?> write = table.newWrite(commitUser);
+        TableCommitImpl commit = table.newCommit(commitUser);
+        write.write(GenericRow.of(1, 10));
+        commit.commit(1, write.prepareCommit(false, 1));
+        write.close();
+        commit.close();
+        Set<String> mirroredBefore = listIcebergMetadataFiles(table);
+
+        table.createBranch("b1");
+        FileStoreTable branchTable =
+                table.copy(Collections.singletonMap(CoreOptions.BRANCH.key(), "b1"));
+        new SchemaManager(table.fileIO(), table.location(), "b1")
+                .commitChanges(SchemaChange.addColumn("w", DataTypes.INT()));
+        branchTable = branchTable.copyWithLatestSchema();
+
+        TableWriteImpl<?> branchWrite = branchTable.newWrite(commitUser);
+        TableCommitImpl branchCommit = branchTable.newCommit(commitUser);
+        branchWrite.write(GenericRow.of(2, 20, 200));
+        assertThatCode(() -> branchCommit.commit(2, branchWrite.prepareCommit(false, 2)))
+                .doesNotThrowAnyException();
+        branchWrite.close();
+        branchCommit.close();
+
+        assertThat(listIcebergMetadataFiles(table)).isEqualTo(mirroredBefore);
+    }
+
+    @Test
+    public void testBranchSchemaEvolutionIsNotGatedByIcebergRules() throws Exception {
+        RowType rowType =
+                RowType.of(
+                        new DataType[] {DataTypes.INT(), DataTypes.INT()}, new String[] {"k", "v"});
+        FileStoreTable table =
+                createPaimonTable(
+                        rowType,
+                        Collections.emptyList(),
+                        Collections.emptyList(),
+                        -1,
+                        Collections.singletonMap(CoreOptions.FILE_FORMAT.key(), "parquet"));
+
+        String commitUser = UUID.randomUUID().toString();
+        TableWriteImpl<?> write = table.newWrite(commitUser);
+        TableCommitImpl commit = table.newCommit(commitUser);
+        write.write(GenericRow.of(1, 10));
+        commit.commit(1, write.prepareCommit(false, 1));
+        write.close();
+        commit.close();
+
+        table.createBranch("b1");
+        SchemaManager branchSchemas = new SchemaManager(table.fileIO(), table.location(), "b1");
+        assertThatCode(
+                        () ->
+                                branchSchemas.commitChanges(
+                                        SchemaChange.addColumn("payload", DataTypes.VARIANT())))
+                .doesNotThrowAnyException();
+    }
+
+    @Test
+    public void testFastForwardIsRefusedWhenBranchSchemaCannotBeMirrored() throws Exception {
+        RowType rowType =
+                RowType.of(
+                        new DataType[] {DataTypes.INT(), DataTypes.INT()}, new String[] {"k", "v"});
+        FileStoreTable table =
+                createPaimonTable(
+                        rowType,
+                        Collections.emptyList(),
+                        Collections.emptyList(),
+                        -1,
+                        Collections.singletonMap(CoreOptions.FILE_FORMAT.key(), "parquet"));
+
+        String commitUser = UUID.randomUUID().toString();
+        TableWriteImpl<?> write = table.newWrite(commitUser);
+        TableCommitImpl commit = table.newCommit(commitUser);
+        write.write(GenericRow.of(1, 10));
+        commit.commit(1, write.prepareCommit(false, 1));
+        write.close();
+        commit.close();
+
+        table.createBranch("b1");
+        new SchemaManager(table.fileIO(), table.location(), "b1")
+                .commitChanges(SchemaChange.addColumn("payload", DataTypes.VARIANT()));
+        FileStoreTable branchTable =
+                table.copy(Collections.singletonMap(CoreOptions.BRANCH.key(), "b1"))
+                        .copyWithLatestSchema();
+        TableWriteImpl<?> branchWrite = branchTable.newWrite(commitUser);
+        TableCommitImpl branchCommit = branchTable.newCommit(commitUser);
+        branchWrite.write(GenericRow.of(2, 20, null));
+        branchCommit.commit(2, branchWrite.prepareCommit(false, 2));
+        branchWrite.close();
+        branchCommit.close();
+
+        assertThatThrownBy(() -> table.fastForward("b1")).hasStackTraceContaining("VARIANT");
+        assertThat(table.snapshotManager().latestSnapshotId()).isEqualTo(1L);
+    }
+
+    @Test
+    public void testFastForwardIsRefusedWhenBranchLowersFormatVersion() throws Exception {
+        RowType rowType =
+                RowType.of(
+                        new DataType[] {DataTypes.INT(), DataTypes.INT()}, new String[] {"k", "v"});
+        Map<String, String> v3Options = new HashMap<>();
+        v3Options.put(IcebergOptions.FORMAT_VERSION.key(), "3");
+        v3Options.put(CoreOptions.FILE_FORMAT.key(), "parquet");
+        FileStoreTable table =
+                createPaimonTable(
+                        rowType, Collections.emptyList(), Collections.emptyList(), -1, v3Options);
+
+        String commitUser = UUID.randomUUID().toString();
+        TableWriteImpl<?> write = table.newWrite(commitUser);
+        TableCommitImpl commit = table.newCommit(commitUser);
+        write.write(GenericRow.of(1, 10));
+        commit.commit(1, write.prepareCommit(false, 1));
+        write.close();
+        commit.close();
+
+        table.createBranch("b1");
+        new SchemaManager(table.fileIO(), table.location(), "b1")
+                .commitChanges(SchemaChange.setOption(IcebergOptions.FORMAT_VERSION.key(), "2"));
+        FileStoreTable branchTable =
+                table.copy(Collections.singletonMap(CoreOptions.BRANCH.key(), "b1"))
+                        .copyWithLatestSchema();
+        TableWriteImpl<?> branchWrite = branchTable.newWrite(commitUser);
+        TableCommitImpl branchCommit = branchTable.newCommit(commitUser);
+        branchWrite.write(GenericRow.of(2, 20));
+        branchCommit.commit(2, branchWrite.prepareCommit(false, 2));
+        branchWrite.close();
+        branchCommit.close();
+
+        assertThatThrownBy(() -> table.fastForward("b1"))
+                .hasStackTraceContaining("cannot be lowered");
+        assertThat(table.snapshotManager().latestSnapshotId()).isEqualTo(1L);
+    }
+
+    @Test
+    public void testFastForwardCannotErasePublishedFormatVersion() throws Exception {
+        RowType rowType =
+                RowType.of(
+                        new DataType[] {DataTypes.INT(), DataTypes.INT()}, new String[] {"k", "v"});
+        FileStoreTable table =
+                createPaimonTable(
+                        rowType,
+                        Collections.emptyList(),
+                        Collections.emptyList(),
+                        -1,
+                        Collections.singletonMap(CoreOptions.FILE_FORMAT.key(), "parquet"));
+
+        String commitUser = UUID.randomUUID().toString();
+        TableWriteImpl<?> write = table.newWrite(commitUser);
+        TableCommitImpl commit = table.newCommit(commitUser);
+        write.write(GenericRow.of(1, 10));
+        commit.commit(1, write.prepareCommit(false, 1));
+        write.close();
+        commit.close();
+
+        table.createBranch("b1");
+        SchemaManager schemaManager = new SchemaManager(table.fileIO(), table.location());
+        schemaManager.commitChanges(
+                SchemaChange.setOption(IcebergOptions.FORMAT_VERSION.key(), "3"));
+        FileStoreTable upgraded = table.copyWithLatestSchema();
+        TableWriteImpl<?> v3Write = upgraded.newWrite(commitUser);
+        TableCommitImpl v3Commit = upgraded.newCommit(commitUser);
+        v3Write.write(GenericRow.of(2, 20));
+        v3Commit.commit(2, v3Write.prepareCommit(false, 2));
+        v3Write.close();
+        v3Commit.close();
+
+        SchemaManager branchSchemas = new SchemaManager(table.fileIO(), table.location(), "b1");
+        branchSchemas.commitChanges(
+                SchemaChange.setOption(IcebergOptions.METADATA_ICEBERG_STORAGE.key(), "disabled"));
+        FileStoreTable b1 =
+                table.copy(Collections.singletonMap(CoreOptions.BRANCH.key(), "b1"))
+                        .copyWithLatestSchema();
+        TableWriteImpl<?> b1Write = b1.newWrite(commitUser);
+        TableCommitImpl b1Commit = b1.newCommit(commitUser);
+        b1Write.write(GenericRow.of(3, 30));
+        b1Commit.commit(3, b1Write.prepareCommit(false, 3));
+        b1Write.close();
+        b1Commit.close();
+
+        assertThatThrownBy(() -> table.fastForward("b1"))
+                .hasStackTraceContaining("cannot be lowered");
+    }
+
+    @Test
+    public void testFastForwardBetweenBranchesIsNotGated() throws Exception {
+        RowType rowType =
+                RowType.of(
+                        new DataType[] {DataTypes.INT(), DataTypes.INT()}, new String[] {"k", "v"});
+        FileStoreTable table =
+                createPaimonTable(
+                        rowType,
+                        Collections.emptyList(),
+                        Collections.emptyList(),
+                        -1,
+                        Collections.singletonMap(CoreOptions.FILE_FORMAT.key(), "parquet"));
+
+        String commitUser = UUID.randomUUID().toString();
+        TableWriteImpl<?> write = table.newWrite(commitUser);
+        TableCommitImpl commit = table.newCommit(commitUser);
+        write.write(GenericRow.of(1, 10));
+        commit.commit(1, write.prepareCommit(false, 1));
+        write.close();
+        commit.close();
+
+        table.createBranch("b1");
+        table.createBranch("b2");
+        new SchemaManager(table.fileIO(), table.location(), "b1")
+                .commitChanges(SchemaChange.addColumn("payload", DataTypes.VARIANT()));
+        FileStoreTable b1 =
+                table.copy(Collections.singletonMap(CoreOptions.BRANCH.key(), "b1"))
+                        .copyWithLatestSchema();
+        TableWriteImpl<?> b1Write = b1.newWrite(commitUser);
+        TableCommitImpl b1Commit = b1.newCommit(commitUser);
+        b1Write.write(GenericRow.of(2, 20, null));
+        b1Commit.commit(2, b1Write.prepareCommit(false, 2));
+        b1Write.close();
+        b1Commit.close();
+
+        FileStoreTable b2 = table.copy(Collections.singletonMap(CoreOptions.BRANCH.key(), "b2"));
+        assertThatCode(() -> b2.fastForward("b1")).doesNotThrowAnyException();
+    }
+
+    @Test
+    public void testRegisteringLegacyUnmirrorableTableIsAllowed() throws Exception {
+        RowType rowType =
+                RowType.of(
+                        new DataType[] {DataTypes.INT(), DataTypes.INT()}, new String[] {"k", "v"});
+        FileStoreTable table =
+                createPaimonTable(
+                        rowType,
+                        Collections.emptyList(),
+                        Collections.emptyList(),
+                        -1,
+                        Collections.singletonMap(CoreOptions.FILE_FORMAT.key(), "parquet"));
+
+        SchemaManager schemaManager = new SchemaManager(table.fileIO(), table.location());
+        TableSchema latest = schemaManager.latest().get();
+        List<DataField> legacyFields = new ArrayList<>(latest.fields());
+        legacyFields.add(
+                new DataField(latest.highestFieldId() + 1, "payload", DataTypes.VARIANT()));
+        TableSchema legacy =
+                new TableSchema(
+                        latest.id() + 1,
+                        legacyFields,
+                        latest.highestFieldId() + 1,
+                        latest.partitionKeys(),
+                        latest.primaryKeys(),
+                        latest.options(),
+                        latest.comment());
+        table.fileIO()
+                .writeFile(
+                        new Path(table.location(), "schema/schema-" + legacy.id()),
+                        legacy.toString(),
+                        true);
+
+        Map<String, String> registration = new HashMap<>(latest.options());
+        registration.put(CoreOptions.PATH.key(), table.location().toString());
+        assertThatCode(
+                        () ->
+                                new SchemaManager(table.fileIO(), table.location())
+                                        .createTable(
+                                                new Schema(
+                                                        Collections.emptyList(),
+                                                        Collections.emptyList(),
+                                                        Collections.emptyList(),
+                                                        registration,
+                                                        ""),
+                                                true))
+                .doesNotThrowAnyException();
+    }
+
+    private FileStoreTable createPaimonTable(
+            RowType rowType, List<String> partitionKeys, List<String> primaryKeys, int numBuckets)
+            throws Exception {
+        return createPaimonTable(rowType, partitionKeys, primaryKeys, numBuckets, new HashMap<>());
+    }
+
+    private FileStoreTable createPaimonTable(
+            RowType rowType,
+            List<String> partitionKeys,
+            List<String> primaryKeys,
+            int numBuckets,
+            Map<String, String> customOptions)
+            throws Exception {
+        LocalFileIO fileIO = LocalFileIO.create();
+        Path path = new Path(tempDir.toString());
+
+        Options options = new Options(customOptions);
+        options.set(CoreOptions.BUCKET, numBuckets);
+        options.set(
+                IcebergOptions.METADATA_ICEBERG_STORAGE, IcebergOptions.StorageType.TABLE_LOCATION);
+        if (!customOptions.containsKey(CoreOptions.FILE_FORMAT.key())) {
+            options.set(CoreOptions.FILE_FORMAT, "avro");
+        }
+        options.set(CoreOptions.TARGET_FILE_SIZE, MemorySize.ofKibiBytes(32));
+        if (!customOptions.containsKey(IcebergOptions.COMPACT_MIN_FILE_NUM.key())) {
+            options.set(IcebergOptions.COMPACT_MIN_FILE_NUM, 8);
+        }
+        options.set(IcebergOptions.METADATA_DELETE_AFTER_COMMIT, true);
+        if (!customOptions.containsKey(IcebergOptions.METADATA_PREVIOUS_VERSIONS_MAX.key())) {
+            options.set(IcebergOptions.METADATA_PREVIOUS_VERSIONS_MAX, 1);
+        }
+        options.set(CoreOptions.MANIFEST_TARGET_FILE_SIZE, MemorySize.ofKibiBytes(8));
+        Schema schema =
+                new Schema(rowType.getFields(), partitionKeys, primaryKeys, options.toMap(), "");
+
+        try (FileSystemCatalog paimonCatalog = new FileSystemCatalog(fileIO, path)) {
+            paimonCatalog.createDatabase("mydb", false);
+            Identifier paimonIdentifier = Identifier.create("mydb", "t");
+            paimonCatalog.createTable(paimonIdentifier, schema, false);
+            return (FileStoreTable) paimonCatalog.getTable(paimonIdentifier);
+        }
+    }
+
+    private org.apache.iceberg.Table getIcebergTable() {
+        HadoopCatalog icebergCatalog = new HadoopCatalog(new Configuration(), tempDir.toString());
+        TableIdentifier icebergIdentifier = TableIdentifier.of("mydb.db", "t");
+        return icebergCatalog.loadTable(icebergIdentifier);
+    }
+
+    private List<String> getIcebergResult() throws Exception {
+        return getIcebergResult(
+                icebergTable -> IcebergGenerics.read(icebergTable).build(), Record::toString);
+    }
+
+    private List<String> getIcebergResult(
+            Function<org.apache.iceberg.Table, CloseableIterable<Record>> query,
+            Function<Record, String> icebergRecordToString)
+            throws Exception {
+        org.apache.iceberg.Table icebergTable = getIcebergTable();
+        CloseableIterable<Record> result = query.apply(icebergTable);
+        List<String> actual = new ArrayList<>();
+        for (Record record : result) {
+            actual.add(icebergRecordToString.apply(record));
+        }
+        result.close();
+        return actual;
+    }
+
+    private void addUnsupportedColumnWhileMirroringOff(
+            SchemaManager schemaManager, String name, DataType type) throws Exception {
+        schemaManager.commitChanges(
+                SchemaChange.setOption(IcebergOptions.METADATA_ICEBERG_STORAGE.key(), "disabled"));
+        schemaManager.commitChanges(SchemaChange.addColumn(name, type));
+    }
+
+    private Set<String> listIcebergMetadataFiles(FileStoreTable table) throws Exception {
+        return Arrays.stream(table.fileIO().listStatus(new Path(table.location(), "metadata")))
+                .map(status -> status.getPath().getName())
+                .collect(Collectors.toSet());
+    }
+}

--- a/paimon-core/src/test/java/org/apache/paimon/rest/RESTCatalogTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/rest/RESTCatalogTest.java
@@ -154,6 +154,7 @@ import static org.apache.paimon.rest.RESTCatalogOptions.IO_CACHE_ENABLED;
 import static org.apache.paimon.rest.auth.DLFToken.TOKEN_DATE_FORMATTER;
 import static org.apache.paimon.utils.SnapshotManagerTest.createSnapshotWithMillis;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
@@ -3350,6 +3351,92 @@ public abstract class RESTCatalogTest extends CatalogTestBase {
         assertThat(table.uuid()).isNotEqualTo(table.fullName());
         assertThat(table.rowType().getField("payload").type())
                 .isInstanceOf(org.apache.paimon.types.VariantType.class);
+    }
+
+    @Test
+    void testRejectedCreateLeavesNoExternalDirectory(@TempDir java.nio.file.Path path)
+            throws Exception {
+        Identifier identifier = Identifier.create("db_that_does_not_exist", "external_rejected");
+        java.nio.file.Path external = path.resolve("not-created-yet");
+        Map<String, String> options = new HashMap<>();
+        options.put(CoreOptions.PATH.key(), external.toUri().toString());
+
+        Schema schema =
+                new Schema(
+                        Lists.newArrayList(new DataField(0, "k", DataTypes.INT())),
+                        Collections.emptyList(),
+                        Collections.emptyList(),
+                        options,
+                        "");
+
+        assertThatThrownBy(() -> catalog.createTable(identifier, schema, false))
+                .isInstanceOf(Catalog.DatabaseNotExistException.class);
+        assertThat(external.toFile().exists()).isFalse();
+    }
+
+    @Test
+    void testCreatingAnExistingTableIsANoOpWhenItCannotBeRead() throws Exception {
+        Identifier identifier = Identifier.create("iceberg_mirror_db", "no_read");
+        catalog.createDatabase(identifier.getDatabaseName(), true);
+        Map<String, String> options = new HashMap<>();
+        options.put("metadata.iceberg.storage", "table-location");
+        options.put(CoreOptions.FILE_FORMAT.key(), "parquet");
+        catalog.createTable(
+                identifier,
+                new Schema(
+                        Lists.newArrayList(new DataField(0, "k", DataTypes.INT())),
+                        Collections.emptyList(),
+                        Collections.emptyList(),
+                        options,
+                        ""),
+                false);
+        revokeTablePermission(identifier);
+
+        Schema unmirrorable =
+                new Schema(
+                        Lists.newArrayList(
+                                new DataField(0, "k", DataTypes.INT()),
+                                new DataField(1, "payload", DataTypes.VARIANT())),
+                        Collections.emptyList(),
+                        Collections.emptyList(),
+                        options,
+                        "");
+
+        assertThatCode(() -> catalog.createTable(identifier, unmirrorable, true))
+                .doesNotThrowAnyException();
+    }
+
+    @Test
+    void testCreateExistingTableWithUnmirrorableSchemaReportsAlreadyExists() throws Exception {
+        Identifier identifier = Identifier.create("iceberg_mirror_db", "t");
+        catalog.createDatabase(identifier.getDatabaseName(), true);
+        Map<String, String> options = new HashMap<>();
+        options.put("metadata.iceberg.storage", "table-location");
+        options.put(CoreOptions.FILE_FORMAT.key(), "parquet");
+        catalog.createTable(
+                identifier,
+                new Schema(
+                        Lists.newArrayList(new DataField(0, "k", DataTypes.INT())),
+                        Collections.emptyList(),
+                        Collections.emptyList(),
+                        options,
+                        ""),
+                false);
+
+        Schema unmirrorable =
+                new Schema(
+                        Lists.newArrayList(
+                                new DataField(0, "k", DataTypes.INT()),
+                                new DataField(1, "payload", DataTypes.VARIANT())),
+                        Collections.emptyList(),
+                        Collections.emptyList(),
+                        options,
+                        "");
+
+        assertThatThrownBy(() -> catalog.createTable(identifier, unmirrorable, false))
+                .isInstanceOf(Catalog.TableAlreadyExistException.class);
+        assertThatCode(() -> catalog.createTable(identifier, unmirrorable, true))
+                .doesNotThrowAnyException();
     }
 
     @Test

--- a/paimon-iceberg/src/test/java/org/apache/paimon/iceberg/IcebergRestMetadataCommitterTest.java
+++ b/paimon-iceberg/src/test/java/org/apache/paimon/iceberg/IcebergRestMetadataCommitterTest.java
@@ -69,6 +69,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.junit.jupiter.api.io.TempDir;
 
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -1067,24 +1068,12 @@ public class IcebergRestMetadataCommitterTest {
         assertThat(getIcebergResult())
                 .containsExactlyInAnyOrder("Record(1, 10)", "Record(3, 30)", "Record(4, 40)");
 
-        org.apache.paimon.iceberg.metadata.IcebergMetadata localMetadata =
-                org.apache.paimon.iceberg.metadata.IcebergMetadata.fromPath(
-                        table.fileIO(),
-                        new org.apache.paimon.fs.Path(
-                                IcebergCommitCallback.catalogTableMetadataPath(table),
-                                "v3.metadata.json"));
-        String localIdentity =
-                localMetadata.snapshots().stream()
-                        .filter(snap -> snap.snapshotId() == 2)
-                        .findFirst()
-                        .get()
-                        .summary()
-                        .get("paimon-commit-identity");
+        String liveIdentity = table.snapshotManager().snapshot(2).uuid();
         Table icebergTable = restCatalog.loadTable(TableIdentifier.of("mydb", "t"));
         org.apache.iceberg.Snapshot catalogSnapshot2 = icebergTable.snapshot(2);
         if (catalogSnapshot2 != null) {
             assertThat(catalogSnapshot2.summary().get("paimon-commit-identity"))
-                    .isEqualTo(localIdentity);
+                    .isEqualTo(liveIdentity);
         }
     }
 
@@ -1194,7 +1183,7 @@ public class IcebergRestMetadataCommitterTest {
                         "Record(6, 60)");
         icebergTable = restCatalog.loadTable(TableIdentifier.of("mydb", "t"));
         assertThat(icebergTable.currentSnapshot().snapshotId()).isEqualTo(7);
-        assertThat(ImmutableList.copyOf(icebergTable.snapshots()).size()).isEqualTo(2);
+        assertThat(ImmutableList.copyOf(icebergTable.snapshots()).size()).isEqualTo(7);
 
         write.write(GenericRow.of(4, 41));
         write.compact(BinaryRow.EMPTY_ROW, 0, true);
@@ -1874,5 +1863,99 @@ public class IcebergRestMetadataCommitterTest {
         } catch (ReflectiveOperationException e) {
             throw new IllegalStateException(e);
         }
+    }
+
+    private static List<String> readAllRecords(Table icebergTable) throws IOException {
+        List<String> records = new ArrayList<>();
+        try (CloseableIterable<Record> result = IcebergGenerics.read(icebergTable).build()) {
+            for (Record record : result) {
+                records.add(record.toString());
+            }
+        }
+        return records;
+    }
+
+    @Test
+    public void testReenableAfterDisableMirrorsAllSnapshots() throws Exception {
+        RowType rowType =
+                RowType.of(
+                        new DataType[] {DataTypes.INT(), DataTypes.INT()}, new String[] {"k", "v"});
+        FileStoreTable table =
+                createPaimonTable(
+                        rowType,
+                        Collections.emptyList(),
+                        Collections.singletonList("k"),
+                        1,
+                        randomFormat(),
+                        Collections.emptyMap());
+
+        String commitUser = UUID.randomUUID().toString();
+        TableWriteImpl<?> write = table.newWrite(commitUser);
+        TableCommitImpl commit = table.newCommit(commitUser);
+
+        write.write(GenericRow.of(1, 10));
+        write.write(GenericRow.of(2, 20));
+        commit.commit(1, write.prepareCommit(false, 1));
+
+        write.write(GenericRow.of(1, 11));
+        write.write(GenericRow.of(3, 30));
+        write.compact(BinaryRow.EMPTY_ROW, 0, true);
+        commit.commit(2, write.prepareCommit(true, 2));
+        assertThat(getIcebergResult())
+                .containsExactlyInAnyOrder("Record(1, 11)", "Record(2, 20)", "Record(3, 30)");
+        Table icebergTable = restCatalog.loadTable(TableIdentifier.of("mydb", "t"));
+        assertThat(icebergTable.currentSnapshot().snapshotId()).isEqualTo(3);
+
+        Map<String, String> options = new HashMap<>();
+        options.put(IcebergOptions.METADATA_ICEBERG_STORAGE.key(), "disabled");
+        table = table.copy(options);
+        write.close();
+        write = table.newWrite(commitUser);
+        commit.close();
+        commit = table.newCommit(commitUser);
+
+        write.write(GenericRow.of(4, 40));
+        write.write(GenericRow.of(5, 50));
+        write.compact(BinaryRow.EMPTY_ROW, 0, true);
+        commit.commit(3, write.prepareCommit(true, 3));
+        assertThat(table.snapshotManager().latestSnapshotId()).isEqualTo(5L);
+
+        options.put(IcebergOptions.METADATA_ICEBERG_STORAGE.key(), "rest-catalog");
+        table = table.copy(options);
+        write.close();
+        write = table.newWrite(commitUser);
+        commit.close();
+        commit = table.newCommit(commitUser);
+
+        write.write(GenericRow.of(6, 60));
+        write.compact(BinaryRow.EMPTY_ROW, 0, true);
+        commit.commit(4, write.prepareCommit(true, 4));
+        assertThat(table.snapshotManager().latestSnapshotId()).isEqualTo(7L);
+        assertThat(getIcebergResult())
+                .containsExactlyInAnyOrder(
+                        "Record(1, 11)",
+                        "Record(2, 20)",
+                        "Record(3, 30)",
+                        "Record(4, 40)",
+                        "Record(5, 50)",
+                        "Record(6, 60)");
+        icebergTable = restCatalog.loadTable(TableIdentifier.of("mydb", "t"));
+        assertThat(icebergTable.currentSnapshot().snapshotId()).isEqualTo(7);
+        assertThat(ImmutableList.copyOf(icebergTable.snapshots()).size()).isEqualTo(7);
+
+        write.write(GenericRow.of(4, 41));
+        write.compact(BinaryRow.EMPTY_ROW, 0, true);
+        commit.commit(5, write.prepareCommit(true, 5));
+        assertThat(getIcebergResult())
+                .containsExactlyInAnyOrder(
+                        "Record(1, 11)",
+                        "Record(2, 20)",
+                        "Record(3, 30)",
+                        "Record(4, 41)",
+                        "Record(5, 50)",
+                        "Record(6, 60)");
+
+        write.close();
+        commit.close();
     }
 }


### PR DESCRIPTION
### Purpose
  Some Paimon schemas cannot be represented in the Iceberg metadata this layer emits, and today the mismatch surfaces only after the Paimon snapshot is published: the mirror then publishes metadata Iceberg misreads, or fails on every retry and leaves the manifests it wrote behind. This PR checks before the commit and vetoes it there.

  Rejected: nanosecond-precision timestamps on any format version (Paimon writes precision > 6 as Parquet INT96, which Iceberg cannot read back as timestamp_ns), VARIANT on a v2 table, VARIANT partition keys, and manifest.legacy-version on v3. The check runs as a pre-commit callback, so the Paimon snapshot is never published, and the manifests written during preparation are cleaned up exactly like a preparation failure.

  Only the schemas a commit newly publishes are gated, so a veto is never permanent: already mirrored schemas stay valid, a schema vetoed at its introduction and since remedied (e.g. the column was dropped) is skipped at emission — with the snapshot entry falling back to the current schema id so no pointer dangles — and a transient read failure is rethrown instead of silently dropping a valid schema.