### PR TITLE
[python] Update paimon-rust to speed up native-plan CI

### DIFF
--- a/.github/workflows/paimon-python-checks.yml
+++ b/.github/workflows/paimon-python-checks.yml
@@ -34,7 +34,7 @@ env:
   JDK_VERSION: 8
   MAVEN_OPTS: -Dmaven.wagon.httpconnectionManager.ttlSeconds=30 -Dmaven.wagon.http.retryHandler.requestSentEnabled=true
   LUMINA_DATA_VERSION: 0.1.0
-  PYPAIMON_RUST_REV: 7a8512f18f47a0634ee02ae8a09f2fff76c12d37
+  PYPAIMON_RUST_REV: c7a71f4c3c9c5bf8883c1621caed09ec0ea2e49b
 
 
 concurrency:


### PR DESCRIPTION
### Purpose

Update the paimon-rust revision used by the Python 3.11 native-plan CI lane to include [apache/paimon-rust#716](https://github.com/apache/paimon-rust/pull/716).

The previous binding performed REST catalog I/O while holding the Python GIL. In-process mock REST tests therefore waited for the 30-second client timeout before falling back to Python planning. The updated binding releases the GIL during catalog I/O, so these tests can exercise native planning without the timeout.

### Verification

- The new revision is a descendant of the currently pinned revision.
- PyPaimon mock REST native planning completed in 0.041 seconds and returned one split with the updated binding; the previous binding timed out after 30 seconds.
- `git diff --check`