### PR TITLE
[format] Close the row-file input stream when the footer or index fails to parse

### DIFF
--- a/paimon-format/src/main/java/org/apache/paimon/format/row/RowFormatReaderFactory.java
+++ b/paimon-format/src/main/java/org/apache/paimon/format/row/RowFormatReaderFactory.java
@@ -53,26 +53,34 @@ public class RowFormatReaderFactory implements FormatReaderFactory {
 
         SeekableInputStream in = fileIO.newInputStream(path);
 
-        int tailSize = (int) Math.min(TAIL_PREFETCH_SIZE, fileSize);
-        long tailOffset = fileSize - tailSize;
-        in.seek(tailOffset);
-        byte[] tailBuf = new byte[tailSize];
-        IOUtils.readFully(in, tailBuf);
+        // Ownership of the stream passes to RowFormatReader only on the last line. Everything
+        // before it parses lengths and offsets taken from the file itself, so a truncated or
+        // corrupt file can throw anywhere in between and would otherwise leak the stream.
+        try {
+            int tailSize = (int) Math.min(TAIL_PREFETCH_SIZE, fileSize);
+            long tailOffset = fileSize - tailSize;
+            in.seek(tailOffset);
+            byte[] tailBuf = new byte[tailSize];
+            IOUtils.readFully(in, tailBuf);
 
-        RowFileFooter footer =
-                RowFileFooter.readFrom(tailBuf, tailSize - RowFileFooter.FOOTER_SIZE);
+            RowFileFooter footer =
+                    RowFileFooter.readFrom(tailBuf, tailSize - RowFileFooter.FOOTER_SIZE);
 
-        RowBlockIndex blockIndex;
-        if (footer.indexOffset >= tailOffset) {
-            int indexOffsetInBuf = (int) (footer.indexOffset - tailOffset);
-            byte[] indexData = new byte[footer.indexLength];
-            System.arraycopy(tailBuf, indexOffsetInBuf, indexData, 0, footer.indexLength);
-            blockIndex = RowBlockIndex.readFrom(indexData);
-        } else {
-            blockIndex = RowBlockIndex.readFrom(in, footer.indexOffset, footer.indexLength);
+            RowBlockIndex blockIndex;
+            if (footer.indexOffset >= tailOffset) {
+                int indexOffsetInBuf = (int) (footer.indexOffset - tailOffset);
+                byte[] indexData = new byte[footer.indexLength];
+                System.arraycopy(tailBuf, indexOffsetInBuf, indexData, 0, footer.indexLength);
+                blockIndex = RowBlockIndex.readFrom(indexData);
+            } else {
+                blockIndex = RowBlockIndex.readFrom(in, footer.indexOffset, footer.indexLength);
+            }
+
+            return new RowFormatReader(
+                    in, path, footer, blockIndex, rowType, projection, context.selection());
+        } catch (Throwable t) {
+            IOUtils.closeQuietly(in);
+            throw t;
         }
-
-        return new RowFormatReader(
-                in, path, footer, blockIndex, rowType, projection, context.selection());
     }
 }

