### PR TITLE
[oss] Add fs.oss.cname.enabled so non-Aliyun endpoints sign the bucket

### DIFF
--- a/paimon-filesystems/paimon-oss-impl/src/main/java/org/apache/paimon/oss/OSSFileIO.java
+++ b/paimon-filesystems/paimon-oss-impl/src/main/java/org/apache/paimon/oss/OSSFileIO.java
@@ -83,6 +83,13 @@ public class OSSFileIO extends HadoopCompliantFileIO implements HadoopOptionsPro
     private static final String OSS_ACCESS_KEY_SECRET = "fs.oss.accessKeySecret";
     private static final String OSS_SECURITY_TOKEN = "fs.oss.securityToken";
     private static final String OSS_SECOND_LEVEL_DOMAIN_ENABLED = "fs.oss.sld.enabled";
+
+    /**
+     * Set to false for an OSS-compatible endpoint that is neither an official Aliyun domain nor a
+     * CNAME custom domain. The SDK otherwise treats such a host as a CNAME and drops the bucket
+     * from the host it signs, which the server rejects with SignatureDoesNotMatch.
+     */
+    private static final String OSS_CNAME_ENABLED = "fs.oss.cname.enabled";
     // Paimon OSS SSE keys, mapping 1:1 to the OSS headers; they take precedence over hadoop's
     // server-side-encryption-algorithm.
     /** SSE method -> x-oss-server-side-encryption (AES256 / KMS / SM4). */
@@ -209,6 +216,10 @@ public class OSSFileIO extends HadoopCompliantFileIO implements HadoopOptionsPro
                         enableSecondLevelDomain(fs);
                     }
 
+                    if (!hadoopOptions.getBoolean(OSS_CNAME_ENABLED, true)) {
+                        disableCname(fs);
+                    }
+
                     SseConfig sse = configuredSse();
                     if (sse != null) {
                         enableSse(fs, sse);
@@ -292,6 +303,26 @@ public class OSSFileIO extends HadoopCompliantFileIO implements HadoopOptionsPro
             LOG.error("Failed to enable second level domain.", e);
             throw new RuntimeException("Failed to enable second level domain.", e);
         }
+    }
+
+    public void disableCname(AliyunOSSFileSystem fs) {
+        try {
+            setSupportCname(getOssClient(fs), false);
+        } catch (Exception e) {
+            LOG.error("Failed to disable CNAME support.", e);
+            throw new RuntimeException("Failed to disable CNAME support.", e);
+        }
+    }
+
+    /**
+     * Flip the SDK's CNAME heuristic; package-private so a test pins the reflected name. The
+     * configuration reached here is the one {@code OSSRequestMessageBuilder} reads while building
+     * every request, so this takes effect on an already-initialized client.
+     */
+    static void setSupportCname(OSSClient ossClient, boolean supportCname) throws Exception {
+        ServiceClient serviceClient =
+                ReflectionUtils.getPrivateFieldValue(ossClient, "serviceClient");
+        serviceClient.getClientConfiguration().setSupportCname(supportCname);
     }
 
     /** Reflectively extract the underlying {@link OSSClient} that hadoop-aliyun keeps private. */

--- a/paimon-filesystems/paimon-oss-impl/src/test/java/org/apache/paimon/oss/OSSFileIOTest.java
+++ b/paimon-filesystems/paimon-oss-impl/src/test/java/org/apache/paimon/oss/OSSFileIOTest.java
@@ -33,6 +33,7 @@ import com.aliyun.oss.common.comm.RequestMessage;
 import com.aliyun.oss.common.comm.ResponseMessage;
 import com.aliyun.oss.common.comm.RetryStrategy;
 import com.aliyun.oss.common.comm.ServiceClient;
+import com.aliyun.oss.internal.OSSUtils;
 import com.aliyun.oss.model.AbortMultipartUploadRequest;
 import com.aliyun.oss.model.CompleteMultipartUploadRequest;
 import com.aliyun.oss.model.CopyObjectRequest;
