### PR TITLE
[iceberg] Emit row-lineage metadata fields for Iceberg format version 3

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/iceberg/IcebergCommitCallback.java
+++ b/paimon-core/src/main/java/org/apache/paimon/iceberg/IcebergCommitCallback.java
@@ -592,6 +592,7 @@ public class IcebergCommitCallback implements CommitCallback, TagCallback {
                                         IcebergPartitionField.FIRST_FIELD_ID - 1),
                         Collections.singletonList(snapshot),
                         (int) snapshotId,
+                        null,
                         refs);
 
         Path metadataPath = pathFactory.toMetadataPath(snapshotId);
@@ -1180,6 +1181,7 @@ public class IcebergCommitCallback implements CommitCallback, TagCallback {
                         baseMetadata.lastPartitionId(),
                         snapshots,
                         (int) snapshotId,
+                        null,
                         refs);
 
         Path metadataPath = pathFactory.toMetadataPath(snapshotId);
@@ -1645,6 +1647,7 @@ public class IcebergCommitCallback implements CommitCallback, TagCallback {
                             baseMetadata.lastPartitionId(),
                             baseMetadata.snapshots(),
                             baseMetadata.currentSnapshotId(),
+                            baseMetadata.nextRowId(),
                             baseMetadata.refs());
 
             /*
@@ -1703,6 +1706,7 @@ public class IcebergCommitCallback implements CommitCallback, TagCallback {
                             baseMetadata.lastPartitionId(),
                             baseMetadata.snapshots(),
                             baseMetadata.currentSnapshotId(),
+                            baseMetadata.nextRowId(),
                             baseMetadata.refs());
 
             /*

--- a/paimon-core/src/main/java/org/apache/paimon/iceberg/IcebergCommitCallback.java
+++ b/paimon-core/src/main/java/org/apache/paimon/iceberg/IcebergCommitCallback.java
@@ -538,6 +538,7 @@ public class IcebergCommitCallback implements CommitCallback, TagCallback {
                 computeSnapshotSummary(
                         IcebergSnapshotSummary.APPEND.operation(), paimonSnapshot, metrics);
 
+        RowLineage rowLineage = computeRowLineage(0L, metrics.addedRecords);
         IcebergSnapshot snapshot =
                 new IcebergSnapshot(
                         snapshotId,
@@ -548,8 +549,8 @@ public class IcebergCommitCallback implements CommitCallback, TagCallback {
                         snapshotSummary,
                         pathFactory.toManifestListPath(manifestListFileName).toString(),
                         snapshotSchemaId,
-                        null,
-                        null);
+                        rowLineage.firstRowId,
+                        rowLineage.addedRows);
 
         // Tags can only be included in Iceberg if they point to an Iceberg snapshot that
         // exists. Otherwise, an Iceberg client fails to parse the metadata and all reads fail.
@@ -592,7 +593,7 @@ public class IcebergCommitCallback implements CommitCallback, TagCallback {
                                         IcebergPartitionField.FIRST_FIELD_ID - 1),
                         Collections.singletonList(snapshot),
                         (int) snapshotId,
-                        null,
+                        rowLineage.nextRowId,
                         refs);
 
         Path metadataPath = pathFactory.toMetadataPath(snapshotId);
@@ -1957,6 +1958,28 @@ public class IcebergCommitCallback implements CommitCallback, TagCallback {
             return false;
         }
         return true;
+    }
+
+    /**
+     * Row-lineage bookkeeping for a new snapshot, mandatory in Iceberg format version 3: the
+     * snapshot's first-row-id starts at the base metadata's next-row-id watermark and the table's
+     * next-row-id advances by the snapshot's added records. For format version 2 all fields stay
+     * null so nothing is written.
+     */
+    private RowLineage computeRowLineage(long baseNextRowId, long addedRecords) {
+        RowLineage lineage = new RowLineage();
+        if (formatVersion >= IcebergMetadata.FORMAT_VERSION_V3) {
+            lineage.firstRowId = baseNextRowId;
+            lineage.addedRows = addedRecords;
+            lineage.nextRowId = baseNextRowId + addedRecords;
+        }
+        return lineage;
+    }
+
+    private static class RowLineage {
+        @Nullable private Long firstRowId;
+        @Nullable private Long addedRows;
+        @Nullable private Long nextRowId;
     }
 
     private class SchemaCache {

--- a/paimon-core/src/main/java/org/apache/paimon/iceberg/IcebergCommitCallback.java
+++ b/paimon-core/src/main/java/org/apache/paimon/iceberg/IcebergCommitCallback.java
@@ -339,6 +339,7 @@ public class IcebergCommitCallback implements CommitCallback, TagCallback {
 
             String abandonedUuid = null;
             int abandonedLastColumnId = 0;
+            long abandonedNextRowId = 0;
             if (table.fileIO().exists(pathFactory.toMetadataPath(snapshotId))) {
                 if (metadataMatchesSnapshot(snapshotId, snapshot)) {
                     // a retry repairs hint, pointer and files only while this snapshot is
@@ -392,6 +393,9 @@ public class IcebergCommitCallback implements CommitCallback, TagCallback {
                 if (abandoned != null) {
                     abandonedUuid = abandoned.tableUuid();
                     abandonedLastColumnId = abandoned.lastColumnId();
+                    if (abandoned.nextRowId() != null) {
+                        abandonedNextRowId = abandoned.nextRowId();
+                    }
                 }
             }
             // steady-state commits skip the listing; anything suspicious lists the actual
@@ -414,6 +418,9 @@ public class IcebergCommitCallback implements CommitCallback, TagCallback {
                     }
                     abandonedLastColumnId =
                             Math.max(abandonedLastColumnId, surviving.lastColumnId());
+                    if (surviving.nextRowId() != null) {
+                        abandonedNextRowId = Math.max(abandonedNextRowId, surviving.nextRowId());
+                    }
                 }
             }
 
@@ -431,9 +438,11 @@ public class IcebergCommitCallback implements CommitCallback, TagCallback {
                                 .collect(Collectors.toList()),
                         snapshot,
                         baseMetadataPath,
-                        abandonedLastColumnId);
+                        abandonedLastColumnId,
+                        abandonedNextRowId);
             } else {
-                createMetadataWithoutBase(snapshotId, abandonedUuid, abandonedLastColumnId);
+                createMetadataWithoutBase(
+                        snapshotId, abandonedUuid, abandonedLastColumnId, abandonedNextRowId);
             }
 
             if (retireSuffix) {
@@ -454,16 +463,19 @@ public class IcebergCommitCallback implements CommitCallback, TagCallback {
     // -------------------------------------------------------------------------------------
 
     private void createMetadataWithoutBase(long snapshotId) throws IOException {
-        createMetadataWithoutBase(snapshotId, null, 0);
+        createMetadataWithoutBase(snapshotId, null, 0, 0L);
     }
 
     private void createMetadataWithoutBase(long snapshotId, @Nullable String inheritUuid)
             throws IOException {
-        createMetadataWithoutBase(snapshotId, inheritUuid, 0);
+        createMetadataWithoutBase(snapshotId, inheritUuid, 0, 0L);
     }
 
     private void createMetadataWithoutBase(
-            long snapshotId, @Nullable String inheritUuid, int lastColumnIdFloor)
+            long snapshotId,
+            @Nullable String inheritUuid,
+            int lastColumnIdFloor,
+            long nextRowIdFloor)
             throws IOException {
         SnapshotReader snapshotReader = table.newSnapshotReader().withSnapshot(snapshotId);
         Snapshot paimonSnapshot = table.snapshotManager().snapshot(snapshotId);
@@ -538,7 +550,8 @@ public class IcebergCommitCallback implements CommitCallback, TagCallback {
                 computeSnapshotSummary(
                         IcebergSnapshotSummary.APPEND.operation(), paimonSnapshot, metrics);
 
-        RowLineage rowLineage = computeRowLineage(0L, metrics.addedRecords);
+        // a rebuild replaces metadata whose ids are already out with readers: never reuse them
+        RowLineage rowLineage = computeRowLineage(nextRowIdFloor, metrics.addedRecords);
         IcebergSnapshot snapshot =
                 new IcebergSnapshot(
                         snapshotId,
@@ -912,10 +925,16 @@ public class IcebergCommitCallback implements CommitCallback, TagCallback {
             List<IndexManifestEntry> indexFiles,
             Snapshot snapshot,
             Path baseMetadataPath,
-            int lastColumnIdFloor)
+            int lastColumnIdFloor,
+            long nextRowIdFloor)
             throws IOException {
         long snapshotId = snapshot.id();
         IcebergMetadata baseMetadata = IcebergMetadata.fromPath(table.fileIO(), baseMetadataPath);
+        // row ids handed out by the base or by abandoned metadata must never be reused
+        long rowIdFloor =
+                Math.max(
+                        nextRowIdFloor,
+                        baseMetadata.nextRowId() == null ? 0L : baseMetadata.nextRowId());
 
         // a base left on the abandoned timeline must be rebuilt, not extended
         if (table.snapshotManager().snapshotExists(snapshotId - 1)
@@ -930,14 +949,18 @@ public class IcebergCommitCallback implements CommitCallback, TagCallback {
             createMetadataWithoutBase(
                     snapshotId,
                     baseMetadata.tableUuid(),
-                    Math.max(lastColumnIdFloor, baseMetadata.lastColumnId()));
+                    Math.max(lastColumnIdFloor, baseMetadata.lastColumnId()),
+                    rowIdFloor);
             return;
         }
 
         if (!isSameFormatVersion(baseMetadata.formatVersion())) {
             // we need to recreate iceberg metadata if format version changed
             createMetadataWithoutBase(
-                    snapshot.id(), null, Math.max(lastColumnIdFloor, baseMetadata.lastColumnId()));
+                    snapshot.id(),
+                    null,
+                    Math.max(lastColumnIdFloor, baseMetadata.lastColumnId()),
+                    rowIdFloor);
             return;
         }
 
@@ -947,7 +970,8 @@ public class IcebergCommitCallback implements CommitCallback, TagCallback {
             createMetadataWithoutBase(
                     snapshot.id(),
                     baseMetadata.tableUuid(),
-                    Math.max(lastColumnIdFloor, baseMetadata.lastColumnId()));
+                    Math.max(lastColumnIdFloor, baseMetadata.lastColumnId()),
+                    rowIdFloor);
             return;
         }
 
@@ -971,7 +995,8 @@ public class IcebergCommitCallback implements CommitCallback, TagCallback {
                 createMetadataWithoutBase(
                         snapshot.id(),
                         baseMetadata.tableUuid(),
-                        Math.max(lastColumnIdFloor, baseMetadata.lastColumnId()));
+                        Math.max(lastColumnIdFloor, baseMetadata.lastColumnId()),
+                        rowIdFloor);
                 return;
             }
         }
