### PR TITLE
[flink] Fix scan partitions with partial partition spec

### DIFF
--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/lookup/StaticPartitionLoader.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/lookup/StaticPartitionLoader.java
@@ -26,6 +26,7 @@ import org.apache.paimon.types.RowType;
 import org.apache.paimon.utils.InternalRowPartitionComputer;
 
 import java.util.ArrayList;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -48,9 +49,12 @@ public class StaticPartitionLoader extends PartitionLoader {
         String defaultPartitionName = Options.fromMap(table.options()).get(PARTITION_DEFAULT_NAME);
         InternalRowSerializer serializer = new InternalRowSerializer(partitionType);
         for (Map<String, String> spec : scanPartitions) {
+            Map<String, String> completedSpec = new LinkedHashMap<>(spec);
+            table.partitionKeys()
+                    .forEach(key -> completedSpec.putIfAbsent(key, defaultPartitionName));
             GenericRow row =
                     InternalRowPartitionComputer.convertSpecToInternalRow(
-                            spec, partitionType, defaultPartitionName);
+                            completedSpec, partitionType, defaultPartitionName);
             partitions.add(serializer.toBinaryRow(row).copy());
         }
     }

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/BatchFileStoreITCase.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/BatchFileStoreITCase.java
@@ -1102,6 +1102,16 @@ public class BatchFileStoreITCase extends CatalogITCaseBase {
     }
 
     @Test
+    public void testScanWithPartialSpecifiedPartition() {
+        sql("CREATE TABLE P (dt STRING, hh INT, v INT) PARTITIONED BY (dt, hh)");
+        sql(
+                "INSERT INTO P VALUES ('20260814', CAST(NULL AS INT), 1), ('20260814', 10, 2), ('20260815', CAST(NULL AS INT), 3)");
+
+        assertThat(sql("SELECT COUNT(*) FROM P /*+ OPTIONS('scan.partitions' = 'dt=20260814') */"))
+                .containsExactly(Row.of(1L));
+    }
+
+    @Test
     public void testScanWithSpecifiedPartitionsWithFieldMapping() {
         sql("CREATE TABLE P (id INT, v INT, pt STRING) PARTITIONED BY (pt)");
         sql("CREATE TABLE Q (id INT)");


### PR DESCRIPTION
### Purpose
 - scan.partitions incorrectly returns data of all partitions, when partial partition spec is provided in the query.
 - The loader passes the incomplete specification to the partition converter. This leads to an exception which is swallowed and the partition filter is completely discarded as a result.
 - Once the partition filter is discarded, the original partial spec is not honored and all rows are returned instead of the partition values.
 - Ensure that missing partial keys are filled with `partition.default-name` to safely create the partition spec.

### Tests
 - UT