### PR TITLE
[ci][python] Fix lint-python native-plan CI failure

### DIFF
--- a/.github/workflows/paimon-python-checks.yml
+++ b/.github/workflows/paimon-python-checks.yml
@@ -34,7 +34,7 @@ env:
   JDK_VERSION: 8
   MAVEN_OPTS: -Dmaven.wagon.httpconnectionManager.ttlSeconds=30 -Dmaven.wagon.http.retryHandler.requestSentEnabled=true
   LUMINA_DATA_VERSION: 0.1.0
-  PYPAIMON_RUST_REV: c7a71f4c3c9c5bf8883c1621caed09ec0ea2e49b
+  PYPAIMON_RUST_REV: be5456e96b326939570b6ef5d63acddda3311c4f
 
 
 concurrency:

--- a/paimon-python/pypaimon/tests/table_update_test.py
+++ b/paimon-python/pypaimon/tests/table_update_test.py
@@ -386,7 +386,7 @@ class _TableUpdateTestBase(DataEvolutionTestBase):
         self.assertEqual([['_ROW_ID']], projections)
         self.assertEqual(
             ['NYC', 'LA', 'Updated', 'Updated', 'Updated'],
-            self._read_all(table)['city'].to_pylist(),
+            self._read_all(table).sort_by('id')['city'].to_pylist(),
         )
 
     def test_update_by_predicate_accepts_array_chunked_and_scalar_values(self):


### PR DESCRIPTION
## Purpose

The `lint-python (3.11)` CI leg builds `pypaimon_rust` and runs the mixed native-plan tests. `table_update_test.py::test_literal_predicate_update_projects_only_row_id` fails deterministically on that leg (values correct, row-group order flipped):

    AssertionError: Lists differ: ['NYC', 'LA', 'Updated', 'Updated', 'Updated']
                              != ['Updated', 'Updated', 'Updated', 'NYC', 'LA']

Split order across row-id groups is not a cross-planner contract: engines may process splits in any order, and the Rust native plan can return the freshly updated group first. The test asserted an unsorted read, unlike its sibling tests which sort by `id` before asserting.

Bumping the pinned Rust revision alone does not fix this (verified on this PR's previous CI run with `be5456e`): apache/paimon-rust#717 aligns file order within row-id groups, not split order across groups.

## Changes

- Sort the test's read output by `id` before asserting, matching the file's convention.
- Bump `PYPAIMON_RUST_REV` from `c7a71f4` to current paimon-rust main `be5456e`, keeping the native leg on the contract-fixed planner (apache/paimon-rust#717, #719).

## Tests

- The two failing variants (Batch/Stream) pass locally with a native-plan-enabled `pypaimon_rust`.
- flake8 passed.