### PR TITLE
[iceberg] Allow publishing VARIANT columns with Iceberg format version 3

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/iceberg/IcebergCommitCallback.java
+++ b/paimon-core/src/main/java/org/apache/paimon/iceberg/IcebergCommitCallback.java
@@ -733,7 +733,7 @@ public class IcebergCommitCallback implements CommitCallback, TagCallback {
         return result;
     }
 
-    /** VARIANT needs Iceberg row lineage, which Paimon Iceberg compatibility cannot publish. */
+    /** VARIANT is an Iceberg format-version-3 type; reject publishing it into v2 metadata. */
     static void checkVariantNotPublishable(RowType rowType) {
         Collection<String> variantFields = new LinkedHashSet<>();
         for (DataField field : rowType.getFields()) {
@@ -741,9 +741,8 @@ public class IcebergCommitCallback implements CommitCallback, TagCallback {
         }
         Preconditions.checkArgument(
                 variantFields.isEmpty(),
-                "Columns %s use the VARIANT type, which Paimon Iceberg compatibility cannot "
-                        + "publish: it is an Iceberg format-version-3 type that requires row "
-                        + "lineage.",
+                "Columns %s use the VARIANT type, which requires Iceberg format version 3. "
+                        + "Set 'metadata.iceberg.format-version' = '3' to publish this table.",
                 variantFields);
     }
 
@@ -2136,8 +2135,11 @@ public class IcebergCommitCallback implements CommitCallback, TagCallback {
                     schemaId,
                     id -> {
                         TableSchema schema = schemaManager.schema(id);
-                        // backstop: reject variant on each schema as it is emitted
-                        checkVariantNotPublishable(schema.logicalRowType());
+                        if (formatVersion < IcebergMetadata.FORMAT_VERSION_V3) {
+                            // VARIANT is an Iceberg format-version-3 type; v2 metadata cannot
+                            // represent it
+                            checkVariantNotPublishable(schema.logicalRowType());
+                        }
                         SchemaValidation.validateIcebergGeospatialTypes(
                                 schema.logicalRowType(), table.coreOptions());
                         return IcebergSchema.create(schema);

--- a/paimon-iceberg/src/test/java/org/apache/paimon/core/IcebergRowLineageCompatibilityTest.java
+++ b/paimon-iceberg/src/test/java/org/apache/paimon/core/IcebergRowLineageCompatibilityTest.java
@@ -23,6 +23,7 @@ import org.apache.paimon.catalog.FileSystemCatalog;
 import org.apache.paimon.catalog.Identifier;
 import org.apache.paimon.data.BinaryRow;
 import org.apache.paimon.data.GenericRow;
+import org.apache.paimon.data.variant.GenericVariant;
 import org.apache.paimon.disk.IOManagerImpl;
 import org.apache.paimon.fs.Path;
 import org.apache.paimon.fs.SeekableInputStream;
@@ -76,6 +77,7 @@ import java.util.Map;
 import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /** Tests for Iceberg format-version 3 row-lineage metadata fields. */
 public class IcebergRowLineageCompatibilityTest {
@@ -232,6 +234,52 @@ public class IcebergRowLineageCompatibilityTest {
         IcebergMetadata metadata = readIcebergMetadata(table, 2);
         assertThat(metadata.refs()).containsKey("t1");
         assertThat(metadata.nextRowId()).isEqualTo(3L);
+    }
+
+    @Test
+    public void testVariantPublishableWithFormatVersion3() throws Exception {
+        RowType rowType =
+                RowType.of(
+                        new DataType[] {DataTypes.INT(), DataTypes.VARIANT()},
+                        new String[] {"k", "payload"});
+        FileStoreTable table = createPaimonTable(rowType, formatVersionOptions(3), "parquet");
+        String commitUser = UUID.randomUUID().toString();
+        TableWriteImpl<?> write =
+                table.newWrite(commitUser)
+                        .withIOManager(new IOManagerImpl(tempDir.toString() + "/tmp"));
+        TableCommitImpl commit = table.newCommit(commitUser);
+
+        write.write(GenericRow.of(1, GenericVariant.fromJson("{\"a\": 1}")));
+        commit.commit(1, write.prepareCommit(false, 1));
+        write.close();
+        commit.close();
+
+        IcebergMetadata metadata = readIcebergMetadata(table, 1);
+        assertThat(metadata.nextRowId()).isEqualTo(1L);
+        assertThat(metadata.schemas().get(metadata.currentSchemaId()).fields().get(1).type())
+                .isEqualTo("variant");
+    }
+
+    @Test
+    public void testVariantRejectedWithFormatVersion2() throws Exception {
+        RowType rowType =
+                RowType.of(
+                        new DataType[] {DataTypes.INT(), DataTypes.VARIANT()},
+                        new String[] {"k", "payload"});
+        FileStoreTable table = createPaimonTable(rowType, formatVersionOptions(2), "parquet");
+        String commitUser = UUID.randomUUID().toString();
+        TableWriteImpl<?> write =
+                table.newWrite(commitUser)
+                        .withIOManager(new IOManagerImpl(tempDir.toString() + "/tmp"));
+        TableCommitImpl commit = table.newCommit(commitUser);
+
+        write.write(GenericRow.of(1, GenericVariant.fromJson("{\"a\": 1}")));
+        // hasStackTraceContaining: robust whether or not the commit path wraps the
+        // IllegalArgumentException from the guard
+        assertThatThrownBy(() -> commit.commit(1, write.prepareCommit(false, 1)))
+                .hasStackTraceContaining("VARIANT");
+        write.close();
+        commit.close();
     }
 
     @Test


### PR DESCRIPTION
Final PR of the 3-PR stack for #8972 — closes #8972. **Stacked on #9244 and #9245**: only the top commit belongs to this PR; the 13 commits below it are the two PRs underneath and will disappear from the diff as they merge.

### Purpose

Iceberg supports the VARIANT type from format version 3 onward, but v3 also made row lineage mandatory. Paimon therefore rejected VARIANT columns in the Iceberg compatibility layer for *all* format versions, because the v3 metadata it produced was not lineage-compliant and GA readers would reject the whole table (#8972).

With #9244 and #9245, Paimon's v3 writer emits complete row lineage (table metadata, manifest lists, manifest entries), so the reason to block VARIANT on v3 is gone. This PR lifts the guard for `metadata.iceberg.format-version` >= 3:

* Tables with VARIANT columns publish Iceberg metadata when the format version is 3, mapping to the Iceberg `variant` type.
* Format version 2 keeps the existing clear rejection (with a message pointing at the format-version option), since VARIANT does not exist in v2.

The guard lift is intentionally the last commit of the stack: every v3 table that can publish VARIANT is guaranteed to have carried full row lineage from its first commit.

### Tests

* `IcebergRowLineageCompatibilityTest#testVariantPublishableWithFormatVersion3`: a VARIANT column publishes on v3, the schema maps to Iceberg `variant`, and lineage fields are present.
* `IcebergRowLineageCompatibilityTest#testVariantRejectedWithFormatVersion2`: v2 commits with VARIANT still fail with the explicit error.

### AI notice
The code is generated using Fable 5 (with reviews from Codex) but has been verified to run on a real cluster with Flink, Paimon, Iceberg, StarRocks and Snowflake.
