### PR TITLE
[python] Avoid native-plan timeouts in mock REST tests

### DIFF
--- a/paimon-python/pypaimon/tests/rest/rest_base_test.py
+++ b/paimon-python/pypaimon/tests/rest/rest_base_test.py
@@ -24,6 +24,7 @@ import unittest
 import uuid
 
 import pyarrow as pa
+import pytest
 
 from pypaimon import CatalogFactory, Schema
 from pypaimon.api.api_response import ConfigResponse, Partition
@@ -40,6 +41,9 @@ from pypaimon.tests.rest.rest_server import RESTCatalogServer
 
 
 class RESTBaseTest(unittest.TestCase):
+    # Native planning blocks the in-process Python REST server until timeout.
+    pytestmark = pytest.mark.python_plan
+
     def setUp(self):
         self.temp_dir = tempfile.mkdtemp(prefix="unittest_")
         self.warehouse = os.path.join(self.temp_dir, 'warehouse')


### PR DESCRIPTION
Follow up on #9011.

### What changed

- Keep tests based on the in-process Python REST server on the Python planner.
- Continue forcing native planning for ordinary filesystem-backed tests in the Python 3.11 lane.

### Why

Synchronous native planning cannot be served by the Python REST server running in another thread. Each affected scan waits about 30 seconds and then falls back to the Python planner, adding CI time without native coverage.

In a recent run, the main pytest session took 30m33s; `rest_permission_test.py` and `rest_read_write_test.py` accounted for about 20 minutes.

### Validation

- Representative REST read: 32.27s before, 2.64s after.
- REST read plus a filesystem read: 3.12s, with one native plan exercised.
- pypaimon-rust 0.4 validation: 2 tests passed in 1.59s, with one native plan exercised.
- Native plan unit/integration tests: 52 passed, 12 subtests passed.
- flake8 and `git diff --check` passed.
