### PR TITLE
[common] Fix like optimization for escaped patterns

### DIFF
--- a/paimon-common/src/main/java/org/apache/paimon/predicate/LikeOptimization.java
+++ b/paimon-common/src/main/java/org/apache/paimon/predicate/LikeOptimization.java
@@ -45,7 +45,7 @@ public class LikeOptimization {
         }
 
         String pattern = patternLiteral.toString();
-        if (pattern.contains("_")) {
+        if (pattern.indexOf('_') >= 0 || pattern.indexOf('\\') >= 0) {
             return Optional.empty();
         }
 

--- a/paimon-common/src/test/java/org/apache/paimon/predicate/PredicateTest.java
+++ b/paimon-common/src/test/java/org/apache/paimon/predicate/PredicateTest.java
@@ -580,6 +580,8 @@ public class PredicateTest {
         assertThat(executeLike("abcde", "%c.e")).isEqualTo(false);
         assertThat(executeLike("a-c", "a\\_c")).isEqualTo(false);
         assertThat(executeLike("a_c", "a\\_c")).isEqualTo(true);
+        assertThat(Arrays.asList(executeLike("a%", "a\\%"), executeLike("a\\anything", "a\\%")))
+                .containsExactly(true, false);
         assertThat(executeLike("startX", "start%")).isEqualTo(true);
         assertThat(executeLike("not_startX", "start%")).isEqualTo(false);
         assertThat(executeLike("xxmiddleyy", "%middle%")).isEqualTo(true);


### PR DESCRIPTION
### Purpose
- Like with escape wildcards such as `a\%` is incorrectly optimized.
- This causes the literal % values to be excluded while values beginning with `a\` are incorrectly included.
- Skip like optimization for patterns containing escape characters so they use the escape aware like evaluator.

### Tests
 - UT