### PR TITLE
[spark] Fix bucketed scan reporting for unsupported timestamp precision

### DIFF
--- a/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/PaimonScan.scala
+++ b/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/PaimonScan.scala
@@ -21,6 +21,7 @@ package org.apache.paimon.spark
 import org.apache.paimon.CoreOptions.BucketFunctionType
 import org.apache.paimon.partition.PartitionPredicate
 import org.apache.paimon.predicate.{FullTextSearch, HybridSearch, Predicate, TopN, VectorSearch}
+import org.apache.paimon.spark.catalog.functions.BucketFunction
 import org.apache.paimon.spark.commands.BucketExpression.quote
 import org.apache.paimon.spark.read.VariantExtractionInfo
 import org.apache.paimon.table.{BucketMode, FileStoreTable, InnerTable}
@@ -66,6 +67,15 @@ case class PaimonScan(
           bucketSpec.getBucketMode != BucketMode.HASH_FIXED || coreOptions
             .bucketFunctionType() != BucketFunctionType.DEFAULT
         ) {
+          None
+        } else if (!BucketFunction.supportsTable(fileStoreTable)) {
+          // Spark tells two scans apart by the canonical name of the bound bucket function, which
+          // is derived from Spark types. Spark's timestamp precision is fixed to 6, so bucket keys
+          // carrying any other precision are indistinguishable there, while Paimon lays their
+          // BinaryRow out differently and thus puts the same value into a different bucket.
+          // Reporting a bucket transform would let Spark treat such tables as co-partitioned and
+          // drop a shuffle that is actually required. This mirrors the same check the write side
+          // already does in `PaimonSparkWriter`.
           None
         } else if (bucketSpec.getBucketKeys.size() > 1) {
           None

--- a/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/sql/BucketedTableQueryTest.scala
+++ b/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/sql/BucketedTableQueryTest.scala
@@ -18,7 +18,10 @@
 
 package org.apache.paimon.spark.sql
 
+import org.apache.paimon.catalog.Identifier
+import org.apache.paimon.schema.Schema
 import org.apache.paimon.spark.PaimonSparkTestBase
+import org.apache.paimon.types.DataTypes
 
 import org.apache.spark.sql.Row
 import org.apache.spark.sql.execution.SortExec
@@ -186,6 +189,41 @@ class BucketedTableQueryTest extends PaimonSparkTestBase with AdaptiveSparkPlanH
       spark.sql(
         "INSERT INTO t7 VALUES (1, 'x1', '2020'), (2, 'x3', '2020'), (3, 'x3', '2021'), (4, 'x4', '2021'), (5, 'x5', '2021')")
       checkAnswerAndShuffleSorts("SELECT * FROM t1 JOIN t7 on t1.id = t7.id1", 2, 2)
+    }
+  }
+
+  test("Query on a bucketed table - join - bucket key of an unsupported timestamp precision") {
+    assume(gteqSpark3_3)
+
+    // Spark cannot express a parameterized timestamp in DDL, so go through the table API. Spark's
+    // timestamp precision is fixed to 6, hence a bucket key of another precision is not
+    // distinguishable in the reported transform while Paimon buckets it differently.
+    Seq(("ts3", DataTypes.TIMESTAMP_MILLIS()), ("ts6", DataTypes.TIMESTAMP())).foreach {
+      case (name, tsType) =>
+        paimonCatalog.createTable(
+          Identifier.create(dbName0, name),
+          Schema.newBuilder
+            .column("ts", tsType)
+            .column("c", DataTypes.STRING())
+            .option("bucket-key", "ts")
+            .option("bucket", "2")
+            .build,
+          false
+        )
+        spark.sql(s"""
+                     |INSERT INTO $name VALUES
+                     |(timestamp'2024-01-01 00:00:01', 'x1'), (timestamp'2024-01-01 00:00:02', 'x2'),
+                     |(timestamp'2024-01-01 00:00:03', 'x3'), (timestamp'2024-01-01 00:00:04', 'x4'),
+                     |(timestamp'2024-01-01 00:00:05', 'x5'), (timestamp'2024-01-01 00:00:06', 'x6'),
+                     |(timestamp'2024-01-01 00:00:07', 'x7'), (timestamp'2024-01-01 00:00:08', 'x8')
+                     |""".stripMargin)
+    }
+
+    try {
+      checkAnswerAndShuffleSorts("SELECT * FROM ts3 JOIN ts6 on ts3.ts = ts6.ts", 2, 2)
+    } finally {
+      spark.sql("DROP TABLE IF EXISTS ts3")
+      spark.sql("DROP TABLE IF EXISTS ts6")
     }
   }
 


### PR DESCRIPTION
### Purpose

A bucketed scan can report a partitioning that does not match how Paimon actually
assigned the buckets, which makes Spark drop a shuffle it still needs and silently
return fewer rows.

Spark's timestamp precision is fixed to 6, so a bucket key of `TIMESTAMP(3)` and one of
`TIMESTAMP(6)` are indistinguishable in the transform reported through
`SupportsReportPartitioning`: the bound bucket function derives its canonical name from
Spark types, and `TransformExpression.isSameFunction` compares exactly that canonical
name to decide whether two scans are co-partitioned. The other two guards do not help
here either, because both tables report the same number of partitions and the same
partition values (the bucket ids `0..n-1`).

Paimon, however, lays those two out differently in `BinaryRow` - a timestamp is stored
compactly when the precision is `<= 3` (`Timestamp.isCompact`, `AbstractBinaryWriter#writeTimestamp`)
- so the same value hashes differently and ends up in a different bucket.

Joining such tables with `spark.sql.sources.v2.bucketing.enabled=true` therefore lets
Spark pair bucket 0 with bucket 0 across two tables whose bucket 0 holds a different set
of rows. Nothing fails, the result is just incomplete. This is easy to hit in a mixed
stack, since Flink pipelines commonly declare `TIMESTAMP(3)` while a Spark DDL
`TIMESTAMP` is precision 6.

The fix skips reporting the bucket transform for these tables, using the same
`BucketFunction.supportsTable` check the write side already performs in
`PaimonSparkWriter`. The asymmetry between the two paths - the write side guarded, the
read side not - is what let this through.

Trade-off worth noting: this is deliberately conservative. Two tables that are *both*
`TIMESTAMP(3)` are encoded identically and could safely skip the shuffle, but they are
now excluded as well. Removing the restriction entirely requires `BucketFunction` to see
the real Paimon type instead of reconstructing it from Spark's `StructType`, which is the
existing `todo` above `supportsType`:

```
todo: find a way get the correct paimon type in BucketFunction, then remove this checker
```

### Tests

Added `BucketedTableQueryTest."Query on a bucketed table - join - bucket key of an
unsupported timestamp precision"`. Spark DDL cannot express a parameterized timestamp, so
the two tables are created through the table API.

- Without the fix the test fails with `Correct Answer - 8` vs `Spark Answer - 4`, and the
  physical plan contains no `Exchange` at all.
- With the fix the shuffle is kept and the join returns all 8 rows.

Full `paimon-spark-ut` run: 806 passed, 11 failed. The 11 failures are all
`LuminaVectorIndexTest` and reproduce identically on an unmodified checkout - they come
from the Lumina native library not loading in this environment
(`org.aliyun.lumina.LuminaNative.<clinit>`), not from this change.

### API and Format

No public API or format change.

### Documentation

No documentation change - this restores the intended behaviour rather than adding a
feature.