--- a/paimon-format/src/test/java/org/apache/paimon/format/row/RowFormatReaderFactoryLeakTest.java
+++ b/paimon-format/src/test/java/org/apache/paimon/format/row/RowFormatReaderFactoryLeakTest.java
@@ -1,0 +1,150 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.format.row;
+
+import org.apache.paimon.format.FileFormat;
+import org.apache.paimon.format.FormatReaderContext;
+import org.apache.paimon.format.FormatReaderFactory;
+import org.apache.paimon.fs.Path;
+import org.apache.paimon.fs.PositionOutputStream;
+import org.apache.paimon.fs.SeekableInputStream;
+import org.apache.paimon.fs.local.LocalFileIO;
+import org.apache.paimon.options.Options;
+import org.apache.paimon.types.DataTypes;
+import org.apache.paimon.types.RowType;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * {@link RowFormatReaderFactory#createReader} opens the input stream before parsing a footer and a
+ * block index whose offsets and lengths come from the file itself. Ownership only passes to {@link
+ * RowFormatReader} on the last line, so a corrupt file must not leave the stream open.
+ *
+ * <p>This matters because {@code DataFileRecordReader.createReader} treats an {@code IOException}
+ * or {@code RuntimeException} from here as an ignorable corrupt file when {@code
+ * ignore-corrupt-files} is set: it logs, returns null, and the scan moves to the next file. One
+ * leaked descriptor per corrupt file, for as long as the scan runs.
+ */
+class RowFormatReaderFactoryLeakTest {
+
+    @TempDir java.nio.file.Path tempDir;
+
+    @Test
+    void aCorruptFooterDoesNotLeakTheInputStream() throws Exception {
+        Path path = new Path(new Path(tempDir.toString()), "corrupt.row");
+        CountingFileIO fileIO = new CountingFileIO();
+
+        // A file long enough to be read as a footer, but with none of the expected content.
+        try (PositionOutputStream out = fileIO.newOutputStream(path, false)) {
+            out.write(new byte[128]);
+        }
+
+        RowType rowType = RowType.of(DataTypes.INT());
+        FormatReaderFactory readerFactory =
+                FileFormat.fromIdentifier("row", new Options())
+                        .createReaderFactory(rowType, rowType, new ArrayList<>());
+
+        assertThatThrownBy(
+                        () ->
+                                readerFactory.createReader(
+                                        new FormatReaderContext(
+                                                fileIO,
+                                                path,
+                                                fileIO.getFileSize(path),
+                                                null,
+                                                null)))
+                .hasMessageContaining("Invalid row file magic");
+
+        assertThat(fileIO.openInputStreams()).isZero();
+    }
+
+    @Test
+    void anEmptyFileDoesNotLeakTheInputStream() throws Exception {
+        Path path = new Path(new Path(tempDir.toString()), "empty.row");
+        CountingFileIO fileIO = new CountingFileIO();
+        try (PositionOutputStream out = fileIO.newOutputStream(path, false)) {
+            // nothing: an aborted write leaves a zero-length object behind
+        }
+
+        RowType rowType = RowType.of(DataTypes.INT());
+        FormatReaderFactory readerFactory =
+                FileFormat.fromIdentifier("row", new Options())
+                        .createReaderFactory(rowType, rowType, new ArrayList<>());
+
+        assertThatThrownBy(
+                () ->
+                        readerFactory.createReader(
+                                new FormatReaderContext(
+                                        fileIO, path, fileIO.getFileSize(path), null, null)));
+
+        assertThat(fileIO.openInputStreams()).isZero();
+    }
+
+    /** Counts input streams that have been opened and not yet closed. */
+    private static class CountingFileIO extends LocalFileIO {
+
+        private final AtomicInteger open = new AtomicInteger();
+
+        int openInputStreams() {
+            return open.get();
+        }
+
+        @Override
+        public SeekableInputStream newInputStream(Path f) throws IOException {
+            SeekableInputStream delegate = super.newInputStream(f);
+            open.incrementAndGet();
+            return new SeekableInputStream() {
+
+                @Override
+                public void seek(long desired) throws IOException {
+                    delegate.seek(desired);
+                }
+
+                @Override
+                public long getPos() throws IOException {
+                    return delegate.getPos();
+                }
+
+                @Override
+                public int read() throws IOException {
+                    return delegate.read();
+                }
+
+                @Override
+                public int read(byte[] b, int off, int len) throws IOException {
+                    return delegate.read(b, off, len);
+                }
+
+                @Override
+                public void close() throws IOException {
+                    open.decrementAndGet();
+                    delegate.close();
+                }
+            };
+        }
+    }
+}


### PR DESCRIPTION
### Purpose

`RowFormatReaderFactory#createReader` opens the input stream on its first line and hands ownership to `RowFormatReader` on its last. Everything in between parses offsets and lengths taken out of the file itself, and any of it can throw on a truncated or corrupt file:

```java
SeekableInputStream in = fileIO.newInputStream(path);

in.seek(tailOffset);
IOUtils.readFully(in, tailBuf);
RowFileFooter footer = RowFileFooter.readFrom(tailBuf, tailSize - RowFileFooter.FOOTER_SIZE);
...
byte[] indexData = new byte[footer.indexLength];                     // length from the file
System.arraycopy(tailBuf, indexOffsetInBuf, indexData, 0, footer.indexLength);
blockIndex = RowBlockIndex.readFrom(indexData);

return new RowFormatReader(in, ...);                                 // ownership passes here
```

Concretely:

* a corrupt or truncated tail — `RowFileFooter.readFrom` throws `IOException("Invalid row file magic: …")`;
* a zero-length file, which is what an aborted write leaves behind — `tailSize` is 0, so the footer is read at offset `-32` and the array access throws;
* a bad `indexLength` or `indexOffset` — `new byte[…]` or the `arraycopy` throws.

On every one of those, `in` is a local that was never handed out, so nothing can close it.

### Why this repeats rather than happening once

`DataFileRecordReader.createReader` wraps this call:

```java
try {
    return readerFactory.createReader(context);
} catch (Exception e) {
    ...
    if (ignoreCorruptException(e, ignoreCorruptFiles)) {
        LOG.warn("Failed to create FileRecordReader for file: {}, ignore exception", ...);
        return null;                       // and the scan moves on
    }
```

and `ignoreCorruptException` accepts `IOException`, `RuntimeException` and `InternalError` — which covers all of the failures above. So with `ignore-corrupt-files` enabled, a scan over a directory containing corrupt `row` files leaks one descriptor per file and keeps going, which is exactly the configuration in which nobody notices.

### What changes

The body is wrapped so the stream is closed if ownership never transfers:

```java
try {
    ...
    return new RowFormatReader(in, ...);
} catch (Throwable t) {
    IOUtils.closeQuietly(in);
    throw t;
}
```

`Throwable` rather than `Exception` because `new byte[footer.indexLength]` with a corrupt length can raise an `Error`, and the caller's ignorable set already includes `InternalError`. `IOUtils` was already imported here for `readFully`.

Not try-with-resources: on the success path the stream must stay open, since `RowFormatReader` owns it from then on and closes it through `BlockPrefetcher`.

### Blast radius

None on a well-formed file — the only added path is the catch, and the success path returns exactly as before. `RowFormatReadWriteTest` (27) and `BlockPrefetcherTest` (14) pass unchanged.

### Tests

`RowFormatReaderFactoryLeakTest`, two cases, over a `LocalFileIO` subclass that counts input streams opened and not yet closed: a 128-byte file of zeros (fails the magic check) and a zero-length file (fails in the footer read). Both assert the count is back to zero after the failure.

Removing the `closeQuietly` fails both:

```
Tests run: 2, Failures: 2, Errors: 0
  aCorruptFooterDoesNotLeakTheInputStream
  anEmptyFileDoesNotLeakTheInputStream
```

`RowFormatReaderFactoryLeakTest`, `RowFormatReadWriteTest` and `BlockPrefetcherTest`: 43 tests, 0 failures. `spotless:apply` and `checkstyle:check` on `paimon-format` are clean.

### API and Format

No change to any public signature, option or on-disk format.
