### PR TITLE
[core] Take the stream position outside the finally so close always runs

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/utils/ObjectsFile.java
+++ b/paimon-core/src/main/java/org/apache/paimon/utils/ObjectsFile.java
@@ -200,17 +200,16 @@ public abstract class ObjectsFile<T> implements SimpleFileReader<T> {
                 }
                 return Pair.of(path.getName(), fileIO.getFileSize(path));
             } else {
-                PositionOutputStream out = fileIO.newOutputStream(path, false);
                 long pos;
-                try {
+                try (PositionOutputStream out = fileIO.newOutputStream(path, false)) {
+                    // Nested rather than a single resource list: the position has to be read
+                    // after the writer has flushed, and before the stream itself is closed.
                     try (FormatWriter writer = writerFactory.create(out, compression)) {
                         while (records.hasNext()) {
                             writer.addElement(serializer.toRow(records.next()));
                         }
                     }
                     pos = out.getPos();
-                } finally {
-                    out.close();
                 }
                 return Pair.of(path.getName(), pos);
             }

--- a/paimon-core/src/main/java/org/apache/paimon/utils/ObjectsFile.java
+++ b/paimon-core/src/main/java/org/apache/paimon/utils/ObjectsFile.java
@@ -208,8 +208,8 @@ public abstract class ObjectsFile<T> implements SimpleFileReader<T> {
                             writer.addElement(serializer.toRow(records.next()));
                         }
                     }
-                } finally {
                     pos = out.getPos();
+                } finally {
                     out.close();
                 }
                 return Pair.of(path.getName(), pos);

