### PR TITLE
[core] Fix incremental diff scan missing first snapshot

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/table/source/snapshot/IncrementalDiffStartingScanner.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/source/snapshot/IncrementalDiffStartingScanner.java
@@ -101,16 +101,20 @@ public class IncrementalDiffStartingScanner extends AbstractStartingScanner {
         return new IncrementalDiffStartingScanner(snapshotManager, start, end);
     }
 
-    public static IncrementalDiffStartingScanner betweenTimestamps(
+    public static StartingScanner betweenTimestamps(
             long startTimestamp, long endTimestamp, SnapshotManager snapshotManager) {
         Snapshot startSnapshot = snapshotManager.earlierOrEqualTimeMills(startTimestamp);
-        if (startSnapshot == null) {
-            startSnapshot = snapshotManager.earliestSnapshot();
-        }
-
         Snapshot endSnapshot = snapshotManager.earlierOrEqualTimeMills(endTimestamp);
         if (endSnapshot == null) {
             endSnapshot = snapshotManager.latestSnapshot();
+        }
+
+        if (startSnapshot == null) {
+            Snapshot earliestSnapshot = snapshotManager.earliestSnapshot();
+            if (earliestSnapshot.id() == Snapshot.FIRST_SNAPSHOT_ID) {
+                return new StaticFromSnapshotStartingScanner(snapshotManager, endSnapshot.id());
+            }
+            startSnapshot = earliestSnapshot;
         }
 
         return new IncrementalDiffStartingScanner(snapshotManager, startSnapshot, endSnapshot);

--- a/paimon-core/src/test/java/org/apache/paimon/table/IncrementalTimeStampTableTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/table/IncrementalTimeStampTableTest.java
@@ -35,6 +35,7 @@ import org.junit.jupiter.api.Test;
 import java.time.LocalDateTime;
 import java.util.List;
 
+import static org.apache.paimon.CoreOptions.INCREMENTAL_BETWEEN_SCAN_MODE;
 import static org.apache.paimon.CoreOptions.INCREMENTAL_BETWEEN_TIMESTAMP;
 import static org.apache.paimon.SnapshotTest.newSnapshotManager;
 import static org.apache.paimon.io.DataFileTestUtils.row;
@@ -44,6 +45,37 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 /** Test for {@link CoreOptions#INCREMENTAL_BETWEEN_TIMESTAMP}. */
 public class IncrementalTimeStampTableTest extends TableTestBase {
+
+    @Test
+    public void testDiffFromBeforeFirstSnapshot() throws Exception {
+        Identifier identifier = identifier("T");
+        Schema schema =
+                Schema.newBuilder()
+                        .column("k", DataTypes.INT())
+                        .column("v", DataTypes.INT())
+                        .build();
+        catalog.createTable(identifier, schema, true);
+        Table table = catalog.getTable(identifier);
+
+        write(table, GenericRow.of(1, 1));
+        write(table, GenericRow.of(2, 2));
+
+        SnapshotManager snapshotManager =
+                newSnapshotManager(
+                        LocalFileIO.create(),
+                        new Path(String.format("%s/%s.db/%s", warehouse, database, "T")));
+        long startTimestamp = snapshotManager.snapshot(1).timeMillis() - 1;
+        long endTimestamp = snapshotManager.snapshot(2).timeMillis();
+
+        assertThat(
+                        read(
+                                table,
+                                Pair.of(
+                                        INCREMENTAL_BETWEEN_TIMESTAMP,
+                                        String.format("%s,%s", startTimestamp, endTimestamp)),
+                                Pair.of(INCREMENTAL_BETWEEN_SCAN_MODE, "diff")))
+                .containsExactlyInAnyOrder(GenericRow.of(1, 1), GenericRow.of(2, 2));
+    }
 
     @Test
     public void testPrimaryKeyTable() throws Exception {


### PR DESCRIPTION
### Purpose
 - Incremental diff scans omit rows from the 1st snapshot when the requested start time < table's first snapshot.
 - This happens because the first snapshot is incorrectly substituted for the nonexistent starting snapshot, causing the diff to exclude rows of 1st snapshot.
- Fix by reading the complete ending snapshot for cases when the interval starts before the 1st snapshot.

### Tests
 - UT