@@ -541,6 +542,65 @@ public class OSSFileIOTest {
                 .containsEntry("x-oss-server-side-encryption", "KMS")
                 .containsEntry("x-oss-server-side-encryption-key-id", "my-cmk")
                 .containsEntry("x-oss-server-side-data-encryption", "SM4");
+    }
+
+    /**
+     * The SDK reads {@code isSupportCname()} while building every request, so an endpoint outside
+     * its exclude list loses the bucket from the host that gets signed. Disabling the heuristic
+     * must put the bucket back.
+     */
+    @Test
+    public void testDisableCnameRestoresTheBucketInTheSignedHost() throws Exception {
+        String endpoint = "http://oss-cn-x.inter.env99.example.com";
+        OSSClient client = hadoopStyleClient(endpoint);
+        try {
+            assertThat(signedHost(client, endpoint, "my-bucket"))
+                    .isEqualTo("oss-cn-x.inter.env99.example.com");
+
+            OSSFileIO.setSupportCname(client, false);
+
+            assertThat(signedHost(client, endpoint, "my-bucket"))
+                    .isEqualTo("my-bucket.oss-cn-x.inter.env99.example.com");
+        } finally {
+            client.shutdown();
+        }
+    }
+
+    /** A public-cloud endpoint already signs the bucket, and the flag must not disturb it. */
+    @Test
+    public void testDisableCnameLeavesPublicCloudEndpointsAlone() throws Exception {
+        String endpoint = "http://oss-cn-hangzhou.aliyuncs.com";
+        OSSClient client = hadoopStyleClient(endpoint);
+        try {
+            assertThat(signedHost(client, endpoint, "my-bucket"))
+                    .isEqualTo("my-bucket.oss-cn-hangzhou.aliyuncs.com");
+
+            OSSFileIO.setSupportCname(client, false);
+
+            assertThat(signedHost(client, endpoint, "my-bucket"))
+                    .isEqualTo("my-bucket.oss-cn-hangzhou.aliyuncs.com");
+        } finally {
+            client.shutdown();
+        }
+    }
+
+    /**
+     * A client configured the way hadoop-aliyun configures it. This matters: {@code
+     * AliyunOSSFileSystemStore} passes a bare {@link ClientConfiguration}, where {@code
+     * supportCname} defaults to true, while {@code OSSClientBuilder} would hand over a {@code
+     * ClientBuilderConfiguration} that turns it off. Only the former reaches this bug.
+     */
+    private static OSSClient hadoopStyleClient(String endpoint) {
+        return new OSSClient(
+                endpoint, new DefaultCredentialProvider("ak", "sk"), new ClientConfiguration());
+    }
+
+    /** The host the signer sees, resolved exactly as OSSRequestMessageBuilder resolves it. */
+    private static String signedHost(OSSClient client, String endpoint, String bucket)
+            throws Exception {
+        return OSSUtils.determineFinalEndpoint(
+                        new URI(endpoint), bucket, client.getClientConfiguration())
+                .getHost();
     }
 
     @Test


### PR DESCRIPTION
### Purpose

Closes #8852.

`OSSFileIO` gives no way to switch off the OSS SDK's CNAME heuristic, and on an OSS-compatible endpoint that is not an Aliyun domain that heuristic drops the bucket out of the host being signed. Every request then fails with `SignatureDoesNotMatch`.

The path, in `aliyun-sdk-oss` 3.17.4 — the version this module pins:

```java
// OSSUtils.buildCanonicalHost
boolean isCname = false;
if (clientConfig.isSupportCname()) {
    isCname = cnameExcludeFilter(host, clientConfig.getCnameExcludeList());
}
if (bucket != null && !isCname && !clientConfig.isSLDEnabled()) {
    cannonicalHost.append(bucket).append(".").append(host);
} else {
    cannonicalHost.append(host);          // <- bucket never reaches the signed host
}
```