--- a/paimon-core/src/test/java/org/apache/paimon/utils/ObjectsFileWriteFailureTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/utils/ObjectsFileWriteFailureTest.java
@@ -1,0 +1,160 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.utils;
+
+import org.apache.paimon.data.InternalRow;
+import org.apache.paimon.format.FormatWriter;
+import org.apache.paimon.fs.FileIO;
+import org.apache.paimon.fs.Path;
+import org.apache.paimon.fs.PositionOutputStream;
+import org.apache.paimon.fs.local.LocalFileIO;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.IOException;
+import java.util.Collections;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * When both the write and the closing of the output stream fail, {@link
+ * ObjectsFile#writeWithoutRolling} must report the write failure and keep the close failure as a
+ * suppressed exception rather than letting the latter replace the former.
+ */
+class ObjectsFileWriteFailureTest {
+
+    @Test
+    void writeFailureSurvivesAFailingStreamClose(@TempDir java.nio.file.Path tempDir) {
+        FailingStream stream = new FailingStream();
+        ObjectsFile<String> file = objectsFile(tempDir, stream, true);
+
+        assertThatThrownBy(() -> file.writeWithoutRolling(Collections.emptyIterator()))
+                .isInstanceOf(RuntimeException.class)
+                .cause()
+                .hasMessage("writer close failed")
+                .satisfies(
+                        cause ->
+                                assertThat(cause.getSuppressed())
+                                        .extracting(Throwable::getMessage)
+                                        .containsExactly("stream close failed"));
+
+        assertThat(stream.closed).isTrue();
+    }
+
+    /** The stream is closed even when the write succeeds and the position read is the last step. */
+    @Test
+    void streamIsClosedOnTheSuccessPath(@TempDir java.nio.file.Path tempDir) throws Exception {
+        FailingStream stream = new FailingStream();
+        stream.failOnClose = false;
+        ObjectsFile<String> file = objectsFile(tempDir, stream, false);
+
+        assertThat(file.writeWithoutRolling(Collections.emptyIterator()).getValue()).isEqualTo(7L);
+        assertThat(stream.closed).isTrue();
+    }
+
+    private static ObjectsFile<String> objectsFile(
+            java.nio.file.Path tempDir, PositionOutputStream stream, boolean writerCloseFails) {
+        Path path = new Path(tempDir.toUri().toString(), "manifest-0");
+        FileIO fileIO =
+                new LocalFileIO() {
+                    @Override
+                    public PositionOutputStream newOutputStream(Path file, boolean overwrite) {
+                        return stream;
+                    }
+                };
+        return new ObjectsFile<String>(
+                fileIO,
+                null,
+                null,
+                (f, size) -> {
+                    throw new UnsupportedOperationException();
+                },
+                (out, compression) -> new StubWriter(writerCloseFails),
+                "none",
+                new PathFactory() {
+                    @Override
+                    public Path newPath() {
+                        return path;
+                    }
+
+                    @Override
+                    public Path toPath(String fileName) {
+                        return path;
+                    }
+                },
+                null) {};
+    }
+
+    private static class StubWriter implements FormatWriter {
+
+        private final boolean failOnClose;
+
+        private StubWriter(boolean failOnClose) {
+            this.failOnClose = failOnClose;
+        }
+
+        @Override
+        public void addElement(InternalRow element) {}
+
+        @Override
+        public boolean reachTargetSize(boolean suggestedCheck, long targetSize) {
+            return false;
+        }
+
+        @Override
+        public void close() throws IOException {
+            if (failOnClose) {
+                throw new IOException("writer close failed");
+            }
+        }
+    }
+
+    private static class FailingStream extends PositionOutputStream {
+
+        private boolean failOnClose = true;
+        private boolean closed = false;
+
+        @Override
+        public long getPos() {
+            return 7L;
+        }
+
+        @Override
+        public void write(int b) {}
+
+        @Override
+        public void write(byte[] b) {}
+
+        @Override
+        public void write(byte[] b, int off, int len) {}
+
+        @Override
+        public void flush() {}
+
+        @Override
+        public void close() throws IOException {
+            closed = true;
+            if (failOnClose) {
+                throw new IOException("stream close failed");
+            }
+        }
+    }
+}


### PR DESCRIPTION
### Purpose

`ObjectsFile#writeWithoutRolling` reads the stream position inside the `finally`, ahead of the close:

```java
PositionOutputStream out = fileIO.newOutputStream(path, false);
long pos;
try {
    try (FormatWriter writer = writerFactory.create(out, compression)) {
        while (records.hasNext()) {
            writer.addElement(serializer.toRow(records.next()));
        }
    }
} finally {
    pos = out.getPos();   // <- declared `throws IOException`
    out.close();          // <- skipped if it does
}
```

`PositionOutputStream#getPos` is `public abstract long getPos() throws IOException`. When it throws, `out.close()` is never reached and the stream leaks, and the `finally`'s exception **replaces** whatever the try body was throwing — a `finally` that throws discards the exception in flight, and nothing is attached as suppressed.

The two failures are not independent. The try body usually throws because the underlying stream is already broken — a full disk, an object store rejecting the upload — and `getPos` on that same stream is then likely to throw as well. So the case where the position read fails is largely the same case where losing the write error hurts most.

### What changes

The whole block becomes try-with-resources, so the stream is closed on every path and a close failure is attached to the original failure rather than promoted over it:

```java
long pos;
try (PositionOutputStream out = fileIO.newOutputStream(path, false)) {
    try (FormatWriter writer = writerFactory.create(out, compression)) {
        while (records.hasNext()) {
            writer.addElement(serializer.toRow(records.next()));
        }
    }
    pos = out.getPos();
}
return Pair.of(path.getName(), pos);
```

The two blocks stay nested rather than folding into a single resource list: the position has to be read after the writer has flushed and before the stream itself closes, and one list would close the writer only on the way out, after `getPos()`.

On a successful write the returned value is identical to before. On a failing write, the stream is closed and the write failure is the one that propagates, with any close failure among its suppressed exceptions.

**An earlier revision of this PR moved `pos` onto the success path but left the `finally { out.close(); }` in place, and claimed that made the original exception propagate.** It did not — @JingsongLi pointed out that a throwing `out.close()` would still replace it, which is the same defect the first paragraph above describes. The test below exists because of that.

### Tests

`ObjectsFileWriteFailureTest`, two cases, driving a stub `FileIO` and `FormatWriter`:

* **both fail** — writer close throws `writer close failed`, stream close throws `stream close failed`. The propagated cause must be the writer failure, with the stream failure attached as suppressed.
* **success path** — the stream is still closed, and the returned position is the one `getPos()` reported.

The first case is what the previous revision got wrong; run against that revision it fails exactly as predicted:

```
Expecting message to be:
  "writer close failed"
but was:
  "stream close failed"
```

`ObjectsFileWriteFailureTest` and `BinaryIndexManifestEntryTest`: 4 tests, 0 failures. `spotless:apply` and `checkstyle:check` on `paimon-core` are clean.

### API and Format

No change to any public signature, option, or on-disk format. Behaviour differs only on the failure path, where the stream is now closed and the write failure is the one that reaches the caller.

### Note

#8927 also touches this method, in the `catch (Throwable e)` block below (`deleteQuietly` → `deleteQuietlyIgnoringInterrupt`). Different lines and a different concern, but worth flagging since they are close together.
