### PR TITLE
[python] Add vectorized splice fast path for variant_set root inserts

### DIFF
--- a/paimon-python/pypaimon/data/variant_path.py
+++ b/paimon-python/pypaimon/data/variant_path.py
@@ -439,6 +439,9 @@ def _matching_value_structures(
                 == expected[offsets],
                 axis=1,
             )
+            if (start + width < position_count
+                    and not np.any(batch_matches)):
+                break
     return matches
 
 
@@ -1940,19 +1943,16 @@ def _apply_edits(
     return _materialize_value(results[0])
 
 
-def _plan_root_insert_splice(
-        values, rows, row_starts, row_lengths, source_data,
-        key_id, key_name, names_by_id, payloads):
-    """Plan a splice and identify rows matching the root layout."""
-    first_view = values.view(int(rows[0]))
-    header = first_view[0]
+def _root_insert_splice_layout(value, key_id, key_name, names_by_id):
+    """Return a root layout that can splice the new field."""
+    header = value[0]
     size, id_size, id_start, data_start, first_offsets, _ = (
-        _checked_object_layout(first_view, 0, len(first_view)))
+        _checked_object_layout(value, 0, len(value)))
     ordered_offsets = sorted(first_offsets)
     end_by_offset = dict(zip(ordered_offsets, ordered_offsets[1:]))
     for index in range(size):
         _checked_object_child_bounds(
-            first_view, data_start, first_offsets, index, end_by_offset)
+            value, data_start, first_offsets, index, end_by_offset)
     type_info = (header >> 2) & 0x3F
     large_size = ((type_info >> 4) & 0x1) != 0
     size_width = _U32_SIZE if large_size else 1