`cnameExcludeFilter` returns `false` only when the host ends with an entry of the exclude list, which defaults to `aliyuncs.com, aliyun-inc.com, aliyun.com`. Any other host — a private-cloud or Apsara Stack deployment, a MinIO-style gateway — therefore takes the `isCname = true` branch. `supportCname` defaults to `true` in `ClientConfiguration:90`, and `hadoop-aliyun` 3.3.4 builds a bare `new ClientConfiguration()` (`AliyunOSSFileSystemStore:99`) with no reference to cname anywhere in that artifact, so there is currently nothing a user can set to opt out.

### What changes

One new key, `fs.oss.cname.enabled`, handled the same way `fs.oss.sld.enabled` already is:

```java
if (!hadoopOptions.getBoolean(OSS_CNAME_ENABLED, true)) {
    disableCname(fs);
}
```

`disableCname` reaches the client's `ClientConfiguration` through the existing `getOssClient(fs)` +
`ReflectionUtils.getPrivateFieldValue(ossClient, "serviceClient")` pair that `enableSecondLevelDomain` uses, and calls `setSupportCname(false)`.

Setting it after `fs.initialize(...)` is enough because the flag is read per request, not captured at construction: `OSSRequestMessageBuilder:170` fetches `innerClient.getClientConfiguration()` while building each request and hands it to `determineFinalEndpoint` on line 177. That is the same object — `ServiceClient.getClientConfiguration()` returns the instance it was constructed with, and `OSSClient.getClientConfiguration()` (`:426`) is a straight delegation to it. The neighbouring `isSLDEnabled()` is consumed one line later, on 178, so the existing `fs.oss.sld.enabled` path already depends on exactly this.

### Blast radius

Unset means unchanged. The default is `true`, matching the SDK's own default, so a catalog that does not set the key builds precisely the client it built before, and a public-cloud endpoint is unaffected in either position of the flag — its host is on the exclude list, so the heuristic never fires. The second test below pins that.

### Tests

Two, both asserting the host the signer actually computes rather than that a setter was called — `signedHost` calls `OSSUtils.determineFinalEndpoint` with the client's own configuration, which is the call `OSSRequestMessageBuilder` makes for every request.

| endpoint | before | after `setSupportCname(false)` |
|---|---|---|
| `oss-cn-x.inter.env99.example.com` | `oss-cn-x.inter.env99.example.com` | `my-bucket.oss-cn-x.inter.env99.example.com` |
| `oss-cn-hangzhou.aliyuncs.com` | `my-bucket.oss-cn-hangzhou.aliyuncs.com` | `my-bucket.oss-cn-hangzhou.aliyuncs.com` |

The first row is the bug — a bucket that never reaches the host, so the client signs one string and the server another. The second is the blast-radius check.

Making `setSupportCname` a no-op fails exactly one of the 17 tests in the class, and it is the first row:

```
[ERROR] OSSFileIOTest.testDisableCnameRestoresTheBucketInTheSignedHost:563
expected: "my-bucket.oss-cn-x.inter.env99.example.com"
 but was: "oss-cn-x.inter.env99.example.com"
[ERROR] Tests run: 17, Failures: 1, Errors: 0, Skipped: 0
```

The public-cloud test stays green under that mutation, which is what makes it a blast-radius check rather than a second copy of the first.

**One thing worth knowing, because it caught me out while writing the test.** My first version built the client with `new OSSClientBuilder().build(endpoint, "ak", "sk")` and the first assertion failed — the bucket was *already* in the host. `ClientBuilderConfiguration extends ClientConfiguration` and sets `supportCname = false` in its constructor, so the SDK's own builder opts out of this heuristic by default. It is specifically the bare `new ClientConfiguration()` that `hadoop-aliyun` uses which leaves it on. The test therefore constructs the client the way `AliyunOSSFileSystemStore` does; a test written against `OSSClientBuilder` would pass without the fix and prove nothing.

I have no private-cloud OSS deployment to point at, so what is verified here is the host string the SDK builds for signing, not an end-to-end request against such an endpoint. That is the step the reporter identified as the failure, and it is the step this change moves.

### API and Format

No change to any existing key, signature or on-disk format. One added configuration key, inert unless set to `false`.
