### PR TITLE
[core] Compare binary elements and keys by value in collect and merge_map

### DIFF
--- a/paimon-common/src/main/java/org/apache/paimon/utils/ByteArrayKey.java
+++ b/paimon-common/src/main/java/org/apache/paimon/utils/ByteArrayKey.java
@@ -39,7 +39,7 @@ public final class ByteArrayKey {
         this.hash = Arrays.hashCode(bytes);
     }
 
-    byte[] bytes() {
+    public byte[] bytes() {
         return bytes;
     }
 

--- a/paimon-core/src/main/java/org/apache/paimon/mergetree/compact/aggregate/BinaryMapKeys.java
+++ b/paimon-core/src/main/java/org/apache/paimon/mergetree/compact/aggregate/BinaryMapKeys.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.mergetree.compact.aggregate;
+
+import org.apache.paimon.data.GenericMap;
+import org.apache.paimon.types.DataType;
+import org.apache.paimon.types.DataTypeFamily;
+import org.apache.paimon.utils.ByteArrayKey;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Value semantics for map keys of type {@code BINARY} or {@code VARBINARY}.
+ *
+ * <p>Such a key arrives as a {@code byte[]}, which inherits identity equality from {@link Object}.
+ * Used directly as a hash key, two keys with the same content occupy two entries, a lookup never
+ * finds an existing entry and a removal never matches. Keys are therefore held in a {@link
+ * ByteArrayKey} for as long as they are in a hash collection and unwrapped when the result map is
+ * built.
+ */
+final class BinaryMapKeys {
+
+    private BinaryMapKeys() {}
+
+    static boolean isBinary(DataType keyType) {
+        return keyType.getTypeRoot().getFamilies().contains(DataTypeFamily.BINARY_STRING);
+    }
+
+    /** Wrap a key for storage in a hash collection; a no-op for every non-binary key type. */
+    static Object hashKey(boolean binaryKey, Object key) {
+        return binaryKey && key != null ? new ByteArrayKey((byte[]) key) : key;
+    }
+
+    /** Build the result map, restoring the original {@code byte[]} of any wrapped key. */
+    static GenericMap toGenericMap(boolean binaryKey, Map<Object, Object> map) {
+        if (!binaryKey) {
+            return new GenericMap(map);
+        }
+        Map<Object, Object> unwrapped = new HashMap<>(map.size());
+        map.forEach(
+                (key, value) ->
+                        unwrapped.put(
+                                key instanceof ByteArrayKey ? ((ByteArrayKey) key).bytes() : key,
+                                value));
+        return new GenericMap(unwrapped);
+    }
+}

--- a/paimon-core/src/main/java/org/apache/paimon/mergetree/compact/aggregate/FieldCollectAgg.java
+++ b/paimon-core/src/main/java/org/apache/paimon/mergetree/compact/aggregate/FieldCollectAgg.java
@@ -36,6 +36,7 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Set;
 import java.util.function.BiFunction;
 
 import static org.apache.paimon.codegen.CodeGenUtils.newRecordEqualiser;
@@ -54,11 +55,7 @@ public class FieldCollectAgg extends FieldAggregator {
         this.distinct = distinct;
         this.elementGetter = InternalArray.createElementGetter(dataType.getElementType());
 
-        if (distinct
-                && dataType.getElementType()
-                        .getTypeRoot()
-                        .getFamilies()
-                        .contains(DataTypeFamily.CONSTRUCTED)) {
+        if (distinct && needsEqualiser(dataType.getElementType())) {
             DataType elementType = dataType.getElementType();
             List<DataType> fieldTypes =
                     elementType instanceof RowType
@@ -80,6 +77,20 @@ public class FieldCollectAgg extends FieldAggregator {
         } else {
             equaliser = null;
         }
+    }
+
+    /**
+     * Whether elements of this type need the generated equaliser rather than {@link Object#equals}.
+     *
+     * <p>Constructed types need it because two rows holding the same values are not necessarily
+     * equal objects. Binary types need it for a blunter reason: an element of {@code BINARY} or
+     * {@code VARBINARY} is a {@code byte[]}, which inherits identity equality from {@link Object},
+     * so two arrays with the same content never compare equal and never share a hash bucket.
+     */
+    private static boolean needsEqualiser(DataType elementType) {
+        Set<DataTypeFamily> families = elementType.getTypeRoot().getFamilies();
+        return families.contains(DataTypeFamily.CONSTRUCTED)
+                || families.contains(DataTypeFamily.BINARY_STRING);
     }
 
     @Override

--- a/paimon-core/src/main/java/org/apache/paimon/mergetree/compact/aggregate/FieldMergeMapAgg.java
+++ b/paimon-core/src/main/java/org/apache/paimon/mergetree/compact/aggregate/FieldMergeMapAgg.java
@@ -21,9 +21,7 @@ package org.apache.paimon.mergetree.compact.aggregate;
 import org.apache.paimon.data.GenericMap;
 import org.apache.paimon.data.InternalArray;
 import org.apache.paimon.data.InternalMap;
-import org.apache.paimon.types.DataTypeFamily;
 import org.apache.paimon.types.MapType;
-import org.apache.paimon.utils.ByteArrayKey;
 
 import java.util.HashMap;
 import java.util.HashSet;
@@ -38,12 +36,7 @@ public class FieldMergeMapAgg extends FieldAggregator {
     private final InternalArray.ElementGetter keyGetter;
     private final InternalArray.ElementGetter valueGetter;
 
-    /**
-     * A key of type {@code BINARY} or {@code VARBINARY} arrives as a {@code byte[]}, which inherits
-     * identity equality from {@link Object}. Used directly, two keys with the same content occupy
-     * two entries and a retraction never matches, so such keys are held in a {@link ByteArrayKey}
-     * while they are in a hash collection and unwrapped again on the way out.
-     */
+    /** See {@link BinaryMapKeys}: a binary key has no value equality of its own. */
     private final boolean binaryKey;
 
     public FieldMergeMapAgg(String name, MapType dataType) {
@@ -51,28 +44,15 @@ public class FieldMergeMapAgg extends FieldAggregator {
 
         this.keyGetter = InternalArray.createElementGetter(dataType.getKeyType());
         this.valueGetter = InternalArray.createElementGetter(dataType.getValueType());
-        this.binaryKey =
-                dataType.getKeyType()
-                        .getTypeRoot()
-                        .getFamilies()
-                        .contains(DataTypeFamily.BINARY_STRING);
+        this.binaryKey = BinaryMapKeys.isBinary(dataType.getKeyType());
     }
 
     private Object hashKey(Object key) {
-        return binaryKey && key != null ? new ByteArrayKey((byte[]) key) : key;
-    }
-
-    private Object originalKey(Object key) {
-        return key instanceof ByteArrayKey ? ((ByteArrayKey) key).bytes() : key;
+        return BinaryMapKeys.hashKey(binaryKey, key);
     }
 
     private GenericMap toGenericMap(Map<Object, Object> map) {
-        if (!binaryKey) {
-            return new GenericMap(map);
-        }
-        Map<Object, Object> unwrapped = new HashMap<>(map.size());
-        map.forEach((k, v) -> unwrapped.put(originalKey(k), v));
-        return new GenericMap(unwrapped);
+        return BinaryMapKeys.toGenericMap(binaryKey, map);
     }
 
     @Override

--- a/paimon-core/src/main/java/org/apache/paimon/mergetree/compact/aggregate/FieldMergeMapAgg.java
+++ b/paimon-core/src/main/java/org/apache/paimon/mergetree/compact/aggregate/FieldMergeMapAgg.java
@@ -21,7 +21,9 @@ package org.apache.paimon.mergetree.compact.aggregate;
 import org.apache.paimon.data.GenericMap;
 import org.apache.paimon.data.InternalArray;
 import org.apache.paimon.data.InternalMap;
+import org.apache.paimon.types.DataTypeFamily;
 import org.apache.paimon.types.MapType;
+import org.apache.paimon.utils.ByteArrayKey;
 
 import java.util.HashMap;
 import java.util.HashSet;
@@ -36,11 +38,41 @@ public class FieldMergeMapAgg extends FieldAggregator {
     private final InternalArray.ElementGetter keyGetter;
     private final InternalArray.ElementGetter valueGetter;
 
+    /**
+     * A key of type {@code BINARY} or {@code VARBINARY} arrives as a {@code byte[]}, which inherits
+     * identity equality from {@link Object}. Used directly, two keys with the same content occupy
+     * two entries and a retraction never matches, so such keys are held in a {@link ByteArrayKey}
+     * while they are in a hash collection and unwrapped again on the way out.
+     */
+    private final boolean binaryKey;
+
     public FieldMergeMapAgg(String name, MapType dataType) {
         super(name, dataType);
 
         this.keyGetter = InternalArray.createElementGetter(dataType.getKeyType());
         this.valueGetter = InternalArray.createElementGetter(dataType.getValueType());
+        this.binaryKey =
+                dataType.getKeyType()
+                        .getTypeRoot()
+                        .getFamilies()
+                        .contains(DataTypeFamily.BINARY_STRING);
+    }
+
+    private Object hashKey(Object key) {
+        return binaryKey && key != null ? new ByteArrayKey((byte[]) key) : key;
+    }
+
+    private Object originalKey(Object key) {
+        return key instanceof ByteArrayKey ? ((ByteArrayKey) key).bytes() : key;
+    }
+
+    private GenericMap toGenericMap(Map<Object, Object> map) {
+        if (!binaryKey) {
+            return new GenericMap(map);
+        }
+        Map<Object, Object> unwrapped = new HashMap<>(map.size());
+        map.forEach((k, v) -> unwrapped.put(originalKey(k), v));
+        return new GenericMap(unwrapped);
     }
 
     @Override
@@ -53,7 +85,7 @@ public class FieldMergeMapAgg extends FieldAggregator {
         putToMap(resultMap, accumulator);
         putToMap(resultMap, inputField);
 
-        return new GenericMap(resultMap);
+        return toGenericMap(resultMap);
     }
 
     private void putToMap(Map<Object, Object> map, Object data) {
@@ -62,7 +94,7 @@ public class FieldMergeMapAgg extends FieldAggregator {
         InternalArray valueArray = mapData.valueArray();
         for (int i = 0; i < keyArray.size(); i++) {
             map.put(
-                    keyGetter.getElementOrNull(keyArray, i),
+                    hashKey(keyGetter.getElementOrNull(keyArray, i)),
                     valueGetter.getElementOrNull(valueArray, i));
         }
     }
@@ -86,7 +118,7 @@ public class FieldMergeMapAgg extends FieldAggregator {
         InternalArray retractKeyArray = retract.keyArray();
         Set<Object> retractKeys = new HashSet<>();
         for (int i = 0; i < retractKeyArray.size(); i++) {
-            retractKeys.add(keyGetter.getElementOrNull(retractKeyArray, i));
+            retractKeys.add(hashKey(keyGetter.getElementOrNull(retractKeyArray, i)));
         }
 
         InternalMap acc = (InternalMap) accumulator;
@@ -94,12 +126,12 @@ public class FieldMergeMapAgg extends FieldAggregator {
         InternalArray accKeyArray = acc.keyArray();
         InternalArray accValueArray = acc.valueArray();
         for (int i = 0; i < accKeyArray.size(); i++) {
-            Object accKey = keyGetter.getElementOrNull(accKeyArray, i);
+            Object accKey = hashKey(keyGetter.getElementOrNull(accKeyArray, i));
             if (!retractKeys.contains(accKey)) {
                 resultMap.put(accKey, valueGetter.getElementOrNull(accValueArray, i));
             }
         }
 
-        return new GenericMap(resultMap);
+        return toGenericMap(resultMap);
     }
 }

--- a/paimon-core/src/main/java/org/apache/paimon/mergetree/compact/aggregate/FieldMergeMapWithKeyTimeAgg.java
+++ b/paimon-core/src/main/java/org/apache/paimon/mergetree/compact/aggregate/FieldMergeMapWithKeyTimeAgg.java
@@ -18,7 +18,6 @@
 
 package org.apache.paimon.mergetree.compact.aggregate;
 
-import org.apache.paimon.data.GenericMap;
 import org.apache.paimon.data.InternalArray;
 import org.apache.paimon.data.InternalMap;
 import org.apache.paimon.data.InternalRow;
@@ -36,11 +35,19 @@ public class FieldMergeMapWithKeyTimeAgg extends FieldAggregator {
     private final InternalArray.ElementGetter valueGetter;
     private final int timestampFieldIndex;
 
+    /** See {@link BinaryMapKeys}: a binary key has no value equality of its own. */
+    private final boolean binaryKey;
+
     public FieldMergeMapWithKeyTimeAgg(String name, MapType dataType, int timestampFieldIndex) {
         super(name, dataType);
         this.keyGetter = InternalArray.createElementGetter(dataType.getKeyType());
         this.valueGetter = InternalArray.createElementGetter(dataType.getValueType());
         this.timestampFieldIndex = timestampFieldIndex;
+        this.binaryKey = BinaryMapKeys.isBinary(dataType.getKeyType());
+    }
+
+    private Object hashKey(Object key) {
+        return BinaryMapKeys.hashKey(binaryKey, key);
     }
 
     @Override
@@ -60,14 +67,14 @@ public class FieldMergeMapWithKeyTimeAgg extends FieldAggregator {
 
         mergeInputMap(resultMap, inputMap);
 
-        return new GenericMap(resultMap);
+        return BinaryMapKeys.toGenericMap(binaryKey, resultMap);
     }
 
     private void putToMap(Map<Object, Object> map, InternalMap data) {
         InternalArray keyArray = data.keyArray();
         InternalArray valueArray = data.valueArray();
         for (int i = 0; i < keyArray.size(); i++) {
-            Object key = keyGetter.getElementOrNull(keyArray, i);
+            Object key = hashKey(keyGetter.getElementOrNull(keyArray, i));
             Object value = valueGetter.getElementOrNull(valueArray, i);
             map.put(key, value);
         }
@@ -78,7 +85,7 @@ public class FieldMergeMapWithKeyTimeAgg extends FieldAggregator {
         InternalArray valueArray = inputMap.valueArray();
 
         for (int i = 0; i < keyArray.size(); i++) {
-            Object key = keyGetter.getElementOrNull(keyArray, i);
+            Object key = hashKey(keyGetter.getElementOrNull(keyArray, i));
             InternalRow newRow = (InternalRow) valueGetter.getElementOrNull(valueArray, i);
 
             if (newRow == null) {

--- a/paimon-core/src/test/java/org/apache/paimon/mergetree/compact/aggregate/FieldAggregatorTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/mergetree/compact/aggregate/FieldAggregatorTest.java
@@ -2100,6 +2100,60 @@ public class FieldAggregatorTest {
         assertThat(unnest(result, elementGetter)).containsExactlyInAnyOrder(1, 2, 3);
     }
 
+    /**
+     * Elements of a binary array are {@code byte[]}, which has identity equality, so distinct
+     * collection has to compare them by content rather than dropping them into a {@link
+     * java.util.HashSet}.
+     */
+    @Test
+    public void testFieldCollectAggWithDistinctBinary() {
+        FieldCollectAgg agg =
+                new FieldCollectAggFactory()
+                        .create(
+                                DataTypes.ARRAY(DataTypes.VARBINARY(10)),
+                                CoreOptions.fromMap(
+                                        ImmutableMap.of("fields.fieldName.distinct", "true")),
+                                "fieldName");
+        InternalArray.ElementGetter elementGetter =
+                InternalArray.createElementGetter(DataTypes.VARBINARY(10));
+
+        InternalArray result =
+                (InternalArray)
+                        agg.agg(
+                                new GenericArray(new Object[] {new byte[] {1, 2}}),
+                                new GenericArray(
+                                        new Object[] {new byte[] {1, 2}, new byte[] {3, 4}}));
+
+        assertThat(unnest(result, elementGetter))
+                .usingRecursiveFieldByFieldElementComparator()
+                .containsExactlyInAnyOrder(new byte[] {1, 2}, new byte[] {3, 4});
+    }
+
+    /** Retraction of a binary element must match by content too. */
+    @Test
+    public void testFieldCollectAggRetractWithDistinctBinary() {
+        FieldCollectAgg agg =
+                new FieldCollectAggFactory()
+                        .create(
+                                DataTypes.ARRAY(DataTypes.VARBINARY(10)),
+                                CoreOptions.fromMap(
+                                        ImmutableMap.of("fields.fieldName.distinct", "true")),
+                                "fieldName");
+        InternalArray.ElementGetter elementGetter =
+                InternalArray.createElementGetter(DataTypes.VARBINARY(10));
+
+        InternalArray result =
+                (InternalArray)
+                        agg.retract(
+                                new GenericArray(
+                                        new Object[] {new byte[] {1, 2}, new byte[] {3, 4}}),
+                                new GenericArray(new Object[] {new byte[] {1, 2}}));
+
+        assertThat(unnest(result, elementGetter))
+                .usingRecursiveFieldByFieldElementComparator()
+                .containsExactly(new byte[] {3, 4});
+    }
+
     @Test
     public void testFiledCollectAggWithRowType() {
         RowType rowType = RowType.of(DataTypes.INT(), DataTypes.STRING());
@@ -2486,6 +2540,72 @@ public class FieldAggregatorTest {
                         new GenericMap(toMap(1, "A", 2, "B", 3, "C")),
                         new GenericMap(toMap(1, "A", 2, "A")));
         assertThat(toJavaMap(result)).containsExactlyInAnyOrderEntriesOf(toMap(3, "C"));
+    }
+
+    /**
+     * A binary key is a {@code byte[]}, which has identity equality, so without wrapping it the
+     * merged map keeps one entry per occurrence instead of one per distinct key.
+     */
+    @Test
+    public void testFieldMergeMapAggWithBinaryKey() {
+        FieldMergeMapAgg agg =
+                new FieldMergeMapAggFactory()
+                        .create(
+                                DataTypes.MAP(DataTypes.VARBINARY(10), DataTypes.INT()),
+                                null,
+                                null);
+
+        Map<Object, Object> first = new HashMap<>();
+        first.put(new byte[] {1, 2}, 1);
+        Map<Object, Object> second = new HashMap<>();
+        second.put(new byte[] {1, 2}, 2);
+        second.put(new byte[] {3, 4}, 3);
+
+        InternalMap merged = (InternalMap) agg.agg(new GenericMap(first), new GenericMap(second));
+
+        assertThat(merged.size()).isEqualTo(2);
+        assertThat(binaryKeyed(merged)).containsOnlyKeys("0102", "0304").containsValues(2, 3);
+    }
+
+    /** The same for retraction: a retracted binary key must match the accumulated one. */
+    @Test
+    public void testFieldMergeMapAggRetractWithBinaryKey() {
+        FieldMergeMapAgg agg =
+                new FieldMergeMapAggFactory()
+                        .create(
+                                DataTypes.MAP(DataTypes.VARBINARY(10), DataTypes.INT()),
+                                null,
+                                null);
+
+        Map<Object, Object> acc = new HashMap<>();
+        acc.put(new byte[] {1, 2}, 1);
+        acc.put(new byte[] {3, 4}, 2);
+        Map<Object, Object> retract = new HashMap<>();
+        retract.put(new byte[] {1, 2}, 1);
+
+        InternalMap result =
+                (InternalMap) agg.retract(new GenericMap(acc), new GenericMap(retract));
+
+        assertThat(result.size()).isEqualTo(1);
+        assertThat(binaryKeyed(result)).containsOnlyKeys("0304");
+    }
+
+    /** Render an {@code InternalMap} with binary keys as hex so it can be asserted by value. */
+    private Map<String, Object> binaryKeyed(InternalMap map) {
+        InternalArray.ElementGetter keyGetter =
+                InternalArray.createElementGetter(DataTypes.VARBINARY(10));
+        InternalArray.ElementGetter valueGetter =
+                InternalArray.createElementGetter(DataTypes.INT());
+        Map<String, Object> out = new HashMap<>();
+        for (int i = 0; i < map.size(); i++) {
+            byte[] key = (byte[]) keyGetter.getElementOrNull(map.keyArray(), i);
+            StringBuilder hex = new StringBuilder();
+            for (byte b : key) {
+                hex.append(String.format("%02x", b));
+            }
+            out.put(hex.toString(), valueGetter.getElementOrNull(map.valueArray(), i));
+        }
+        return out;
     }
 
     @Test

--- a/paimon-core/src/test/java/org/apache/paimon/mergetree/compact/aggregate/FieldAggregatorTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/mergetree/compact/aggregate/FieldAggregatorTest.java
@@ -2903,6 +2903,58 @@ public class FieldAggregatorTest {
                 createExpectedEntry("key3", "C"));
     }
 
+    /**
+     * With a binary key the timestamp comparison never runs, because the lookup of the existing
+     * entry misses: the newer row is appended as a second entry under the same logical key, and a
+     * null row fails to remove anything.
+     */
+    @Test
+    public void testFieldMergeMapWithKeyTimeAggWithBinaryKey() {
+        MapType mapType =
+                DataTypes.MAP(
+                        DataTypes.VARBINARY(10),
+                        DataTypes.ROW(
+                                DataTypes.FIELD(0, "actual_value", DataTypes.STRING()),
+                                DataTypes.FIELD(1, "dbsync_ts", DataTypes.STRING())));
+        FieldMergeMapWithKeyTimeAgg agg = new FieldMergeMapWithKeyTimeAgg("test", mapType, 1);
+
+        Object acc = agg.agg(null, binaryKeyedMap(new byte[] {1, 2}, "A", "100"));
+
+        // Newer timestamp for the same key wins, and does not become a second entry.
+        acc = agg.agg(acc, binaryKeyedMap(new byte[] {1, 2}, "A1", "200"));
+        InternalMap merged = (InternalMap) acc;
+        assertThat(merged.size()).isEqualTo(1);
+        assertThat(firstRowValue(merged)).isEqualTo("A1");
+
+        // Older timestamp is ignored rather than appended.
+        acc = agg.agg(acc, binaryKeyedMap(new byte[] {1, 2}, "A0", "050"));
+        merged = (InternalMap) acc;
+        assertThat(merged.size()).isEqualTo(1);
+        assertThat(firstRowValue(merged)).isEqualTo("A1");
+
+        // A null row is a tombstone and must remove the entry.
+        Map<Object, Object> tombstone = new HashMap<>();
+        tombstone.put(new byte[] {1, 2}, null);
+        acc = agg.agg(acc, new GenericMap(tombstone));
+        assertThat(((InternalMap) acc).size()).isEqualTo(0);
+    }
+
+    private GenericMap binaryKeyedMap(byte[] key, String value, String ts) {
+        Map<Object, Object> map = new HashMap<>();
+        map.put(key, GenericRow.of(BinaryString.fromString(value), BinaryString.fromString(ts)));
+        return new GenericMap(map);
+    }
+
+    private String firstRowValue(InternalMap map) {
+        InternalArray.ElementGetter valueGetter =
+                InternalArray.createElementGetter(
+                        DataTypes.ROW(
+                                DataTypes.FIELD(0, "actual_value", DataTypes.STRING()),
+                                DataTypes.FIELD(1, "dbsync_ts", DataTypes.STRING())));
+        InternalRow row = (InternalRow) valueGetter.getElementOrNull(map.valueArray(), 0);
+        return row.getString(0).toString();
+    }
+
     private Map.Entry<BinaryString, InternalRow> createEntry(String key, String value, String ts) {
         return new AbstractMap.SimpleEntry<>(
                 BinaryString.fromString(key),


### PR DESCRIPTION
### Purpose

`collect(distinct)` and `merge_map` compare their elements and keys with `Object.equals`. When those are `BINARY` or `VARBINARY` the value is a `byte[]`, which inherits identity equality, so nothing with the same content is ever recognised as the same thing.

Measured on `master` (`91ce4d6`), before any change:

| aggregator | input | result | expected |
|---|---|---|---|
| `collect(distinct)` on `ARRAY<BYTES>` | `[0x0102]` merged with `[0x0102]` | **2 elements** | 1 |
| `merge_map` on `MAP<BYTES, INT>` | `{0x0102: 1}` merged with `{0x0102: 2}` | **2 entries** | 1 |
| `merge_map` retract | `{0x0102: 1}` retract `{0x0102: 1}` | **1 entry** | 0 |

The middle row is the worst of the three: the aggregator hands back a `GenericMap` containing the same logical key twice, which is not a well-formed map at all. The third means a retraction on such a table never removes anything.

### Why it happens

**`FieldCollectAgg`** builds a generated `RecordEqualiser` and uses it instead of `Object.equals`, but only for constructed element types:

```java
if (distinct
        && dataType.getElementType().getTypeRoot().getFamilies()
                .contains(DataTypeFamily.CONSTRUCTED)) {
```

`BINARY` and `VARBINARY` are `(PREDEFINED, BINARY_STRING)` — not `CONSTRUCTED` — so `equaliser` stays null, `agg` falls into the `new HashSet<>()` branch, and the private `equals(a, b)` that `retract` uses degrades to `a.equals(b)` on two `byte[]`.

**`FieldMergeMapAgg`** has no equaliser at all: it keys a `HashMap` directly with `keyGetter.getElementOrNull(...)`, and its `retract` probes a `HashSet` of the same raw keys.

**`FieldMergeMapWithKeyTimeAgg`** — raised in review by @ArnavBalyan — does the same, and there the damage is larger, because it uses the key for two lookups rather than only for insertion:

```java
if (newRow == null) {
    resultMap.remove(key);                   // tombstone never matches
    continue;
}
Object existingValue = resultMap.get(key);   // always null for a byte[] key
if (existingValue == null) {
    resultMap.put(key, newRow);              // so this is always the branch taken
} else {
    ... newTs.compareTo(existingTs) > 0 ...  // never reached
}
```

The last-write-wins-by-timestamp behaviour the aggregator exists for is therefore bypassed entirely: an out-of-order older row is appended instead of discarded, and a tombstone removes nothing.

### What changes

**`FieldCollectAgg`** — the element type is routed to the existing equaliser path when it is binary as well as when it is constructed. The generated equaliser already compares `VARBINARY` by value; I checked that directly rather than assuming:

```java
RecordEqualiser eq = newRecordEqualiser(singletonList(DataTypes.VARBINARY(10)));
eq.equals(GenericRow.of(new byte[] {1, 2}), GenericRow.of(new byte[] {1, 2}))  // true
eq.equals(GenericRow.of(new byte[] {1, 2}), GenericRow.of(new byte[] {1, 3}))  // false
```

The gate on `distinct` stays. It has to: `agg` treats a non-null equaliser as "deduplicate", so building one unconditionally would make plain `collect` start dropping duplicates.

**Both map aggregators** — binary keys are held in `ByteArrayKey` (`paimon-common`, already used by `PartitionDictionary`, `ManifestEntryRunMergeEntry` and `DataEvolutionRowIdAssignmentPlanner`) while they sit in the hash collections, and unwrapped when the `GenericMap` is built. Since two classes need it, the wrapping lives in one place, `BinaryMapKeys`, as static methods so that nothing new has to be serialisable. `ByteArrayKey.bytes()` becomes `public` for the unwrap; it was package-private and the class exists for nothing else.

### Blast radius

Nothing changes for a non-binary key or element. `binaryKey` is false for every other type, so `BinaryMapKeys.hashKey` is the identity and `BinaryMapKeys.toGenericMap` returns `new GenericMap(map)` — the same object construction as before. In `FieldCollectAgg` the added branch is reachable only for `BINARY`/`VARBINARY`, which is exactly the case that is broken today. All pre-existing cases in `FieldAggregatorTest` pass unchanged.

### Tests

Five, in `FieldAggregatorTest`: distinct collect and its retraction on `ARRAY<VARBINARY>`, merge and retraction on `MAP<VARBINARY, INT>`, and a four-step walk of `merge_map_with_keytime` on a binary key covering newer-wins, older-ignored and tombstone-removes. Each mutation is isolated — reverting one fix fails only its own tests:

| reverted | failures |
|---|---|
| `needsEqualiser` back to `CONSTRUCTED` only | `testFieldCollectAggWithDistinctBinary`, `testFieldCollectAggRetractWithDistinctBinary` |
| `FieldMergeMapAgg.hashKey` back to the identity | `testFieldMergeMapAggWithBinaryKey`, `testFieldMergeMapAggRetractWithBinaryKey` |
| `FieldMergeMapWithKeyTimeAgg.hashKey` back to the identity | `testFieldMergeMapWithKeyTimeAggWithBinaryKey` |

`FieldAggregatorTest` (101), `FieldAggregatorRetractNullTest` (19) and `AggregateMergeFunctionTest` (3): 123 tests, 0 failures. `spotless:apply` and `checkstyle:check` on `paimon-common` and `paimon-core` are clean.

### Not in this PR

`FieldCollectAgg.retract` uses `equals(a, b)`, which is the raw `Object.equals` whenever `distinct` is false — so retraction of a non-distinct `collect` still compares constructed and binary elements by identity. That gap predates this change and applies to `ROW`/`ARRAY`/`MAP` elements too, so fixing it means giving `retract` an equality function of its own rather than borrowing the one `agg` uses for deduplication. Happy to do that separately if you want it.

### API and Format

No change to any option, on-disk format or public signature, other than widening `ByteArrayKey.bytes()` from package-private to public.