@@ -989,7 +1014,8 @@ public class IcebergCommitCallback implements CommitCallback, TagCallback {
                 createMetadataWithoutBase(
                         snapshot.id(),
                         baseMetadata.tableUuid(),
-                        Math.max(lastColumnIdFloor, baseMetadata.lastColumnId()));
+                        Math.max(lastColumnIdFloor, baseMetadata.lastColumnId()),
+                        rowIdFloor);
                 return;
             }
         }
@@ -1134,10 +1160,7 @@ public class IcebergCommitCallback implements CommitCallback, TagCallback {
         }
         // a schema-pointer rollback (validated above): only the current pointer moves
 
-        RowLineage rowLineage =
-                computeRowLineage(
-                        baseMetadata.nextRowId() == null ? 0L : baseMetadata.nextRowId(),
-                        metrics.addedRecords);
+        RowLineage rowLineage = computeRowLineage(rowIdFloor, metrics.addedRecords);
 
         List<IcebergSnapshot> snapshots = new ArrayList<>(baseMetadata.snapshots());
         snapshots.add(

--- a/paimon-core/src/main/java/org/apache/paimon/iceberg/IcebergCommitCallback.java
+++ b/paimon-core/src/main/java/org/apache/paimon/iceberg/IcebergCommitCallback.java
@@ -941,6 +941,16 @@ public class IcebergCommitCallback implements CommitCallback, TagCallback {
             return;
         }
 
+        if (formatVersion == IcebergMetadata.FORMAT_VERSION_V3
+                && baseMetadata.nextRowId() == null) {
+            // v3 base metadata written before Paimon emitted row lineage; recreate to self-heal
+            createMetadataWithoutBase(
+                    snapshot.id(),
+                    baseMetadata.tableUuid(),
+                    Math.max(lastColumnIdFloor, baseMetadata.lastColumnId()));
+            return;
+        }
+
         // decide the schema story before any manifest is written
         SchemaCache schemaCache = new SchemaCache();
         int schemaId = (int) schemaCache.getLatestSchemaId();
@@ -1124,6 +1134,11 @@ public class IcebergCommitCallback implements CommitCallback, TagCallback {
         }
         // a schema-pointer rollback (validated above): only the current pointer moves
 
+        RowLineage rowLineage =
+                computeRowLineage(
+                        baseMetadata.nextRowId() == null ? 0L : baseMetadata.nextRowId(),
+                        metrics.addedRecords);
+
         List<IcebergSnapshot> snapshots = new ArrayList<>(baseMetadata.snapshots());
         snapshots.add(
                 new IcebergSnapshot(
@@ -1136,8 +1151,8 @@ public class IcebergCommitCallback implements CommitCallback, TagCallback {
                         pathFactory.toManifestListPath(manifestListFileName).toString(),
                         // the snapshot's own schema, for time travel
                         snapshotSchemaId,
-                        null,
-                        null));
+                        rowLineage.firstRowId,
+                        rowLineage.addedRows));
 
         // all snapshots in this list, except the last one, need to expire
         List<IcebergSnapshot> toExpireExceptLast = new ArrayList<>();
