### PR TITLE
[spark] Merge into query fails for is non null condition

### DIFF
--- a/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/catalyst/analysis/RowLevelHelper.scala
+++ b/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/catalyst/analysis/RowLevelHelper.scala
@@ -66,6 +66,7 @@ trait RowLevelHelper extends SQLConfHelper {
       .filterNot {
         case BinaryExpression(left, right) => left == right
         case Assignment(key, value) => key == value
+        case _ => false
       }
       .exists {
         case EqualTo(left: AttributeReference, right: AttributeReference) =>

--- a/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/sql/MergeIntoAlignmentTest.scala
+++ b/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/sql/MergeIntoAlignmentTest.scala
@@ -24,6 +24,29 @@ import org.apache.spark.sql.Row
 
 class MergeIntoAlignmentTest extends PaimonSparkTestBase {
 
+  test("merge into with is not null in condition") {
+    withTable("t") {
+      sql("""CREATE TABLE t (id INT, b INT, v STRING)
+            | USING paimon
+            | TBLPROPERTIES ('primary-key' = 'id', 'bucket' = '1')""".stripMargin)
+      sql("INSERT INTO t VALUES (1, 10, 'old-1'), (2, NULL, 'old-2')")
+
+      spark
+        .sql("SELECT 1 AS id, 'new-1' AS v")
+        .createOrReplaceTempView("s")
+
+      sql("""MERGE INTO t
+            | USING s
+            | ON t.id = s.id AND t.b IS NOT NULL
+            | WHEN MATCHED THEN UPDATE SET v = s.v""".stripMargin)
+
+      checkAnswer(
+        sql("SELECT id, b, v FROM t ORDER BY id"),
+        Seq(Row(1, 10, "new-1"), Row(2, null, "old-2"))
+      )
+    }
+  }
+
   test("basic merge: matched UPDATE *, not-matched INSERT *") {
     withTable("t") {
       sql("""CREATE TABLE t (id INT, name STRING)


### PR DESCRIPTION
### Purpose
- Merge into query fails with MatchError when the condition contains is not null.
- The PK validation does not handle not null expressions.
- Fix by retaining non null expression during validation.

### Tests
 - UT