### PR TITLE
[docs] Clarify snapshot record count semantics

### DIFF
--- a/docs/docs/concepts/spec/snapshot.md
+++ b/docs/docs/concepts/spec/snapshot.md
@@ -58,11 +58,16 @@ Snapshot File is JSON, it includes:
 11. commitKind: type of changes in this snapshot, including append, compact, overwrite and analyze.
 12. timeMillis: commit time millis.
 13. logOffsets: commit log offsets.
-14. totalRecordCount: record count of all changes occurred in this snapshot.
-15. deltaRecordCount: record count of all new changes occurred in this snapshot.
+14. totalRecordCount: unmerged record count of all live data files in this snapshot.
+15. deltaRecordCount: net change of the unmerged record count from data files added and deleted in this snapshot.
 16. changelogRecordCount: record count of all changelog produced in this snapshot.
 17. watermark: watermark for input records, from Flink watermark mechanism, Long.MIN_VALUE if there is no watermark.
 18. statistics: stats file name for statistics of this table.
 19. properties: additional key-value properties of this snapshot.
 20. nextRowId: next row id for row tracking.
 21. operation: logical operation type, e.g. WRITE, DELETE, UPDATE, MERGE. Null if not set.
+
+The record counts are calculated per data file and are not logical row counts. For example, a
+Dedicated Format table stores the regular columns and each dedicated BLOB column in separate data
+files. Appending `N` logical rows to a table with one dedicated BLOB column therefore increases the
+`deltaRecordCount` by `2 * N`. Use `COUNT(*)` when you need the logical row count.

--- a/docs/docs/concepts/system-tables.mdx
+++ b/docs/docs/concepts/system-tables.mdx
@@ -64,6 +64,12 @@ SELECT * FROM my_table$snapshots;
 
 By querying the snapshots table, you can know the commit and expiration information about that table and time travel through the data.
 
+`total_record_count` and `delta_record_count` are unmerged counts calculated from data files, not
+logical row counts. All dedicated data files contribute to these values. For example, appending `N`
+logical rows to a table with one [dedicated BLOB column](../multimodal-table/blob#storage-layout)
+adds `N` records to the regular data files and `N` records to the BLOB files, so
+`delta_record_count` increases by `2 * N`. Use `COUNT(*)` when you need the logical row count.
+
 ### Schemas Table
 
 You can query the historical schemas of the table through schemas table.

--- a/docs/docs/pypaimon/system-tables.md
+++ b/docs/docs/pypaimon/system-tables.md
@@ -86,11 +86,16 @@ One row per persisted snapshot.
 | `base_manifest_list`      | STRING NOT NULL |                                |
 | `delta_manifest_list`     | STRING NOT NULL |                                |
 | `changelog_manifest_list` | STRING          |                                |
-| `total_record_count`      | BIGINT          |                                |
-| `delta_record_count`      | BIGINT          |                                |
+| `total_record_count`      | BIGINT          | Unmerged record count of all live data files; not a logical row count |
+| `delta_record_count`      | BIGINT          | Net change of the unmerged record count from added and deleted data files |
 | `changelog_record_count`  | BIGINT          |                                |
 | `watermark`               | BIGINT          |                                |
 | `next_row_id`             | BIGINT          |                                |
+
+Dedicated Format columns are stored in separate data files, and each of those files contributes to
+the snapshot record counts. For example, appending `N` logical rows to a table with one dedicated
+BLOB column increases `delta_record_count` by `2 * N`. Use `COUNT(*)` when you need the logical row
+count.
 
 ### `$schemas`
 

--- a/paimon-api/src/main/java/org/apache/paimon/Snapshot.java
+++ b/paimon-api/src/main/java/org/apache/paimon/Snapshot.java
@@ -148,11 +148,11 @@ public class Snapshot implements Serializable {
     @JsonProperty(FIELD_TIME_MILLIS)
     protected final long timeMillis;
 
-    // record count of all changes occurred in this snapshot
+    // unmerged record count of all live data files in this snapshot
     @JsonProperty(FIELD_TOTAL_RECORD_COUNT)
     protected final long totalRecordCount;
 
-    // record count of all new changes occurred in this snapshot
+    // net change of the unmerged record count from data files added and deleted in this snapshot
     @JsonProperty(FIELD_DELTA_RECORD_COUNT)
     protected final long deltaRecordCount;
 

--- a/paimon-core/src/test/java/org/apache/paimon/append/BlobTableTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/append/BlobTableTest.java
@@ -134,6 +134,11 @@ public class BlobTableTest extends TableTestBase {
 
         commitDefault(writeDataDefault(1000, 1));
 
+        assertThat(getTableDefault().snapshotManager().latestSnapshot().totalRecordCount())
+                .isEqualTo(2000L);
+        assertThat(getTableDefault().snapshotManager().latestSnapshot().deltaRecordCount())
+                .isEqualTo(2000L);
+
         AtomicInteger integer = new AtomicInteger(0);
 
         List<DataFileMeta> filesMetas =

--- a/paimon-core/src/test/java/org/apache/paimon/append/MultipleBlobTableTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/append/MultipleBlobTableTest.java
@@ -62,6 +62,11 @@ public class MultipleBlobTableTest extends TableTestBase {
 
         commitDefault(writeDataDefault(1000, 1));
 
+        assertThat(getTableDefault().snapshotManager().latestSnapshot().totalRecordCount())
+                .isEqualTo(3000L);
+        assertThat(getTableDefault().snapshotManager().latestSnapshot().deltaRecordCount())
+                .isEqualTo(3000L);
+
         AtomicInteger integer = new AtomicInteger(0);
 
         FileStoreTable table = getTableDefault();


### PR DESCRIPTION
### Purpose

`totalRecordCount` and `deltaRecordCount` in snapshots are calculated from the row counts of data files. They are file-level, unmerged counts rather than logical table row counts.

This distinction is especially visible for Dedicated Format tables: appending `N` logical rows with one dedicated BLOB column produces `N` records in regular data files and `N` records in BLOB data files, so `deltaRecordCount` increases by `2 * N`.

This PR preserves the existing file-level semantics discussed in #7779 and #7828. It clarifies the API and documentation instead of changing the counters to logical-row semantics.

### Changes

- Clarify `totalRecordCount` and `deltaRecordCount` in the snapshot spec, system-table docs, PyPaimon docs, and Java API comments.
- Document the Dedicated BLOB example and recommend `COUNT(*)` when the logical row count is needed.
- Add regression assertions for one dedicated BLOB column (`2 * N`) and two dedicated BLOB columns (`3 * N`), while the existing reader assertions continue to verify `N` logical rows.

### Tests

```text
mvn -pl paimon-core -am -Pfast-build \
  -DfailIfNoTests=false \
  -Dsurefire.failIfNoSpecifiedTests=false \
  -DwildcardSuites=none \
  -Dtest=BlobTableTest#testBasic,MultipleBlobTableTest#testBasic package
```

Result: 2 tests passed, 0 failures/errors.