@@ -1182,7 +1197,7 @@ public class IcebergCommitCallback implements CommitCallback, TagCallback {
                         baseMetadata.lastPartitionId(),
                         snapshots,
                         (int) snapshotId,
-                        null,
+                        rowLineage.nextRowId,
                         refs);
 
         Path metadataPath = pathFactory.toMetadataPath(snapshotId);

--- a/paimon-core/src/main/java/org/apache/paimon/iceberg/metadata/IcebergMetadata.java
+++ b/paimon-core/src/main/java/org/apache/paimon/iceberg/metadata/IcebergMetadata.java
@@ -25,6 +25,7 @@ import org.apache.paimon.utils.JsonSerdeUtil;
 import org.apache.paimon.shade.jackson2.com.fasterxml.jackson.annotation.JsonCreator;
 import org.apache.paimon.shade.jackson2.com.fasterxml.jackson.annotation.JsonGetter;
 import org.apache.paimon.shade.jackson2.com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import org.apache.paimon.shade.jackson2.com.fasterxml.jackson.annotation.JsonInclude;
 import org.apache.paimon.shade.jackson2.com.fasterxml.jackson.annotation.JsonProperty;
 
 import javax.annotation.Nullable;
@@ -63,6 +64,7 @@ public class IcebergMetadata {
     private static final String FIELD_SNAPSHOTS = "snapshots";
     private static final String FIELD_CURRENT_SNAPSHOT_ID = "current-snapshot-id";
     private static final String FIELD_PROPERTIES = "properties";
+    private static final String FIELD_NEXT_ROW_ID = "next-row-id";
     private static final String FIELD_REFS = "refs";
 
     @JsonProperty(FIELD_FORMAT_VERSION)
@@ -110,6 +112,11 @@ public class IcebergMetadata {
     @JsonProperty(FIELD_CURRENT_SNAPSHOT_ID)
     private final long currentSnapshotId;
 
+    @JsonProperty(FIELD_NEXT_ROW_ID)
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    @Nullable
+    private final Long nextRowId;
+
     @JsonProperty(FIELD_PROPERTIES)
     @Nullable
     private final Map<String, String> properties;
@@ -130,6 +137,7 @@ public class IcebergMetadata {
             int lastPartitionId,
             List<IcebergSnapshot> snapshots,
             long currentSnapshotId,
+            @Nullable Long nextRowId,
             @Nullable Map<String, IcebergRef> refs) {
         this(
                 formatVersion,
@@ -147,6 +155,7 @@ public class IcebergMetadata {
                 IcebergSortOrder.ORDER_ID,
                 snapshots,
                 currentSnapshotId,
+                nextRowId,
                 new HashMap<>(),
                 refs);
     }
@@ -168,6 +177,7 @@ public class IcebergMetadata {
             @JsonProperty(FIELD_DEFAULT_SORT_ORDER_ID) int defaultSortOrderId,
             @JsonProperty(FIELD_SNAPSHOTS) List<IcebergSnapshot> snapshots,
             @JsonProperty(FIELD_CURRENT_SNAPSHOT_ID) long currentSnapshotId,
+            @JsonProperty(FIELD_NEXT_ROW_ID) @Nullable Long nextRowId,
             @JsonProperty(FIELD_PROPERTIES) @Nullable Map<String, String> properties,
             @JsonProperty(FIELD_REFS) @Nullable Map<String, IcebergRef> refs) {
         this.formatVersion = formatVersion;
@@ -185,6 +195,7 @@ public class IcebergMetadata {
         this.defaultSortOrderId = defaultSortOrderId;
         this.snapshots = snapshots;
         this.currentSnapshotId = currentSnapshotId;
+        this.nextRowId = nextRowId;
         this.properties = properties;
         this.refs = refs;
     }
@@ -264,6 +275,12 @@ public class IcebergMetadata {
         return currentSnapshotId;
     }
 
+    @JsonGetter(FIELD_NEXT_ROW_ID)
+    @Nullable
+    public Long nextRowId() {
+        return nextRowId;
+    }
+
     @JsonGetter(FIELD_PROPERTIES)
     public Map<String, String> properties() {
         return properties == null ? new HashMap<>() : properties;
@@ -319,6 +336,7 @@ public class IcebergMetadata {
                 defaultSortOrderId,
                 snapshots,
                 currentSnapshotId,
+                nextRowId,
                 properties,
                 refs);
     }
@@ -348,6 +366,7 @@ public class IcebergMetadata {
                 && defaultSortOrderId == that.defaultSortOrderId
                 && Objects.equals(snapshots, that.snapshots)
                 && currentSnapshotId == that.currentSnapshotId
+                && Objects.equals(nextRowId, that.nextRowId)
                 && Objects.equals(properties, that.properties)
                 && Objects.equals(refs, that.refs);
     }

--- a/paimon-core/src/test/java/org/apache/paimon/iceberg/metadata/IcebergMetadataNextRowIdTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/iceberg/metadata/IcebergMetadataNextRowIdTest.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.iceberg.metadata;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Tests for the {@code next-row-id} row-lineage field of {@link IcebergMetadata}. */
+class IcebergMetadataNextRowIdTest {
+
+    @Test
+    void testV3MetadataRoundTripsNextRowId() {
+        String v3Json =
+                "{\"format-version\":3,\"table-uuid\":\"uuid\",\"location\":\"loc\",\"next-row-id\":42}";
+        IcebergMetadata metadata = IcebergMetadata.fromJson(v3Json);
+        assertThat(metadata.nextRowId()).isEqualTo(42L);
+
+        String serialized = metadata.toJson();
+        assertThat(serialized).contains("next-row-id");
+        assertThat(IcebergMetadata.fromJson(serialized).nextRowId()).isEqualTo(42L);
+    }
+
+    @Test
+    void testV2MetadataOmitsNextRowId() {
+        String v2Json = "{\"format-version\":2,\"table-uuid\":\"uuid\",\"location\":\"loc\"}";
+        IcebergMetadata metadata = IcebergMetadata.fromJson(v2Json);
+        assertThat(metadata.nextRowId()).isNull();
+        assertThat(metadata.toJson()).doesNotContain("next-row-id");
+    }
+}

--- a/paimon-iceberg/src/main/java/org/apache/paimon/iceberg/IcebergRestMetadataCommitter.java
+++ b/paimon-iceberg/src/main/java/org/apache/paimon/iceberg/IcebergRestMetadataCommitter.java
@@ -567,6 +567,7 @@ public class IcebergRestMetadataCommitter implements IcebergMetadataCommitter {
                                                         s.addedRows()))
                                 .collect(Collectors.toList()),
                         newIcebergMetadata.currentSnapshotId(),
+                        newIcebergMetadata.nextRowId(),
                         newIcebergMetadata.refs());
         TableMetadata shiftedTableMetadata =
                 TableMetadataParser.fromJson(shiftedForConversion.toJson());
@@ -663,6 +664,7 @@ public class IcebergRestMetadataCommitter implements IcebergMetadataCommitter {
                 newIcebergMetadata.lastPartitionId(),
                 snapshots,
                 newIcebergMetadata.currentSnapshotId(),
+                newIcebergMetadata.nextRowId(),
                 newIcebergMetadata.refs());
     }
 

--- a/paimon-iceberg/src/main/java/org/apache/paimon/iceberg/IcebergRestMetadataCommitter.java
+++ b/paimon-iceberg/src/main/java/org/apache/paimon/iceberg/IcebergRestMetadataCommitter.java
@@ -40,6 +40,7 @@ import org.apache.iceberg.SnapshotRef;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.TableMetadata;
 import org.apache.iceberg.TableMetadataParser;
+import org.apache.iceberg.TableProperties;
 import org.apache.iceberg.catalog.Catalog;
 import org.apache.iceberg.catalog.Namespace;
 import org.apache.iceberg.catalog.TableIdentifier;
@@ -230,6 +231,9 @@ public class IcebergRestMetadataCommitter implements IcebergMetadataCommitter {
     private TableMetadata.Builder updatesForCorrectBase(
             TableMetadata base, TableMetadata newMetadata, boolean isNewTable) {
         TableMetadata.Builder updateBuilder = TableMetadata.buildFrom(base);
+        if (newMetadata.formatVersion() > base.formatVersion()) {
+            updateBuilder.upgradeFormatVersion(newMetadata.formatVersion());
+        }
 
         int schemaId = icebergTable.schema().schemaId();
         if (isNewTable) {
@@ -366,13 +370,13 @@ public class IcebergRestMetadataCommitter implements IcebergMetadataCommitter {
         try {
             // Path-based catalogs (e.g. Hadoop) derive and assign the table location themselves
             // and reject a custom one, so first try letting the catalog assign it.
-            return newTableBuilder(schema, spec).create();
+            return newTableBuilder(schema, spec, newMetadata.formatVersion()).create();
         } catch (RuntimeException e) {
             // Some Iceberg REST catalogs (notably AWS Glue) do not auto-assign a table location
             // and reject creation without one. Retry with the location Paimon writes its metadata
             // to, normalised to the s3:// scheme such catalogs require.
             try {
-                return newTableBuilder(schema, spec)
+                return newTableBuilder(schema, spec, newMetadata.formatVersion())
                         .withLocation(toRestLocation(newMetadata.location()))
                         .create();
             } catch (RuntimeException retryError) {
@@ -382,8 +386,13 @@ public class IcebergRestMetadataCommitter implements IcebergMetadataCommitter {
         }
     }
 
-    private Catalog.TableBuilder newTableBuilder(Schema schema, @Nullable PartitionSpec spec) {
-        Catalog.TableBuilder builder = restCatalog.buildTable(icebergTableIdentifier, schema);
+    private Catalog.TableBuilder newTableBuilder(
+            Schema schema, @Nullable PartitionSpec spec, int formatVersion) {
+        Catalog.TableBuilder builder =
+                restCatalog
+                        .buildTable(icebergTableIdentifier, schema)
+                        .withProperty(
+                                TableProperties.FORMAT_VERSION, String.valueOf(formatVersion));
         return spec == null ? builder : builder.withPartitionSpec(spec);
     }
 

--- a/paimon-iceberg/src/test/java/org/apache/paimon/core/IcebergRowLineageCompatibilityTest.java
+++ b/paimon-iceberg/src/test/java/org/apache/paimon/core/IcebergRowLineageCompatibilityTest.java
@@ -1,0 +1,165 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.core;
+
+import org.apache.paimon.CoreOptions;
+import org.apache.paimon.catalog.FileSystemCatalog;
+import org.apache.paimon.catalog.Identifier;
+import org.apache.paimon.data.GenericRow;
+import org.apache.paimon.disk.IOManagerImpl;
+import org.apache.paimon.fs.Path;
+import org.apache.paimon.fs.local.LocalFileIO;
+import org.apache.paimon.iceberg.IcebergOptions;
+import org.apache.paimon.iceberg.metadata.IcebergMetadata;
+import org.apache.paimon.iceberg.metadata.IcebergSnapshot;
+import org.apache.paimon.options.MemorySize;
+import org.apache.paimon.options.Options;
+import org.apache.paimon.schema.Schema;
+import org.apache.paimon.table.FileStoreTable;
+import org.apache.paimon.table.sink.TableCommitImpl;
+import org.apache.paimon.table.sink.TableWriteImpl;
+import org.apache.paimon.types.DataType;
+import org.apache.paimon.types.DataTypes;
+import org.apache.paimon.types.RowType;
+
+import org.apache.iceberg.TableMetadata;
+import org.apache.iceberg.TableMetadataParser;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Tests for Iceberg format-version 3 row-lineage metadata fields. */
+public class IcebergRowLineageCompatibilityTest {
+
+    @TempDir java.nio.file.Path tempDir;
+
+    @Test
+    public void testFreshV3MetadataHasRowLineageFields() throws Exception {
+        FileStoreTable table = createPaimonTable(defaultRowType(), formatVersionOptions(3), "avro");
+        String commitUser = UUID.randomUUID().toString();
+        TableWriteImpl<?> write =
+                table.newWrite(commitUser)
+                        .withIOManager(new IOManagerImpl(tempDir.toString() + "/tmp"));
+        TableCommitImpl commit = table.newCommit(commitUser);
+
+        write.write(GenericRow.of(1, 10));
+        write.write(GenericRow.of(2, 20));
+        commit.commit(1, write.prepareCommit(false, 1));
+        write.close();
+        commit.close();
+
+        IcebergMetadata metadata = readIcebergMetadata(table, 1);
+        assertThat(metadata.formatVersion()).isEqualTo(3);
+        assertThat(metadata.nextRowId()).isEqualTo(2L);
+        IcebergSnapshot snapshot = metadata.currentSnapshot();
+        assertThat(snapshot.firstRowId()).isEqualTo(0L);
+        assertThat(snapshot.addedRows()).isEqualTo(2L);
+
+        // the bundled Iceberg parser must still accept the metadata
+        TableMetadata parsed = TableMetadataParser.fromJson(readMetadataJson(table, 1));
+        assertThat(parsed.formatVersion()).isEqualTo(3);
+    }
+
+    @Test
+    public void testV2MetadataHasNoRowLineageFields() throws Exception {
+        FileStoreTable table = createPaimonTable(defaultRowType(), formatVersionOptions(2), "avro");
+        String commitUser = UUID.randomUUID().toString();
+        TableWriteImpl<?> write =
+                table.newWrite(commitUser)
+                        .withIOManager(new IOManagerImpl(tempDir.toString() + "/tmp"));
+        TableCommitImpl commit = table.newCommit(commitUser);
+
+        write.write(GenericRow.of(1, 10));
+        commit.commit(1, write.prepareCommit(false, 1));
+        write.close();
+        commit.close();
+
+        String json = readMetadataJson(table, 1);
+        assertThat(json)
+                .doesNotContain("next-row-id")
+                .doesNotContain("first-row-id")
+                .doesNotContain("added-rows");
+        IcebergMetadata metadata = IcebergMetadata.fromJson(json);
+        assertThat(metadata.nextRowId()).isNull();
+        assertThat(metadata.currentSnapshot().firstRowId()).isNull();
+        assertThat(metadata.currentSnapshot().addedRows()).isNull();
+    }
+
+    // ------------------------------------------------------------------------
+    //  helpers
+    // ------------------------------------------------------------------------
+
+    private RowType defaultRowType() {
+        return RowType.of(
+                new DataType[] {DataTypes.INT(), DataTypes.INT()}, new String[] {"k", "v"});
+    }
+
+    private Map<String, String> formatVersionOptions(int formatVersion) {
+        Map<String, String> options = new HashMap<>();
+        options.put(IcebergOptions.FORMAT_VERSION.key(), String.valueOf(formatVersion));
+        return options;
+    }
+
+    private FileStoreTable createPaimonTable(
+            RowType rowType, Map<String, String> customOptions, String fileFormat)
+            throws Exception {
+        LocalFileIO fileIO = LocalFileIO.create();
+        Path path = new Path(tempDir.toString());
+
+        Options options = new Options(customOptions);
+        options.set(CoreOptions.BUCKET, -1);
+        options.set(
+                IcebergOptions.METADATA_ICEBERG_STORAGE, IcebergOptions.StorageType.TABLE_LOCATION);
+        options.set(CoreOptions.FILE_FORMAT, fileFormat);
+        options.set(CoreOptions.TARGET_FILE_SIZE, MemorySize.ofKibiBytes(32));
+
+        Schema schema =
+                new Schema(
+                        rowType.getFields(),
+                        Collections.<String>emptyList(),
+                        Collections.<String>emptyList(),
+                        options.toMap(),
+                        "");
+
+        try (FileSystemCatalog paimonCatalog = new FileSystemCatalog(fileIO, path)) {
+            paimonCatalog.createDatabase("mydb", false);
+            Identifier paimonIdentifier = Identifier.create("mydb", "t");
+            paimonCatalog.createTable(paimonIdentifier, schema, false);
+            return (FileStoreTable) paimonCatalog.getTable(paimonIdentifier);
+        }
+    }
+
+    private Path metadataPath(FileStoreTable table, long snapshotId) {
+        return new Path(table.location(), String.format("metadata/v%d.metadata.json", snapshotId));
+    }
+
+    private IcebergMetadata readIcebergMetadata(FileStoreTable table, long snapshotId) {
+        return IcebergMetadata.fromPath(LocalFileIO.create(), metadataPath(table, snapshotId));
+    }
+
+    private String readMetadataJson(FileStoreTable table, long snapshotId) throws Exception {
+        return LocalFileIO.create().readFileUtf8(metadataPath(table, snapshotId));
+    }
+}

--- a/paimon-iceberg/src/test/java/org/apache/paimon/core/IcebergRowLineageCompatibilityTest.java
+++ b/paimon-iceberg/src/test/java/org/apache/paimon/core/IcebergRowLineageCompatibilityTest.java
@@ -222,6 +222,85 @@ public class IcebergRowLineageCompatibilityTest {
         return options;
     }
 
+    @Test
+    public void testRollbackDoesNotReuseRowIds() throws Exception {
+        FileStoreTable table = createPaimonTable(defaultRowType(), formatVersionOptions(3), "avro");
+        String commitUser = UUID.randomUUID().toString();
+        TableWriteImpl<?> write =
+                table.newWrite(commitUser)
+                        .withIOManager(new IOManagerImpl(tempDir.toString() + "/tmp"));
+        TableCommitImpl commit = table.newCommit(commitUser);
+        write.write(GenericRow.of(1, 10));
+        write.write(GenericRow.of(2, 20));
+        commit.commit(1, write.prepareCommit(false, 1));
+        write.write(GenericRow.of(3, 30));
+        commit.commit(2, write.prepareCommit(false, 2));
+        write.close();
+        commit.close();
+        assertThat(readIcebergMetadata(table, 2).nextRowId()).isEqualTo(3L);
+
+        // deletes snapshot 2; its Iceberg metadata stays behind as an abandoned twin
+        table.rollbackTo(1);
+
+        // the next commit reuses snapshot id 2; ids 0..2 were already handed out by the
+        // abandoned timeline, so the replacement snapshot must start above them
+        TableWriteImpl<?> write2 =
+                table.newWrite(commitUser)
+                        .withIOManager(new IOManagerImpl(tempDir.toString() + "/tmp"));
+        TableCommitImpl commit2 = table.newCommit(commitUser);
+        write2.write(GenericRow.of(4, 40));
+        commit2.commit(3, write2.prepareCommit(false, 3));
+        write2.close();
+        commit2.close();
+
+        IcebergMetadata regenerated =
+                readIcebergMetadata(table, table.snapshotManager().latestSnapshotId());
+        // the rollback triggers a from-scratch rebuild re-exporting all 3 live rows; they
+        // start above the abandoned watermark instead of reusing ids 0..2
+        assertThat(regenerated.currentSnapshot().firstRowId()).isEqualTo(3L);
+        assertThat(regenerated.currentSnapshot().addedRows()).isEqualTo(3L);
+        assertThat(regenerated.nextRowId()).isEqualTo(6L);
+    }
+
+    @Test
+    public void testRollbackRegenerationWithoutBaseKeepsRowIdWatermark() throws Exception {
+        FileStoreTable table = createPaimonTable(defaultRowType(), formatVersionOptions(3), "avro");
+        String commitUser = UUID.randomUUID().toString();
+        TableWriteImpl<?> write =
+                table.newWrite(commitUser)
+                        .withIOManager(new IOManagerImpl(tempDir.toString() + "/tmp"));
+        TableCommitImpl commit = table.newCommit(commitUser);
+        write.write(GenericRow.of(1, 10));
+        write.write(GenericRow.of(2, 20));
+        commit.commit(1, write.prepareCommit(false, 1));
+        write.write(GenericRow.of(3, 30));
+        commit.commit(2, write.prepareCommit(false, 2));
+        write.close();
+        commit.close();
+
+        table.rollbackTo(1);
+
+        // no base metadata survives, so regeneration must run from scratch and still
+        // respect the abandoned watermark
+        LocalFileIO.create().deleteQuietly(metadataPath(table, 1));
+
+        TableWriteImpl<?> write2 =
+                table.newWrite(commitUser)
+                        .withIOManager(new IOManagerImpl(tempDir.toString() + "/tmp"));
+        TableCommitImpl commit2 = table.newCommit(commitUser);
+        write2.write(GenericRow.of(4, 40));
+        commit2.commit(3, write2.prepareCommit(false, 3));
+        write2.close();
+        commit2.close();
+
+        IcebergMetadata regenerated =
+                readIcebergMetadata(table, table.snapshotManager().latestSnapshotId());
+        // the regenerated snapshot re-exports all 3 live rows starting at the watermark
+        assertThat(regenerated.currentSnapshot().firstRowId()).isEqualTo(3L);
+        assertThat(regenerated.currentSnapshot().addedRows()).isEqualTo(3L);
+        assertThat(regenerated.nextRowId()).isEqualTo(6L);
+    }
+
     private FileStoreTable createPaimonTable(
             RowType rowType, Map<String, String> customOptions, String fileFormat)
             throws Exception {

--- a/paimon-iceberg/src/test/java/org/apache/paimon/core/IcebergRowLineageCompatibilityTest.java
+++ b/paimon-iceberg/src/test/java/org/apache/paimon/core/IcebergRowLineageCompatibilityTest.java
@@ -107,6 +107,106 @@ public class IcebergRowLineageCompatibilityTest {
         assertThat(metadata.currentSnapshot().addedRows()).isNull();
     }
 
+    @Test
+    public void testNextRowIdAdvancesAcrossCommits() throws Exception {
+        FileStoreTable table = createPaimonTable(defaultRowType(), formatVersionOptions(3), "avro");
+        String commitUser = UUID.randomUUID().toString();
+        TableWriteImpl<?> write =
+                table.newWrite(commitUser)
+                        .withIOManager(new IOManagerImpl(tempDir.toString() + "/tmp"));
+        TableCommitImpl commit = table.newCommit(commitUser);
+
+        write.write(GenericRow.of(1, 10));
+        write.write(GenericRow.of(2, 20));
+        commit.commit(1, write.prepareCommit(false, 1));
+
+        write.write(GenericRow.of(3, 30));
+        commit.commit(2, write.prepareCommit(false, 2));
+        write.close();
+        commit.close();
+
+        IcebergMetadata metadata = readIcebergMetadata(table, 2);
+        assertThat(metadata.nextRowId()).isEqualTo(3L);
+        IcebergSnapshot snapshot = metadata.currentSnapshot();
+        assertThat(snapshot.firstRowId()).isEqualTo(2L);
+        assertThat(snapshot.addedRows()).isEqualTo(1L);
+
+        TableMetadata parsed = TableMetadataParser.fromJson(readMetadataJson(table, 2));
+        assertThat(parsed.formatVersion()).isEqualTo(3);
+    }
+
+    @Test
+    public void testRegenerateWhenBaseHasNoNextRowId() throws Exception {
+        FileStoreTable table = createPaimonTable(defaultRowType(), formatVersionOptions(3), "avro");
+        String commitUser = UUID.randomUUID().toString();
+        TableWriteImpl<?> write =
+                table.newWrite(commitUser)
+                        .withIOManager(new IOManagerImpl(tempDir.toString() + "/tmp"));
+        TableCommitImpl commit = table.newCommit(commitUser);
+
+        write.write(GenericRow.of(1, 10));
+        write.write(GenericRow.of(2, 20));
+        commit.commit(1, write.prepareCommit(false, 1));
+
+        // Strip next-row-id from the committed metadata, simulating a v3 file written by
+        // Paimon before this fix.
+        IcebergMetadata base = readIcebergMetadata(table, 1);
+        IcebergMetadata stripped =
+                new IcebergMetadata(
+                        base.formatVersion(),
+                        base.tableUuid(),
+                        base.location(),
+                        base.lastSequenceNumber(),
+                        base.lastColumnId(),
+                        base.schemas(),
+                        base.currentSchemaId(),
+                        base.partitionSpecs(),
+                        base.lastPartitionId(),
+                        base.snapshots(),
+                        base.currentSnapshotId(),
+                        null,
+                        base.refs());
+        LocalFileIO.create().overwriteFileUtf8(metadataPath(table, 1), stripped.toJson());
+        assertThat(readIcebergMetadata(table, 1).nextRowId()).isNull();
+
+        write.write(GenericRow.of(3, 30));
+        commit.commit(2, write.prepareCommit(false, 2));
+        write.close();
+        commit.close();
+
+        // metadata must be regenerated from scratch with valid lineage fields
+        IcebergMetadata regenerated = readIcebergMetadata(table, 2);
+        assertThat(regenerated.nextRowId()).isEqualTo(3L);
+        assertThat(regenerated.snapshots()).hasSize(1);
+        assertThat(regenerated.currentSnapshot().firstRowId()).isEqualTo(0L);
+        assertThat(regenerated.currentSnapshot().addedRows()).isEqualTo(3L);
+    }
+
+    @Test
+    public void testTagPreservesNextRowId() throws Exception {
+        FileStoreTable table = createPaimonTable(defaultRowType(), formatVersionOptions(3), "avro");
+        String commitUser = UUID.randomUUID().toString();
+        TableWriteImpl<?> write =
+                table.newWrite(commitUser)
+                        .withIOManager(new IOManagerImpl(tempDir.toString() + "/tmp"));
+        TableCommitImpl commit = table.newCommit(commitUser);
+
+        write.write(GenericRow.of(1, 10));
+        write.write(GenericRow.of(2, 20));
+        commit.commit(1, write.prepareCommit(false, 1));
+
+        write.write(GenericRow.of(3, 30));
+        commit.commit(2, write.prepareCommit(false, 2));
+        write.close();
+        commit.close();
+
+        table.createTag("t1", 1);
+
+        IcebergMetadata metadata = readIcebergMetadata(table, 2);
+        assertThat(metadata.refs()).containsKey("t1");
+        assertThat(metadata.nextRowId()).isEqualTo(3L);
+    }
+
     // ------------------------------------------------------------------------
     //  helpers
     // ------------------------------------------------------------------------

--- a/paimon-iceberg/src/test/java/org/apache/paimon/iceberg/IcebergRestMetadataCommitterTest.java
+++ b/paimon-iceberg/src/test/java/org/apache/paimon/iceberg/IcebergRestMetadataCommitterTest.java
@@ -46,6 +46,7 @@ import org.apache.iceberg.CatalogProperties;
 import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.Table;
+import org.apache.iceberg.TableUtil;
 import org.apache.iceberg.catalog.Namespace;
 import org.apache.iceberg.catalog.TableIdentifier;
 import org.apache.iceberg.data.IcebergGenerics;
@@ -1221,6 +1222,132 @@ public class IcebergRestMetadataCommitterTest {
         assertThat(IcebergRestMetadataCommitter.toRestLocation("file:///tmp/db/t"))
                 .isEqualTo("file:///tmp/db/t");
         assertThat(IcebergRestMetadataCommitter.toRestLocation(null)).isNull();
+    }
+
+    @Test
+    public void testFormatVersion3TableRegistersV3() throws Exception {
+        RowType rowType =
+                RowType.of(
+                        new DataType[] {DataTypes.INT(), DataTypes.INT()}, new String[] {"k", "v"});
+        Map<String, String> customOptions = new HashMap<>();
+        customOptions.put(IcebergOptions.FORMAT_VERSION.key(), "3");
+        FileStoreTable table =
+                createPaimonTable(
+                        rowType,
+                        Collections.emptyList(),
+                        Collections.emptyList(),
+                        -1,
+                        "avro",
+                        customOptions);
+
+        String commitUser = UUID.randomUUID().toString();
+        TableWriteImpl<?> write = table.newWrite(commitUser);
+        TableCommitImpl commit = table.newCommit(commitUser);
+
+        write.write(GenericRow.of(1, 10));
+        write.write(GenericRow.of(2, 20));
+        commit.commit(1, write.prepareCommit(true, 1));
+
+        write.write(GenericRow.of(3, 30));
+        commit.commit(2, write.prepareCommit(true, 2));
+        write.close();
+        commit.close();
+
+        Table icebergTable = restCatalog.loadTable(TableIdentifier.of("mydb", "t"));
+        assertThat(TableUtil.formatVersion(icebergTable)).isEqualTo(3);
+        assertThat(getIcebergResult())
+                .containsExactlyInAnyOrder("Record(1, 10)", "Record(2, 20)", "Record(3, 30)");
+    }
+
+    @Test
+    public void testUpgradeFormatVersionOnRestTable() throws Exception {
+        RowType rowType =
+                RowType.of(
+                        new DataType[] {DataTypes.INT(), DataTypes.INT()}, new String[] {"k", "v"});
+        FileStoreTable table =
+                createPaimonTable(
+                        rowType,
+                        Collections.emptyList(),
+                        Collections.emptyList(),
+                        -1,
+                        "avro",
+                        new HashMap<>());
+
+        String commitUser = UUID.randomUUID().toString();
+        TableWriteImpl<?> write = table.newWrite(commitUser);
+        TableCommitImpl commit = table.newCommit(commitUser);
+
+        write.write(GenericRow.of(1, 10));
+        write.write(GenericRow.of(2, 20));
+        commit.commit(1, write.prepareCommit(true, 1));
+        write.close();
+        commit.close();
+
+        Table icebergTable = restCatalog.loadTable(TableIdentifier.of("mydb", "t"));
+        assertThat(TableUtil.formatVersion(icebergTable)).isEqualTo(2);
+
+        // upgrade paimon side to format-version 3
+        Map<String, String> upgrade = new HashMap<>();
+        upgrade.put(IcebergOptions.FORMAT_VERSION.key(), "3");
+        table = table.copy(upgrade);
+        write = table.newWrite(commitUser);
+        commit = table.newCommit(commitUser);
+
+        write.write(GenericRow.of(3, 30));
+        commit.commit(2, write.prepareCommit(true, 2));
+        write.close();
+        commit.close();
+
+        icebergTable = restCatalog.loadTable(TableIdentifier.of("mydb", "t"));
+        assertThat(TableUtil.formatVersion(icebergTable)).isEqualTo(3);
+        assertThat(getIcebergResult())
+                .containsExactlyInAnyOrder("Record(1, 10)", "Record(2, 20)", "Record(3, 30)");
+    }
+
+    @Test
+    public void testRecreateWithNonZeroLineageWatermark() throws Exception {
+        RowType rowType =
+                RowType.of(
+                        new DataType[] {DataTypes.INT(), DataTypes.INT()}, new String[] {"k", "v"});
+        Map<String, String> customOptions = new HashMap<>();
+        customOptions.put(IcebergOptions.FORMAT_VERSION.key(), "3");
+        FileStoreTable table =
+                createPaimonTable(
+                        rowType,
+                        Collections.emptyList(),
+                        Collections.emptyList(),
+                        -1,
+                        "avro",
+                        customOptions);
+
+        String commitUser = UUID.randomUUID().toString();
+        TableWriteImpl<?> write = table.newWrite(commitUser);
+        TableCommitImpl commit = table.newCommit(commitUser);
+
+        write.write(GenericRow.of(1, 10));
+        write.write(GenericRow.of(2, 20));
+        commit.commit(1, write.prepareCommit(true, 1));
+        write.write(GenericRow.of(3, 30));
+        commit.commit(2, write.prepareCommit(true, 2));
+        // local lineage watermark is now 3
+
+        // simulate external table loss: the committer must recreate the server table
+        // while the locally emitted snapshot carries a nonzero first-row-id
+        restCatalog.dropTable(TableIdentifier.of("mydb", "t"), false);
+
+        write.write(GenericRow.of(4, 40));
+        commit.commit(3, write.prepareCommit(true, 3));
+        write.close();
+        commit.close();
+
+        Table icebergTable = restCatalog.loadTable(TableIdentifier.of("mydb", "t"));
+        assertThat(TableUtil.formatVersion(icebergTable)).isEqualTo(3);
+        assertThat(getIcebergResult())
+                .containsExactlyInAnyOrder(
+                        "Record(1, 10)", "Record(2, 20)", "Record(3, 30)", "Record(4, 40)");
+        // Known Layer 1 limitation (documented in the spec): the server-side next-row-id
+        // watermark restarts on recreation and stays behind the local metadata; commits
+        // must keep succeeding regardless (validation is first-row-id >= next-row-id).
     }
 
     private static class TestRecord {


### PR DESCRIPTION
First PR of a 3-PR stack for #8972: metadata-level lineage (this PR) -> manifest-level lineage (`iceberg-v3-manifest-row-lineage`) -> VARIANT enablement (`iceberg-v3-variant`).

### Purpose

Since row lineage went GA in Iceberg v3 (Iceberg 1.10+), `next-row-id` is a mandatory table-metadata field: `TableMetadataParser` fails on any v3 metadata that omits it, and snapshots are expected to carry `first-row-id` / `added-rows`. Paimon's Iceberg compatibility layer wrote v3 metadata without these fields, so every GA reader — including AWS Glue's REST catalog and Iceberg 1.11 clients — rejects Paimon v3 tables outright (see #8972).

**Why synthetic lineage, and how it relates to Paimon's own row tracking.** Paimon already has a native row-lineage mechanism (`row-tracking.enabled`, the basis of data evolution): a per-snapshot `nextRowId` watermark, per-file `firstRowId` assigned at commit, and row id + sequence number materialized as physical columns upon rewrite of data files. Conceptually it matches Iceberg's model, but it is not fully compatible:
* Paimon writes its lineage columns under its own reserved field ids (`_ROW_ID` = `Integer.MAX_VALUE - 5`) while Iceberg readers resolve the reserved `_row_id` = `Integer.MAX_VALUE - 107` / `_last_updated_sequence_number` = `Integer.MAX_VALUE - 108` from the embedded Parquet field ids (before any name mapping applies) , so a compacted file's row identity cannot be resolved by an Iceberg reader from these physical columns.
* PK tables have no row tracking at all (the LSM merge path does not carry row identity).
 
What this set of PR is doing is creating a **synthetic** layer: spec-compliant row lineage generated and accounted entirely at the Iceberg-metadata layer, independent of Paimon's native ids. The resulting ids are stable as long as a file is not rewritten; a rewrite (compaction) legally re-assigns them, which readers observe as delete+insert rather than update. True native lineage export (a single id space shared with Paimon's row tracking, surviving compaction via materialized columns) requires Paimon format changes (writing the Iceberg-reserved field ids, opt-in for compatibility with existing files, plus row tracking for PK tables) and is beyond the scope of this set of changes. It can be built on top of these though.

This PR makes the metadata level spec-compliant:

* `IcebergMetadata` gains a nullable `next-row-id` field (serialized only when set, so v2 metadata is byte-identical to before).
* Metadata created without a base starts the row-id space at 0 and records the snapshot's `first-row-id` / `added-rows`; subsequent commits advance `next-row-id` by the committed record count.
* v3 base metadata written by older Paimon (no `next-row-id`) self-heals: the next commit detects the missing field and recreates metadata from scratch, preserving the table UUID.
* The REST metadata committer now propagates `format-version` when registering a table with a REST catalog (previously tables were always created as v2), and upgrades the catalog table when the local format version is newer.

Scope notes:

* Manifest-level lineage (`first_row_id` in manifest lists and manifest entries, Iceberg spec fields 520/142) is the next PR in the stack; until it lands, v3 stays writer-side incomplete at the manifest level, which GA readers tolerate for reads but which the follow-up makes spec-compliant.
* VARIANT publication remains gated off for all format versions in this PR; it is enabled for v3 at the top of the stack once the writer is fully lineage-compliant.
* `EnableRowLineage` is deliberately never sent to REST catalogs: the update was removed in Iceberg 1.10 GA and breaks Glue commits.

### Tests

* `IcebergMetadataNextRowIdTest`: JSON round-trip of the new field, absence on v2.
* `IcebergRowLineageCompatibilityTest`: fresh v3 metadata carries `next-row-id` / `first-row-id` / `added-rows` and parses with the bundled Iceberg `TableMetadataParser`; values advance across commits; v2 metadata is unchanged (no lineage keys in JSON); self-heal regenerates valid metadata when the base lacks `next-row-id`; tags survive regeneration.
* `IcebergRestMetadataCommitterTest`: v3 tables register with format-version 3 via the REST `TableBuilder`; existing v2 catalog tables are upgraded when Paimon moves to v3.

### AI notice
The code is generated using Fable 5 (with reviews from Codex) but has been verified to run on a real cluster with Flink, Paimon, Iceberg, StarRocks and Snowflake.


