### PR TITLE
[python] Tighten lazy import comments

### DIFF
--- a/paimon-python/pypaimon/__init__.py
+++ b/paimon-python/pypaimon/__init__.py
@@ -53,10 +53,8 @@ _LAZY_EXPORTS = {
     "SQLContext": ("pypaimon_rust.datafusion", "SQLContext"),
 }
 
-# Unsynchronized lazy imports from two threads can acquire module locks in
-# opposite orders (pypaimon.tag initializes both tag and tag_manager) and
-# fail with _DeadlockError; the eager imports previously serialized this on
-# the root module lock.
+# Serialize first-time imports: racing threads can otherwise acquire module
+# locks in opposite orders and fail with _DeadlockError.
 _LAZY_IMPORT_LOCK = threading.RLock()
 
 

--- a/paimon-python/pypaimon/globalindex/__init__.py
+++ b/paimon-python/pypaimon/globalindex/__init__.py
@@ -107,11 +107,8 @@ _MODULE_BY_EXPORT = {
     'Range': 'pypaimon.utils.range',
 }
 
-# Eagerly importing the exports above builds a circular chain: submodules
-# such as index_file_meta initialize this package on first import, while
-# create_global_index and the scanner chain import those submodules back.
-# Lazy resolution keeps this package init trivial; the lock serializes
-# first-time imports racing from multiple threads.
+# Eager exports would cycle: index_file_meta initializes this package while
+# create_global_index imports it back. The lock serializes racing imports.
 _LAZY_IMPORT_LOCK = threading.RLock()
 
 

--- a/paimon-python/pypaimon/tag/__init__.py
+++ b/paimon-python/pypaimon/tag/__init__.py
@@ -31,9 +31,8 @@ _MODULE_BY_EXPORT = {
     "TagManager": "pypaimon.tag.tag_manager",
 }
 
-# Eagerly importing both siblings here lets two threads acquire the module
-# locks of tag and tag_manager in opposite orders and fail with
-# _DeadlockError; lazy resolution keeps this package init trivial.
+# Eager sibling imports let threads lock tag and tag_manager in opposite
+# orders and fail with _DeadlockError. The lock serializes racing imports.
 _LAZY_IMPORT_LOCK = threading.RLock()
 
 

--- a/paimon-python/pypaimon/tests/concurrent_import_test.py
+++ b/paimon-python/pypaimon/tests/concurrent_import_test.py
@@ -140,8 +140,7 @@ if errors:
     print("\n".join(sorted(set(errors))))
     raise SystemExit(1)
 """
-        # The lazy names resolve once per process, so each attempt needs a
-        # fresh interpreter.
+        # Lazy names resolve once per process, so retries need fresh ones.
         for attempt in range(8):
             result = subprocess.run(
                 [sys.executable, "-c", script],
@@ -157,10 +156,8 @@ if errors:
             )
 
     def test_fresh_import_of_cycle_prone_leaf_modules(self):
-        # Each module must be importable as the very first pypaimon import
-        # of a process. Heavy package initializers used to pull circular
-        # chains (index_file_meta -> globalindex -> create_global_index)
-        # that the eager root import happened to mask.
+        # Each module must import cleanly as a process's first pypaimon
+        # import, without a package init pulling a circular chain.
         for module in [
             "pypaimon.index.index_file_meta",
             "pypaimon.manifest.index_manifest_entry",


### PR DESCRIPTION
## Purpose

Follow-up to #9250. The lazy-import rationale comments were more verbose than needed; this condenses them while keeping the non-obvious reasons (module-lock ordering, the package-init cycle) documented.

Comment-only change, no behavior difference.

## Tests

- `concurrent_import_test.py`: 3 passed
- flake8 passed