### PR TITLE
[common] Fix incorrect date for casting pre epoch time

### DIFF
--- a/paimon-common/src/main/java/org/apache/paimon/casting/TimestampToDateCastRule.java
+++ b/paimon-common/src/main/java/org/apache/paimon/casting/TimestampToDateCastRule.java
@@ -45,7 +45,8 @@ class TimestampToDateCastRule extends AbstractCastRule<Timestamp, Number> {
     @Override
     public CastExecutor<Timestamp, Number> create(DataType inputType, DataType targetType) {
         if (inputType.is(DataTypeRoot.TIMESTAMP_WITHOUT_TIME_ZONE)) {
-            return value -> (int) (value.getMillisecond() / DateTimeUtils.MILLIS_PER_DAY);
+            return value ->
+                    (int) Math.floorDiv(value.getMillisecond(), DateTimeUtils.MILLIS_PER_DAY);
         } else if (inputType.is(DataTypeRoot.TIMESTAMP_WITH_LOCAL_TIME_ZONE)) {
             return value ->
                     DateTimeUtils.timestampWithLocalZoneToDate(value, TimeZone.getDefault());

--- a/paimon-common/src/test/java/org/apache/paimon/casting/CastExecutorTest.java
+++ b/paimon-common/src/test/java/org/apache/paimon/casting/CastExecutorTest.java
@@ -828,6 +828,24 @@ public class CastExecutorTest {
     }
 
     @Test
+    public void testTimestampToDatePreEpoch() {
+        CastExecutor<?, ?> cast = CastExecutors.resolve(new TimestampType(6), new DateType());
+        LocalDateTime[] timestamps = {
+            LocalDateTime.of(1969, 12, 31, 23, 59, 59),
+            LocalDateTime.of(1960, 6, 15, 10, 30),
+            LocalDateTime.of(1969, 12, 31, 0, 0),
+            LocalDateTime.of(2024, 3, 4, 5, 6, 7)
+        };
+
+        for (LocalDateTime timestamp : timestamps) {
+            compareCastResult(
+                    cast,
+                    Timestamp.fromLocalDateTime(timestamp),
+                    (int) timestamp.toLocalDate().toEpochDay());
+        }
+    }
+
+    @Test
     public void testTimestampToTimePreEpoch() {
         CastExecutor<?, ?> cast = CastExecutors.resolve(new TimestampType(3), new TimeType(3));
 


### PR DESCRIPTION
### Purpose
 - Casting an epoch timestamp to date truncates negative epoch milliseconds toward zero.
 - This means `1969-12-31 23:59:59` wrongly becomes 1970-01-01 and shifts other timestamps forward by one day. (for all values before 1970)
 - Fix the conversion by using Math.floorDiv to calculate the correct signed epoch day.

### Tests
 - UT
