### PR TITLE
[core] Validate deletion vector mode when resetting table options

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/schema/SchemaManager.java
+++ b/paimon-core/src/main/java/org/apache/paimon/schema/SchemaManager.java
@@ -1446,6 +1446,14 @@ public class SchemaManager implements Serializable {
             throw new UnsupportedOperationException(String.format("Cannot reset %s.", key));
         }
 
+        if (DELETION_VECTORS_ENABLED.key().equals(key)) {
+            checkAlterTableOption(
+                    options,
+                    key,
+                    options.get(key),
+                    DELETION_VECTORS_ENABLED.defaultValue().toString());
+        }
+
         if (options.containsKey(PK_CLUSTERING_OVERRIDE.key())
                 && CLUSTERING_COLUMNS.key().equals(key)) {
             throw new UnsupportedOperationException(

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/DataEvolutionDeleteSqlITCase.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/DataEvolutionDeleteSqlITCase.java
@@ -134,6 +134,22 @@ public class DataEvolutionDeleteSqlITCase extends CatalogITCaseBase {
     }
 
     @Test
+    public void testResetDeletionVectorsAfterDelete() throws Exception {
+        createTable();
+        sql("INSERT INTO T VALUES (1, 'one', 'A'), (2, 'two', 'A'), (3, 'three', 'A')");
+        sql("DELETE FROM T WHERE id = 2");
+
+        assertThat(deletionVectorCardinality(paimonTable("T"))).isEqualTo(1L);
+        assertThatThrownBy(() -> sql("ALTER TABLE T RESET ('deletion-vectors.enabled')"))
+                .hasRootCauseMessage(
+                        "Cannot change deletion vectors mode from true to false. If modifying table "
+                                + "deletion-vectors mode without full-compaction, this may result in data "
+                                + "duplication. If you are confident, you can set table option "
+                                + "'deletion-vectors.modifiable' = 'true' to allow deletion vectors modification.");
+        assertThat(sql("SELECT id FROM T ORDER BY id")).containsExactly(Row.of(1), Row.of(3));
+    }
+
+    @Test
     public void testDeleteWithSubquery() {
         createTable();
         sql("INSERT INTO T VALUES (1, 'one', 'A'), (2, 'two', 'A'), (3, 'three', 'A')");


### PR DESCRIPTION
### Purpose
- Resetting `deletion-vectors.enabled` bypasses the deletion vector mode validation on table with existing snapshots.
- Since the option defaults to false, resetting it can stop DV from being applied and expose logically deleted rows illegally.
- Fix by adding validation on changes to the default value through the existing DV validation logic.

### Tests
 - UT