@@ -1963,13 +1963,35 @@ def _plan_root_insert_splice(
     if key_id >= 1 << (8 * id_size):
         return None
     ids = [
-        _read_unsigned(first_view, id_start + i * id_size, id_size)
+        _read_unsigned(value, id_start + i * id_size, id_size)
         for i in range(size)
     ]
     names = [names_by_id.get(field_id) for field_id in ids]
     if any(name is None for name in names) or names != sorted(names):
         return None
     slot = sum(name < key_name for name in names)
+    return (
+        header, size, size_width, id_size, id_start, data_start,
+        offset_size, offset_start, ids, slot,
+    )
+
+
+def _plan_root_insert_splice(
+        values, rows, row_starts, row_lengths, source_data,
+        key_id, key_name, names_by_id, payloads):
+    """Plan a splice and identify rows matching one root layout."""
+    layout = None
+    for row in rows:
+        layout = _root_insert_splice_layout(
+            values.view(int(row)), key_id, key_name, names_by_id)
+        if layout is not None:
+            break
+    if layout is None:
+        return None
+    (
+        header, size, size_width, id_size, id_start, data_start,
+        offset_size, offset_start, ids, slot,
+    ) = layout
 
     widths = np.full(len(rows), size_width, dtype=np.int64)
     ok = source_data[row_starts] == header
@@ -2071,8 +2093,7 @@ def _root_insert_splice(
             continue
         original = values.view(row)
         if source_metadata_size is not None:
-            if (matching_structures is None
-                    or not matching_structures[index]):
+            if not matching_structures[index]:
                 _validate_value_field_ids(
                     original, 0, len(original), source_metadata_size)
         else:

--- a/paimon-python/pypaimon/data/variant_path.py
+++ b/paimon-python/pypaimon/data/variant_path.py
@@ -70,6 +70,10 @@ _INDEX_PATTERN = re.compile(r"\[(\d+)]")
 _KEY_PATTERN = re.compile(r"\.([^\.\[]+)|\['([^']+)']|\[\"([^\"]+)\"]")
 _Path = Tuple[Tuple[str, object], ...]
 _SLOW_PATH_ROWS = 64
+_STRUCTURE_MATCH_GROUPS = 8
+_STRUCTURE_MATCH_MAX_BYTES = 64 * 1024
+_STRUCTURE_MATCH_ROWS = 16384
+_STRUCTURE_MATCH_WIDTH = 64
 
 
 @functools.lru_cache(maxsize=256)
@@ -345,7 +349,8 @@ def _checked_value_size(value, pos, limit=None):
     return end - pos
 
 
-def _validate_value_field_ids(value, pos, limit, metadata_size):
+def _validate_value_field_ids(
+        value, pos, limit, metadata_size, structure_ranges=None):
     """Validate object field ids in one unedited value subtree."""
     stack = [(pos, limit)]
     while stack:
@@ -356,6 +361,8 @@ def _validate_value_field_ids(value, pos, limit, metadata_size):
             size, id_size, id_start, data_start, offsets, value_end = (
                 _checked_object_layout(
                     value, current_pos, current_limit))
+            if structure_ranges is not None:
+                structure_ranges.append((current_pos, data_start))
             ids = [
                 _read_unsigned(value, id_start + i * id_size, id_size)
                 for i in range(size)
@@ -374,6 +381,8 @@ def _validate_value_field_ids(value, pos, limit, metadata_size):
         elif basic_type == _ARRAY:
             size, data_start, offsets, value_end = _checked_array_layout(
                 value, current_pos, current_limit)
+            if structure_ranges is not None:
+                structure_ranges.append((current_pos, data_start))
             for index in range(size):
                 stack.append((
                     data_start + offsets[index],
@@ -382,8 +391,52 @@ def _validate_value_field_ids(value, pos, limit, metadata_size):
         else:
             value_end = current_pos + _checked_value_size(
                 value, current_pos, current_limit)
+            if structure_ranges is not None:
+                type_info = (value[current_pos] >> 2) & 0x3F
+                structure_end = current_pos + 1
+                if basic_type == _PRIMITIVE:
+                    if type_info in (_BINARY, _LONG_STR):
+                        structure_end += _U32_SIZE
+                    elif type_info in (
+                            _DECIMAL4, _DECIMAL8, _DECIMAL16):
+                        structure_end = value_end
+                structure_ranges.append((current_pos, structure_end))
         if value_end != current_limit:
             _malformed("child size does not match container offsets")
+
+
+def _matching_value_structures(
+        value, source_data, row_starts, row_lengths, metadata_size):
+    """Match rows against one fully validated value structure."""
+    ranges = []
+    _validate_value_field_ids(
+        value, 0, len(value), metadata_size, ranges)
+    position_count = sum(end - start for start, end in ranges)
+    if position_count > _STRUCTURE_MATCH_MAX_BYTES:
+        return None
+    positions = np.empty(position_count, dtype=np.int64)
+    cursor = 0
+    for start, end in ranges:
+        count = end - start
+        positions[cursor:cursor + count] = np.arange(
+            start, end, dtype=np.int64)
+        cursor += count
+
+    matches = row_lengths == len(value)
+    safe_starts = np.where(matches, row_starts, 0)
+    expected = np.frombuffer(value, dtype=np.uint8)
+    for row_start in range(0, len(matches), _STRUCTURE_MATCH_ROWS):
+        row_end = min(row_start + _STRUCTURE_MATCH_ROWS, len(matches))
+        batch_matches = matches[row_start:row_end]
+        batch_starts = safe_starts[row_start:row_end]
+        for start in range(0, position_count, _STRUCTURE_MATCH_WIDTH):
+            offsets = positions[start:start + _STRUCTURE_MATCH_WIDTH]
+            batch_matches &= np.all(
+                source_data[batch_starts[:, None] + offsets]
+                == expected[offsets],
+                axis=1,
+            )
+    return matches
 
 
 def _field_slot(id_table: bytes, id_size: int, key_id: int) -> Optional[int]:
@@ -1971,6 +2024,23 @@ def _root_insert_splice(
         header, size, size_width, id_size, id_start, data_start,
         offset_size, offset_start, slot, sentinels, ok,
     ) = plan
+    matching_structures = None
+    if source_metadata_size is not None:
+        matching_structures = np.zeros(len(rows), dtype=bool)
+        remaining = ok.copy()
+        for _ in range(_STRUCTURE_MATCH_GROUPS):
+            candidates = np.flatnonzero(remaining)
+            if not len(candidates):
+                break
+            exemplar = int(candidates[0])
+            matches = _matching_value_structures(
+                values.view(int(rows[exemplar])), source_data,
+                row_starts, row_lengths, source_metadata_size)
+            if matches is None:
+                break
+            matches &= remaining
+            matching_structures |= matches
+            remaining &= ~matches
 
     if state.data is not None:
         source_view = memoryview(state.data)
@@ -1992,8 +2062,10 @@ def _root_insert_splice(
             continue
         original = values.view(row)
         if source_metadata_size is not None:
-            _validate_value_field_ids(
-                original, 0, len(original), source_metadata_size)
+            if (matching_structures is None
+                    or not matching_structures[index]):
+                _validate_value_field_ids(
+                    original, 0, len(original), source_metadata_size)
         else:
             row_size, _, _, row_data_start, offsets, _ = (
                 _checked_object_layout(original, 0, len(original)))

--- a/paimon-python/pypaimon/data/variant_path.py
+++ b/paimon-python/pypaimon/data/variant_path.py
@@ -74,6 +74,8 @@ _SLOW_PATH_ROWS = 64
 _STRUCTURE_MATCH_INDEX_BUDGET = 8 * 1024 * 1024
 # Bound encoded variable-width payloads retained while rebuilt rows accumulate.
 _ROOT_INSERT_SPLICE_PAYLOAD_BUDGET = 8 * 1024 * 1024
+# Bound per-row Python and NumPy temporaries for tiny payloads.
+_ROOT_INSERT_SPLICE_MAX_BATCH_ROWS = 64 * 1024
 
 
 @functools.lru_cache(maxsize=256)
@@ -1980,7 +1982,7 @@ def _root_insert_splice_layout(value, key_id, key_name, names_by_id):
 
 
 def _encoded_payload_batches(rows, provider, global_row):
-    """Encode array-backed splice payloads within a byte budget."""
+    """Encode array-backed splice payloads within byte and row budgets."""
     batch_start = 0
     payloads = []
     payload_bytes = 0
@@ -1988,8 +1990,10 @@ def _encoded_payload_batches(rows, provider, global_row):
         payload = provider.encode(
             provider.scalar_at(global_row + int(row)))
         if (payloads
-                and payload_bytes + len(payload)
-                > _ROOT_INSERT_SPLICE_PAYLOAD_BUDGET):
+                and (len(payloads)
+                     >= _ROOT_INSERT_SPLICE_MAX_BATCH_ROWS
+                     or payload_bytes + len(payload)
+                     > _ROOT_INSERT_SPLICE_PAYLOAD_BUDGET)):
             yield batch_start, index, payloads
             batch_start = index
             payloads = []
@@ -1998,6 +2002,20 @@ def _encoded_payload_batches(rows, provider, global_row):
         payload_bytes += len(payload)
     if payloads:
         yield batch_start, len(rows), payloads
+
+
+def _repeated_payload_batches(row_count, payload):
+    """Repeat a scalar payload without creating an unbounded row batch."""
+    for batch_start in range(
+            0, row_count, _ROOT_INSERT_SPLICE_MAX_BATCH_ROWS):
+        batch_end = min(
+            batch_start + _ROOT_INSERT_SPLICE_MAX_BATCH_ROWS,
+            row_count)
+        yield (
+            batch_start,
+            batch_end,
+            [payload] * (batch_end - batch_start),
+        )
 
 
 def _plan_root_insert_splice(
@@ -2275,9 +2293,8 @@ def _set_chunk(chunk, values, parsed, global_row):
                 continue
             if provider._array is None:
                 payload = payload_for(insert_index, provider, 0)
-                batches = (
-                    (0, len(live_rows), [payload] * len(live_rows)),
-                )
+                batches = _repeated_payload_batches(
+                    len(live_rows), payload)
             else:
                 batches = _encoded_payload_batches(
                     live_rows, provider, global_row)

--- a/paimon-python/pypaimon/data/variant_path.py
+++ b/paimon-python/pypaimon/data/variant_path.py
@@ -2039,9 +2039,15 @@ def _root_insert_splice(
             boundaries = np.flatnonzero(lengths[1:] != lengths[:-1]) + 1
             for group in np.split(candidates, boundaries):
                 exemplar = int(group[0])
+                value = values.view(int(rows[exemplar]))
+                if len(group) == 1:
+                    _validate_value_field_ids(
+                        value, 0, len(value), source_metadata_size)
+                    matching_structures[exemplar] = True
+                    continue
                 matches = _matching_value_structures(
-                    values.view(int(rows[exemplar])), source_data,
-                    row_starts[group], source_metadata_size)
+                    value, source_data, row_starts[group],
+                    source_metadata_size)
                 if matches is not None:
                     matching_structures[group[matches]] = True
 

--- a/paimon-python/pypaimon/data/variant_path.py
+++ b/paimon-python/pypaimon/data/variant_path.py
@@ -1880,11 +1880,11 @@ def _apply_edits(
     return _materialize_value(results[0])
 
 
-def _root_insert_splice(
-        values, state, rows, row_starts, row_lengths, source_data,
+def _plan_root_insert_splice(
+        values, rows, row_starts, row_lengths, source_data,
         key_id, key_name, names_by_id, payloads,
-        source_metadata_size, output_metadata_size):
-    """Splice one field into uniform root objects."""
+        source_metadata_size):
+    """Plan a splice and identify rows matching the root layout."""
     first_view = values.view(int(rows[0]))
     header = first_view[0]
     size, id_size, id_start, data_start, first_offsets, _ = (
@@ -1952,6 +1952,28 @@ def _root_insert_splice(
         (len(payload) for payload in payloads), np.int64, len(payloads))
     new_sentinels = sentinels + payload_lengths
     ok &= new_sentinels < 1 << (8 * offset_size)
+
+    return (
+        header, size, size_width, id_size, id_start, data_start,
+        offset_size, offset_start, slot, sentinels, ok,
+    )
+
+
+def _root_insert_splice(
+        values, state, rows, row_starts, row_lengths, source_data,
+        key_id, key_name, names_by_id, payloads,
+        source_metadata_size, output_metadata_size):
+    """Splice one field into uniform root objects."""
+    plan = _plan_root_insert_splice(
+        values, rows, row_starts, row_lengths, source_data,
+        key_id, key_name, names_by_id, payloads,
+        source_metadata_size)
+    if plan is None:
+        return None
+    (
+        header, size, size_width, id_size, id_start, data_start,
+        offset_size, offset_start, slot, sentinels, ok,
+    ) = plan
 
     if state.data is not None:
         source_view = memoryview(state.data)

--- a/paimon-python/pypaimon/data/variant_path.py
+++ b/paimon-python/pypaimon/data/variant_path.py
@@ -350,14 +350,12 @@ def _validate_value_field_ids(value, pos, limit, metadata_size):
     stack = [(pos, limit)]
     while stack:
         current_pos, current_limit = stack.pop()
-        value_end = current_pos + _checked_value_size(
-            value, current_pos, current_limit)
-        if value_end != current_limit:
-            _malformed("child size does not match container offsets")
+        _require_range(current_pos, 1, current_limit)
         basic_type = value[current_pos] & 0x3
         if basic_type == _OBJECT:
-            size, id_size, id_start, data_start, offsets, _ = (
-                _checked_object_layout(value, current_pos, value_end))
+            size, id_size, id_start, data_start, offsets, value_end = (
+                _checked_object_layout(
+                    value, current_pos, current_limit))
             ids = [
                 _read_unsigned(value, id_start + i * id_size, id_size)
                 for i in range(size)
@@ -368,18 +366,24 @@ def _validate_value_field_ids(value, pos, limit, metadata_size):
             end_by_offset = dict(zip(
                 ordered_offsets, ordered_offsets[1:]))
             for slot in range(size):
-                child_start, child_end = _checked_object_child_bounds(
-                    value, data_start, offsets, slot, end_by_offset)
-                if (value[child_start] & 0x3) in (_OBJECT, _ARRAY):
-                    stack.append((child_start, child_end))
+                child_offset = offsets[slot]
+                stack.append((
+                    data_start + child_offset,
+                    data_start + end_by_offset[child_offset],
+                ))
         elif basic_type == _ARRAY:
-            size, data_start, offsets, _ = _checked_array_layout(
-                value, current_pos, value_end)
+            size, data_start, offsets, value_end = _checked_array_layout(
+                value, current_pos, current_limit)
             for index in range(size):
                 stack.append((
                     data_start + offsets[index],
                     data_start + offsets[index + 1],
                 ))
+        else:
+            value_end = current_pos + _checked_value_size(
+                value, current_pos, current_limit)
+        if value_end != current_limit:
+            _malformed("child size does not match container offsets")
 
 
 def _field_slot(id_table: bytes, id_size: int, key_id: int) -> Optional[int]:
@@ -1882,8 +1886,7 @@ def _apply_edits(
 
 def _plan_root_insert_splice(
         values, rows, row_starts, row_lengths, source_data,
-        key_id, key_name, names_by_id, payloads,
-        source_metadata_size):
+        key_id, key_name, names_by_id, payloads):
     """Plan a splice and identify rows matching the root layout."""
     first_view = values.view(int(rows[0]))
     header = first_view[0]
@@ -1891,14 +1894,9 @@ def _plan_root_insert_splice(
         _checked_object_layout(first_view, 0, len(first_view)))
     ordered_offsets = sorted(first_offsets)
     end_by_offset = dict(zip(ordered_offsets, ordered_offsets[1:]))
-    has_nested_child = False
     for index in range(size):
-        child_start, _ = _checked_object_child_bounds(
+        _checked_object_child_bounds(
             first_view, data_start, first_offsets, index, end_by_offset)
-        has_nested_child |= (
-            first_view[child_start] & 0x3) in (_OBJECT, _ARRAY)
-    if source_metadata_size is not None and has_nested_child:
-        return None
     type_info = (header >> 2) & 0x3F
     large_size = ((type_info >> 4) & 0x1) != 0
     size_width = _U32_SIZE if large_size else 1
@@ -1966,8 +1964,7 @@ def _root_insert_splice(
     """Splice one field into uniform root objects."""
     plan = _plan_root_insert_splice(
         values, rows, row_starts, row_lengths, source_data,
-        key_id, key_name, names_by_id, payloads,
-        source_metadata_size)
+        key_id, key_name, names_by_id, payloads)
     if plan is None:
         return None
     (

--- a/paimon-python/pypaimon/data/variant_path.py
+++ b/paimon-python/pypaimon/data/variant_path.py
@@ -1880,6 +1880,134 @@ def _apply_edits(
     return _materialize_value(results[0])
 
 
+def _root_insert_splice(
+        values, state, rows, row_starts, row_lengths, source_data,
+        key_id, key_name, names_by_id, payloads,
+        source_metadata_size, output_metadata_size):
+    """Splice one field into uniform root objects."""
+    first_view = values.view(int(rows[0]))
+    header = first_view[0]
+    size, id_size, id_start, data_start, first_offsets, _ = (
+        _checked_object_layout(first_view, 0, len(first_view)))
+    ordered_offsets = sorted(first_offsets)
+    end_by_offset = dict(zip(ordered_offsets, ordered_offsets[1:]))
+    has_nested_child = False
+    for index in range(size):
+        child_start, _ = _checked_object_child_bounds(
+            first_view, data_start, first_offsets, index, end_by_offset)
+        has_nested_child |= (
+            first_view[child_start] & 0x3) in (_OBJECT, _ARRAY)
+    if source_metadata_size is not None and has_nested_child:
+        return None
+    type_info = (header >> 2) & 0x3F
+    large_size = ((type_info >> 4) & 0x1) != 0
+    size_width = _U32_SIZE if large_size else 1
+    offset_size = (type_info & 0x3) + 1
+    offset_start = id_start + size * id_size
+    if not large_size and size + 1 > _U8_MAX:
+        return None
+    if key_id >= 1 << (8 * id_size):
+        return None
+    ids = [
+        _read_unsigned(first_view, id_start + i * id_size, id_size)
+        for i in range(size)
+    ]
+    names = [names_by_id.get(field_id) for field_id in ids]
+    if any(name is None for name in names) or names != sorted(names):
+        return None
+    slot = sum(name < key_name for name in names)
+
+    widths = np.full(len(rows), size_width, dtype=np.int64)
+    ok = source_data[row_starts] == header
+    ok &= row_lengths >= data_start
+    safe_starts = np.where(ok, row_starts, 0)
+    ok &= _take_unsigned(source_data, safe_starts + 1, widths) == size
+    widths = np.full(len(rows), id_size, dtype=np.int64)
+    for index in range(size):
+        ok &= _take_unsigned(
+            source_data,
+            safe_starts + id_start + index * id_size,
+            widths,
+        ) == ids[index]
+    widths = np.full(len(rows), offset_size, dtype=np.int64)
+    sentinels = _take_unsigned(
+        source_data,
+        safe_starts + offset_start + size * offset_size,
+        widths,
+    )
+    ok &= data_start + sentinels == row_lengths
+    if size:
+        minimum = None
+        for index in range(size):
+            entry = _take_unsigned(
+                source_data,
+                safe_starts + offset_start + index * offset_size,
+                widths,
+            )
+            ok &= entry < sentinels
+            minimum = entry if minimum is None else np.minimum(
+                minimum, entry)
+        ok &= minimum == 0
+    payload_lengths = np.fromiter(
+        (len(payload) for payload in payloads), np.int64, len(payloads))
+    new_sentinels = sentinels + payload_lengths
+    ok &= new_sentinels < 1 << (8 * offset_size)
+
+    if state.data is not None:
+        source_view = memoryview(state.data)
+        source_base = state.data_start
+    else:
+        source_view = values.data
+        source_base = 0
+    prefix = bytes([header]) + (size + 1).to_bytes(size_width, 'little')
+    id_bytes = key_id.to_bytes(id_size, 'little')
+    id_slot = id_start + slot * id_size
+    offset_slot = offset_start + slot * offset_size
+    sentinel_slot = offset_start + size * offset_size
+    rebuilt = {}
+    fallback_rows = []
+    for index, row in enumerate(rows):
+        row = int(row)
+        if not ok[index]:
+            fallback_rows.append(row)
+            continue
+        original = values.view(row)
+        if source_metadata_size is not None:
+            _validate_value_field_ids(
+                original, 0, len(original), source_metadata_size)
+        else:
+            row_size, _, _, row_data_start, offsets, _ = (
+                _checked_object_layout(original, 0, len(original)))
+            if row_size != size:
+                fallback_rows.append(row)
+                continue
+            ordered = sorted(offsets)
+            ends = dict(zip(ordered, ordered[1:]))
+            for child in range(row_size):
+                _checked_object_child_bounds(
+                    original, row_data_start, offsets, child, ends)
+        base = int(row_starts[index]) - source_base
+        sentinel = int(sentinels[index])
+        _check_variant_sizes(
+            int(row_lengths[index]) + id_size + offset_size
+            + len(payloads[index]),
+            output_metadata_size,
+        )
+        rebuilt[row] = b''.join((
+            prefix,
+            source_view[base + id_start:base + id_slot],
+            id_bytes,
+            source_view[base + id_slot:base + offset_slot],
+            sentinel.to_bytes(offset_size, 'little'),
+            source_view[base + offset_slot:base + sentinel_slot],
+            (sentinel + len(payloads[index])).to_bytes(
+                offset_size, 'little'),
+            source_view[base + data_start:base + data_start + sentinel],
+            payloads[index],
+        ))
+    return rebuilt, fallback_rows
+
+
 def _set_chunk(chunk, values, parsed, global_row):
     parsed_paths = [parsed_path for _, parsed_path, _ in parsed]
     parent_paths = [parsed_path[:-1] for parsed_path in parsed_paths]
@@ -1939,6 +2067,8 @@ def _set_chunk(chunk, values, parsed, global_row):
         target_positions = positions[:count]
         target_limits = limits[:count]
         parent_positions = positions[count:]
+        parent_limits = limits[count:]
+        group_slow = set()
         insert_indices = []
         for index, (path, parsed_path, provider) in enumerate(parsed):
             if target_positions[index] is not None:
@@ -1976,8 +2106,75 @@ def _set_chunk(chunk, values, parsed, global_row):
         new_metadata, key_ids, names_by_id = _metadata_with_keys(
             first_metadata, insert_keys)
         insert_set = set(insert_indices)
+        splice_eligible = (
+            len(insert_indices) == 1
+            and len(parsed[insert_indices[0]][1]) == 1
+            and all(
+                index in insert_set
+                or parsed[index][2]._fixed_size is not None
+                for index in range(count))
+        )
+        if splice_eligible:
+            insert_index = insert_indices[0]
+            replace_indices = [
+                index for index in range(count) if index != insert_index
+            ]
+            if replace_indices:
+                _patch_planned_group(
+                    (rows, row_starts, source_data,
+                     [target_positions[index] for index in replace_indices],
+                     [target_limits[index] for index in replace_indices]),
+                    [parsed[index] for index in replace_indices],
+                    len(chunk), global_row, state, group_slow, False)
+                slow_rows |= group_slow
+            if group_slow:
+                keep = np.fromiter(
+                    (int(row) not in group_slow for row in rows),
+                    bool, len(rows))
+                live_rows = rows[keep]
+                live_starts = row_starts[keep]
+                live_lengths = parent_limits[insert_index][keep]
+            else:
+                live_rows = rows
+                live_starts = row_starts
+                live_lengths = parent_limits[insert_index]
+            provider = parsed[insert_index][2]
+            if provider._array is None:
+                payloads = [
+                    payload_for(insert_index, provider, 0)
+                ] * len(live_rows)
+            else:
+                payloads = [
+                    provider.encode(
+                        provider.scalar_at(global_row + int(row)))
+                    for row in live_rows
+                ]
+            key_name = parsed[insert_index][1][-1][1]
+            spliced = (
+                _root_insert_splice(
+                    values, state, live_rows, live_starts, live_lengths,
+                    source_data, key_ids[key_name], key_name,
+                    names_by_id, payloads, source_metadata_size,
+                    len(new_metadata if new_metadata is not None
+                        else first_metadata))
+                if len(live_rows) else ({}, [])
+            )
+            if spliced is not None:
+                rebuilt, fallback_rows = spliced
+                rebuilt_rows.update(rebuilt)
+                if new_metadata is not None:
+                    for row in rebuilt:
+                        rebuilt_metadata[row] = new_metadata
+                for row in fallback_rows:
+                    rebuild_row(
+                        row, values.view(row), insert_set, key_ids,
+                        names_by_id, first_metadata, new_metadata,
+                        source_metadata_size)
+                continue
         for offset_index, row in enumerate(rows):
             row = int(row)
+            if row in group_slow:
+                continue
             rebuild_row(
                 row, values.view(row), insert_set, key_ids, names_by_id,
                 first_metadata, new_metadata, source_metadata_size,

--- a/paimon-python/pypaimon/data/variant_path.py
+++ b/paimon-python/pypaimon/data/variant_path.py
@@ -70,10 +70,8 @@ _INDEX_PATTERN = re.compile(r"\[(\d+)]")
 _KEY_PATTERN = re.compile(r"\.([^\.\[]+)|\['([^']+)']|\[\"([^\"]+)\"]")
 _Path = Tuple[Tuple[str, object], ...]
 _SLOW_PATH_ROWS = 64
-_STRUCTURE_MATCH_GROUPS = 8
-_STRUCTURE_MATCH_MAX_BYTES = 64 * 1024
-_STRUCTURE_MATCH_ROWS = 16384
-_STRUCTURE_MATCH_WIDTH = 64
+# Bound the dominant temporary allocation during batch structure matching.
+_STRUCTURE_MATCH_INDEX_BUDGET = 8 * 1024 * 1024
 
 
 @functools.lru_cache(maxsize=256)
@@ -406,14 +404,18 @@ def _validate_value_field_ids(
 
 
 def _matching_value_structures(
-        value, source_data, row_starts, row_lengths, metadata_size):
-    """Match rows against one fully validated value structure."""
+        value, source_data, row_starts, metadata_size):
+    """Match equal-length rows against one validated value structure."""
     ranges = []
     _validate_value_field_ids(
         value, 0, len(value), metadata_size, ranges)
     position_count = sum(end - start for start, end in ranges)
-    if position_count > _STRUCTURE_MATCH_MAX_BYTES:
+    index_size = np.dtype(np.int64).itemsize
+    position_bytes = position_count * index_size
+    available_bytes = _STRUCTURE_MATCH_INDEX_BUDGET - position_bytes
+    if available_bytes < index_size:
         return None
+    max_cells = available_bytes // index_size
     positions = np.empty(position_count, dtype=np.int64)
     cursor = 0
     for start, end in ranges:
@@ -422,15 +424,16 @@ def _matching_value_structures(
             start, end, dtype=np.int64)
         cursor += count
 
-    matches = row_lengths == len(value)
-    safe_starts = np.where(matches, row_starts, 0)
+    matches = np.ones(len(row_starts), dtype=bool)
     expected = np.frombuffer(value, dtype=np.uint8)
-    for row_start in range(0, len(matches), _STRUCTURE_MATCH_ROWS):
-        row_end = min(row_start + _STRUCTURE_MATCH_ROWS, len(matches))
+    width = max(1, min(position_count, max_cells))
+    row_chunk_size = min(len(matches), max(1, max_cells // width))
+    for row_start in range(0, len(matches), row_chunk_size):
+        row_end = min(row_start + row_chunk_size, len(matches))
         batch_matches = matches[row_start:row_end]
-        batch_starts = safe_starts[row_start:row_end]
-        for start in range(0, position_count, _STRUCTURE_MATCH_WIDTH):
-            offsets = positions[start:start + _STRUCTURE_MATCH_WIDTH]
+        batch_starts = row_starts[row_start:row_end]
+        for start in range(0, position_count, width):
+            offsets = positions[start:start + width]
             batch_matches &= np.all(
                 source_data[batch_starts[:, None] + offsets]
                 == expected[offsets],
@@ -2027,20 +2030,20 @@ def _root_insert_splice(
     matching_structures = None
     if source_metadata_size is not None:
         matching_structures = np.zeros(len(rows), dtype=bool)
-        remaining = ok.copy()
-        for _ in range(_STRUCTURE_MATCH_GROUPS):
-            candidates = np.flatnonzero(remaining)
-            if not len(candidates):
-                break
-            exemplar = int(candidates[0])
-            matches = _matching_value_structures(
-                values.view(int(rows[exemplar])), source_data,
-                row_starts, row_lengths, source_metadata_size)
-            if matches is None:
-                break
-            matches &= remaining
-            matching_structures |= matches
-            remaining &= ~matches
+        candidates = np.flatnonzero(ok)
+        if len(candidates):
+            lengths = row_lengths[candidates]
+            order = np.argsort(lengths, kind='stable')
+            candidates = candidates[order]
+            lengths = lengths[order]
+            boundaries = np.flatnonzero(lengths[1:] != lengths[:-1]) + 1
+            for group in np.split(candidates, boundaries):
+                exemplar = int(group[0])
+                matches = _matching_value_structures(
+                    values.view(int(rows[exemplar])), source_data,
+                    row_starts[group], source_metadata_size)
+                if matches is not None:
+                    matching_structures[group[matches]] = True
 
     if state.data is not None:
         source_view = memoryview(state.data)

--- a/paimon-python/pypaimon/data/variant_path.py
+++ b/paimon-python/pypaimon/data/variant_path.py
@@ -72,6 +72,8 @@ _Path = Tuple[Tuple[str, object], ...]
 _SLOW_PATH_ROWS = 64
 # Bound the dominant temporary allocation during batch structure matching.
 _STRUCTURE_MATCH_INDEX_BUDGET = 8 * 1024 * 1024
+# Bound encoded variable-width payloads retained while rebuilt rows accumulate.
+_ROOT_INSERT_SPLICE_PAYLOAD_BUDGET = 8 * 1024 * 1024
 
 
 @functools.lru_cache(maxsize=256)
@@ -1946,14 +1948,9 @@ def _apply_edits(
 
 def _root_insert_splice_layout(value, key_id, key_name, names_by_id):
     """Return a root layout that can splice the new field."""
-    header = value[0]
     size, id_size, id_start, data_start, first_offsets, _ = (
         _checked_object_layout(value, 0, len(value)))
-    ordered_offsets = sorted(first_offsets)
-    end_by_offset = dict(zip(ordered_offsets, ordered_offsets[1:]))
-    for index in range(size):
-        _checked_object_child_bounds(
-            value, data_start, first_offsets, index, end_by_offset)
+    header = value[0]
     type_info = (header >> 2) & 0x3F
     large_size = ((type_info >> 4) & 0x1) != 0
     size_width = _U32_SIZE if large_size else 1
@@ -1963,6 +1960,11 @@ def _root_insert_splice_layout(value, key_id, key_name, names_by_id):
         return None
     if key_id >= 1 << (8 * id_size):
         return None
+    ordered_offsets = sorted(first_offsets)
+    end_by_offset = dict(zip(ordered_offsets, ordered_offsets[1:]))
+    for index in range(size):
+        _checked_object_child_bounds(
+            value, data_start, first_offsets, index, end_by_offset)
     ids = [
         _read_unsigned(value, id_start + i * id_size, id_size)
         for i in range(size)
@@ -1975,6 +1977,27 @@ def _root_insert_splice_layout(value, key_id, key_name, names_by_id):
         header, size, size_width, id_size, id_start, data_start,
         offset_size, offset_start, ids, slot,
     )
+
+
+def _encoded_payload_batches(rows, provider, global_row):
+    """Encode array-backed splice payloads within a byte budget."""
+    batch_start = 0
+    payloads = []
+    payload_bytes = 0
+    for index, row in enumerate(rows):
+        payload = provider.encode(
+            provider.scalar_at(global_row + int(row)))
+        if (payloads
+                and payload_bytes + len(payload)
+                > _ROOT_INSERT_SPLICE_PAYLOAD_BUDGET):
+            yield batch_start, index, payloads
+            batch_start = index
+            payloads = []
+            payload_bytes = 0
+        payloads.append(payload)
+        payload_bytes += len(payload)
+    if payloads:
+        yield batch_start, len(rows), payloads
 
 
 def _plan_root_insert_splice(
@@ -2050,29 +2073,27 @@ def _root_insert_splice(
         header, size, size_width, id_size, id_start, data_start,
         offset_size, offset_start, slot, sentinels, ok,
     ) = plan
-    matching_structures = None
-    if source_metadata_size is not None:
-        matching_structures = np.zeros(len(rows), dtype=bool)
-        candidates = np.flatnonzero(ok)
-        if len(candidates):
-            lengths = row_lengths[candidates]
-            order = np.argsort(lengths, kind='stable')
-            candidates = candidates[order]
-            lengths = lengths[order]
-            boundaries = np.flatnonzero(lengths[1:] != lengths[:-1]) + 1
-            for group in np.split(candidates, boundaries):
-                exemplar = int(group[0])
-                value = values.view(int(rows[exemplar]))
-                if len(group) == 1:
-                    _validate_value_field_ids(
-                        value, 0, len(value), source_metadata_size)
-                    matching_structures[exemplar] = True
-                    continue
-                matches = _matching_value_structures(
-                    value, source_data, row_starts[group],
-                    source_metadata_size)
-                if matches is not None:
-                    matching_structures[group[matches]] = True
+    matching_structures = np.zeros(len(rows), dtype=bool)
+    candidates = np.flatnonzero(ok)
+    if len(candidates):
+        lengths = row_lengths[candidates]
+        order = np.argsort(lengths, kind='stable')
+        candidates = candidates[order]
+        lengths = lengths[order]
+        boundaries = np.flatnonzero(lengths[1:] != lengths[:-1]) + 1
+        for group in np.split(candidates, boundaries):
+            exemplar = int(group[0])
+            value = values.view(int(rows[exemplar]))
+            if len(group) == 1:
+                _validate_value_field_ids(
+                    value, 0, len(value), source_metadata_size)
+                matching_structures[exemplar] = True
+                continue
+            matches = _matching_value_structures(
+                value, source_data, row_starts[group],
+                source_metadata_size)
+            if matches is not None:
+                matching_structures[group[matches]] = True
 
     if state.data is not None:
         source_view = memoryview(state.data)
@@ -2093,21 +2114,9 @@ def _root_insert_splice(
             fallback_rows.append(row)
             continue
         original = values.view(row)
-        if source_metadata_size is not None:
-            if not matching_structures[index]:
-                _validate_value_field_ids(
-                    original, 0, len(original), source_metadata_size)
-        else:
-            row_size, _, _, row_data_start, offsets, _ = (
-                _checked_object_layout(original, 0, len(original)))
-            if row_size != size:
-                fallback_rows.append(row)
-                continue
-            ordered = sorted(offsets)
-            ends = dict(zip(ordered, ordered[1:]))
-            for child in range(row_size):
-                _checked_object_child_bounds(
-                    original, row_data_start, offsets, child, ends)
+        if not matching_structures[index]:
+            _validate_value_field_ids(
+                original, 0, len(original), source_metadata_size)
         base = int(row_starts[index]) - source_base
         sentinel = int(sentinels[index])
         _check_variant_sizes(
@@ -2220,8 +2229,9 @@ def _set_chunk(chunk, values, parsed, global_row):
         insert_keys = tuple(
             parsed[index][1][-1][1] for index in insert_indices)
         metadata_key_ids = _cached_metadata_key_ids(first_metadata)
-        source_metadata_size = (
-            len(metadata_key_ids)
+        source_metadata_size = len(metadata_key_ids)
+        rebuild_validation_size = (
+            source_metadata_size
             if any(key not in metadata_key_ids for key in insert_keys)
             else None
         )
@@ -2261,27 +2271,37 @@ def _set_chunk(chunk, values, parsed, global_row):
                 live_starts = row_starts
                 live_lengths = parent_limits[insert_index]
             provider = parsed[insert_index][2]
+            if not len(live_rows):
+                continue
             if provider._array is None:
-                payloads = [
-                    payload_for(insert_index, provider, 0)
-                ] * len(live_rows)
+                payload = payload_for(insert_index, provider, 0)
+                batches = (
+                    (0, len(live_rows), [payload] * len(live_rows)),
+                )
             else:
-                payloads = [
-                    provider.encode(
-                        provider.scalar_at(global_row + int(row)))
-                    for row in live_rows
-                ]
+                batches = _encoded_payload_batches(
+                    live_rows, provider, global_row)
             key_name = parsed[insert_index][1][-1][1]
-            spliced = (
-                _root_insert_splice(
-                    values, state, live_rows, live_starts, live_lengths,
+            output_metadata_size = len(
+                new_metadata if new_metadata is not None
+                else first_metadata)
+            for batch_start, batch_end, payloads in batches:
+                batch_rows = live_rows[batch_start:batch_end]
+                spliced = _root_insert_splice(
+                    values, state, batch_rows,
+                    live_starts[batch_start:batch_end],
+                    live_lengths[batch_start:batch_end],
                     source_data, key_ids[key_name], key_name,
                     names_by_id, payloads, source_metadata_size,
-                    len(new_metadata if new_metadata is not None
-                        else first_metadata))
-                if len(live_rows) else ({}, [])
-            )
-            if spliced is not None:
+                    output_metadata_size)
+                if spliced is None:
+                    for row in batch_rows:
+                        row = int(row)
+                        rebuild_row(
+                            row, values.view(row), insert_set, key_ids,
+                            names_by_id, first_metadata, new_metadata,
+                            rebuild_validation_size)
+                    continue
                 rebuilt, fallback_rows = spliced
                 rebuilt_rows.update(rebuilt)
                 if new_metadata is not None:
@@ -2291,15 +2311,15 @@ def _set_chunk(chunk, values, parsed, global_row):
                     rebuild_row(
                         row, values.view(row), insert_set, key_ids,
                         names_by_id, first_metadata, new_metadata,
-                        source_metadata_size)
-                continue
+                        rebuild_validation_size)
+            continue
         for offset_index, row in enumerate(rows):
             row = int(row)
             if row in group_slow:
                 continue
             rebuild_row(
                 row, values.view(row), insert_set, key_ids, names_by_id,
-                first_metadata, new_metadata, source_metadata_size,
+                first_metadata, new_metadata, rebuild_validation_size,
                 [
                     None if target_positions[index] is None
                     else int(target_positions[index][offset_index])
@@ -2333,8 +2353,9 @@ def _set_chunk(chunk, values, parsed, global_row):
             insert_set.add(index)
             insert_keys.append(parsed_path[-1][1])
         metadata_key_ids = _cached_metadata_key_ids(row_metadata)
-        source_metadata_size = (
-            len(metadata_key_ids)
+        source_metadata_size = len(metadata_key_ids)
+        rebuild_validation_size = (
+            source_metadata_size
             if any(key not in metadata_key_ids for key in insert_keys)
             else None
         )
@@ -2342,7 +2363,7 @@ def _set_chunk(chunk, values, parsed, global_row):
             row_metadata, tuple(insert_keys))
         rebuild_row(
             row, view, insert_set, key_ids, names_by_id, row_metadata,
-            new_metadata, source_metadata_size)
+            new_metadata, rebuild_validation_size)
 
     if rebuilt_rows:
         state.ensure()

--- a/paimon-python/pypaimon/data/variant_path.py
+++ b/paimon-python/pypaimon/data/variant_path.py
@@ -253,8 +253,9 @@ def _checked_object_layout(value, pos, limit):
             value, offset_start + index * offset_width, offset_width)
         offsets.append(offset)
     sentinel = offsets[-1]
-    if ((size and (min(offsets[:-1]) != 0
-                   or len(set(offsets[:-1])) != size))
+    if ((not size and sentinel != 0)
+            or (size and (min(offsets[:-1]) != 0
+                          or len(set(offsets[:-1])) != size))
             or any(offset >= sentinel for offset in offsets[:-1])):
         _malformed("invalid object offsets")
     if size and len({

--- a/paimon-python/pypaimon/tests/variant_set_test.py
+++ b/paimon-python/pypaimon/tests/variant_set_test.py
@@ -824,6 +824,18 @@ class TestVariantSetErrors(unittest.TestCase):
         with self.assertRaisesRegex(ValueError, "MALFORMED_VARIANT"):
             variant_set(column, '$.processed', pa.scalar(True))
 
+    def test_root_splice_rejects_empty_object_with_orphan_data(self):
+        empty = GenericVariant.from_python({})
+        corrupt = bytearray(empty.value())
+        corrupt[-1] = 1
+        corrupt.append(0)
+        column = GenericVariant.to_arrow_array([
+            GenericVariant(bytes(corrupt), empty.metadata()),
+        ])
+
+        with self.assertRaisesRegex(ValueError, "MALFORMED_VARIANT"):
+            variant_set(column, '$.processed', pa.scalar(True))
+
     def test_rejects_unknown_field_id_on_insert(self):
         metadata = GenericVariant.from_python({'value': 0}).metadata()
         orphan = _build_object_value([

--- a/paimon-python/pypaimon/tests/variant_set_test.py
+++ b/paimon-python/pypaimon/tests/variant_set_test.py
@@ -636,6 +636,28 @@ class TestVariantSetFastPaths(unittest.TestCase):
             [True] * len(column),
         )
 
+    def test_insert_validates_singleton_lengths_without_batching(self):
+        lengths = list(range(1, 13))
+        column = _variants([
+            {'nested': {'value': 'x' * length}}
+            for length in lengths
+        ])
+
+        with patch(
+                'pypaimon.data.variant_path._matching_value_structures',
+        ) as structure_match, patch(
+                'pypaimon.data.variant_path._validate_value_field_ids',
+                wraps=_validate_value_field_ids,
+        ) as subtree_validation:
+            result = variant_set(column, '$.processed', pa.scalar(True))
+
+        structure_match.assert_not_called()
+        self.assertEqual(subtree_validation.call_count, len(lengths))
+        self.assertEqual(
+            variant_get(result, '$.processed', pa.bool_()).to_pylist(),
+            [True] * len(column),
+        )
+
     def test_insert_validates_deep_unmodified_sibling_iteratively(self):
         metadata = GenericVariant.from_python(
             {'sibling': [], 'target': {}}).metadata()

--- a/paimon-python/pypaimon/tests/variant_set_test.py
+++ b/paimon-python/pypaimon/tests/variant_set_test.py
@@ -556,22 +556,30 @@ class TestVariantSetFastPaths(unittest.TestCase):
             [True] * 4096,
         )
 
-    def test_insert_fuses_root_validation_with_rebuild(self):
+    def test_insert_splices_nested_root_after_validation(self):
         column = _variants([
-            {'nested': {'value': float(index)}, 'other': float(index)}
+            {
+                'nested_object': {'value': float(index)},
+                'nested_array': [{'value': float(index)}],
+                'other': float(index),
+            }
             for index in range(100)
         ])
 
         with patch(
                 'pypaimon.data.variant_path._validate_value_field_ids',
                 wraps=_validate_value_field_ids,
-        ) as subtree_validation:
+        ) as subtree_validation, patch(
+                'pypaimon.data.variant_path._apply_edits',
+                wraps=_apply_edits,
+        ) as rebuild:
             result = variant_set(column, '$.processed', pa.scalar(True))
 
-        self.assertFalse(any(
+        self.assertTrue(any(
             args[1] == 0
             for args, _ in subtree_validation.call_args_list
         ))
+        rebuild.assert_not_called()
         self.assertEqual(
             variant_get(result, '$.processed', pa.bool_()).to_pylist(),
             [True] * 100,

--- a/paimon-python/pypaimon/tests/variant_set_test.py
+++ b/paimon-python/pypaimon/tests/variant_set_test.py
@@ -32,6 +32,8 @@ from pypaimon.data.variant_path import (
     _metadata_with_keys,
     _path_positions,
     _rebuilt_offsets,
+    _root_insert_splice,
+    _root_insert_splice_layout,
     _validate_value_field_ids,
     variant_get,
 )
@@ -688,6 +690,47 @@ class TestVariantSetFastPaths(unittest.TestCase):
             [True] * len(column),
         )
 
+    def test_variable_insert_bounds_encoded_payload_memory(self):
+        column = _variants([
+            {'value': float(index)}
+            for index in range(10)
+        ])
+        tags = pa.array(['x' * 10] * len(column))
+
+        with patch(
+                'pypaimon.data.variant_path.'
+                '_ROOT_INSERT_SPLICE_PAYLOAD_BUDGET',
+                24,
+        ), patch(
+                'pypaimon.data.variant_path._root_insert_splice',
+                wraps=_root_insert_splice,
+        ) as splice:
+            result = variant_set(column, '$.tag', tags)
+
+        self.assertGreater(splice.call_count, 1)
+        for call in splice.call_args_list:
+            self.assertLessEqual(
+                sum(len(payload) for payload in call.args[9]),
+                24,
+            )
+        self.assertEqual(
+            variant_get(result, '$.tag', pa.string()).to_pylist(),
+            tags.to_pylist(),
+        )
+
+    def test_ineligible_splice_layout_skips_child_validation(self):
+        value = _build_object_value([
+            (0, _encode_scalar_to_value_bytes(1.0, pa.float64())),
+        ])
+
+        with patch(
+                'pypaimon.data.variant_path._checked_object_child_bounds',
+                side_effect=AssertionError(
+                    "ineligible layout validated children"),
+        ):
+            self.assertIsNone(_root_insert_splice_layout(
+                value, 256, 'new', {0: 'value'}))
+
     def test_insert_validates_deep_unmodified_sibling_iteratively(self):
         metadata = GenericVariant.from_python(
             {'sibling': [], 'target': {}}).metadata()
@@ -835,6 +878,34 @@ class TestVariantSetErrors(unittest.TestCase):
 
         with self.assertRaisesRegex(ValueError, "MALFORMED_VARIANT"):
             variant_set(column, '$.processed', pa.scalar(True))
+
+    def test_root_splice_validates_nested_values_when_metadata_reused(self):
+        metadata = GenericVariant.from_python({
+            'nested': {'bad': None, 'target': 0.0},
+            'new': True,
+        }).metadata()
+        key_ids = _metadata_key_ids(metadata)
+        malformed_null = (
+            _encode_scalar_to_value_bytes(None, pa.null()) + b'\x00')
+        nested = _build_object_value([
+            (key_ids['bad'], malformed_null),
+            (
+                key_ids['target'],
+                _encode_scalar_to_value_bytes(1.0, pa.float64()),
+            ),
+        ])
+        root = _build_object_value([
+            (key_ids['nested'], nested),
+        ])
+        column = GenericVariant.to_arrow_array([
+            GenericVariant(root, metadata),
+        ])
+
+        with self.assertRaisesRegex(ValueError, "MALFORMED_VARIANT"):
+            variant_set(column, {
+                '$.nested.target': pa.scalar(2.0),
+                '$.new': pa.scalar(True),
+            })
 
     def test_rejects_unknown_field_id_on_insert(self):
         metadata = GenericVariant.from_python({'value': 0}).metadata()

--- a/paimon-python/pypaimon/tests/variant_set_test.py
+++ b/paimon-python/pypaimon/tests/variant_set_test.py
@@ -612,6 +612,30 @@ class TestVariantSetFastPaths(unittest.TestCase):
             [True] * len(column),
         )
 
+    def test_insert_batches_all_nested_structure_lengths(self):
+        lengths = list(range(1, 13))
+        column = _variants([
+            {'nested': {'value': 'x' * length}}
+            for length in lengths
+            for _ in range(10)
+        ])
+
+        with patch(
+                'pypaimon.data.variant_path._validate_value_field_ids',
+                wraps=_validate_value_field_ids,
+        ) as subtree_validation, patch(
+                'pypaimon.data.variant_path._apply_edits',
+                wraps=_apply_edits,
+        ) as rebuild:
+            result = variant_set(column, '$.processed', pa.scalar(True))
+
+        self.assertEqual(subtree_validation.call_count, len(lengths))
+        rebuild.assert_not_called()
+        self.assertEqual(
+            variant_get(result, '$.processed', pa.bool_()).to_pylist(),
+            [True] * len(column),
+        )
+
     def test_insert_validates_deep_unmodified_sibling_iteratively(self):
         metadata = GenericVariant.from_python(
             {'sibling': [], 'target': {}}).metadata()

--- a/paimon-python/pypaimon/tests/variant_set_test.py
+++ b/paimon-python/pypaimon/tests/variant_set_test.py
@@ -579,10 +579,37 @@ class TestVariantSetFastPaths(unittest.TestCase):
             args[1] == 0
             for args, _ in subtree_validation.call_args_list
         ))
+        self.assertEqual(subtree_validation.call_count, 1)
         rebuild.assert_not_called()
         self.assertEqual(
             variant_get(result, '$.processed', pa.bool_()).to_pylist(),
             [True] * 100,
+        )
+
+    def test_insert_batches_multiple_nested_structures(self):
+        sequences = [0, 128, 32768]
+        column = _variants([
+            {
+                'nested': {'value': float(index)},
+                'sequence': sequences[index % len(sequences)],
+            }
+            for index in range(300)
+        ])
+
+        with patch(
+                'pypaimon.data.variant_path._validate_value_field_ids',
+                wraps=_validate_value_field_ids,
+        ) as subtree_validation, patch(
+                'pypaimon.data.variant_path._apply_edits',
+                wraps=_apply_edits,
+        ) as rebuild:
+            result = variant_set(column, '$.processed', pa.scalar(True))
+
+        self.assertEqual(subtree_validation.call_count, len(sequences))
+        rebuild.assert_not_called()
+        self.assertEqual(
+            variant_get(result, '$.processed', pa.bool_()).to_pylist(),
+            [True] * len(column),
         )
 
     def test_insert_validates_deep_unmodified_sibling_iteratively(self):
@@ -769,6 +796,12 @@ class TestVariantSetErrors(unittest.TestCase):
     def test_root_splice_rejects_nested_unknown_field_id(self):
         metadata = GenericVariant.from_python({'sibling': {}}).metadata()
         key_ids = _metadata_key_ids(metadata)
+        valid_sibling = _build_object_value([
+            (
+                key_ids['sibling'],
+                _encode_scalar_to_value_bytes(1.0, pa.float64()),
+            ),
+        ])
         corrupt_sibling = _build_object_value([
             (
                 len(key_ids),
@@ -779,6 +812,9 @@ class TestVariantSetErrors(unittest.TestCase):
             (key_ids['sibling'], corrupt_sibling),
         ])
         column = GenericVariant.to_arrow_array([
+            GenericVariant(_build_object_value([
+                (key_ids['sibling'], valid_sibling),
+            ]), metadata),
             GenericVariant(corrupt_root, metadata),
         ])
 

--- a/paimon-python/pypaimon/tests/variant_set_test.py
+++ b/paimon-python/pypaimon/tests/variant_set_test.py
@@ -718,6 +718,55 @@ class TestVariantSetFastPaths(unittest.TestCase):
             tags.to_pylist(),
         )
 
+    def test_small_variable_insert_bounds_payload_batch_rows(self):
+        column = _variants([
+            {'value': float(index)}
+            for index in range(10)
+        ])
+        tags = pa.array([''] * len(column))
+
+        with patch(
+                'pypaimon.data.variant_path.'
+                '_ROOT_INSERT_SPLICE_MAX_BATCH_ROWS',
+                3,
+        ), patch(
+                'pypaimon.data.variant_path._root_insert_splice',
+                wraps=_root_insert_splice,
+        ) as splice:
+            result = variant_set(column, '$.tag', tags)
+
+        self.assertGreater(splice.call_count, 1)
+        for call in splice.call_args_list:
+            self.assertLessEqual(len(call.args[9]), 3)
+        self.assertEqual(
+            variant_get(result, '$.tag', pa.string()).to_pylist(),
+            tags.to_pylist(),
+        )
+
+    def test_scalar_insert_bounds_splice_batch_rows(self):
+        column = _variants([
+            {'value': float(index)}
+            for index in range(10)
+        ])
+
+        with patch(
+                'pypaimon.data.variant_path.'
+                '_ROOT_INSERT_SPLICE_MAX_BATCH_ROWS',
+                3,
+        ), patch(
+                'pypaimon.data.variant_path._root_insert_splice',
+                wraps=_root_insert_splice,
+        ) as splice:
+            result = variant_set(column, '$.processed', pa.scalar(True))
+
+        self.assertEqual(splice.call_count, 4)
+        for call in splice.call_args_list:
+            self.assertLessEqual(len(call.args[9]), 3)
+        self.assertEqual(
+            variant_get(result, '$.processed', pa.bool_()).to_pylist(),
+            [True] * len(column),
+        )
+
     def test_ineligible_splice_layout_skips_child_validation(self):
         value = _build_object_value([
             (0, _encode_scalar_to_value_bytes(1.0, pa.float64())),

--- a/paimon-python/pypaimon/tests/variant_set_test.py
+++ b/paimon-python/pypaimon/tests/variant_set_test.py
@@ -26,6 +26,7 @@ from pypaimon.data.generic_variant import GenericVariant, _check_variant_sizes
 from pypaimon.data.variant_path import (
     _apply_edits,
     _build_object_value_ordered,
+    _checked_object_layout,
     _materialize_value,
     _metadata_key_ids,
     _metadata_with_keys,
@@ -541,10 +542,14 @@ class TestVariantSetFastPaths(unittest.TestCase):
         ) as slow_path, patch(
                 'pypaimon.data.variant_path._metadata_key_ids',
                 wraps=_metadata_key_ids,
-        ) as metadata_parse:
+        ) as metadata_parse, patch(
+                'pypaimon.data.variant_path._apply_edits',
+                wraps=_apply_edits,
+        ) as rebuild:
             result = variant_set(column, '$.processed', pa.scalar(True))
 
         slow_path.assert_not_called()
+        rebuild.assert_not_called()
         self.assertLessEqual(metadata_parse.call_count, 2)
         self.assertEqual(
             variant_get(result, '$.processed', pa.bool_()).to_pylist(),
@@ -753,6 +758,25 @@ class TestVariantSetErrors(unittest.TestCase):
         with self.assertRaisesRegex(ValueError, "MALFORMED_VARIANT"):
             variant_set(column, '$.child.new', pa.scalar(True))
 
+    def test_root_splice_rejects_nested_unknown_field_id(self):
+        metadata = GenericVariant.from_python({'sibling': {}}).metadata()
+        key_ids = _metadata_key_ids(metadata)
+        corrupt_sibling = _build_object_value([
+            (
+                len(key_ids),
+                _encode_scalar_to_value_bytes(2.0, pa.float64()),
+            ),
+        ])
+        corrupt_root = _build_object_value([
+            (key_ids['sibling'], corrupt_sibling),
+        ])
+        column = GenericVariant.to_arrow_array([
+            GenericVariant(corrupt_root, metadata),
+        ])
+
+        with self.assertRaisesRegex(ValueError, "MALFORMED_VARIANT"):
+            variant_set(column, '$.new', pa.scalar(True))
+
     def test_rejects_duplicate_source_field_id(self):
         metadata = GenericVariant.from_python({'value': 0}).metadata()
         corrupt = _build_object_value([
@@ -781,6 +805,35 @@ class TestVariantSetErrors(unittest.TestCase):
                 with self.assertRaisesRegex(
                         ValueError, "MALFORMED_VARIANT"):
                     updater(column, '$.a', pa.scalar(9.0))
+
+    def test_root_splice_rejects_duplicate_peer_offsets(self):
+        valid = GenericVariant.from_python({'a': 1.0, 'b': 2.0})
+        corrupt = bytearray(valid.value())
+        size, id_size, id_start, _, _, _ = _checked_object_layout(
+            corrupt, 0, len(corrupt))
+        offset_size = ((corrupt[0] >> 2) & 0x3) + 1
+        offset_start = id_start + size * id_size
+        corrupt[offset_start + offset_size:
+                offset_start + 2 * offset_size] = (
+            0).to_bytes(offset_size, 'little')
+        column = GenericVariant.to_arrow_array([
+            valid, GenericVariant(bytes(corrupt), valid.metadata()),
+        ])
+
+        with self.assertRaisesRegex(ValueError, "MALFORMED_VARIANT"):
+            variant_set(column, '$.new', pa.scalar(True))
+
+    def test_root_splice_enforces_value_size_limit(self):
+        variant = GenericVariant.from_python({'padding': 'x' * 100})
+        column = GenericVariant.to_arrow_array([variant])
+
+        with patch(
+                'pypaimon.data.generic_variant._SIZE_LIMIT',
+                len(variant.value()) + 2,
+        ):
+            with self.assertRaisesRegex(
+                    ValueError, 'VARIANT_CONSTRUCTOR_SIZE_LIMIT'):
+                variant_set(column, '$.new', pa.scalar(True))
 
     def test_rejects_truncated_child_offsets(self):
         valid = GenericVariant.from_python({'a': 1.0, 'b': 2.0})

--- a/paimon-python/pypaimon/tests/variant_set_test.py
+++ b/paimon-python/pypaimon/tests/variant_set_test.py
@@ -658,6 +658,36 @@ class TestVariantSetFastPaths(unittest.TestCase):
             [True] * len(column),
         )
 
+    def test_insert_uses_layout_after_noncanonical_first_row(self):
+        metadata = GenericVariant.from_python({'a': 0, 'b': 0}).metadata()
+        key_ids = _metadata_key_ids(metadata)
+        a_value = _encode_scalar_to_value_bytes(1.0, pa.float64())
+        b_value = _encode_scalar_to_value_bytes(2.0, pa.float64())
+        noncanonical = _build_object_value_ordered([
+            (key_ids['b'], b_value),
+            (key_ids['a'], a_value),
+        ])
+        canonical = _build_object_value_ordered([
+            (key_ids['a'], a_value),
+            (key_ids['b'], b_value),
+        ])
+        column = GenericVariant.to_arrow_array([
+            GenericVariant(noncanonical, metadata),
+            *[GenericVariant(canonical, metadata) for _ in range(99)],
+        ])
+
+        with patch(
+                'pypaimon.data.variant_path._apply_edits',
+                wraps=_apply_edits,
+        ) as rebuild:
+            result = variant_set(column, '$.processed', pa.scalar(True))
+
+        self.assertEqual(rebuild.call_count, 1)
+        self.assertEqual(
+            variant_get(result, '$.processed', pa.bool_()).to_pylist(),
+            [True] * len(column),
+        )
+
     def test_insert_validates_deep_unmodified_sibling_iteratively(self):
         metadata = GenericVariant.from_python(
             {'sibling': [], 'target': {}}).metadata()


### PR DESCRIPTION
### Purpose

#9253 rebuilds each affected row when inserting a missing key. This PR adds a
vectorized fast path for root OBJECT inserts: eligible rows are emitted by
joining byte slices because only the object size, one id, one offset, and the
sentinel change.

For nested values, rows are grouped by encoded length. One exemplar per group
is fully validated and NumPy compares its structural bytes across the group.
Rows with a different structure or encoding width fall back to full validation
or rebuilding.

### Performance and memory

- 50k flat OBJECT rows: 19.6k -> 164k rows/s
- 20k synthetic 42-leaf nested IMU rows: 6.9k -> 276k-297k rows/s

The dominant temporary allocation is an `int64` advanced-index matrix, capped
at 8 MiB (about 1,048,576 comparisons). Row and position chunk sizes are
derived from this budget. It is an execution heuristic, not a total-memory,
API, or format limit; gathered bytes and comparison results add smaller
temporary arrays.

100k-row nested IMU sensitivity: 1/4/8/16 MiB produced
244k/287k/302k/256k rows/s, balancing NumPy call overhead against allocation
and cache pressure.

### Tests

Existing `variant_set` tests plus nested inserts, more than eight encoded
lengths, malformed nested field ids, no-rebuild paths, and mixed
splice/rebuild offset-width boundaries. No API or format change.
