### PR TITLE
[common] Compare maps of different representations without throwing

### DIFF
--- a/paimon-common/src/main/java/org/apache/paimon/utils/InternalRowUtils.java
+++ b/paimon-common/src/main/java/org/apache/paimon/utils/InternalRowUtils.java
@@ -91,23 +91,12 @@ public class InternalRowUtils {
                     return false;
                 }
                 MapType mapType = (MapType) dataType;
-                GenericMap map1;
-                GenericMap map2;
-                if (data1 instanceof GenericMap) {
-                    map1 = (GenericMap) data1;
-                    map2 = (GenericMap) data2;
-                } else {
-                    map1 =
-                            copyToGenericMap(
-                                    (InternalMap) data1,
-                                    mapType.getKeyType(),
-                                    mapType.getValueType());
-                    map2 =
-                            copyToGenericMap(
-                                    (InternalMap) data2,
-                                    mapType.getKeyType(),
-                                    mapType.getValueType());
-                }
+                // Decide per operand. One MapType is represented by GenericMap, BinaryMap or
+                // ColumnarMap interchangeably -- which is why the conversion below exists at all --
+                // so gating data2's cast on data1's concrete class threw ClassCastException
+                // whenever the two sides happened to use different representations.
+                GenericMap map1 = toGenericMap((InternalMap) data1, mapType);
+                GenericMap map2 = toGenericMap((InternalMap) data2, mapType);
                 InternalArray keyArray1 = map1.keyArray();
                 InternalArray keyArray2 = map2.keyArray();
                 InternalArray valueArray1 = map1.valueArray();
@@ -282,6 +271,12 @@ public class InternalRowUtils {
         }
 
         return copyToGenericMap(map, keyType, valueType);
+    }
+
+    private static GenericMap toGenericMap(InternalMap map, MapType mapType) {
+        return map instanceof GenericMap
+                ? (GenericMap) map
+                : copyToGenericMap(map, mapType.getKeyType(), mapType.getValueType());
     }
 
     private static GenericMap copyToGenericMap(

--- a/paimon-common/src/test/java/org/apache/paimon/utils/InternalRowUtilsTest.java
+++ b/paimon-common/src/test/java/org/apache/paimon/utils/InternalRowUtilsTest.java
@@ -18,6 +18,9 @@
 
 package org.apache.paimon.utils;
 
+import org.apache.paimon.data.BinaryArray;
+import org.apache.paimon.data.BinaryArrayWriter;
+import org.apache.paimon.data.BinaryMap;
 import org.apache.paimon.data.BinaryRow;
 import org.apache.paimon.data.BinaryString;
 import org.apache.paimon.data.BinaryVector;
@@ -33,6 +36,7 @@ import org.apache.paimon.datagen.DataGenerator;
 import org.apache.paimon.datagen.RandomGeneratorVisitor;
 import org.apache.paimon.datagen.RowDataGenerator;
 import org.apache.paimon.options.Options;
+import org.apache.paimon.types.DataType;
 import org.apache.paimon.types.DataTypeRoot;
 import org.apache.paimon.types.DataTypes;
 import org.apache.paimon.types.RowType;
@@ -298,5 +302,35 @@ public class InternalRowUtilsTest {
         GenericRow rowWithMap2 = new GenericRow(1);
         rowWithMap2.setField(0, new GenericMap(map2));
         assertThat(InternalRowUtils.equals(rowWithMap1, rowWithMap2, rowType2)).isFalse();
+    }
+
+    @Test
+    public void testEqualsAcrossMapImplementations() {
+        DataType mapType = DataTypes.MAP(DataTypes.STRING(), DataTypes.INT());
+
+        Map<Object, Object> entries = new HashMap<>();
+        entries.put(BinaryString.fromString("a"), 1);
+        GenericMap generic = new GenericMap(entries);
+
+        BinaryArray keys = new BinaryArray();
+        BinaryArrayWriter keyWriter = new BinaryArrayWriter(keys, 1, 8);
+        keyWriter.writeString(0, BinaryString.fromString("a"));
+        keyWriter.complete();
+        BinaryArray values = new BinaryArray();
+        BinaryArrayWriter valueWriter = new BinaryArrayWriter(values, 1, 4);
+        valueWriter.writeInt(0, 1);
+        valueWriter.complete();
+        BinaryMap binary = BinaryMap.valueOf(keys, values);
+
+        // hash() already treats the two representations as interchangeable, so equals() throwing
+        // for one ordering is the inconsistency being fixed here.
+        assertThat(InternalRowUtils.hash(generic, mapType))
+                .isEqualTo(InternalRowUtils.hash(binary, mapType));
+
+        // Both orderings must agree. Only the generic-first one changes: it used to pick the
+        // GenericMap fast path off data1 and then cast data2 to GenericMap unconditionally,
+        // throwing ClassCastException for a BinaryMap.
+        assertThat(InternalRowUtils.equals(generic, binary, mapType)).isTrue();
+        assertThat(InternalRowUtils.equals(binary, generic, mapType)).isTrue();
     }
 }


### PR DESCRIPTION
### Purpose

Closes #9210.

`InternalRowUtils.equals` picked the `GenericMap` fast path by testing **data1**, then cast **data2** with no test of its own:

```java
if (data1 instanceof GenericMap) {
    map1 = (GenericMap) data1;
    map2 = (GenericMap) data2;      // BinaryMap -> ClassCastException
```

so `equals(generic, binary, mapType)` throws while `equals(binary, generic, mapType)` returns `true`.

Two things say this is unintended rather than a restriction:

- **The `else` branch exists because the representation varies.** One `MapType` is carried by `GenericMap`, `BinaryMap` or `ColumnarMap` interchangeably; the conversion is there to normalise exactly that. Gating it on data1's concrete class contradicts the branch it guards.
- **`InternalRowUtils.hash` already treats them as interchangeable**, returning the same value for both. The class says "equal" by hash and throws when asked directly.

Each operand is now converted on its own, keeping the fast path when both are already `GenericMap`.

**Scope, deliberately narrow.** The other casts in this method — `(InternalRow) data2`, `(InternalArray) data2` — look like the same shape but are **interface** casts, and every representation implements those interfaces, so they cannot fail this way. Only the map branch casts to a concrete class. I have left them alone.

### Tests

One case in `InternalRowUtilsTest` asserting three things:

| assertion | before |
|---|---|
| `hash(generic) == hash(binary)` | green — this is what pins the intent |
| `equals(binary, generic)` | green |
| `equals(generic, binary)` | **ClassCastException** |

Only the third changes. The other two being green both before and after is the point: they establish that the two representations were already meant to be equivalent, so the third is a defect rather than a new feature.

```
InternalRowUtilsTest ... ClassCastException: class BinaryMap cannot be cast to class GenericMap
Tests run: 7, Failures: 0, Errors: 1      <- master

Tests run: 7, Failures: 0, Errors: 0      <- with the fix
```

Related suites pass (`InternalRowSerializerTest`, `RowCompactedSerializerTest`). `spotless:check` and `checkstyle:check` exit 0.
