### PR TITLE
[core] Support nested fields in global indexes

### DIFF
--- a/docs/docs/multimodal-table/global-index.mdx
+++ b/docs/docs/multimodal-table/global-index.mdx
@@ -52,6 +52,20 @@ Global indexes work on top of Data Evolution tables. To use global indexes, your
 - `'row-tracking.enabled' = 'true'`
 - `'data-evolution.enabled' = 'true'`
 
+### Nested ROW Fields
+
+Flink, Spark, and the Java API support global indexes on leaf fields inside nested `ROW` columns.
+Use a dot-separated path such as `profile.address.zip` for index build, drop, and search APIs.
+Flink and Spark SQL scalar predicates preserve the structured path, so a BTree or Bitmap index is
+used automatically for filters such as `WHERE profile.address.zip = 100`. Spark also supports
+Top-N pushdown on an indexed nested field. Full-text and vector search APIs accept the same path,
+for example `profile.content` or `profile.embedding`.
+
+Nested paths traverse `ROW` fields only. Traversing `ARRAY` elements or `MAP` keys and values is not
+supported. If a table has a top-level column whose literal name contains dots, string-based APIs
+resolve that exact top-level name before interpreting the dots as a nested path; avoid defining both
+forms in the same schema. PyPaimon does not yet support nested global-index field paths.
+
 > Global index queries may not be exact when the index only covers part of the table data. If a query predicate matches the index, Paimon returns only the results from the indexed portion. Matching records in data that has not been indexed yet will not be returned.
 
 ## Prerequisites

--- a/docs/docs/multimodal-table/global-index/bitmap.mdx
+++ b/docs/docs/multimodal-table/global-index/bitmap.mdx
@@ -182,6 +182,9 @@ print(matched_files)
 
 Once a bitmap index is built, it is automatically used during scan when a filter
 predicate matches the indexed column.
+For a leaf inside nested `ROW` columns, build the index with a dot-separated path such as
+`profile.tag`; Flink and Spark SQL then use it for normal predicates such as
+`WHERE profile.tag IN ('vip', 'trial')`.
 
 <Tabs groupId="bitmap-search">
 

--- a/docs/docs/multimodal-table/global-index/btree.mdx
+++ b/docs/docs/multimodal-table/global-index/btree.mdx
@@ -160,6 +160,12 @@ The legacy `btree-index.records-per-range` and
 ## Query with BTree Index
 
 Once a BTree index is built, it is automatically used during scan when a filter predicate matches the indexed column.
+Flink and Spark SQL can query a leaf inside nested `ROW` columns. Build the index with a
+dot-separated path such as `profile.address.zip`, then use the normal structured predicate:
+
+```sql
+SELECT * FROM my_table WHERE profile.address.zip BETWEEN 100 AND 200;
+```
 
 <Tabs groupId="btree-search">
 

--- a/docs/docs/multimodal-table/global-index/full-text.mdx
+++ b/docs/docs/multimodal-table/global-index/full-text.mdx
@@ -44,6 +44,9 @@ Build full-text indexes on `STRING`, `CHAR`, or `VARCHAR` columns. Null values
 are skipped by the native text index, while row-id coverage is still tracked by
 Paimon.
 
+A full-text index can target a string leaf inside nested `ROW` columns. Pass its dot-separated
+path, such as `profile.content`, as `index_column` and use the same path when searching.
+
 <Tabs groupId="fulltext-build">
 
 <TabItem value="sql" label="SQL">
@@ -202,6 +205,9 @@ Spark SQL uses the `full_text_search(table_name, column, query, limit)`
 table-valued function. The `column` argument is the Paimon table column to
 search. The `query` argument is passed to the native full-text reader as a JSON
 string.
+
+The Spark SQL and Java search APIs accept nested `ROW` paths such as `profile.content`. In `full`
+and `detail` search modes, raw-row fallback also reads the nested value for index-uncovered ranges.
 
 <Tabs groupId="fulltext-search">
 

--- a/docs/docs/multimodal-table/global-index/vector.mdx
+++ b/docs/docs/multimodal-table/global-index/vector.mdx
@@ -64,6 +64,10 @@ is accepted.
 
 ## Build Vector Index
 
+A vector index can target an `ARRAY<FLOAT>` or `VECTOR<FLOAT>` leaf inside nested `ROW` columns.
+Pass its dot-separated path, such as `profile.embedding`, as `index_column` and use the same path
+for vector search.
+
 <Tabs groupId="vector-build">
 
 <TabItem value="sql" label="SQL">
@@ -280,6 +284,10 @@ With the properties above, `title_embedding` is indexed with `nlist=256` while `
 uses `nlist=512` and trains with half of the non-null vectors.
 
 ## Vector Search
+
+Spark SQL, the Flink vector-search procedure, and the Java single-query and batch-query builders
+accept nested `ROW` paths such as `profile.embedding`. Raw-vector fallback and reranking read the
+nested leaf value for index-uncovered ranges.
 
 Search-time options are passed with each vector search request:
 

--- a/paimon-common/src/main/java/org/apache/paimon/globalindex/GlobalIndexEvaluator.java
+++ b/paimon-common/src/main/java/org/apache/paimon/globalindex/GlobalIndexEvaluator.java
@@ -30,7 +30,6 @@ import org.apache.paimon.predicate.LeafTernaryFunction;
 import org.apache.paimon.predicate.Or;
 import org.apache.paimon.predicate.Predicate;
 import org.apache.paimon.predicate.TopN;
-import org.apache.paimon.types.ResolvedFieldPath;
 import org.apache.paimon.types.RowType;
 import org.apache.paimon.utils.IOUtils;
 
@@ -172,9 +171,8 @@ public class GlobalIndexEvaluator implements Closeable {
     }
 
     private int resolveFieldId(FieldRef fieldRef) {
-        return ResolvedFieldPath.resolve(rowType, fieldRef.name())
+        return fieldRef.resolveField(rowType)
                 .orElseThrow(() -> new RuntimeException("Cannot find field: " + fieldRef.name()))
-                .leafField()
                 .id();
     }
 

--- a/paimon-common/src/main/java/org/apache/paimon/globalindex/GlobalIndexEvaluator.java
+++ b/paimon-common/src/main/java/org/apache/paimon/globalindex/GlobalIndexEvaluator.java
@@ -30,6 +30,7 @@ import org.apache.paimon.predicate.LeafTernaryFunction;
 import org.apache.paimon.predicate.Or;
 import org.apache.paimon.predicate.Predicate;
 import org.apache.paimon.predicate.TopN;
+import org.apache.paimon.types.ResolvedFieldPath;
 import org.apache.paimon.types.RowType;
 import org.apache.paimon.utils.IOUtils;
 
@@ -93,7 +94,7 @@ public class GlobalIndexEvaluator implements Closeable {
 
     public Optional<GlobalIndexResult> evaluateTopN(TopN topN) {
         FieldRef fieldRef = topN.orders().get(0).field();
-        int fieldId = rowType.getField(fieldRef.name()).id();
+        int fieldId = resolveFieldId(fieldRef);
         Collection<GlobalIndexReader> readers =
                 indexReadersCache.computeIfAbsent(fieldId, readersFunction::apply);
 
@@ -134,7 +135,7 @@ public class GlobalIndexEvaluator implements Closeable {
             return CompletableFuture.completedFuture(Optional.empty());
         }
         FieldRef fieldRef = fieldRefOptional.get();
-        int fieldId = rowType.getField(fieldRef.name()).id();
+        int fieldId = resolveFieldId(fieldRef);
         Collection<GlobalIndexReader> readers =
                 indexReadersCache.computeIfAbsent(fieldId, readersFunction::apply);
 
@@ -168,6 +169,13 @@ public class GlobalIndexEvaluator implements Closeable {
                                     result ->
                                             new Evaluation(result, Collections.singleton(fieldId)));
                         });
+    }
+
+    private int resolveFieldId(FieldRef fieldRef) {
+        return ResolvedFieldPath.resolve(rowType, fieldRef.name())
+                .orElseThrow(() -> new RuntimeException("Cannot find field: " + fieldRef.name()))
+                .leafField()
+                .id();
     }
 
     private CompletableFuture<Optional<Evaluation>> visitCompoundAsync(

--- a/paimon-common/src/main/java/org/apache/paimon/predicate/CastTransform.java
+++ b/paimon-common/src/main/java/org/apache/paimon/predicate/CastTransform.java
@@ -33,8 +33,6 @@ import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 
-import static org.apache.paimon.utils.InternalRowUtils.get;
-
 /** Transform that casts a field to a new type. */
 public class CastTransform implements Transform {
 
@@ -112,7 +110,7 @@ public class CastTransform implements Transform {
 
     @Override
     public Object transform(InternalRow row) {
-        return cast.cast(get(row, fieldRef.index(), fieldRef.type()));
+        return cast.cast(fieldRef.get(row));
     }
 
     @Override

--- a/paimon-common/src/main/java/org/apache/paimon/predicate/FieldRef.java
+++ b/paimon-common/src/main/java/org/apache/paimon/predicate/FieldRef.java
@@ -18,13 +18,23 @@
 
 package org.apache.paimon.predicate;
 
+import org.apache.paimon.data.InternalRow;
+import org.apache.paimon.types.DataField;
 import org.apache.paimon.types.DataType;
+import org.apache.paimon.types.ResolvedFieldPath;
+import org.apache.paimon.types.RowType;
+import org.apache.paimon.utils.InternalRowUtils;
 
 import org.apache.paimon.shade.jackson2.com.fasterxml.jackson.annotation.JsonCreator;
+import org.apache.paimon.shade.jackson2.com.fasterxml.jackson.annotation.JsonInclude;
 import org.apache.paimon.shade.jackson2.com.fasterxml.jackson.annotation.JsonProperty;
 
 import java.io.Serializable;
+import java.util.Arrays;
 import java.util.Objects;
+import java.util.Optional;
+
+import static org.apache.paimon.utils.Preconditions.checkArgument;
 
 /** A reference to a field in an input. */
 public class FieldRef implements Serializable {
@@ -34,19 +44,46 @@ public class FieldRef implements Serializable {
     private static final String FIELD_INDEX = "index";
     private static final String FIELD_NAME = "name";
     private static final String FIELD_TYPE = "type";
+    private static final String FIELD_NESTED_INDEXES = "nestedIndexes";
+    private static final String FIELD_NESTED_ARITIES = "nestedArities";
 
     private final int index;
     private final String name;
     private final DataType type;
+    private final int[] nestedIndexes;
+    private final int[] nestedArities;
+
+    public FieldRef(int index, String name, DataType type) {
+        this(index, name, type, null, null);
+    }
 
     @JsonCreator
     public FieldRef(
             @JsonProperty(FIELD_INDEX) int index,
             @JsonProperty(FIELD_NAME) String name,
-            @JsonProperty(FIELD_TYPE) DataType type) {
+            @JsonProperty(FIELD_TYPE) DataType type,
+            @JsonProperty(FIELD_NESTED_INDEXES) int[] nestedIndexes,
+            @JsonProperty(FIELD_NESTED_ARITIES) int[] nestedArities) {
+        int[] indexes = nestedIndexes == null ? new int[0] : nestedIndexes;
+        int[] arities = nestedArities == null ? new int[0] : nestedArities;
+        checkArgument(
+                indexes.length == arities.length,
+                "Nested indexes and arities must have the same length.");
         this.index = index;
         this.name = name;
         this.type = type;
+        this.nestedIndexes = Arrays.copyOf(indexes, indexes.length);
+        this.nestedArities = Arrays.copyOf(arities, arities.length);
+    }
+
+    /** Creates a field reference which preserves the structured positions of a resolved path. */
+    public static FieldRef from(ResolvedFieldPath path) {
+        return new FieldRef(
+                path.topLevelIndex(),
+                path.fullName(),
+                path.leafField().type(),
+                path.nestedIndexes(),
+                path.nestedArities());
     }
 
     @JsonProperty(FIELD_INDEX)
@@ -64,6 +101,73 @@ public class FieldRef implements Serializable {
         return type;
     }
 
+    @JsonProperty(FIELD_NESTED_INDEXES)
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    public int[] nestedIndexes() {
+        return Arrays.copyOf(nestedIndexes, nestedIndexes.length);
+    }
+
+    @JsonProperty(FIELD_NESTED_ARITIES)
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    public int[] nestedArities() {
+        return Arrays.copyOf(nestedArities, nestedArities.length);
+    }
+
+    public boolean isNested() {
+        return nestedIndexes.length > 0;
+    }
+
+    /** Returns this reference with a remapped top-level field position. */
+    public FieldRef withIndex(int newIndex) {
+        return new FieldRef(newIndex, name, type, nestedIndexes, nestedArities);
+    }
+
+    /** Resolves the referenced field against a row type without losing structured path identity. */
+    public Optional<DataField> resolveField(RowType rowType) {
+        if (!isNested()) {
+            return ResolvedFieldPath.resolve(rowType, name).map(ResolvedFieldPath::leafField);
+        }
+
+        if (index < 0 || index >= rowType.getFieldCount()) {
+            return Optional.empty();
+        }
+        DataField field = rowType.getFields().get(index);
+        for (int nestedIndex : nestedIndexes) {
+            if (!(field.type() instanceof RowType)) {
+                return Optional.empty();
+            }
+            RowType nestedRowType = (RowType) field.type();
+            if (nestedIndex < 0 || nestedIndex >= nestedRowType.getFieldCount()) {
+                return Optional.empty();
+            }
+            field = nestedRowType.getFields().get(nestedIndex);
+        }
+        return Optional.of(field);
+    }
+
+    /** Extracts this field from a row, returning null if any parent ROW is null. */
+    public Object get(InternalRow row) {
+        if (!isNested()) {
+            return InternalRowUtils.get(row, index, type);
+        }
+
+        if (row.isNullAt(index)) {
+            return null;
+        }
+        InternalRow nestedRow = row.getRow(index, nestedArities[0]);
+        for (int i = 0; i < nestedIndexes.length; i++) {
+            int nestedIndex = nestedIndexes[i];
+            if (i == nestedIndexes.length - 1) {
+                return InternalRowUtils.get(nestedRow, nestedIndex, type);
+            }
+            if (nestedRow.isNullAt(nestedIndex)) {
+                return null;
+            }
+            nestedRow = nestedRow.getRow(nestedIndex, nestedArities[i + 1]);
+        }
+        throw new IllegalStateException("Invalid nested field reference: " + name);
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) {
@@ -75,12 +179,17 @@ public class FieldRef implements Serializable {
         FieldRef fieldRef = (FieldRef) o;
         return index == fieldRef.index
                 && Objects.equals(name, fieldRef.name)
-                && Objects.equals(type, fieldRef.type);
+                && Objects.equals(type, fieldRef.type)
+                && Arrays.equals(nestedIndexes, fieldRef.nestedIndexes)
+                && Arrays.equals(nestedArities, fieldRef.nestedArities);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(index, name, type);
+        int result = Objects.hash(index, name, type);
+        result = 31 * result + Arrays.hashCode(nestedIndexes);
+        result = 31 * result + Arrays.hashCode(nestedArities);
+        return result;
     }
 
     @Override

--- a/paimon-common/src/main/java/org/apache/paimon/predicate/FieldTransform.java
+++ b/paimon-common/src/main/java/org/apache/paimon/predicate/FieldTransform.java
@@ -29,7 +29,6 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 
-import static org.apache.paimon.utils.InternalRowUtils.get;
 import static org.apache.paimon.utils.Preconditions.checkArgument;
 
 /** Transform that extracts a field from a row. */
@@ -71,7 +70,7 @@ public class FieldTransform implements Transform {
 
     @Override
     public Object transform(InternalRow row) {
-        return get(row, fieldRef.index(), fieldRef.type());
+        return fieldRef.get(row);
     }
 
     @Override

--- a/paimon-common/src/main/java/org/apache/paimon/predicate/LeafPredicate.java
+++ b/paimon-common/src/main/java/org/apache/paimon/predicate/LeafPredicate.java
@@ -146,6 +146,11 @@ public class LeafPredicate implements Predicate {
             return !(function instanceof AlwaysFalse);
         }
         FieldRef fieldRef = fieldRefOptional.get();
+        if (fieldRef.isNested()) {
+            // File statistics are currently stored for top-level fields. They cannot safely be
+            // interpreted using the nested leaf type, so retain the file for row-level filtering.
+            return true;
+        }
         int index = fieldRef.index();
         DataType type = fieldRef.type();
 

--- a/paimon-common/src/main/java/org/apache/paimon/predicate/PredicateBuilder.java
+++ b/paimon-common/src/main/java/org/apache/paimon/predicate/PredicateBuilder.java
@@ -25,6 +25,7 @@ import org.apache.paimon.data.Timestamp;
 import org.apache.paimon.types.DataField;
 import org.apache.paimon.types.DataType;
 import org.apache.paimon.types.DecimalType;
+import org.apache.paimon.types.ResolvedFieldPath;
 import org.apache.paimon.types.RowType;
 import org.apache.paimon.utils.Pair;
 import org.apache.paimon.utils.Preconditions;
@@ -72,6 +73,29 @@ public class PredicateBuilder {
 
     public int indexOf(String field) {
         return fieldNames.indexOf(field);
+    }
+
+    /** Returns a transform for a top-level or ROW-nested field path. */
+    public Transform field(String fieldPath) {
+        return new FieldTransform(
+                FieldRef.from(
+                        ResolvedFieldPath.resolve(rowType, fieldPath)
+                                .orElseThrow(
+                                        () ->
+                                                new IllegalArgumentException(
+                                                        "Cannot find field: " + fieldPath))));
+    }
+
+    /** Returns a transform for an unambiguous structured field path. */
+    public Transform field(List<String> fieldPath) {
+        return new FieldTransform(
+                FieldRef.from(
+                        ResolvedFieldPath.resolve(rowType, fieldPath)
+                                .orElseThrow(
+                                        () ->
+                                                new IllegalArgumentException(
+                                                        "Cannot find field: "
+                                                                + String.join(".", fieldPath)))));
     }
 
     public Predicate equal(int idx, Object literal) {

--- a/paimon-common/src/main/java/org/apache/paimon/predicate/PredicateProjectionConverter.java
+++ b/paimon-common/src/main/java/org/apache/paimon/predicate/PredicateProjectionConverter.java
@@ -92,7 +92,7 @@ public class PredicateProjectionConverter implements PredicateVisitor<Optional<P
                 FieldRef fieldRef = (FieldRef) input;
                 Integer mappedIndex = reversed.get(fieldRef.index());
                 if (mappedIndex != null) {
-                    newInputs.add(new FieldRef(mappedIndex, fieldRef.name(), fieldRef.type()));
+                    newInputs.add(fieldRef.withIndex(mappedIndex));
                 } else {
                     return Optional.empty();
                 }

--- a/paimon-common/src/main/java/org/apache/paimon/predicate/PredicateVisitor.java
+++ b/paimon-common/src/main/java/org/apache/paimon/predicate/PredicateVisitor.java
@@ -18,6 +18,7 @@
 
 package org.apache.paimon.predicate;
 
+import org.apache.paimon.types.ResolvedFieldPath;
 import org.apache.paimon.types.RowType;
 
 import javax.annotation.Nullable;
@@ -46,9 +47,8 @@ public interface PredicateVisitor<T> {
         }
         Set<Integer> fieldIds = new HashSet<>();
         for (String name : collectFieldNames(predicate)) {
-            if (rowType.containsField(name)) {
-                fieldIds.add(rowType.getField(name).id());
-            }
+            ResolvedFieldPath.resolve(rowType, name)
+                    .ifPresent(path -> fieldIds.add(path.leafField().id()));
         }
         return fieldIds;
     }

--- a/paimon-common/src/main/java/org/apache/paimon/predicate/PredicateVisitor.java
+++ b/paimon-common/src/main/java/org/apache/paimon/predicate/PredicateVisitor.java
@@ -18,7 +18,6 @@
 
 package org.apache.paimon.predicate;
 
-import org.apache.paimon.types.ResolvedFieldPath;
 import org.apache.paimon.types.RowType;
 
 import javax.annotation.Nullable;
@@ -46,11 +45,34 @@ public interface PredicateVisitor<T> {
             return Collections.emptySet();
         }
         Set<Integer> fieldIds = new HashSet<>();
-        for (String name : collectFieldNames(predicate)) {
-            ResolvedFieldPath.resolve(rowType, name)
-                    .ifPresent(path -> fieldIds.add(path.leafField().id()));
+        for (FieldRef fieldRef : predicate.visit(new FieldRefCollector())) {
+            fieldRef.resolveField(rowType).ifPresent(field -> fieldIds.add(field.id()));
         }
         return fieldIds;
+    }
+
+    /** A visitor that collects all field references used by a predicate. */
+    class FieldRefCollector implements PredicateVisitor<Set<FieldRef>> {
+
+        @Override
+        public Set<FieldRef> visit(LeafPredicate predicate) {
+            Set<FieldRef> fieldRefs = new HashSet<>();
+            for (Object input : predicate.transform().inputs()) {
+                if (input instanceof FieldRef) {
+                    fieldRefs.add((FieldRef) input);
+                }
+            }
+            return fieldRefs;
+        }
+
+        @Override
+        public Set<FieldRef> visit(CompoundPredicate predicate) {
+            Set<FieldRef> fieldRefs = new HashSet<>();
+            for (Predicate child : predicate.children()) {
+                fieldRefs.addAll(child.visit(this));
+            }
+            return fieldRefs;
+        }
     }
 
     /** A visitor that collects all field names referenced by a predicate. */

--- a/paimon-common/src/main/java/org/apache/paimon/predicate/StringTransform.java
+++ b/paimon-common/src/main/java/org/apache/paimon/predicate/StringTransform.java
@@ -130,8 +130,7 @@ public abstract class StringTransform implements Transform {
         for (Object input : inputs) {
             if (input instanceof FieldRef) {
                 FieldRef ref = (FieldRef) input;
-                int i = ref.index();
-                strings.add(row.isNullAt(i) ? null : row.getString(i));
+                strings.add((BinaryString) ref.get(row));
             } else {
                 strings.add((BinaryString) input);
             }

--- a/paimon-common/src/main/java/org/apache/paimon/predicate/SubstringTransform.java
+++ b/paimon-common/src/main/java/org/apache/paimon/predicate/SubstringTransform.java
@@ -56,8 +56,7 @@ public class SubstringTransform implements Transform {
         if (source instanceof FieldRef) {
             FieldRef sourceFieldRef = (FieldRef) source;
             checkArgument(sourceFieldRef.type().is(CHARACTER_STRING));
-            int sourceIndex = sourceFieldRef.index();
-            sourceString = row.isNullAt(sourceIndex) ? null : row.getString(sourceIndex);
+            sourceString = (BinaryString) sourceFieldRef.get(row);
         } else {
             sourceString = (BinaryString) inputs.get(0);
         }
@@ -71,7 +70,7 @@ public class SubstringTransform implements Transform {
         if (begin instanceof FieldRef) {
             FieldRef beginRef = (FieldRef) begin;
             checkArgument(beginRef.type().is(INTEGER_NUMERIC));
-            beginIndex = row.getInt(beginRef.index());
+            beginIndex = ((Number) beginRef.get(row)).intValue();
         } else {
             beginIndex = Integer.parseInt(inputs.get(1).toString());
         }
@@ -85,7 +84,7 @@ public class SubstringTransform implements Transform {
             if (end instanceof FieldRef) {
                 FieldRef endRef = (FieldRef) inputs.get(2);
                 checkArgument(endRef.type().is(INTEGER_NUMERIC));
-                endIndex = beginIndex + row.getInt(endRef.index()) - 1;
+                endIndex = beginIndex + ((Number) endRef.get(row)).intValue() - 1;
             } else {
                 endIndex = beginIndex + Integer.parseInt(inputs.get(2).toString()) - 1;
             }

--- a/paimon-common/src/main/java/org/apache/paimon/types/ResolvedFieldPath.java
+++ b/paimon-common/src/main/java/org/apache/paimon/types/ResolvedFieldPath.java
@@ -1,0 +1,272 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.types;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+
+/**
+ * A resolved path from a root {@link RowType} to one of its ROW-nested fields.
+ *
+ * <p>Collection elements and map keys or values are not traversed.
+ */
+public final class ResolvedFieldPath implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    private final List<DataField> fields;
+    private final int[] indexes;
+
+    private ResolvedFieldPath(List<DataField> fields, int[] indexes) {
+        if (fields.isEmpty() || fields.size() != indexes.length) {
+            throw new IllegalArgumentException("Fields and indexes must form a non-empty path.");
+        }
+        this.fields = Collections.unmodifiableList(new ArrayList<>(fields));
+        this.indexes = Arrays.copyOf(indexes, indexes.length);
+    }
+
+    /**
+     * Resolves a field name. An exact top-level field name takes precedence over interpreting dots
+     * as nested path separators.
+     */
+    public static Optional<ResolvedFieldPath> resolve(RowType rowType, String fieldName) {
+        Objects.requireNonNull(rowType, "Row type must not be null.");
+        Objects.requireNonNull(fieldName, "Field name must not be null.");
+
+        if (fieldName.isEmpty()) {
+            return Optional.empty();
+        }
+
+        int topLevelIndex = rowType.getFieldIndex(fieldName);
+        if (topLevelIndex >= 0) {
+            return Optional.of(
+                    new ResolvedFieldPath(
+                            Collections.singletonList(rowType.getFields().get(topLevelIndex)),
+                            new int[] {topLevelIndex}));
+        }
+
+        return resolve(rowType, Arrays.asList(fieldName.split("\\.", -1)));
+    }
+
+    /** Resolves a field path whose elements are unambiguous field names. */
+    public static Optional<ResolvedFieldPath> resolve(RowType rowType, List<String> fieldNames) {
+        Objects.requireNonNull(rowType, "Row type must not be null.");
+        Objects.requireNonNull(fieldNames, "Field names must not be null.");
+
+        if (fieldNames.isEmpty()) {
+            return Optional.empty();
+        }
+
+        List<DataField> fields = new ArrayList<>(fieldNames.size());
+        int[] indexes = new int[fieldNames.size()];
+        RowType currentRowType = rowType;
+        for (int i = 0; i < fieldNames.size(); i++) {
+            String fieldName = fieldNames.get(i);
+            if (fieldName == null || fieldName.isEmpty()) {
+                return Optional.empty();
+            }
+
+            int index = currentRowType.getFieldIndex(fieldName);
+            if (index < 0) {
+                return Optional.empty();
+            }
+
+            DataField field = currentRowType.getFields().get(index);
+            fields.add(field);
+            indexes[i] = index;
+
+            if (i < fieldNames.size() - 1) {
+                if (!(field.type() instanceof RowType)) {
+                    return Optional.empty();
+                }
+                currentRowType = (RowType) field.type();
+            }
+        }
+
+        return Optional.of(new ResolvedFieldPath(fields, indexes));
+    }
+
+    /** Resolves a field ID by traversing nested {@link RowType}s. */
+    public static Optional<ResolvedFieldPath> resolve(RowType rowType, int fieldId) {
+        Objects.requireNonNull(rowType, "Row type must not be null.");
+        return resolveById(rowType, fieldId);
+    }
+
+    /** Resolves field paths in their declared order. */
+    public static Optional<List<ResolvedFieldPath>> resolveAll(
+            RowType rowType, List<String> fieldPaths) {
+        Objects.requireNonNull(rowType, "Row type must not be null.");
+        Objects.requireNonNull(fieldPaths, "Field paths must not be null.");
+
+        List<ResolvedFieldPath> resolved = new ArrayList<>(fieldPaths.size());
+        for (String fieldPath : fieldPaths) {
+            Optional<ResolvedFieldPath> path = resolve(rowType, fieldPath);
+            if (!path.isPresent()) {
+                return Optional.empty();
+            }
+            resolved.add(path.get());
+        }
+        return Optional.of(Collections.unmodifiableList(resolved));
+    }
+
+    /**
+     * Projects the distinct top-level fields needed to read the supplied paths, preserving their
+     * first-use order. All paths must have been resolved from {@code rowType}.
+     */
+    public static RowType projectTopLevel(
+            RowType rowType, List<ResolvedFieldPath> resolvedFieldPaths) {
+        Objects.requireNonNull(rowType, "Row type must not be null.");
+        Objects.requireNonNull(resolvedFieldPaths, "Resolved field paths must not be null.");
+
+        Set<Integer> indexes = new LinkedHashSet<>();
+        for (ResolvedFieldPath path : resolvedFieldPaths) {
+            indexes.add(path.topLevelIndex());
+        }
+        int[] projection = new int[indexes.size()];
+        int pos = 0;
+        for (Integer index : indexes) {
+            projection[pos++] = index;
+        }
+        return rowType.project(projection);
+    }
+
+    private static Optional<ResolvedFieldPath> resolveById(RowType rowType, int fieldId) {
+        List<DataField> fields = rowType.getFields();
+        for (int i = 0; i < fields.size(); i++) {
+            DataField field = fields.get(i);
+            if (field.id() == fieldId) {
+                return Optional.of(
+                        new ResolvedFieldPath(Collections.singletonList(field), new int[] {i}));
+            }
+
+            if (field.type() instanceof RowType) {
+                Optional<ResolvedFieldPath> nested = resolveById((RowType) field.type(), fieldId);
+                if (nested.isPresent()) {
+                    return Optional.of(nested.get().prepend(field, i));
+                }
+            }
+        }
+        return Optional.empty();
+    }
+
+    private ResolvedFieldPath prepend(DataField field, int index) {
+        List<DataField> prependedFields = new ArrayList<>(fields.size() + 1);
+        prependedFields.add(field);
+        prependedFields.addAll(fields);
+
+        int[] prependedIndexes = new int[indexes.length + 1];
+        prependedIndexes[0] = index;
+        System.arraycopy(indexes, 0, prependedIndexes, 1, indexes.length);
+        return new ResolvedFieldPath(prependedFields, prependedIndexes);
+    }
+
+    /** Returns all fields in the path, including the top-level field and leaf field. */
+    public List<DataField> fields() {
+        return fields;
+    }
+
+    /** Returns all field names in the path as its unambiguous structured representation. */
+    public List<String> fieldNames() {
+        List<String> names = new ArrayList<>(fields.size());
+        for (DataField field : fields) {
+            names.add(field.name());
+        }
+        return Collections.unmodifiableList(names);
+    }
+
+    /** Returns all ordinal positions in the path, including the top-level position. */
+    public int[] indexes() {
+        return Arrays.copyOf(indexes, indexes.length);
+    }
+
+    /** Returns the top-level ordinal position. */
+    public int topLevelIndex() {
+        return indexes[0];
+    }
+
+    /** Returns ordinal positions below the top-level row. */
+    public int[] nestedIndexes() {
+        return Arrays.copyOfRange(indexes, 1, indexes.length);
+    }
+
+    /** Returns the arity of each row traversed below the top-level field. */
+    public int[] nestedArities() {
+        int[] arities = new int[fields.size() - 1];
+        for (int i = 0; i < arities.length; i++) {
+            arities[i] = ((RowType) fields.get(i).type()).getFieldCount();
+        }
+        return arities;
+    }
+
+    /** Returns the top-level field. */
+    public DataField topLevelField() {
+        return fields.get(0);
+    }
+
+    /** Returns the leaf field. */
+    public DataField leafField() {
+        return fields.get(fields.size() - 1);
+    }
+
+    /** Returns whether this path traverses at least one nested row. */
+    public boolean isNested() {
+        return fields.size() > 1;
+    }
+
+    /** Returns the dot-separated path. */
+    public String fullName() {
+        StringBuilder builder = new StringBuilder();
+        for (DataField field : fields) {
+            if (builder.length() > 0) {
+                builder.append('.');
+            }
+            builder.append(field.name());
+        }
+        return builder.toString();
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof ResolvedFieldPath)) {
+            return false;
+        }
+        ResolvedFieldPath that = (ResolvedFieldPath) o;
+        return fields.equals(that.fields) && Arrays.equals(indexes, that.indexes);
+    }
+
+    @Override
+    public int hashCode() {
+        return 31 * fields.hashCode() + Arrays.hashCode(indexes);
+    }
+
+    @Override
+    public String toString() {
+        return fullName();
+    }
+}

--- a/paimon-common/src/test/java/org/apache/paimon/globalindex/GlobalIndexEvaluatorTest.java
+++ b/paimon-common/src/test/java/org/apache/paimon/globalindex/GlobalIndexEvaluatorTest.java
@@ -20,7 +20,9 @@ package org.apache.paimon.globalindex;
 
 import org.apache.paimon.predicate.And;
 import org.apache.paimon.predicate.CompoundPredicate;
+import org.apache.paimon.predicate.Equal;
 import org.apache.paimon.predicate.FieldRef;
+import org.apache.paimon.predicate.LeafPredicate;
 import org.apache.paimon.predicate.Predicate;
 import org.apache.paimon.predicate.PredicateBuilder;
 import org.apache.paimon.predicate.TopN;
@@ -165,6 +167,106 @@ class GlobalIndexEvaluatorTest {
         assertThat(secondResult).isPresent();
         assertBitmapContainsExactly(secondResult.get().results(), 1L, 2L, 3L);
         assertThat(readersCreated).hasValue(1);
+        evaluator.close();
+    }
+
+    @Test
+    void testNestedFieldPredicateUsesLeafFieldId() {
+        RowType rowType =
+                new RowType(
+                        Arrays.asList(
+                                new DataField(0, "id", DataTypes.INT()),
+                                new DataField(
+                                        1,
+                                        "profile",
+                                        new RowType(
+                                                Arrays.asList(
+                                                        new DataField(
+                                                                7, "zip", DataTypes.INT()))))));
+        AtomicInteger requestedFieldId = new AtomicInteger(-1);
+        AtomicBoolean nestedReferenceVisited = new AtomicBoolean();
+        GlobalIndexEvaluator evaluator =
+                new GlobalIndexEvaluator(
+                        rowType,
+                        fieldId -> {
+                            requestedFieldId.set(fieldId);
+                            return Collections.singletonList(
+                                    new StubGlobalIndexReader(null) {
+                                        @Override
+                                        public CompletableFuture<Optional<GlobalIndexResult>>
+                                                visitEqual(FieldRef fieldRef, Object literal) {
+                                            nestedReferenceVisited.set(
+                                                    fieldRef.name().equals("profile.zip")
+                                                            && literal.equals(42));
+                                            return CompletableFuture.completedFuture(
+                                                    Optional.of(resultOf(5, 8)));
+                                        }
+                                    });
+                        });
+        Predicate predicate =
+                new LeafPredicate(
+                        Equal.INSTANCE,
+                        DataTypes.INT(),
+                        1,
+                        "profile.zip",
+                        Collections.singletonList(42));
+
+        Optional<GlobalIndexEvaluator.Evaluation> evaluation =
+                evaluator.evaluateWithContributingFields(predicate);
+
+        assertThat(evaluation).isPresent();
+        assertThat(requestedFieldId).hasValue(7);
+        assertThat(nestedReferenceVisited).isTrue();
+        assertThat(evaluation.get().contributingFieldIds()).containsExactly(7);
+        assertBitmapContainsExactly(evaluation.get().result().results(), 5L, 8L);
+        evaluator.close();
+    }
+
+    @Test
+    void testNestedFieldTopNUsesLeafFieldId() {
+        RowType rowType =
+                new RowType(
+                        Collections.singletonList(
+                                new DataField(
+                                        1,
+                                        "profile",
+                                        new RowType(
+                                                Collections.singletonList(
+                                                        new DataField(
+                                                                7, "zip", DataTypes.INT()))))));
+        AtomicInteger requestedFieldId = new AtomicInteger(-1);
+        AtomicBoolean nestedTopNVisited = new AtomicBoolean();
+        GlobalIndexEvaluator evaluator =
+                new GlobalIndexEvaluator(
+                        rowType,
+                        fieldId -> {
+                            requestedFieldId.set(fieldId);
+                            return Collections.singletonList(
+                                    new StubGlobalIndexReader(null) {
+                                        @Override
+                                        public CompletableFuture<Optional<GlobalIndexResult>>
+                                                visitTopN(TopN topN) {
+                                            nestedTopNVisited.set(
+                                                    topN.orders()
+                                                            .get(0)
+                                                            .field()
+                                                            .name()
+                                                            .equals("profile.zip"));
+                                            return CompletableFuture.completedFuture(
+                                                    Optional.of(resultOf(3, 4)));
+                                        }
+                                    });
+                        });
+        TopN topN =
+                new TopN(
+                        new FieldRef(1, "profile.zip", DataTypes.INT()), DESCENDING, NULLS_LAST, 2);
+
+        Optional<GlobalIndexResult> result = evaluator.evaluateTopN(topN);
+
+        assertThat(result).isPresent();
+        assertThat(requestedFieldId).hasValue(7);
+        assertThat(nestedTopNVisited).isTrue();
+        assertBitmapContainsExactly(result.get().results(), 3L, 4L);
         evaluator.close();
     }
 

--- a/paimon-common/src/test/java/org/apache/paimon/globalindex/GlobalIndexEvaluatorTest.java
+++ b/paimon-common/src/test/java/org/apache/paimon/globalindex/GlobalIndexEvaluatorTest.java
@@ -20,9 +20,7 @@ package org.apache.paimon.globalindex;
 
 import org.apache.paimon.predicate.And;
 import org.apache.paimon.predicate.CompoundPredicate;
-import org.apache.paimon.predicate.Equal;
 import org.apache.paimon.predicate.FieldRef;
-import org.apache.paimon.predicate.LeafPredicate;
 import org.apache.paimon.predicate.Predicate;
 import org.apache.paimon.predicate.PredicateBuilder;
 import org.apache.paimon.predicate.TopN;
@@ -181,8 +179,8 @@ class GlobalIndexEvaluatorTest {
                                         "profile",
                                         new RowType(
                                                 Arrays.asList(
-                                                        new DataField(
-                                                                7, "zip", DataTypes.INT()))))));
+                                                        new DataField(7, "zip", DataTypes.INT())))),
+                                new DataField(8, "profile.zip", DataTypes.STRING())));
         AtomicInteger requestedFieldId = new AtomicInteger(-1);
         AtomicBoolean nestedReferenceVisited = new AtomicBoolean();
         GlobalIndexEvaluator evaluator =
@@ -203,13 +201,8 @@ class GlobalIndexEvaluatorTest {
                                         }
                                     });
                         });
-        Predicate predicate =
-                new LeafPredicate(
-                        Equal.INSTANCE,
-                        DataTypes.INT(),
-                        1,
-                        "profile.zip",
-                        Collections.singletonList(42));
+        PredicateBuilder builder = new PredicateBuilder(rowType);
+        Predicate predicate = builder.equal(builder.field(Arrays.asList("profile", "zip")), 42);
 
         Optional<GlobalIndexEvaluator.Evaluation> evaluation =
                 evaluator.evaluateWithContributingFields(predicate);
@@ -226,14 +219,14 @@ class GlobalIndexEvaluatorTest {
     void testNestedFieldTopNUsesLeafFieldId() {
         RowType rowType =
                 new RowType(
-                        Collections.singletonList(
+                        Arrays.asList(
                                 new DataField(
                                         1,
                                         "profile",
                                         new RowType(
                                                 Collections.singletonList(
-                                                        new DataField(
-                                                                7, "zip", DataTypes.INT()))))));
+                                                        new DataField(7, "zip", DataTypes.INT())))),
+                                new DataField(8, "profile.zip", DataTypes.STRING())));
         AtomicInteger requestedFieldId = new AtomicInteger(-1);
         AtomicBoolean nestedTopNVisited = new AtomicBoolean();
         GlobalIndexEvaluator evaluator =
@@ -257,9 +250,10 @@ class GlobalIndexEvaluatorTest {
                                         }
                                     });
                         });
-        TopN topN =
-                new TopN(
-                        new FieldRef(1, "profile.zip", DataTypes.INT()), DESCENDING, NULLS_LAST, 2);
+        PredicateBuilder builder = new PredicateBuilder(rowType);
+        FieldRef fieldRef =
+                (FieldRef) builder.field(Arrays.asList("profile", "zip")).inputs().get(0);
+        TopN topN = new TopN(fieldRef, DESCENDING, NULLS_LAST, 2);
 
         Optional<GlobalIndexResult> result = evaluator.evaluateTopN(topN);
 

--- a/paimon-common/src/test/java/org/apache/paimon/predicate/LeafPredicateTest.java
+++ b/paimon-common/src/test/java/org/apache/paimon/predicate/LeafPredicateTest.java
@@ -22,6 +22,7 @@ import org.apache.paimon.data.BinaryString;
 import org.apache.paimon.data.GenericArray;
 import org.apache.paimon.data.GenericRow;
 import org.apache.paimon.types.DataTypes;
+import org.apache.paimon.types.ResolvedFieldPath;
 import org.apache.paimon.types.RowType;
 import org.apache.paimon.utils.InstantiationUtil;
 
@@ -34,6 +35,51 @@ import java.util.List;
 import static org.assertj.core.api.Assertions.assertThat;
 
 class LeafPredicateTest {
+
+    @Test
+    public void testNestedFieldReference() {
+        RowType rowType =
+                DataTypes.ROW(
+                        DataTypes.FIELD(
+                                0,
+                                "profile",
+                                DataTypes.ROW(
+                                        DataTypes.FIELD(1, "name", DataTypes.STRING()),
+                                        DataTypes.FIELD(
+                                                2,
+                                                "address",
+                                                DataTypes.ROW(
+                                                        DataTypes.FIELD(
+                                                                3, "zip", DataTypes.INT()))))));
+        FieldRef ref =
+                FieldRef.from(ResolvedFieldPath.resolve(rowType, "profile.address.zip").get());
+        LeafPredicate predicate =
+                LeafPredicate.of(
+                        new FieldTransform(ref),
+                        Equal.INSTANCE,
+                        java.util.Collections.singletonList(100));
+
+        assertThat(ref.isNested()).isTrue();
+        assertThat(ref.index()).isZero();
+        assertThat(ref.nestedIndexes()).containsExactly(1, 0);
+        assertThat(ref.nestedArities()).containsExactly(2, 1);
+        assertThat(predicate.test(GenericRow.of(GenericRow.of("Alice", GenericRow.of(100)))))
+                .isTrue();
+        assertThat(predicate.test(GenericRow.of(GenericRow.of("Alice", GenericRow.of(200)))))
+                .isFalse();
+        assertThat(predicate.test(GenericRow.of((Object) null))).isFalse();
+
+        // Top-level file statistics do not contain leaf statistics for nested fields. The
+        // predicate must therefore degrade to "might match" instead of interpreting the parent
+        // ROW value as the leaf type.
+        assertThat(
+                        predicate.test(
+                                1,
+                                GenericRow.of(GenericRow.of("Alice", GenericRow.of(100))),
+                                GenericRow.of(GenericRow.of("Alice", GenericRow.of(100))),
+                                new GenericArray(new long[] {0})))
+                .isTrue();
+    }
 
     @Test
     public void testReturnTrue() {

--- a/paimon-common/src/test/java/org/apache/paimon/predicate/PredicateVisitorTest.java
+++ b/paimon-common/src/test/java/org/apache/paimon/predicate/PredicateVisitorTest.java
@@ -25,6 +25,7 @@ import org.apache.paimon.types.RowType;
 import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
+import java.util.Collections;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -49,5 +50,29 @@ public class PredicateVisitorTest {
         assertThat(PredicateVisitor.collectFieldIds(rowType, predicate))
                 .containsExactlyInAnyOrder(10, 20);
         assertThat(PredicateVisitor.collectFieldIds(rowType, null)).isEmpty();
+    }
+
+    @Test
+    public void testCollectNestedFieldIds() {
+        RowType rowType =
+                new RowType(
+                        Arrays.asList(
+                                new DataField(0, "id", DataTypes.INT()),
+                                new DataField(
+                                        1,
+                                        "profile",
+                                        new RowType(
+                                                Collections.singletonList(
+                                                        new DataField(
+                                                                7, "zip", DataTypes.INT()))))));
+        Predicate predicate =
+                new LeafPredicate(
+                        Equal.INSTANCE,
+                        DataTypes.INT(),
+                        1,
+                        "profile.zip",
+                        Collections.singletonList(42));
+
+        assertThat(PredicateVisitor.collectFieldIds(rowType, predicate)).containsExactly(7);
     }
 }

--- a/paimon-common/src/test/java/org/apache/paimon/predicate/PredicateVisitorTest.java
+++ b/paimon-common/src/test/java/org/apache/paimon/predicate/PredicateVisitorTest.java
@@ -63,15 +63,10 @@ public class PredicateVisitorTest {
                                         "profile",
                                         new RowType(
                                                 Collections.singletonList(
-                                                        new DataField(
-                                                                7, "zip", DataTypes.INT()))))));
-        Predicate predicate =
-                new LeafPredicate(
-                        Equal.INSTANCE,
-                        DataTypes.INT(),
-                        1,
-                        "profile.zip",
-                        Collections.singletonList(42));
+                                                        new DataField(7, "zip", DataTypes.INT())))),
+                                new DataField(8, "profile.zip", DataTypes.STRING())));
+        PredicateBuilder builder = new PredicateBuilder(rowType);
+        Predicate predicate = builder.equal(builder.field(Arrays.asList("profile", "zip")), 42);
 
         assertThat(PredicateVisitor.collectFieldIds(rowType, predicate)).containsExactly(7);
     }

--- a/paimon-common/src/test/java/org/apache/paimon/predicate/TransformJsonSerdeTest.java
+++ b/paimon-common/src/test/java/org/apache/paimon/predicate/TransformJsonSerdeTest.java
@@ -49,6 +49,18 @@ class TransformJsonSerdeTest {
                         .expectJson(
                                 "{\"name\":\"FIELD_REF\",\"fieldRef\":{\"index\":1,\"name\":\"f1\",\"type\":\"STRING\"}}"),
 
+                // Nested FieldTransform
+                TestSpec.forTransform(
+                                new FieldTransform(
+                                        new FieldRef(
+                                                1,
+                                                "profile.address.zip",
+                                                DataTypes.INT(),
+                                                new int[] {1, 0},
+                                                new int[] {2, 1})))
+                        .expectJson(
+                                "{\"name\":\"FIELD_REF\",\"fieldRef\":{\"index\":1,\"name\":\"profile.address.zip\",\"type\":\"INT\",\"nestedIndexes\":[1,0],\"nestedArities\":[2,1]}}"),
+
                 // CastTransform - INT to BIGINT
                 TestSpec.forTransform(
                                 new CastTransform(

--- a/paimon-common/src/test/java/org/apache/paimon/types/ResolvedFieldPathTest.java
+++ b/paimon-common/src/test/java/org/apache/paimon/types/ResolvedFieldPathTest.java
@@ -1,0 +1,166 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.types;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/** Tests for {@link ResolvedFieldPath}. */
+class ResolvedFieldPathTest {
+
+    private static final int ID = 0;
+    private static final int PROFILE = 1;
+    private static final int NAME = 2;
+    private static final int ADDRESS = 3;
+    private static final int CITY = 4;
+    private static final int ZIP = 5;
+    private static final int DOTTED_TOP_LEVEL = 6;
+    private static final int ITEMS = 7;
+    private static final int ITEM_VALUE = 8;
+
+    private static RowType rowType() {
+        RowType addressType =
+                DataTypes.ROW(
+                        DataTypes.FIELD(CITY, "city", DataTypes.STRING()),
+                        DataTypes.FIELD(ZIP, "zip", DataTypes.INT()));
+        RowType profileType =
+                DataTypes.ROW(
+                        DataTypes.FIELD(NAME, "name", DataTypes.STRING()),
+                        DataTypes.FIELD(ADDRESS, "address", addressType));
+        RowType itemType = DataTypes.ROW(DataTypes.FIELD(ITEM_VALUE, "value", DataTypes.INT()));
+        return DataTypes.ROW(
+                DataTypes.FIELD(ID, "id", DataTypes.BIGINT()),
+                DataTypes.FIELD(PROFILE, "profile", profileType),
+                DataTypes.FIELD(DOTTED_TOP_LEVEL, "profile.address.zip", DataTypes.STRING()),
+                DataTypes.FIELD(ITEMS, "items", DataTypes.ARRAY(itemType)));
+    }
+
+    @Test
+    void testResolveNestedRowFieldByDottedName() {
+        ResolvedFieldPath path = ResolvedFieldPath.resolve(rowType(), "profile.address.city").get();
+
+        assertThat(path.fieldNames()).containsExactly("profile", "address", "city");
+        assertThat(path.indexes()).containsExactly(1, 1, 0);
+        assertThat(path.nestedIndexes()).containsExactly(1, 0);
+        assertThat(path.nestedArities()).containsExactly(2, 2);
+        assertThat(path.topLevelIndex()).isEqualTo(1);
+        assertThat(path.topLevelField().id()).isEqualTo(PROFILE);
+        assertThat(path.leafField().id()).isEqualTo(CITY);
+        assertThat(path.fullName()).isEqualTo("profile.address.city");
+        assertThat(path.isNested()).isTrue();
+    }
+
+    @Test
+    void testExactTopLevelNameTakesPrecedenceOverDottedPath() {
+        ResolvedFieldPath path = ResolvedFieldPath.resolve(rowType(), "profile.address.zip").get();
+
+        assertThat(path.fieldNames()).containsExactly("profile.address.zip");
+        assertThat(path.indexes()).containsExactly(2);
+        assertThat(path.nestedIndexes()).isEmpty();
+        assertThat(path.nestedArities()).isEmpty();
+        assertThat(path.leafField().id()).isEqualTo(DOTTED_TOP_LEVEL);
+        assertThat(path.isNested()).isFalse();
+    }
+
+    @Test
+    void testStructuredPathCanAddressFieldWhenDottedNameIsAmbiguous() {
+        ResolvedFieldPath path =
+                ResolvedFieldPath.resolve(rowType(), Arrays.asList("profile", "address", "zip"))
+                        .get();
+
+        assertThat(path.fieldNames()).containsExactly("profile", "address", "zip");
+        assertThat(path.indexes()).containsExactly(1, 1, 1);
+        assertThat(path.leafField().id()).isEqualTo(ZIP);
+    }
+
+    @Test
+    void testResolveNestedRowFieldByLeafId() {
+        ResolvedFieldPath path = ResolvedFieldPath.resolve(rowType(), ZIP).get();
+
+        assertThat(path.fieldNames()).containsExactly("profile", "address", "zip");
+        assertThat(path.indexes()).containsExactly(1, 1, 1);
+        assertThat(path.leafField().id()).isEqualTo(ZIP);
+
+        ResolvedFieldPath topLevelPath = ResolvedFieldPath.resolve(rowType(), ID).get();
+        assertThat(topLevelPath.fieldNames()).containsExactly("id");
+        assertThat(topLevelPath.indexes()).containsExactly(0);
+    }
+
+    @Test
+    void testUnsupportedOrMissingPathsReturnEmpty() {
+        RowType rowType = rowType();
+
+        assertThat(ResolvedFieldPath.resolve(rowType, "missing")).isEmpty();
+        assertThat(ResolvedFieldPath.resolve(rowType, "profile.missing")).isEmpty();
+        assertThat(ResolvedFieldPath.resolve(rowType, "profile..city")).isEmpty();
+        assertThat(ResolvedFieldPath.resolve(rowType, "id.value")).isEmpty();
+        assertThat(ResolvedFieldPath.resolve(rowType, "")).isEmpty();
+        assertThat(ResolvedFieldPath.resolve(rowType, ITEM_VALUE)).isEmpty();
+        assertThat(ResolvedFieldPath.resolve(rowType, 999)).isEmpty();
+        assertThat(ResolvedFieldPath.resolve(rowType, Collections.emptyList())).isEmpty();
+        assertThat(ResolvedFieldPath.resolve(rowType, Arrays.asList("profile", ""))).isEmpty();
+    }
+
+    @Test
+    void testReturnedIndexesAreDefensiveCopies() {
+        Optional<ResolvedFieldPath> resolved =
+                ResolvedFieldPath.resolve(rowType(), "profile.address.city");
+        assertThat(resolved).isPresent();
+        assertThatThrownBy(() -> resolved.get().fields().clear())
+                .isInstanceOf(UnsupportedOperationException.class);
+        assertThatThrownBy(() -> resolved.get().fieldNames().clear())
+                .isInstanceOf(UnsupportedOperationException.class);
+
+        int[] indexes = resolved.get().indexes();
+        int[] nestedIndexes = resolved.get().nestedIndexes();
+        int[] nestedArities = resolved.get().nestedArities();
+        indexes[0] = 99;
+        nestedIndexes[0] = 99;
+        nestedArities[0] = 99;
+
+        assertThat(resolved.get().indexes()).containsExactly(1, 1, 0);
+        assertThat(resolved.get().nestedIndexes()).containsExactly(1, 0);
+        assertThat(resolved.get().nestedArities()).containsExactly(2, 2);
+    }
+
+    @Test
+    void testResolveAllAndProjectDistinctTopLevelFields() {
+        RowType rowType = rowType();
+        List<ResolvedFieldPath> paths =
+                ResolvedFieldPath.resolveAll(
+                                rowType,
+                                Arrays.asList("profile.address.city", "profile.name", "id"))
+                        .get();
+
+        assertThat(paths)
+                .extracting(ResolvedFieldPath::fullName)
+                .containsExactly("profile.address.city", "profile.name", "id");
+        assertThat(ResolvedFieldPath.projectTopLevel(rowType, paths).getFieldNames())
+                .containsExactly("profile", "id");
+        assertThat(ResolvedFieldPath.resolveAll(rowType, Arrays.asList("profile.name", "missing")))
+                .isEmpty();
+    }
+}

--- a/paimon-core/src/main/java/org/apache/paimon/globalindex/DataEvolutionBatchScan.java
+++ b/paimon-core/src/main/java/org/apache/paimon/globalindex/DataEvolutionBatchScan.java
@@ -38,6 +38,7 @@ import org.apache.paimon.table.source.DataSplit;
 import org.apache.paimon.table.source.DataTableScan;
 import org.apache.paimon.table.source.InnerTableScan;
 import org.apache.paimon.table.source.Split;
+import org.apache.paimon.types.ResolvedFieldPath;
 import org.apache.paimon.types.RowType;
 import org.apache.paimon.utils.Filter;
 import org.apache.paimon.utils.Range;
@@ -390,7 +391,8 @@ public class DataEvolutionBatchScan implements DataTableScan {
         if (topN == null
                 || pushDownLimit != null
                 || globalIndexResult != null
-                || !table.rowType().containsField(topN.orders().get(0).field().name())) {
+                || !ResolvedFieldPath.resolve(table.rowType(), topN.orders().get(0).field().name())
+                        .isPresent()) {
             return false;
         }
         CoreOptions options = table.coreOptions();

--- a/paimon-core/src/main/java/org/apache/paimon/globalindex/DataEvolutionGlobalIndexRefreshPlanner.java
+++ b/paimon-core/src/main/java/org/apache/paimon/globalindex/DataEvolutionGlobalIndexRefreshPlanner.java
@@ -33,6 +33,7 @@ import org.apache.paimon.manifest.ManifestFileMeta;
 import org.apache.paimon.manifest.ProjectedManifestEntry;
 import org.apache.paimon.partition.PartitionPredicate;
 import org.apache.paimon.schema.SchemaManager;
+import org.apache.paimon.schema.TableSchema;
 import org.apache.paimon.table.FileStoreTable;
 import org.apache.paimon.table.source.ScanMode;
 import org.apache.paimon.types.DataField;
@@ -53,8 +54,6 @@ import java.util.Map;
 import java.util.NavigableMap;
 import java.util.Set;
 import java.util.TreeMap;
-
-import static org.apache.paimon.utils.DataEvolutionUtils.fileFieldIds;
 
 /** Plans existing global index files which need refresh after data-evolution updates. */
 public final class DataEvolutionGlobalIndexRefreshPlanner {
@@ -247,9 +246,33 @@ public final class DataEvolutionGlobalIndexRefreshPlanner {
         Set<Integer> physicalFieldIds =
                 fileFieldIdsCache.computeIfAbsent(
                         Pair.of(file.schemaId(), file.writeCols()),
-                        key -> fileFieldIds(schemaManager::schema, file));
+                        key -> fileFieldIds(schemaManager, file));
         if (!disjoint(indexedFieldIds, physicalFieldIds)) {
             group.addUpdatedFile(file.maxSequenceNumber(), file.nonNullRowIdRange());
+        }
+    }
+
+    private static Set<Integer> fileFieldIds(SchemaManager schemaManager, DataFileMeta file) {
+        TableSchema schema = schemaManager.schema(file.schemaId());
+        List<String> writeCols = file.writeCols();
+        Set<String> writeColNames = writeCols == null ? null : new HashSet<>(writeCols);
+        Set<Integer> ids = new HashSet<>();
+        for (DataField field : schema.fields()) {
+            // writeCols describes top-level physical columns. Writing a ROW writes all of its
+            // nested fields, whose IDs are used by nested global-index metadata.
+            if (writeColNames == null || writeColNames.contains(field.name())) {
+                collectFieldIds(field, ids);
+            }
+        }
+        return ids;
+    }
+
+    private static void collectFieldIds(DataField field, Set<Integer> ids) {
+        ids.add(field.id());
+        if (field.type() instanceof RowType) {
+            for (DataField nestedField : ((RowType) field.type()).getFields()) {
+                collectFieldIds(nestedField, ids);
+            }
         }
     }
 

--- a/paimon-core/src/main/java/org/apache/paimon/globalindex/DataEvolutionGlobalIndexScanner.java
+++ b/paimon-core/src/main/java/org/apache/paimon/globalindex/DataEvolutionGlobalIndexScanner.java
@@ -33,6 +33,7 @@ import org.apache.paimon.predicate.Predicate;
 import org.apache.paimon.predicate.TopN;
 import org.apache.paimon.table.FileStoreTable;
 import org.apache.paimon.types.DataField;
+import org.apache.paimon.types.ResolvedFieldPath;
 import org.apache.paimon.types.RowType;
 import org.apache.paimon.utils.Filter;
 import org.apache.paimon.utils.Range;
@@ -207,13 +208,13 @@ public class DataEvolutionGlobalIndexScanner implements Closeable {
 
         /** The primary index column. */
         DataField indexField(RowType rowType) {
-            return rowType.getField(indexFieldId);
+            return resolveFieldPath(rowType, indexFieldId).leafField();
         }
 
         /** The extra columns beyond the primary one; empty for a single-column index. */
         List<DataField> extraFields(RowType rowType) {
             return fieldIds.subList(1, fieldIds.size()).stream()
-                    .map(rowType::getField)
+                    .map(fieldId -> resolveFieldPath(rowType, fieldId).leafField())
                     .collect(Collectors.toList());
         }
     }
@@ -281,7 +282,12 @@ public class DataEvolutionGlobalIndexScanner implements Closeable {
             return Optional.empty();
         }
 
-        DataField indexField = table.rowType().getField(topN.orders().get(0).field().name());
+        Optional<ResolvedFieldPath> fieldPath =
+                ResolvedFieldPath.resolve(table.rowType(), topN.orders().get(0).field().name());
+        if (!fieldPath.isPresent()) {
+            return Optional.empty();
+        }
+        DataField indexField = fieldPath.get().leafField();
         int fieldId = indexField.id();
         @Nullable Snapshot snapshot = tryTravelOrLatest(table);
         List<IndexFileMeta> indexFiles =
@@ -384,7 +390,7 @@ public class DataEvolutionGlobalIndexScanner implements Closeable {
             return Optional.of(GlobalIndexResult.createEmpty());
         }
         String fieldName = topN.orders().get(0).field().name();
-        if (!rowType.containsField(fieldName)) {
+        if (!ResolvedFieldPath.resolve(rowType, fieldName).isPresent()) {
             return Optional.empty();
         }
         return globalIndexEvaluator.evaluateTopN(topN);
@@ -410,7 +416,12 @@ public class DataEvolutionGlobalIndexScanner implements Closeable {
     public GlobalIndexResult unindexedRows(TopN topN) {
         String fieldName = topN.orders().get(0).field().name();
         RoaringNavigableMap64 rows = new RoaringNavigableMap64();
-        for (Range range : coverage.unindexedRanges(rowType.getField(fieldName).id())) {
+        int fieldId =
+                ResolvedFieldPath.resolve(rowType, fieldName)
+                        .orElseThrow(() -> new RuntimeException("Cannot find field: " + fieldName))
+                        .leafField()
+                        .id();
+        for (Range range : coverage.unindexedRanges(fieldId)) {
             rows.addRange(range);
         }
         return GlobalIndexResult.create(rows);
@@ -465,13 +476,23 @@ public class DataEvolutionGlobalIndexScanner implements Closeable {
                                             table.name(),
                                             indexType,
                                             group.fieldIds.stream()
-                                                    .map(rowType::getField)
-                                                    .map(DataField::name)
+                                                    .map(
+                                                            fieldId ->
+                                                                    resolveFieldPath(
+                                                                                    rowType,
+                                                                                    fieldId)
+                                                                            .fullName())
                                                     .collect(Collectors.toList()),
                                             duration / 1_000_000)));
         }
 
         return readers;
+    }
+
+    private static ResolvedFieldPath resolveFieldPath(RowType rowType, int fieldId) {
+        return ResolvedFieldPath.resolve(rowType, fieldId)
+                .orElseThrow(
+                        () -> new RuntimeException("Cannot find field by field id: " + fieldId));
     }
 
     private GlobalIndexIOMeta toGlobalMeta(IndexFileMeta meta) {

--- a/paimon-core/src/main/java/org/apache/paimon/globalindex/RowIdIndexFieldsExtractor.java
+++ b/paimon-core/src/main/java/org/apache/paimon/globalindex/RowIdIndexFieldsExtractor.java
@@ -21,15 +21,23 @@ package org.apache.paimon.globalindex;
 import org.apache.paimon.codegen.CodeGenUtils;
 import org.apache.paimon.codegen.Projection;
 import org.apache.paimon.data.BinaryRow;
+import org.apache.paimon.data.GenericRow;
 import org.apache.paimon.data.InternalRow;
 import org.apache.paimon.data.InternalRow.FieldGetter;
 import org.apache.paimon.table.SpecialFields;
+import org.apache.paimon.types.DataField;
+import org.apache.paimon.types.ResolvedFieldPath;
 import org.apache.paimon.types.RowType;
 
 import javax.annotation.Nullable;
 
 import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
+
+import static org.apache.paimon.utils.Preconditions.checkArgument;
 
 /** The extractor to get partition, index field and row id from records. */
 public class RowIdIndexFieldsExtractor implements Serializable {
@@ -39,17 +47,31 @@ public class RowIdIndexFieldsExtractor implements Serializable {
     private final int rowIdPos;
     private final RowType readType;
     private final List<String> partitionKeys;
-    private final String indexField;
+    private final List<String> indexFields;
 
     private transient Projection lazyPartitionProjection;
-    private transient FieldGetter lazyIndexFieldGetter;
+    private transient FieldGetter[] lazyIndexFieldGetters;
 
     public RowIdIndexFieldsExtractor(
             RowType readType, List<String> partitionKeys, String indexField) {
+        this(readType, partitionKeys, Collections.singletonList(indexField));
+    }
+
+    public RowIdIndexFieldsExtractor(
+            RowType readType, List<String> partitionKeys, List<String> indexFields) {
         this.readType = readType;
         this.partitionKeys = partitionKeys;
-        this.indexField = indexField;
+        this.indexFields = Collections.unmodifiableList(new ArrayList<>(indexFields));
         this.rowIdPos = readType.getFieldIndex(SpecialFields.ROW_ID.name());
+
+        checkArgument(!indexFields.isEmpty(), "Index field paths must not be empty.");
+        for (String indexField : indexFields) {
+            Optional<ResolvedFieldPath> resolved = ResolvedFieldPath.resolve(readType, indexField);
+            checkArgument(
+                    resolved.isPresent(),
+                    "Index field path '%s' does not exist in the read type.",
+                    indexField);
+        }
     }
 
     private Projection partitionProjection() {
@@ -59,13 +81,34 @@ public class RowIdIndexFieldsExtractor implements Serializable {
         return lazyPartitionProjection;
     }
 
-    private FieldGetter indexFieldGetter() {
-        if (lazyIndexFieldGetter == null) {
-            int indexFieldPos = readType.getFieldIndex(indexField);
-            lazyIndexFieldGetter =
-                    InternalRow.createFieldGetter(readType.getTypeAt(indexFieldPos), indexFieldPos);
+    private FieldGetter[] indexFieldGetters() {
+        if (lazyIndexFieldGetters == null) {
+            lazyIndexFieldGetters = new FieldGetter[indexFields.size()];
+            for (int i = 0; i < indexFields.size(); i++) {
+                ResolvedFieldPath path =
+                        ResolvedFieldPath.resolve(readType, indexFields.get(i)).get();
+                List<DataField> fields = path.fields();
+                int[] indexes = path.indexes();
+                FieldGetter[] pathGetters = new FieldGetter[indexes.length];
+                for (int j = 0; j < indexes.length; j++) {
+                    pathGetters[j] =
+                            InternalRow.createFieldGetter(fields.get(j).type(), indexes[j]);
+                }
+
+                lazyIndexFieldGetters[i] =
+                        row -> {
+                            Object current = row;
+                            for (FieldGetter pathGetter : pathGetters) {
+                                if (current == null) {
+                                    return null;
+                                }
+                                current = pathGetter.getFieldOrNull((InternalRow) current);
+                            }
+                            return current;
+                        };
+            }
         }
-        return lazyIndexFieldGetter;
+        return lazyIndexFieldGetters;
     }
 
     public BinaryRow extractPartition(InternalRow record) {
@@ -74,7 +117,16 @@ public class RowIdIndexFieldsExtractor implements Serializable {
 
     @Nullable
     public Object extractIndexField(InternalRow record) {
-        return indexFieldGetter().getFieldOrNull(record);
+        return indexFieldGetters()[0].getFieldOrNull(record);
+    }
+
+    public InternalRow extractIndexFields(InternalRow record) {
+        FieldGetter[] getters = indexFieldGetters();
+        Object[] values = new Object[getters.length];
+        for (int i = 0; i < getters.length; i++) {
+            values[i] = getters[i].getFieldOrNull(record);
+        }
+        return GenericRow.of(values);
     }
 
     public Long extractRowId(InternalRow record) {

--- a/paimon-core/src/main/java/org/apache/paimon/globalindex/generic/GenericGlobalIndexScanner.java
+++ b/paimon-core/src/main/java/org/apache/paimon/globalindex/generic/GenericGlobalIndexScanner.java
@@ -28,6 +28,7 @@ import org.apache.paimon.options.Options;
 import org.apache.paimon.partition.PartitionPredicate;
 import org.apache.paimon.table.FileStoreTable;
 import org.apache.paimon.types.DataField;
+import org.apache.paimon.types.ResolvedFieldPath;
 import org.apache.paimon.utils.Range;
 import org.apache.paimon.utils.RowRangeIndex;
 
@@ -69,12 +70,14 @@ public class GenericGlobalIndexScanner implements Serializable {
         checkArgument(!indexColumns.isEmpty(), "Index columns must not be empty.");
         List<DataField> indexFields = new ArrayList<>(indexColumns.size());
         for (String indexColumn : indexColumns) {
+            Optional<ResolvedFieldPath> resolvedFieldPath =
+                    ResolvedFieldPath.resolve(table.rowType(), indexColumn);
             checkArgument(
-                    table.rowType().containsField(indexColumn),
+                    resolvedFieldPath.isPresent(),
                     "Column '%s' does not exist in table '%s'.",
                     indexColumn,
                     table.fullName());
-            indexFields.add(table.rowType().getField(indexColumn));
+            indexFields.add(resolvedFieldPath.get().leafField());
         }
         this.indexType = indexType;
         this.indexFields = Collections.unmodifiableList(indexFields);

--- a/paimon-core/src/main/java/org/apache/paimon/globalindex/sorted/SortedGlobalIndexScanner.java
+++ b/paimon-core/src/main/java/org/apache/paimon/globalindex/sorted/SortedGlobalIndexScanner.java
@@ -30,6 +30,7 @@ import org.apache.paimon.table.Table;
 import org.apache.paimon.table.source.DataSplit;
 import org.apache.paimon.table.source.snapshot.SnapshotReader;
 import org.apache.paimon.types.DataField;
+import org.apache.paimon.types.ResolvedFieldPath;
 import org.apache.paimon.types.RowType;
 import org.apache.paimon.utils.Preconditions;
 import org.apache.paimon.utils.Range;
@@ -76,12 +77,14 @@ public class SortedGlobalIndexScanner implements Serializable {
     }
 
     public SortedGlobalIndexScanner withIndexField(String indexField) {
+        Optional<ResolvedFieldPath> resolvedFieldPath =
+                ResolvedFieldPath.resolve(rowType, indexField);
         checkArgument(
-                rowType.containsField(indexField),
+                resolvedFieldPath.isPresent(),
                 "Column '%s' does not exist in table '%s'.",
                 indexField,
                 table.fullName());
-        this.indexField = rowType.getField(indexField);
+        this.indexField = resolvedFieldPath.get().leafField();
         return this;
     }
 

--- a/paimon-core/src/main/java/org/apache/paimon/globalindex/sorted/SortedGlobalIndexWriter.java
+++ b/paimon-core/src/main/java/org/apache/paimon/globalindex/sorted/SortedGlobalIndexWriter.java
@@ -34,6 +34,7 @@ import org.apache.paimon.table.Table;
 import org.apache.paimon.table.sink.CommitMessage;
 import org.apache.paimon.table.sink.CommitMessageImpl;
 import org.apache.paimon.types.DataField;
+import org.apache.paimon.types.ResolvedFieldPath;
 import org.apache.paimon.types.RowType;
 import org.apache.paimon.utils.Range;
 
@@ -43,6 +44,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Optional;
 
 import static org.apache.paimon.globalindex.GlobalIndexBuilderUtils.createIndexWriter;
 import static org.apache.paimon.globalindex.GlobalIndexBuilderUtils.toIndexFileMetas;
@@ -76,12 +78,14 @@ public class SortedGlobalIndexWriter implements Serializable {
     }
 
     public SortedGlobalIndexWriter withIndexField(String indexField) {
+        Optional<ResolvedFieldPath> resolvedFieldPath =
+                ResolvedFieldPath.resolve(rowType, indexField);
         checkArgument(
-                rowType.containsField(indexField),
+                resolvedFieldPath.isPresent(),
                 "Column '%s' does not exist in table '%s'.",
                 indexField,
                 table.fullName());
-        this.indexField = rowType.getField(indexField);
+        this.indexField = resolvedFieldPath.get().leafField();
         return this;
     }
 

--- a/paimon-core/src/main/java/org/apache/paimon/index/GlobalIndexMeta.java
+++ b/paimon-core/src/main/java/org/apache/paimon/index/GlobalIndexMeta.java
@@ -22,6 +22,7 @@ import org.apache.paimon.types.BigIntType;
 import org.apache.paimon.types.DataField;
 import org.apache.paimon.types.DataTypes;
 import org.apache.paimon.types.IntType;
+import org.apache.paimon.types.ResolvedFieldPath;
 import org.apache.paimon.types.RowType;
 import org.apache.paimon.utils.Range;
 
@@ -132,14 +133,14 @@ public class GlobalIndexMeta {
     public List<DataField> getIndexedFields(RowType rowType) {
         List<DataField> fields = new ArrayList<>();
         for (int id : getIndexedFieldIds()) {
-            fields.add(rowType.getField(id));
+            fields.add(resolveFieldPath(rowType, id).leafField());
         }
         return fields;
     }
 
     /** The primary index column. */
     public DataField getIndexField(RowType rowType) {
-        return rowType.getField(indexFieldId);
+        return resolveFieldPath(rowType, indexFieldId).leafField();
     }
 
     /** The extra columns beyond the primary one; empty for a single-column index. */
@@ -147,7 +148,7 @@ public class GlobalIndexMeta {
         List<DataField> fields = new ArrayList<>();
         if (extraFieldIds != null) {
             for (int id : extraFieldIds) {
-                fields.add(rowType.getField(id));
+                fields.add(resolveFieldPath(rowType, id).leafField());
             }
         }
         return fields;
@@ -156,9 +157,24 @@ public class GlobalIndexMeta {
     public List<String> getIndexedFieldNames(RowType rowType) {
         List<String> names = new ArrayList<>();
         for (int id : getIndexedFieldIds()) {
-            names.add(rowType.getField(id).name());
+            names.add(resolveFieldPath(rowType, id).fullName());
         }
         return names;
+    }
+
+    /** The top-level fields containing the indexed fields, in index column order. */
+    public List<String> getIndexedTopLevelFieldNames(RowType rowType) {
+        List<String> names = new ArrayList<>();
+        for (int id : getIndexedFieldIds()) {
+            names.add(resolveFieldPath(rowType, id).topLevelField().name());
+        }
+        return names;
+    }
+
+    private static ResolvedFieldPath resolveFieldPath(RowType rowType, int fieldId) {
+        return ResolvedFieldPath.resolve(rowType, fieldId)
+                .orElseThrow(
+                        () -> new RuntimeException("Cannot find field by field id: " + fieldId));
     }
 
     @Override

--- a/paimon-core/src/main/java/org/apache/paimon/table/source/AbstractDataEvolutionVectorRead.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/source/AbstractDataEvolutionVectorRead.java
@@ -41,6 +41,7 @@ import org.apache.paimon.index.IndexFileMeta;
 import org.apache.paimon.index.IndexPathFactory;
 import org.apache.paimon.partition.PartitionPredicate;
 import org.apache.paimon.predicate.BatchVectorSearch;
+import org.apache.paimon.predicate.FieldRef;
 import org.apache.paimon.predicate.Predicate;
 import org.apache.paimon.predicate.PredicateVisitor;
 import org.apache.paimon.predicate.VectorSearch;
@@ -49,6 +50,7 @@ import org.apache.paimon.table.FileStoreTable;
 import org.apache.paimon.table.SpecialFields;
 import org.apache.paimon.types.DataField;
 import org.apache.paimon.types.DataTypeRoot;
+import org.apache.paimon.types.ResolvedFieldPath;
 import org.apache.paimon.types.RowType;
 import org.apache.paimon.utils.IOUtils;
 import org.apache.paimon.utils.Range;
@@ -443,7 +445,7 @@ public abstract class AbstractDataEvolutionVectorRead implements Serializable {
         TableScan.Plan plan =
                 newRawReadBuilder(readType, false).withRowRanges(rawRowRanges).newScan().plan();
         ReadBuilder readBuilder = newRawReadBuilder(readType, includeFilter);
-        int vectorIndex = readType.getFieldIndex(vectorColumn.name());
+        FieldRef vectorRef = vectorFieldRef(readType);
         int rowIdIndex = readType.getFieldIndex(SpecialFields.ROW_ID.name());
         PriorityQueue<long[]> topKHeap =
                 new PriorityQueue<>(Math.max(1, limit + 1), WEAKEST_SCORE_FIRST);
@@ -456,10 +458,11 @@ public abstract class AbstractDataEvolutionVectorRead implements Serializable {
                         if (scoreCandidates != null && !scoreCandidates.contains(rowId)) {
                             return;
                         }
-                        if (row.isNullAt(vectorIndex)) {
+                        Object storedValue = vectorRef.get(row);
+                        if (storedValue == null) {
                             return;
                         }
-                        float[] stored = getVector(row, vectorIndex);
+                        float[] stored = getVector(storedValue);
                         checkVectorDimension(queryVector, stored);
                         offerScore(
                                 topKHeap,
@@ -493,7 +496,7 @@ public abstract class AbstractDataEvolutionVectorRead implements Serializable {
                 newRawReadBuilder(readType, false).withRowRanges(rawRowRanges).newScan().plan();
         ReadBuilder readBuilder = newRawReadBuilder(readType, includeFilter);
         Map<Long, float[]> rawVectors = new HashMap<>();
-        int vectorIndex = readType.getFieldIndex(vectorColumn.name());
+        FieldRef vectorRef = vectorFieldRef(readType);
         int rowIdIndex = readType.getFieldIndex(SpecialFields.ROW_ID.name());
 
         try (RecordReader<InternalRow> reader =
@@ -504,10 +507,11 @@ public abstract class AbstractDataEvolutionVectorRead implements Serializable {
                         if (candidates != null && !candidates.contains(rowId)) {
                             return;
                         }
-                        if (row.isNullAt(vectorIndex)) {
+                        Object storedValue = vectorRef.get(row);
+                        if (storedValue == null) {
                             return;
                         }
-                        float[] stored = getVector(row, vectorIndex);
+                        float[] stored = getVector(storedValue);
                         rawVectors.put(rowId, stored);
                     });
         } catch (IOException e) {
@@ -590,14 +594,15 @@ public abstract class AbstractDataEvolutionVectorRead implements Serializable {
     protected RowType rawSearchReadType(boolean includeFilter) {
         RowType tableRowType = table.rowType();
         List<String> readFields = new ArrayList<>();
-        readFields.add(vectorColumn.name());
+        readFields.add(vectorFieldPath(tableRowType).topLevelField().name());
 
         if (includeFilter && filter != null) {
             Set<String> filterFields = PredicateVisitor.collectFieldNames(filter);
-            for (String field : tableRowType.getFieldNames()) {
-                if (filterFields.contains(field) && !readFields.contains(field)) {
-                    readFields.add(field);
-                }
+            for (String field : filterFields) {
+                ResolvedFieldPath.resolve(tableRowType, field)
+                        .map(path -> path.topLevelField().name())
+                        .filter(name -> !readFields.contains(name))
+                        .ifPresent(readFields::add);
             }
         }
 
@@ -668,12 +673,25 @@ public abstract class AbstractDataEvolutionVectorRead implements Serializable {
         return null;
     }
 
-    private float[] getVector(InternalRow row, int vectorIndex) {
+    private ResolvedFieldPath vectorFieldPath(RowType rowType) {
+        return ResolvedFieldPath.resolve(rowType, vectorColumn.id())
+                .orElseThrow(
+                        () ->
+                                new IllegalArgumentException(
+                                        "Cannot find vector column by field id: "
+                                                + vectorColumn.id()));
+    }
+
+    private FieldRef vectorFieldRef(RowType rowType) {
+        return FieldRef.from(vectorFieldPath(rowType));
+    }
+
+    private float[] getVector(Object value) {
         if (vectorColumn.type().getTypeRoot() == DataTypeRoot.VECTOR) {
-            InternalVector vector = row.getVector(vectorIndex);
+            InternalVector vector = (InternalVector) value;
             return vector.toFloatArray();
         } else if (vectorColumn.type().getTypeRoot() == DataTypeRoot.ARRAY) {
-            InternalArray array = row.getArray(vectorIndex);
+            InternalArray array = (InternalArray) value;
             return array.toFloatArray();
         }
         throw new IllegalArgumentException(

--- a/paimon-core/src/main/java/org/apache/paimon/table/source/BatchVectorSearchBuilderImpl.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/source/BatchVectorSearchBuilderImpl.java
@@ -24,6 +24,7 @@ import org.apache.paimon.predicate.PredicateBuilder;
 import org.apache.paimon.table.FileStoreTable;
 import org.apache.paimon.table.InnerTable;
 import org.apache.paimon.types.DataField;
+import org.apache.paimon.types.ResolvedFieldPath;
 import org.apache.paimon.utils.Pair;
 
 import java.util.Arrays;
@@ -47,6 +48,7 @@ public class BatchVectorSearchBuilderImpl implements BatchVectorSearchBuilder {
     protected Predicate filter;
     protected int limit;
     protected DataField vectorColumn;
+    protected String vectorColumnPath;
     protected float[][] vectors;
     protected Map<String, String> options = new HashMap<>();
 
@@ -99,7 +101,9 @@ public class BatchVectorSearchBuilderImpl implements BatchVectorSearchBuilder {
 
     @Override
     public BatchVectorSearchBuilder withVectorColumn(String name) {
-        this.vectorColumn = table.rowType().getField(name);
+        ResolvedFieldPath path = ResolvedFieldPath.resolve(table.rowType(), name).orElse(null);
+        this.vectorColumn = path == null ? null : path.leafField();
+        this.vectorColumnPath = path == null ? name : path.fullName();
         return this;
     }
 
@@ -129,7 +133,7 @@ public class BatchVectorSearchBuilderImpl implements BatchVectorSearchBuilder {
             return new PrimaryKeyVectorScan(
                     table,
                     vectorColumn.id(),
-                    table.coreOptions().primaryKeyVectorIndexType(vectorColumn.name()),
+                    table.coreOptions().primaryKeyVectorIndexType(vectorColumnPath),
                     partitionFilter,
                     filter);
         }
@@ -155,6 +159,6 @@ public class BatchVectorSearchBuilderImpl implements BatchVectorSearchBuilder {
 
     protected boolean isPrimaryKeyVectorSearch() {
         return vectorColumn != null
-                && table.coreOptions().primaryKeyVectorIndexColumns().contains(vectorColumn.name());
+                && table.coreOptions().primaryKeyVectorIndexColumns().contains(vectorColumnPath);
     }
 }

--- a/paimon-core/src/main/java/org/apache/paimon/table/source/DataEvolutionFullTextRead.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/source/DataEvolutionFullTextRead.java
@@ -35,6 +35,7 @@ import org.apache.paimon.partition.PartitionPredicate;
 import org.apache.paimon.predicate.FullTextSearch;
 import org.apache.paimon.table.FileStoreTable;
 import org.apache.paimon.types.DataField;
+import org.apache.paimon.types.ResolvedFieldPath;
 import org.apache.paimon.utils.IOUtils;
 import org.apache.paimon.utils.Range;
 import org.apache.paimon.utils.RoaringNavigableMap64;
@@ -59,6 +60,7 @@ public class DataEvolutionFullTextRead implements FullTextRead {
     @Nullable private final PartitionPredicate partitionFilter;
     private final int limit;
     private final DataField textColumn;
+    private final String textColumnPath;
     private final String query;
 
     public DataEvolutionFullTextRead(
@@ -75,6 +77,14 @@ public class DataEvolutionFullTextRead implements FullTextRead {
                     "Full-text search expects exactly one text column, got: " + textColumns);
         }
         this.textColumn = textColumns.get(0);
+        this.textColumnPath =
+                ResolvedFieldPath.resolve(table.rowType(), textColumn.id())
+                        .orElseThrow(
+                                () ->
+                                        new IllegalArgumentException(
+                                                "Cannot find text column by field id: "
+                                                        + textColumn.id()))
+                        .fullName();
         this.query = query;
     }
 
@@ -146,7 +156,7 @@ public class DataEvolutionFullTextRead implements FullTextRead {
             ExecutorService executor,
             @Nullable RoaringNavigableMap64 liveRows) {
         return evalColumnQuery(
-                textColumn.name(),
+                textColumnPath,
                 splitsByColumn,
                 indexPathFactory,
                 indexFileReader,

--- a/paimon-core/src/main/java/org/apache/paimon/table/source/DataEvolutionFullTextScan.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/source/DataEvolutionFullTextScan.java
@@ -31,6 +31,7 @@ import org.apache.paimon.partition.PartitionPredicate;
 import org.apache.paimon.table.FileStoreTable;
 import org.apache.paimon.table.source.snapshot.TimeTravelUtil;
 import org.apache.paimon.types.DataField;
+import org.apache.paimon.types.ResolvedFieldPath;
 import org.apache.paimon.utils.Filter;
 import org.apache.paimon.utils.Range;
 
@@ -95,7 +96,15 @@ public class DataEvolutionFullTextScan implements FullTextScan {
         Map<Integer, String> idToColumn = new HashMap<>();
         for (DataField textColumn : textColumns) {
             textColumnIds.add(textColumn.id());
-            idToColumn.put(textColumn.id(), textColumn.name());
+            idToColumn.put(
+                    textColumn.id(),
+                    ResolvedFieldPath.resolve(table.rowType(), textColumn.id())
+                            .orElseThrow(
+                                    () ->
+                                            new IllegalArgumentException(
+                                                    "Cannot find text column by field id: "
+                                                            + textColumn.id()))
+                            .fullName());
         }
 
         @Nullable

--- a/paimon-core/src/main/java/org/apache/paimon/table/source/FullTextSearchBuilderImpl.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/source/FullTextSearchBuilderImpl.java
@@ -25,6 +25,7 @@ import org.apache.paimon.partition.PartitionPredicate;
 import org.apache.paimon.table.FileStoreTable;
 import org.apache.paimon.table.InnerTable;
 import org.apache.paimon.types.DataField;
+import org.apache.paimon.types.ResolvedFieldPath;
 
 import javax.annotation.Nullable;
 
@@ -102,9 +103,9 @@ public class FullTextSearchBuilderImpl implements FullTextSearchBuilder {
     private DataField textColumn() {
         checkNotNull(query, "Query must be set via withQuery()");
         checkNotNull(fieldName, "Field name must be set via withQuery()");
-        DataField textColumn = table.rowType().getField(fieldName);
-        checkNotNull(textColumn, "Text column '%s' does not exist.", fieldName);
-        return textColumn;
+        ResolvedFieldPath path = ResolvedFieldPath.resolve(table.rowType(), fieldName).orElse(null);
+        checkNotNull(path, "Text column '%s' does not exist.", fieldName);
+        return path.leafField();
     }
 
     private Optional<PrimaryKeyIndexDefinition> primaryKeyFullTextDefinition(DataField textColumn) {

--- a/paimon-core/src/main/java/org/apache/paimon/table/source/RawFullTextReadImpl.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/source/RawFullTextReadImpl.java
@@ -20,6 +20,7 @@ package org.apache.paimon.table.source;
 
 import org.apache.paimon.CoreOptions;
 import org.apache.paimon.Snapshot;
+import org.apache.paimon.data.BinaryString;
 import org.apache.paimon.data.InternalRow;
 import org.apache.paimon.fs.Path;
 import org.apache.paimon.fs.PositionOutputStream;
@@ -37,10 +38,12 @@ import org.apache.paimon.index.IndexFileMeta;
 import org.apache.paimon.index.IndexPathFactory;
 import org.apache.paimon.options.Options;
 import org.apache.paimon.partition.PartitionPredicate;
+import org.apache.paimon.predicate.FieldRef;
 import org.apache.paimon.reader.RecordReader;
 import org.apache.paimon.table.FileStoreTable;
 import org.apache.paimon.table.SpecialFields;
 import org.apache.paimon.types.DataField;
+import org.apache.paimon.types.ResolvedFieldPath;
 import org.apache.paimon.types.RowType;
 import org.apache.paimon.utils.CloseableIterator;
 import org.apache.paimon.utils.IOUtils;
@@ -179,7 +182,14 @@ class RawFullTextReadImpl {
         long rowRangeStart = rawRowRanges.get(0).from;
         long rowRangeEnd = rawRowRanges.get(rawRowRanges.size() - 1).to;
         String fallbackIndexType = firstIndexType(splitsByColumn);
-        String column = textColumn.name();
+        ResolvedFieldPath textColumnPath =
+                ResolvedFieldPath.resolve(readType, textColumn.id())
+                        .orElseThrow(
+                                () ->
+                                        new IllegalArgumentException(
+                                                "Cannot find text column by field id: "
+                                                        + textColumn.id()));
+        String column = textColumnPath.fullName();
         String indexType = indexType(column, splitsByColumn);
         if (indexType == null) {
             indexType = checkNotNull(fallbackIndexType);
@@ -197,7 +207,7 @@ class RawFullTextReadImpl {
                     column,
                     new RawFullTextIndex(
                             column,
-                            readColumnIndex(textColumn, readType),
+                            FieldRef.from(textColumnPath),
                             indexType,
                             textColumn.id(),
                             rowRangeStart,
@@ -232,10 +242,6 @@ class RawFullTextReadImpl {
             }
         }
         return null;
-    }
-
-    private static int readColumnIndex(DataField textColumn, RowType readType) {
-        return readType.getFieldIndexByFieldId(textColumn.id());
     }
 
     private static byte[] rawFileBytes(Map<String, RawFullTextIndex> rawIndexes, String fileName) {
@@ -290,7 +296,7 @@ class RawFullTextReadImpl {
     private static class RawFullTextIndex implements Closeable {
 
         private final String column;
-        private final int columnIndex;
+        private final FieldRef columnRef;
         private final String indexType;
         private final int fieldId;
         private final long rowRangeStart;
@@ -301,7 +307,7 @@ class RawFullTextReadImpl {
 
         private RawFullTextIndex(
                 String column,
-                int columnIndex,
+                FieldRef columnRef,
                 String indexType,
                 int fieldId,
                 long rowRangeStart,
@@ -309,7 +315,7 @@ class RawFullTextReadImpl {
                 GlobalIndexSingleColumnWriter writer,
                 RawFullTextIndexFileWriter fileWriter) {
             this.column = column;
-            this.columnIndex = columnIndex;
+            this.columnRef = columnRef;
             this.indexType = indexType;
             this.fieldId = fieldId;
             this.rowRangeStart = rowRangeStart;
@@ -319,10 +325,11 @@ class RawFullTextReadImpl {
         }
 
         private void write(InternalRow row, long rowId) {
-            if (row.isNullAt(columnIndex)) {
+            BinaryString value = (BinaryString) columnRef.get(row);
+            if (value == null) {
                 return;
             }
-            writer.write(row.getString(columnIndex), rowId - rowRangeStart);
+            writer.write(value, rowId - rowRangeStart);
             indexedRows.add(rowId);
         }
 

--- a/paimon-core/src/main/java/org/apache/paimon/table/source/TopNDataSplitEvaluator.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/source/TopNDataSplitEvaluator.java
@@ -53,7 +53,9 @@ public class TopNDataSplitEvaluator {
     }
 
     public List<Split> evaluate(SortValue order, int limit, List<Split> splits) {
-        if (limit > splits.size()) {
+        if (limit > splits.size() || order.field().isNested()) {
+            // Top-level file statistics do not contain nested leaf min/max values. The global
+            // index may still narrow row ranges, but split-level TopN pruning must be conservative.
             return splits;
         }
         return getTopNSplits(order, limit, splits);

--- a/paimon-core/src/main/java/org/apache/paimon/table/source/VectorSearchBuilderImpl.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/source/VectorSearchBuilderImpl.java
@@ -25,6 +25,7 @@ import org.apache.paimon.predicate.PredicateBuilder;
 import org.apache.paimon.table.FileStoreTable;
 import org.apache.paimon.table.InnerTable;
 import org.apache.paimon.types.DataField;
+import org.apache.paimon.types.ResolvedFieldPath;
 import org.apache.paimon.utils.Pair;
 
 import javax.annotation.Nullable;
@@ -49,6 +50,7 @@ public class VectorSearchBuilderImpl implements VectorSearchBuilder {
     protected Predicate filter;
     protected int limit;
     protected DataField vectorColumn;
+    protected String vectorColumnPath;
     protected float[] vector;
     protected Map<String, String> options = new HashMap<>();
     @Nullable private Snapshot pinnedSnapshot;
@@ -102,7 +104,9 @@ public class VectorSearchBuilderImpl implements VectorSearchBuilder {
 
     @Override
     public VectorSearchBuilder withVectorColumn(String name) {
-        this.vectorColumn = table.rowType().getField(name);
+        ResolvedFieldPath path = ResolvedFieldPath.resolve(table.rowType(), name).orElse(null);
+        this.vectorColumn = path == null ? null : path.leafField();
+        this.vectorColumnPath = path == null ? name : path.fullName();
         return this;
     }
 
@@ -132,7 +136,7 @@ public class VectorSearchBuilderImpl implements VectorSearchBuilder {
             return new PrimaryKeyVectorScan(
                     table,
                     vectorColumn.id(),
-                    table.coreOptions().primaryKeyVectorIndexType(vectorColumn.name()),
+                    table.coreOptions().primaryKeyVectorIndexType(vectorColumnPath),
                     partitionFilter,
                     filter,
                     pinnedSnapshot);
@@ -153,7 +157,7 @@ public class VectorSearchBuilderImpl implements VectorSearchBuilder {
 
     protected boolean isPrimaryKeyVectorSearch() {
         return vectorColumn != null
-                && table.coreOptions().primaryKeyVectorIndexColumns().contains(vectorColumn.name());
+                && table.coreOptions().primaryKeyVectorIndexColumns().contains(vectorColumnPath);
     }
 
     public VectorSearchBuilderImpl withSnapshot(Snapshot snapshot) {

--- a/paimon-core/src/test/java/org/apache/paimon/globalindex/DataEvolutionGlobalIndexRefreshPlannerTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/globalindex/DataEvolutionGlobalIndexRefreshPlannerTest.java
@@ -34,6 +34,7 @@ import org.apache.paimon.types.ArrayType;
 import org.apache.paimon.types.DataField;
 import org.apache.paimon.types.FloatType;
 import org.apache.paimon.types.IntType;
+import org.apache.paimon.types.RowType;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -56,6 +57,14 @@ class DataEvolutionGlobalIndexRefreshPlannerTest {
             new DataField(1, "vector", new ArrayType(new FloatType()));
     private static final DataField OTHER_FIELD = new DataField(2, "other", new IntType());
     private static final DataField UNRELATED_FIELD = new DataField(3, "unrelated", new IntType());
+    private static final DataField NESTED_ZIP_FIELD = new DataField(5, "zip", new IntType());
+    private static final DataField PROFILE_FIELD =
+            new DataField(
+                    4,
+                    "profile",
+                    new RowType(
+                            Arrays.asList(
+                                    NESTED_ZIP_FIELD, new DataField(6, "score", new IntType()))));
 
     private SchemaManager schemaManager;
 
@@ -94,6 +103,16 @@ class DataEvolutionGlobalIndexRefreshPlannerTest {
                                         OTHER_FIELD,
                                         UNRELATED_FIELD),
                                 3,
+                                Collections.emptyList(),
+                                Collections.emptyList(),
+                                new HashMap<>(),
+                                ""));
+        when(schemaManager.schema(3L))
+                .thenReturn(
+                        new TableSchema(
+                                3L,
+                                Arrays.asList(PROFILE_FIELD, UNRELATED_FIELD),
+                                7,
                                 Collections.emptyList(),
                                 Collections.emptyList(),
                                 new HashMap<>(),
@@ -235,6 +254,27 @@ class DataEvolutionGlobalIndexRefreshPlannerTest {
                                         data("unrelated-update", 0, 100, 6, 1, "unrelated")),
                                 Collections.singletonList(index),
                                 indexedFields))
+                .isEmpty();
+    }
+
+    @Test
+    void testNestedIndexRefreshesWhenParentRowIsWritten() {
+        IndexManifestEntry index =
+                index("nested", "btree", NESTED_ZIP_FIELD, 0, 99, 5L, BinaryRow.EMPTY_ROW, 0);
+
+        assertThat(
+                        plan(
+                                Collections.singletonList(
+                                        data("profile-update", 0, 100, 6, 3, "profile")),
+                                Collections.singletonList(index),
+                                Collections.singletonList(NESTED_ZIP_FIELD)))
+                .containsExactly(index);
+        assertThat(
+                        plan(
+                                Collections.singletonList(
+                                        data("unrelated-update", 0, 100, 6, 3, "unrelated")),
+                                Collections.singletonList(index),
+                                Collections.singletonList(NESTED_ZIP_FIELD)))
                 .isEmpty();
     }
 

--- a/paimon-core/src/test/java/org/apache/paimon/globalindex/RowIdIndexFieldsExtractorTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/globalindex/RowIdIndexFieldsExtractorTest.java
@@ -1,0 +1,138 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.globalindex;
+
+import org.apache.paimon.data.BinaryString;
+import org.apache.paimon.data.GenericRow;
+import org.apache.paimon.data.InternalRow;
+import org.apache.paimon.table.SpecialFields;
+import org.apache.paimon.types.DataTypes;
+import org.apache.paimon.types.RowType;
+import org.apache.paimon.utils.InstantiationUtil;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.Collections;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/** Tests for {@link RowIdIndexFieldsExtractor}. */
+class RowIdIndexFieldsExtractorTest {
+
+    private static final RowType ADDRESS_TYPE =
+            DataTypes.ROW(
+                    DataTypes.FIELD(3, "city", DataTypes.STRING()),
+                    DataTypes.FIELD(4, "zip", DataTypes.INT()));
+
+    private static final RowType PROFILE_TYPE =
+            DataTypes.ROW(
+                    DataTypes.FIELD(1, "name", DataTypes.STRING()),
+                    DataTypes.FIELD(2, "address", ADDRESS_TYPE));
+
+    private static final RowType READ_TYPE =
+            SpecialFields.rowTypeWithRowId(
+                    DataTypes.ROW(
+                            DataTypes.FIELD(0, "partition", DataTypes.STRING()),
+                            DataTypes.FIELD(5, "profile", PROFILE_TYPE),
+                            DataTypes.FIELD(6, "profile.address.city", DataTypes.STRING())));
+
+    @Test
+    void testExtractNestedField() {
+        RowIdIndexFieldsExtractor extractor = extractor("profile.address.zip");
+        GenericRow record = record(GenericRow.of(string("Hangzhou"), 310000), 42L);
+
+        assertThat(extractor.extractIndexField(record)).isEqualTo(310000);
+        assertThat(extractor.extractRowId(record)).isEqualTo(42L);
+    }
+
+    @Test
+    void testExactTopLevelNameTakesPrecedence() {
+        RowIdIndexFieldsExtractor extractor = extractor("profile.address.city");
+        GenericRow record = record(GenericRow.of(string("nested"), 310000), 42L);
+
+        assertThat(extractor.extractIndexField(record)).isEqualTo(string("top-level"));
+    }
+
+    @Test
+    void testNestedNullIsPropagated() {
+        RowIdIndexFieldsExtractor extractor = extractor("profile.address.zip");
+
+        assertThat(extractor.extractIndexField(record(null, 42L))).isNull();
+        assertThat(
+                        extractor.extractIndexField(
+                                GenericRow.of(string("p0"), null, string("top-level"), 42L)))
+                .isNull();
+        assertThat(
+                        extractor.extractIndexField(
+                                record(GenericRow.of(string("Hangzhou"), null), 42L)))
+                .isNull();
+    }
+
+    @Test
+    void testNestedGetterIsRestoredAfterSerialization() throws Exception {
+        RowIdIndexFieldsExtractor extractor = extractor("profile.address.zip");
+        GenericRow record = record(GenericRow.of(string("Hangzhou"), 310000), 42L);
+        assertThat(extractor.extractIndexField(record)).isEqualTo(310000);
+
+        RowIdIndexFieldsExtractor restored = InstantiationUtil.clone(extractor);
+
+        assertThat(restored.extractIndexField(record)).isEqualTo(310000);
+    }
+
+    @Test
+    void testExtractMultipleNestedFieldsInDeclaredOrder() {
+        RowIdIndexFieldsExtractor extractor =
+                new RowIdIndexFieldsExtractor(
+                        READ_TYPE,
+                        Collections.singletonList("partition"),
+                        Arrays.asList("profile.address.zip", "profile.name"));
+        GenericRow record = record(GenericRow.of(string("Hangzhou"), 310000), 42L);
+
+        InternalRow indexFields = extractor.extractIndexFields(record);
+
+        assertThat(indexFields.getInt(0)).isEqualTo(310000);
+        assertThat(indexFields.getString(1)).isEqualTo(string("Alice"));
+    }
+
+    @Test
+    void testRejectInvalidPath() {
+        assertThatThrownBy(() -> extractor("profile.missing"))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("profile.missing");
+        assertThatThrownBy(() -> extractor("partition.value"))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("partition.value");
+    }
+
+    private static RowIdIndexFieldsExtractor extractor(String indexField) {
+        return new RowIdIndexFieldsExtractor(
+                READ_TYPE, Collections.singletonList("partition"), indexField);
+    }
+
+    private static GenericRow record(GenericRow address, long rowId) {
+        return GenericRow.of(
+                string("p0"), GenericRow.of(string("Alice"), address), string("top-level"), rowId);
+    }
+
+    private static BinaryString string(String value) {
+        return BinaryString.fromString(value);
+    }
+}

--- a/paimon-core/src/test/java/org/apache/paimon/globalindex/generic/GenericGlobalIndexScannerTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/globalindex/generic/GenericGlobalIndexScannerTest.java
@@ -19,9 +19,14 @@
 package org.apache.paimon.globalindex.generic;
 
 import org.apache.paimon.CoreOptions;
+import org.apache.paimon.data.BinaryRow;
 import org.apache.paimon.data.BinaryString;
 import org.apache.paimon.data.GenericRow;
 import org.apache.paimon.globalindex.ScanResult;
+import org.apache.paimon.index.GlobalIndexMeta;
+import org.apache.paimon.index.IndexFileMeta;
+import org.apache.paimon.io.CompactIncrement;
+import org.apache.paimon.io.DataIncrement;
 import org.apache.paimon.manifest.ManifestEntry;
 import org.apache.paimon.options.Options;
 import org.apache.paimon.schema.Schema;
@@ -30,12 +35,18 @@ import org.apache.paimon.table.TableTestBase;
 import org.apache.paimon.table.sink.BatchTableCommit;
 import org.apache.paimon.table.sink.BatchTableWrite;
 import org.apache.paimon.table.sink.BatchWriteBuilder;
+import org.apache.paimon.table.sink.CommitMessageImpl;
+import org.apache.paimon.types.DataField;
 import org.apache.paimon.types.DataTypes;
+import org.apache.paimon.types.ResolvedFieldPath;
 import org.apache.paimon.utils.Range;
 
 import org.junit.jupiter.api.Test;
 
+import java.util.Arrays;
 import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -88,6 +99,19 @@ public class GenericGlobalIndexScannerTest extends TableTestBase {
     }
 
     @Test
+    public void testIncrementalScanMatchesNestedIndexFields() throws Exception {
+        FileStoreTable table = writeNestedRows();
+        List<String> indexColumns = Arrays.asList("profile.zip", "profile.city");
+        commitIndex(table, "test-index", indexColumns);
+
+        assertThat(
+                        new GenericGlobalIndexScanner(table)
+                                .withIndex("test-index", indexColumns, new Options())
+                                .incrementalScan())
+                .isEmpty();
+    }
+
+    @Test
     public void testScanEmptyTable() throws Exception {
         createTableDefault();
 
@@ -107,5 +131,59 @@ public class GenericGlobalIndexScannerTest extends TableTestBase {
             }
         }
         return table;
+    }
+
+    private FileStoreTable writeNestedRows() throws Exception {
+        Schema schema =
+                Schema.newBuilder()
+                        .column("id", DataTypes.INT())
+                        .column(
+                                "profile",
+                                DataTypes.ROW(
+                                        DataTypes.FIELD(0, "city", DataTypes.STRING()),
+                                        DataTypes.FIELD(1, "zip", DataTypes.INT())))
+                        .option(CoreOptions.BUCKET.key(), "-1")
+                        .option(CoreOptions.ROW_TRACKING_ENABLED.key(), "true")
+                        .option(CoreOptions.DATA_EVOLUTION_ENABLED.key(), "true")
+                        .build();
+        catalog.createTable(identifier("NestedTable"), schema, false);
+        FileStoreTable table = getTable(identifier("NestedTable"));
+        BatchWriteBuilder builder = table.newBatchWriteBuilder();
+        try (BatchTableWrite write = builder.newWrite()) {
+            for (int i = 0; i < 10; i++) {
+                write.write(
+                        GenericRow.of(
+                                i, GenericRow.of(BinaryString.fromString("city-" + i), i * 100)));
+            }
+            try (BatchTableCommit commit = builder.newCommit()) {
+                commit.commit(write.prepareCommit());
+            }
+        }
+        return table;
+    }
+
+    private void commitIndex(FileStoreTable table, String indexType, List<String> indexColumns)
+            throws Exception {
+        List<DataField> fields =
+                indexColumns.stream()
+                        .map(column -> ResolvedFieldPath.resolve(table.rowType(), column).get())
+                        .map(ResolvedFieldPath::leafField)
+                        .collect(Collectors.toList());
+        int[] extraFieldIds =
+                fields.subList(1, fields.size()).stream().mapToInt(DataField::id).toArray();
+        GlobalIndexMeta globalIndexMeta =
+                new GlobalIndexMeta(0, 9, fields.get(0).id(), extraFieldIds, null);
+        IndexFileMeta indexFile =
+                new IndexFileMeta(indexType, "nested-index", 1L, 10L, globalIndexMeta, null);
+        CommitMessageImpl message =
+                new CommitMessageImpl(
+                        BinaryRow.EMPTY_ROW,
+                        0,
+                        null,
+                        DataIncrement.indexIncrement(Collections.singletonList(indexFile)),
+                        CompactIncrement.emptyIncrement());
+        try (BatchTableCommit commit = table.newBatchWriteBuilder().newCommit()) {
+            commit.commit(Collections.singletonList(message));
+        }
     }
 }

--- a/paimon-core/src/test/java/org/apache/paimon/globalindex/sorted/SortedGlobalIndexScannerTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/globalindex/sorted/SortedGlobalIndexScannerTest.java
@@ -34,7 +34,9 @@ import org.apache.paimon.index.DataEvolutionIndexSourceMeta;
 import org.apache.paimon.index.GlobalIndexMeta;
 import org.apache.paimon.index.IndexFileHandler;
 import org.apache.paimon.index.IndexFileMeta;
+import org.apache.paimon.io.CompactIncrement;
 import org.apache.paimon.io.DataFileMeta;
+import org.apache.paimon.io.DataIncrement;
 import org.apache.paimon.manifest.IndexManifestEntry;
 import org.apache.paimon.manifest.ManifestEntry;
 import org.apache.paimon.memory.MemorySlice;
@@ -52,6 +54,7 @@ import org.apache.paimon.table.source.DataSplit;
 import org.apache.paimon.table.source.EndOfScanException;
 import org.apache.paimon.types.DataField;
 import org.apache.paimon.types.DataTypes;
+import org.apache.paimon.types.ResolvedFieldPath;
 import org.apache.paimon.types.RowType;
 import org.apache.paimon.utils.Pair;
 
@@ -240,6 +243,37 @@ public class SortedGlobalIndexScannerTest extends TableTestBase {
         Assertions.assertFalse(
                 builder.incrementalScan().isPresent(),
                 "incrementalScan should return empty when all data is already indexed");
+    }
+
+    @Test
+    public void testIncrementalScanMatchesNestedIndexField() throws Exception {
+        FileStoreTable table = writeNestedRows();
+        DataField indexField =
+                ResolvedFieldPath.resolve(table.rowType(), "profile.zip").get().leafField();
+        IndexFileMeta indexFile =
+                new IndexFileMeta(
+                        "btree",
+                        "nested-index",
+                        1L,
+                        10L,
+                        new GlobalIndexMeta(0, 9, indexField.id(), null, null),
+                        null);
+        CommitMessage message =
+                new CommitMessageImpl(
+                        BinaryRow.EMPTY_ROW,
+                        0,
+                        null,
+                        DataIncrement.indexIncrement(Collections.singletonList(indexFile)),
+                        CompactIncrement.emptyIncrement());
+        try (BatchTableCommit commit = table.newBatchWriteBuilder().newCommit()) {
+            commit.commit(Collections.singletonList(message));
+        }
+
+        assertThat(
+                        new SortedGlobalIndexScanner(table, "btree")
+                                .withIndexField("profile.zip")
+                                .incrementalScan())
+                .isEmpty();
     }
 
     @Test
@@ -432,6 +466,34 @@ public class SortedGlobalIndexScannerTest extends TableTestBase {
                 commit.commit(messages);
             }
         }
+    }
+
+    private FileStoreTable writeNestedRows() throws Exception {
+        Schema schema =
+                Schema.newBuilder()
+                        .column(
+                                "profile",
+                                DataTypes.ROW(
+                                        DataTypes.FIELD(0, "city", DataTypes.STRING()),
+                                        DataTypes.FIELD(1, "zip", DataTypes.INT())))
+                        .option(CoreOptions.BUCKET.key(), "-1")
+                        .option(CoreOptions.ROW_TRACKING_ENABLED.key(), "true")
+                        .option(CoreOptions.DATA_EVOLUTION_ENABLED.key(), "true")
+                        .build();
+        catalog.createTable(identifier("NestedSortedTable"), schema, false);
+        FileStoreTable table = getTable(identifier("NestedSortedTable"));
+        BatchWriteBuilder builder = table.newBatchWriteBuilder();
+        try (BatchTableWrite write = builder.newWrite()) {
+            for (int i = 0; i < 10; i++) {
+                write.write(
+                        GenericRow.of(
+                                GenericRow.of(BinaryString.fromString("city-" + i), i * 100)));
+            }
+            try (BatchTableCommit commit = builder.newCommit()) {
+                commit.commit(write.prepareCommit());
+            }
+        }
+        return table;
     }
 
     private void setFirstRowId(List<CommitMessage> messages, long firstRowId) {

--- a/paimon-core/src/test/java/org/apache/paimon/globalindex/sorted/SortedGlobalIndexWriterTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/globalindex/sorted/SortedGlobalIndexWriterTest.java
@@ -18,13 +18,19 @@
 
 package org.apache.paimon.globalindex.sorted;
 
+import org.apache.paimon.data.BinaryRow;
 import org.apache.paimon.data.GenericRow;
 import org.apache.paimon.data.InternalRow;
+import org.apache.paimon.fs.Path;
 import org.apache.paimon.globalindex.GlobalIndexSingleColumnWriter;
 import org.apache.paimon.globalindex.ResultEntry;
+import org.apache.paimon.index.IndexFileMeta;
 import org.apache.paimon.schema.Schema;
+import org.apache.paimon.table.FileStoreTable;
 import org.apache.paimon.table.TableTestBase;
+import org.apache.paimon.table.sink.CommitMessageImpl;
 import org.apache.paimon.types.DataTypes;
+import org.apache.paimon.types.ResolvedFieldPath;
 import org.apache.paimon.utils.Range;
 
 import org.junit.jupiter.api.Test;
@@ -119,6 +125,40 @@ public class SortedGlobalIndexWriterTest extends TableTestBase {
                 .hasMessage("write failed");
 
         verify((Closeable) activeWriter).close();
+    }
+
+    @Test
+    public void testNestedIndexFieldUsesLeafFieldId() throws Exception {
+        Schema schema =
+                Schema.newBuilder()
+                        .column(
+                                "profile",
+                                DataTypes.ROW(
+                                        DataTypes.FIELD(11, "city", DataTypes.STRING()),
+                                        DataTypes.FIELD(12, "zip", DataTypes.INT())))
+                        .build();
+        catalog.createTable(identifier("NestedTable"), schema, false);
+        FileStoreTable table = getTable(identifier("NestedTable"));
+        Path indexPath = table.store().pathFactory().globalIndexFileFactory().newPath();
+        table.fileIO().newOutputStream(indexPath, false).close();
+
+        CommitMessageImpl message =
+                (CommitMessageImpl)
+                        new SortedGlobalIndexWriter(table, "btree")
+                                .withIndexField("profile.zip")
+                                .flushIndex(
+                                        new Range(0, 9),
+                                        Collections.singletonList(
+                                                new ResultEntry(indexPath.getName(), 10, null)),
+                                        BinaryRow.EMPTY_ROW,
+                                        1L);
+
+        IndexFileMeta indexFile = message.newFilesIncrement().newIndexFiles().get(0);
+        ResolvedFieldPath fieldPath =
+                ResolvedFieldPath.resolve(table.rowType(), "profile.zip").get();
+        assertThat(indexFile.globalIndexMeta().indexFieldId())
+                .isEqualTo(fieldPath.leafField().id())
+                .isNotEqualTo(fieldPath.topLevelField().id());
     }
 
     @Override

--- a/paimon-core/src/test/java/org/apache/paimon/index/GlobalIndexMetaTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/index/GlobalIndexMetaTest.java
@@ -1,0 +1,66 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.index;
+
+import org.apache.paimon.types.DataField;
+import org.apache.paimon.types.DataTypes;
+import org.apache.paimon.types.RowType;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.Collections;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Tests for {@link GlobalIndexMeta}. */
+class GlobalIndexMetaTest {
+
+    @Test
+    void testResolveNestedIndexedFields() {
+        DataField zip = new DataField(7, "zip", DataTypes.INT());
+        DataField country = new DataField(8, "country", DataTypes.STRING());
+        RowType rowType =
+                new RowType(
+                        Arrays.asList(
+                                new DataField(0, "id", DataTypes.INT()),
+                                new DataField(
+                                        1, "profile", new RowType(Arrays.asList(zip, country)))));
+        GlobalIndexMeta meta = new GlobalIndexMeta(0, 9, 7, new int[] {8}, null);
+
+        assertThat(meta.getIndexField(rowType)).isEqualTo(zip);
+        assertThat(meta.getExtraFields(rowType)).containsExactly(country);
+        assertThat(meta.getIndexedFields(rowType)).containsExactly(zip, country);
+        assertThat(meta.getIndexedFieldNames(rowType))
+                .containsExactly("profile.zip", "profile.country");
+        assertThat(meta.getIndexedTopLevelFieldNames(rowType))
+                .containsExactly("profile", "profile");
+    }
+
+    @Test
+    void testResolveTopLevelIndexedFieldNamesUnchanged() {
+        DataField id = new DataField(0, "id", DataTypes.INT());
+        RowType rowType = new RowType(Collections.singletonList(id));
+        GlobalIndexMeta meta = new GlobalIndexMeta(0, 9, 0, null, null);
+
+        assertThat(meta.getIndexedFields(rowType)).containsExactly(id);
+        assertThat(meta.getIndexedFieldNames(rowType)).containsExactly("id");
+        assertThat(meta.getIndexedTopLevelFieldNames(rowType)).containsExactly("id");
+    }
+}

--- a/paimon-core/src/test/java/org/apache/paimon/table/source/FullTextSearchBuilderTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/table/source/FullTextSearchBuilderTest.java
@@ -53,6 +53,7 @@ import org.apache.paimon.table.sink.CommitMessage;
 import org.apache.paimon.table.sink.CommitMessageImpl;
 import org.apache.paimon.types.DataField;
 import org.apache.paimon.types.DataTypes;
+import org.apache.paimon.types.ResolvedFieldPath;
 import org.apache.paimon.types.RowType;
 import org.apache.paimon.utils.Range;
 
@@ -894,6 +895,74 @@ public class FullTextSearchBuilderTest extends TableTestBase {
         }
 
         assertThat(rawDeserialized.rowRanges()).isEqualTo(rawOriginal.rowRanges());
+    }
+
+    @Test
+    public void testNestedFullTextSearchWithRawFallback() throws Exception {
+        Identifier identifier = identifier("nested_full_text_search");
+        Schema schema =
+                Schema.newBuilder()
+                        .column("id", DataTypes.INT())
+                        .column(
+                                "profile",
+                                DataTypes.ROW(DataTypes.FIELD(0, "content", DataTypes.STRING())))
+                        .option(CoreOptions.BUCKET.key(), "-1")
+                        .option(CoreOptions.ROW_TRACKING_ENABLED.key(), "true")
+                        .option(CoreOptions.DATA_EVOLUTION_ENABLED.key(), "true")
+                        .option(CoreOptions.FULL_TEXT_INDEX_SEARCH_MODE.key(), "full")
+                        .build();
+        catalog.createTable(identifier, schema, false);
+        FileStoreTable table = getTable(identifier);
+        String[] documents = {"paimon indexed", "other indexed", "paimon raw", "other raw"};
+
+        BatchWriteBuilder writeBuilder = table.newBatchWriteBuilder();
+        try (BatchTableWrite write = writeBuilder.newWrite();
+                BatchTableCommit commit = writeBuilder.newCommit()) {
+            for (int i = 0; i < documents.length; i++) {
+                write.write(GenericRow.of(i, GenericRow.of(BinaryString.fromString(documents[i]))));
+            }
+            commit.commit(write.prepareCommit());
+        }
+
+        DataField textField =
+                ResolvedFieldPath.resolve(table.rowType(), "profile.content").get().leafField();
+        GlobalIndexSingleColumnWriter indexWriter =
+                (GlobalIndexSingleColumnWriter)
+                        GlobalIndexBuilderUtils.createIndexWriter(
+                                table,
+                                TestFullTextGlobalIndexerFactory.IDENTIFIER,
+                                textField,
+                                table.coreOptions().toConfiguration());
+        indexWriter.write(documents[0], 0);
+        indexWriter.write(documents[1], 1);
+        List<IndexFileMeta> indexFiles =
+                GlobalIndexBuilderUtils.toIndexFileMetas(
+                        table.fileIO(),
+                        table.store().pathFactory().globalIndexFileFactory(),
+                        table.coreOptions(),
+                        new Range(0, 1),
+                        textField.id(),
+                        TestFullTextGlobalIndexerFactory.IDENTIFIER,
+                        indexWriter.finish());
+        try (BatchTableCommit commit = table.newBatchWriteBuilder().newCommit()) {
+            commit.commit(
+                    Collections.singletonList(
+                            new CommitMessageImpl(
+                                    BinaryRow.EMPTY_ROW,
+                                    0,
+                                    null,
+                                    DataIncrement.indexIncrement(indexFiles),
+                                    CompactIncrement.emptyIncrement())));
+        }
+
+        GlobalIndexResult result =
+                table.newFullTextSearchBuilder()
+                        .withQuery("profile.content", matchQuery("paimon"))
+                        .withLimit(10)
+                        .executeLocal();
+
+        assertThat(result.results()).containsExactlyInAnyOrder(0L, 2L);
+        assertThat(readIds(table, result)).containsExactlyInAnyOrder(0, 2);
     }
 
     // ====================== Helper methods ======================

--- a/paimon-core/src/test/java/org/apache/paimon/table/source/VectorSearchBuilderTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/table/source/VectorSearchBuilderTest.java
@@ -61,6 +61,7 @@ import org.apache.paimon.table.sink.CommitMessageImpl;
 import org.apache.paimon.types.ArrayType;
 import org.apache.paimon.types.DataField;
 import org.apache.paimon.types.DataTypes;
+import org.apache.paimon.types.ResolvedFieldPath;
 import org.apache.paimon.types.RowType;
 import org.apache.paimon.utils.Range;
 import org.apache.paimon.utils.RoaringNavigableMap64;
@@ -1666,6 +1667,87 @@ public class VectorSearchBuilderTest extends TableTestBase {
                 impl.newFilesIncrement().newFiles().add(file.assignFirstRowId(firstRowId));
             }
         }
+    }
+
+    @Test
+    public void testNestedVectorSearchWithRawFallback() throws Exception {
+        catalog.createTable(
+                identifier("nested_vector_search"),
+                withVectorSchemaOptions(
+                                Schema.newBuilder()
+                                        .column("id", DataTypes.INT())
+                                        .column(
+                                                "profile",
+                                                DataTypes.ROW(
+                                                        DataTypes.FIELD(
+                                                                0,
+                                                                "vec",
+                                                                new ArrayType(DataTypes.FLOAT())))))
+                        .option(CoreOptions.VECTOR_INDEX_SEARCH_MODE.key(), "full")
+                        .build(),
+                false);
+        FileStoreTable table = getTable(identifier("nested_vector_search"));
+        float[][] vectors = {{10.0f, 0.0f}, {9.0f, 0.0f}, {0.0f, 0.0f}, {1.0f, 0.0f}};
+
+        BatchWriteBuilder writeBuilder = table.newBatchWriteBuilder();
+        try (BatchTableWrite write = writeBuilder.newWrite();
+                BatchTableCommit commit = writeBuilder.newCommit()) {
+            for (int i = 0; i < vectors.length; i++) {
+                write.write(GenericRow.of(i, GenericRow.of(new GenericArray(vectors[i]))));
+            }
+            commit.commit(write.prepareCommit());
+        }
+
+        DataField vectorField =
+                ResolvedFieldPath.resolve(table.rowType(), "profile.vec").get().leafField();
+        GlobalIndexSingleColumnWriter indexWriter =
+                (GlobalIndexSingleColumnWriter)
+                        GlobalIndexBuilderUtils.createIndexWriter(
+                                table,
+                                TestVectorGlobalIndexerFactory.IDENTIFIER,
+                                vectorField,
+                                table.coreOptions().toConfiguration());
+        indexWriter.write(vectors[0], 0);
+        indexWriter.write(vectors[1], 1);
+        List<IndexFileMeta> indexFiles =
+                GlobalIndexBuilderUtils.toIndexFileMetas(
+                        table.fileIO(),
+                        table.store().pathFactory().globalIndexFileFactory(),
+                        table.coreOptions(),
+                        new Range(0, 1),
+                        vectorField.id(),
+                        TestVectorGlobalIndexerFactory.IDENTIFIER,
+                        indexWriter.finish());
+        try (BatchTableCommit commit = table.newBatchWriteBuilder().newCommit()) {
+            commit.commit(
+                    Collections.singletonList(
+                            new CommitMessageImpl(
+                                    BinaryRow.EMPTY_ROW,
+                                    0,
+                                    null,
+                                    DataIncrement.indexIncrement(indexFiles),
+                                    CompactIncrement.emptyIncrement())));
+        }
+
+        GlobalIndexResult result =
+                table.newVectorSearchBuilder()
+                        .withVector(new float[] {0.0f, 0.0f})
+                        .withLimit(1)
+                        .withVectorColumn("profile.vec")
+                        .executeLocal();
+
+        assertThat(result.results()).containsExactly(2L);
+        assertThat(readIds(table, result)).containsExactly(2);
+
+        List<GlobalIndexResult> batchResults =
+                table.newBatchVectorSearchBuilder()
+                        .withVectors(new float[][] {{0.0f, 0.0f}, {10.0f, 0.0f}})
+                        .withLimit(1)
+                        .withVectorColumn("profile.vec")
+                        .executeBatchLocal();
+        assertThat(batchResults).hasSize(2);
+        assertThat(batchResults.get(0).results()).containsExactly(2L);
+        assertThat(batchResults.get(1).results()).containsExactly(0L);
     }
 
     private void writeVectors(FileStoreTable table, float[][] vectors) throws Exception {

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/PredicateConverter.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/PredicateConverter.java
@@ -21,6 +21,7 @@ package org.apache.paimon.flink;
 import org.apache.paimon.data.BinaryString;
 import org.apache.paimon.predicate.Predicate;
 import org.apache.paimon.predicate.PredicateBuilder;
+import org.apache.paimon.predicate.Transform;
 import org.apache.paimon.utils.TypeUtils;
 
 import org.apache.flink.table.data.conversion.DataStructureConverters;
@@ -28,6 +29,7 @@ import org.apache.flink.table.expressions.CallExpression;
 import org.apache.flink.table.expressions.Expression;
 import org.apache.flink.table.expressions.ExpressionVisitor;
 import org.apache.flink.table.expressions.FieldReferenceExpression;
+import org.apache.flink.table.expressions.NestedFieldReferenceExpression;
 import org.apache.flink.table.expressions.ResolvedExpression;
 import org.apache.flink.table.expressions.TypeLiteralExpression;
 import org.apache.flink.table.expressions.ValueLiteralExpression;
@@ -40,6 +42,8 @@ import org.apache.flink.table.types.logical.RowType;
 
 import java.util.ArrayDeque;
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.Deque;
 import java.util.List;
 import java.util.Objects;
@@ -94,35 +98,35 @@ public class PredicateConverter implements ExpressionVisitor<Predicate> {
         } else if (func == BuiltInFunctionDefinitions.LESS_THAN_OR_EQUAL) {
             return visitBiFunction(children, builder::lessOrEqual, builder::greaterOrEqual);
         } else if (func == BuiltInFunctionDefinitions.IN) {
-            FieldReferenceExpression fieldRefExpr =
+            ResolvedFieldReference fieldRefExpr =
                     extractFieldReference(children.get(0)).orElseThrow(UnsupportedExpression::new);
             List<Object> literals = new ArrayList<>();
             for (int i = 1; i < children.size(); i++) {
-                literals.add(extractLiteral(fieldRefExpr.getOutputDataType(), children.get(i)));
+                literals.add(extractLiteral(fieldRefExpr.outputDataType, children.get(i)));
             }
-            return builder.in(builder.indexOf(fieldRefExpr.getName()), literals);
+            return builder.in(fieldRefExpr.transform(builder), literals);
         } else if (func == BuiltInFunctionDefinitions.IS_NULL) {
             return extractFieldReference(children.get(0))
-                    .map(FieldReferenceExpression::getName)
-                    .map(builder::indexOf)
+                    .map(field -> field.transform(builder))
                     .map(builder::isNull)
                     .orElseThrow(UnsupportedExpression::new);
         } else if (func == BuiltInFunctionDefinitions.IS_NOT_NULL) {
             return extractFieldReference(children.get(0))
-                    .map(FieldReferenceExpression::getName)
-                    .map(builder::indexOf)
+                    .map(field -> field.transform(builder))
                     .map(builder::isNotNull)
                     .orElseThrow(UnsupportedExpression::new);
         } else if (func == BuiltInFunctionDefinitions.BETWEEN) {
-            FieldReferenceExpression fieldRefExpr =
+            ResolvedFieldReference fieldRefExpr =
                     extractFieldReference(children.get(0)).orElseThrow(UnsupportedExpression::new);
             return builder.between(
-                    builder.indexOf(fieldRefExpr.getName()), children.get(1), children.get(2));
+                    fieldRefExpr.transform(builder),
+                    extractLiteral(fieldRefExpr.outputDataType, children.get(1)),
+                    extractLiteral(fieldRefExpr.outputDataType, children.get(2)));
         } else if (func == BuiltInFunctionDefinitions.LIKE) {
-            FieldReferenceExpression fieldRefExpr =
+            ResolvedFieldReference fieldRefExpr =
                     extractFieldReference(children.get(0)).orElseThrow(UnsupportedExpression::new);
             if (fieldRefExpr
-                    .getOutputDataType()
+                    .outputDataType
                     .getLogicalType()
                     .getTypeRoot()
                     .getFamilies()
@@ -130,14 +134,14 @@ public class PredicateConverter implements ExpressionVisitor<Predicate> {
                 String sqlPattern =
                         Objects.requireNonNull(
                                         extractLiteral(
-                                                fieldRefExpr.getOutputDataType(), children.get(1)))
+                                                fieldRefExpr.outputDataType, children.get(1)))
                                 .toString();
                 String escape =
                         children.size() <= 2
                                 ? null
                                 : Objects.requireNonNull(
                                                 extractLiteral(
-                                                        fieldRefExpr.getOutputDataType(),
+                                                        fieldRefExpr.outputDataType,
                                                         children.get(2)))
                                         .toString();
                 String escapedSqlPattern = sqlPattern;
@@ -183,19 +187,19 @@ public class PredicateConverter implements ExpressionVisitor<Predicate> {
                     Matcher beginMatcher = BEGIN_PATTERN.matcher(escapedSqlPattern);
                     if (beginMatcher.matches()) {
                         return builder.startsWith(
-                                builder.indexOf(fieldRefExpr.getName()),
+                                fieldRefExpr.transform(builder),
                                 BinaryString.fromString(beginMatcher.group(1)));
                     }
                 }
             }
         } else if (func == BuiltInFunctionDefinitions.IS_TRUE) {
-            FieldReferenceExpression fieldRefExpr =
+            ResolvedFieldReference fieldRefExpr =
                     extractFieldReference(children.get(0)).orElseThrow(UnsupportedExpression::new);
-            return builder.equal(builder.indexOf(fieldRefExpr.getName()), Boolean.TRUE);
+            return builder.equal(fieldRefExpr.transform(builder), Boolean.TRUE);
         } else if (func == BuiltInFunctionDefinitions.IS_FALSE) {
-            FieldReferenceExpression fieldRefExpr =
+            ResolvedFieldReference fieldRefExpr =
                     extractFieldReference(children.get(0)).orElseThrow(UnsupportedExpression::new);
-            return builder.equal(builder.indexOf(fieldRefExpr.getName()), Boolean.FALSE);
+            return builder.equal(fieldRefExpr.transform(builder), Boolean.FALSE);
         }
 
         // TODO is_xxx, between_xxx, similar, in, not_in, not?
@@ -240,30 +244,56 @@ public class PredicateConverter implements ExpressionVisitor<Predicate> {
 
     private Predicate visitBiFunction(
             List<Expression> children,
-            BiFunction<Integer, Object, Predicate> visit1,
-            BiFunction<Integer, Object, Predicate> visit2) {
-        Optional<FieldReferenceExpression> fieldRefExpr = extractFieldReference(children.get(0));
+            BiFunction<Transform, Object, Predicate> visit1,
+            BiFunction<Transform, Object, Predicate> visit2) {
+        Optional<ResolvedFieldReference> fieldRefExpr = extractFieldReference(children.get(0));
         if (fieldRefExpr.isPresent()) {
-            Object literal =
-                    extractLiteral(fieldRefExpr.get().getOutputDataType(), children.get(1));
-            return visit1.apply(builder.indexOf(fieldRefExpr.get().getName()), literal);
+            Object literal = extractLiteral(fieldRefExpr.get().outputDataType, children.get(1));
+            return visit1.apply(fieldRefExpr.get().transform(builder), literal);
         } else {
             fieldRefExpr = extractFieldReference(children.get(1));
             if (fieldRefExpr.isPresent()) {
-                Object literal =
-                        extractLiteral(fieldRefExpr.get().getOutputDataType(), children.get(0));
-                return visit2.apply(builder.indexOf(fieldRefExpr.get().getName()), literal);
+                Object literal = extractLiteral(fieldRefExpr.get().outputDataType, children.get(0));
+                return visit2.apply(fieldRefExpr.get().transform(builder), literal);
             }
         }
 
         throw new UnsupportedExpression();
     }
 
-    private Optional<FieldReferenceExpression> extractFieldReference(Expression expression) {
+    private Optional<ResolvedFieldReference> extractFieldReference(Expression expression) {
         if (expression instanceof FieldReferenceExpression) {
-            return Optional.of((FieldReferenceExpression) expression);
+            FieldReferenceExpression field = (FieldReferenceExpression) expression;
+            return Optional.of(
+                    new ResolvedFieldReference(
+                            Collections.singletonList(field.getName()), field.getOutputDataType()));
+        }
+        if (expression instanceof NestedFieldReferenceExpression) {
+            NestedFieldReferenceExpression field = (NestedFieldReferenceExpression) expression;
+            return Optional.of(
+                    new ResolvedFieldReference(
+                            Arrays.asList(field.getFieldNames()), field.getOutputDataType()));
         }
         return Optional.empty();
+    }
+
+    private static class ResolvedFieldReference {
+
+        private final List<String> fieldNames;
+        private final DataType outputDataType;
+
+        private ResolvedFieldReference(List<String> fieldNames, DataType outputDataType) {
+            this.fieldNames = fieldNames;
+            this.outputDataType = outputDataType;
+        }
+
+        private Transform transform(PredicateBuilder builder) {
+            try {
+                return builder.field(fieldNames);
+            } catch (IllegalArgumentException e) {
+                throw new UnsupportedExpression();
+            }
+        }
     }
 
     private Object extractLiteral(DataType expectedType, Expression expression) {
@@ -335,6 +365,11 @@ public class PredicateConverter implements ExpressionVisitor<Predicate> {
 
     @Override
     public Predicate visit(FieldReferenceExpression fieldReferenceExpression) {
+        throw new UnsupportedExpression();
+    }
+
+    @Override
+    public Predicate visit(NestedFieldReferenceExpression nestedFieldReferenceExpression) {
         throw new UnsupportedExpression();
     }
 

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/dataevolution/MergeIntoUpdateChecker.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/dataevolution/MergeIntoUpdateChecker.java
@@ -107,7 +107,8 @@ public class MergeIntoUpdateChecker extends BoundedOneInputOperator<Committable,
                                             entry.indexFile().globalIndexMeta();
                                     if (globalIndexMeta != null) {
                                         List<String> indexedNames =
-                                                globalIndexMeta.getIndexedFieldNames(rowType);
+                                                globalIndexMeta.getIndexedTopLevelFieldNames(
+                                                        rowType);
                                         boolean overlaps =
                                                 indexedNames.stream()
                                                         .anyMatch(updatedColumns::contains);

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/globalindex/GenericIndexTopoBuilder.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/globalindex/GenericIndexTopoBuilder.java
@@ -34,6 +34,7 @@ import org.apache.paimon.globalindex.GlobalIndexSingleColumnWriter;
 import org.apache.paimon.globalindex.GlobalIndexWriter;
 import org.apache.paimon.globalindex.IndexedSplit;
 import org.apache.paimon.globalindex.ResultEntry;
+import org.apache.paimon.globalindex.RowIdIndexFieldsExtractor;
 import org.apache.paimon.globalindex.ScanResult;
 import org.apache.paimon.globalindex.generic.GenericGlobalIndexScanner;
 import org.apache.paimon.index.DataEvolutionIndexSourceMeta;
@@ -51,9 +52,9 @@ import org.apache.paimon.table.sink.CommitMessageImpl;
 import org.apache.paimon.table.source.ReadBuilder;
 import org.apache.paimon.table.source.TableRead;
 import org.apache.paimon.types.DataField;
+import org.apache.paimon.types.ResolvedFieldPath;
 import org.apache.paimon.types.RowType;
 import org.apache.paimon.utils.CloseableIterator;
-import org.apache.paimon.utils.ProjectedRow;
 import org.apache.paimon.utils.Range;
 
 import org.apache.flink.streaming.api.datastream.DataStream;
@@ -219,13 +220,18 @@ public class GenericIndexTopoBuilder {
                 indexColumns);
 
         RowType rowType = table.rowType();
-        DataField indexField = rowType.getField(indexColumn);
-        List<DataField> extraFields =
-                extraColumns.stream().map(rowType::getField).collect(Collectors.toList());
-        // Project indexColumns + _ROW_ID so we can read the actual row ID from data
-        List<String> readColumns = new ArrayList<>(indexColumns);
-        readColumns.add(SpecialFields.ROW_ID.name());
-        RowType projectedRowType = SpecialFields.rowTypeWithRowId(rowType).project(readColumns);
+        List<ResolvedFieldPath> indexFieldPaths =
+                ResolvedFieldPath.resolveAll(rowType, indexColumns).get();
+        List<DataField> indexFields =
+                indexFieldPaths.stream()
+                        .map(ResolvedFieldPath::leafField)
+                        .collect(Collectors.toList());
+        DataField indexField = indexFields.get(0);
+        List<DataField> extraFields = new ArrayList<>(indexFields.subList(1, indexFields.size()));
+        // Nested values are extracted from the projected parent ROW fields in the build operator.
+        RowType projectedRowType =
+                SpecialFields.rowTypeWithRowId(
+                        ResolvedFieldPath.projectTopLevel(rowType, indexFieldPaths));
 
         Options mergedOptions = new Options(table.options(), userOptions.toMap());
         byte[] sourceMeta =
@@ -371,10 +377,8 @@ public class GenericIndexTopoBuilder {
 
         private transient TableRead tableRead;
         private transient List<DataField> indexedFields;
-        private transient InternalRow.FieldGetter[] indexFieldGetters;
-        private transient int rowIdFieldIndex;
+        private transient RowIdIndexFieldsExtractor indexFieldsExtractor;
         private transient boolean multiColumn;
-        private transient ProjectedRow writerProjection;
 
         BuildIndexOperator(
                 ReadBuilder readBuilder,
@@ -404,22 +408,15 @@ public class GenericIndexTopoBuilder {
             this.indexedFields = new ArrayList<>(1 + extraFields.size());
             indexedFields.add(indexField);
             indexedFields.addAll(extraFields);
-            this.indexFieldGetters = new InternalRow.FieldGetter[indexedFields.size()];
-            for (int i = 0; i < indexedFields.size(); i++) {
-                DataField field = indexedFields.get(i);
-                indexFieldGetters[i] =
-                        InternalRow.createFieldGetter(
-                                field.type(), projectedRowType.getFieldIndex(field.name()));
+            List<String> indexFieldPaths = new ArrayList<>(indexedFields.size());
+            for (DataField field : indexedFields) {
+                indexFieldPaths.add(
+                        ResolvedFieldPath.resolve(projectedRowType, field.id()).get().fullName());
             }
-            this.rowIdFieldIndex = projectedRowType.getFieldIndex(SpecialFields.ROW_ID.name());
+            this.indexFieldsExtractor =
+                    new RowIdIndexFieldsExtractor(
+                            projectedRowType, Collections.emptyList(), indexFieldPaths);
             this.multiColumn = !extraFields.isEmpty();
-            if (multiColumn) {
-                int[] projection = new int[indexedFields.size()];
-                for (int i = 0; i < indexedFields.size(); i++) {
-                    projection[i] = projectedRowType.getFieldIndex(indexedFields.get(i).name());
-                }
-                this.writerProjection = ProjectedRow.from(projection);
-            }
         }
 
         @Override
@@ -450,7 +447,7 @@ public class GenericIndexTopoBuilder {
                         CloseableIterator<InternalRow> iter = reader.toCloseableIterator()) {
                     while (iter.hasNext()) {
                         InternalRow row = iter.next();
-                        long currentRowId = row.getLong(rowIdFieldIndex);
+                        long currentRowId = indexFieldsExtractor.extractRowId(row);
 
                         if (currentRowId < lastRowId) {
                             throw new IllegalStateException(
@@ -473,11 +470,10 @@ public class GenericIndexTopoBuilder {
                             long rowId = currentRowId - shardRange.from;
                             if (multiColumn) {
                                 ((GlobalIndexMultiColumnWriter) indexWriter)
-                                        .write(rowId, writerProjection.replaceRow(row));
+                                        .write(rowId, indexFieldsExtractor.extractIndexFields(row));
                             } else {
-                                Object fieldData = indexFieldGetters[0].getFieldOrNull(row);
                                 ((GlobalIndexSingleColumnWriter) indexWriter)
-                                        .write(fieldData, rowId);
+                                        .write(indexFieldsExtractor.extractIndexField(row), rowId);
                             }
                             rowsSeen++;
                         }

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/globalindex/SortedIndexTopoBuilder.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/globalindex/SortedIndexTopoBuilder.java
@@ -38,6 +38,7 @@ import org.apache.paimon.flink.utils.BoundedOneInputOperator;
 import org.apache.paimon.flink.utils.JavaTypeInfo;
 import org.apache.paimon.flink.utils.StreamExecutionEnvironmentUtils;
 import org.apache.paimon.globalindex.GlobalIndexSingleColumnWriter;
+import org.apache.paimon.globalindex.RowIdIndexFieldsExtractor;
 import org.apache.paimon.globalindex.ScanResult;
 import org.apache.paimon.globalindex.sorted.SortedGlobalIndexScanner;
 import org.apache.paimon.globalindex.sorted.SortedGlobalIndexWriter;
@@ -58,6 +59,7 @@ import org.apache.paimon.table.source.TableRead;
 import org.apache.paimon.types.DataField;
 import org.apache.paimon.types.DataType;
 import org.apache.paimon.types.DataTypes;
+import org.apache.paimon.types.ResolvedFieldPath;
 import org.apache.paimon.types.RowType;
 import org.apache.paimon.utils.Range;
 
@@ -90,6 +92,7 @@ public class SortedIndexTopoBuilder {
 
     private static final String BUILD_TASK_ID_FIELD = "_SORTED_INDEX_BUILD_TASK_ID";
     private static final int BUILD_TASK_ID_FIELD_ID = -1;
+    private static final String INDEX_KEY_FIELD = "_SORTED_INDEX_KEY";
     private static final HashSet<String> SUPPORTED_INDEX_TYPES =
             new HashSet<>(Arrays.asList("btree", "bitmap"));
 
@@ -162,16 +165,25 @@ public class SortedIndexTopoBuilder {
                 continue;
             }
 
-            // 2. Select necessary columns (index field + ROW_ID)
-            List<String> selectedColumns = new ArrayList<>();
-            selectedColumns.add(indexColumn);
-
+            // 2. Read the top-level parent ROW and flatten the nested leaf before sorting.
+            ResolvedFieldPath indexFieldPath =
+                    ResolvedFieldPath.resolve(table.rowType(), indexColumn).get();
+            RowType sourceReadType =
+                    SpecialFields.rowTypeWithRowId(
+                            ResolvedFieldPath.projectTopLevel(
+                                    table.rowType(), Collections.singletonList(indexFieldPath)));
             RowType dataReadType =
-                    SpecialFields.rowTypeWithRowId(table.rowType().project(selectedColumns));
+                    SpecialFields.rowTypeWithRowId(
+                            new RowType(
+                                    Collections.singletonList(
+                                            new DataField(
+                                                    indexFieldPath.leafField().id(),
+                                                    INDEX_KEY_FIELD,
+                                                    indexFieldPath.leafField().type()))));
             String buildTaskIdField = buildTaskIdFieldName(dataReadType);
             RowType sortReadType = withBuildTaskId(dataReadType, buildTaskIdField);
             int taskIdPos = sortReadType.getFieldIndex(buildTaskIdField);
-            int indexFieldPos = sortReadType.getFieldIndex(indexColumn);
+            int indexFieldPos = sortReadType.getFieldIndex(INDEX_KEY_FIELD);
             int rowIdPos = sortReadType.getFieldIndex(SpecialFields.ROW_ID.name());
             DataType indexFieldType = sortReadType.getTypeAt(indexFieldPos);
 
@@ -183,8 +195,16 @@ public class SortedIndexTopoBuilder {
 
             // 4. Build one topology for all contiguous row ranges
             CoreOptions coreOptions = table.coreOptions();
-            ReadBuilder readBuilder = table.newReadBuilder().withReadType(dataReadType);
-            List<String> sortColumns = createSortColumns(buildTaskIdField, indexColumn);
+            ReadBuilder readBuilder = table.newReadBuilder().withReadType(sourceReadType);
+            RowIdIndexFieldsExtractor indexFieldsExtractor =
+                    new RowIdIndexFieldsExtractor(
+                            sourceReadType,
+                            Collections.emptyList(),
+                            ResolvedFieldPath.resolve(
+                                            sourceReadType, indexFieldPath.leafField().id())
+                                    .get()
+                                    .fullName());
+            List<String> sortColumns = createSortColumns(buildTaskIdField, INDEX_KEY_FIELD);
             int partitionFieldSize = table.partitionKeys().size();
             BinaryRowSerializer binaryRowSerializer = new BinaryRowSerializer(partitionFieldSize);
             List<SortedBuildTask> buildTasks = new ArrayList<>();
@@ -218,6 +238,7 @@ public class SortedIndexTopoBuilder {
                             buildTasks,
                             splitTasks,
                             readBuilder,
+                            indexFieldsExtractor,
                             new SortedGlobalIndexWriter(table, indexType, userOptions)
                                     .withIndexField(indexColumn),
                             scanResult.scanSnapshotId(),
@@ -297,6 +318,7 @@ public class SortedIndexTopoBuilder {
             List<SortedBuildTask> buildTasks,
             List<SortedSplitTask> splitTasks,
             ReadBuilder readBuilder,
+            RowIdIndexFieldsExtractor indexFieldsExtractor,
             SortedGlobalIndexWriter indexWriter,
             long scanSnapshotId,
             int partitionFieldSize,
@@ -322,7 +344,7 @@ public class SortedIndexTopoBuilder {
                         .transform(
                                 "Read Data",
                                 InternalTypeInfo.of(LogicalTypeConversion.toLogicalType(readType)),
-                                new ReadDataOperator(readBuilder))
+                                new ReadDataOperator(readBuilder, indexFieldsExtractor))
                         .setParallelism(parallelism);
 
         TableSortInfo sortInfo =
@@ -393,6 +415,13 @@ public class SortedIndexTopoBuilder {
         return new RowType(readType.isNullable(), fields);
     }
 
+    static InternalRow flattenIndexRow(
+            RowIdIndexFieldsExtractor indexFieldsExtractor, InternalRow row) {
+        return GenericRow.of(
+                indexFieldsExtractor.extractIndexField(row),
+                indexFieldsExtractor.extractRowId(row));
+    }
+
     private static void commit(
             FileStoreTable table, DataStream<Committable> written, String commitUser) {
         OneInputStreamOperatorFactory<Committable, Committable> committerOperator =
@@ -419,11 +448,14 @@ public class SortedIndexTopoBuilder {
         private static final long serialVersionUID = 1L;
 
         private final ReadBuilder readBuilder;
+        private final RowIdIndexFieldsExtractor indexFieldsExtractor;
 
         private transient TableRead tableRead;
 
-        public ReadDataOperator(ReadBuilder readBuilder) {
+        public ReadDataOperator(
+                ReadBuilder readBuilder, RowIdIndexFieldsExtractor indexFieldsExtractor) {
             this.readBuilder = readBuilder;
+            this.indexFieldsExtractor = indexFieldsExtractor;
         }
 
         @Override
@@ -441,7 +473,12 @@ public class SortedIndexTopoBuilder {
                         row ->
                                 output.collect(
                                         new StreamRecord<>(
-                                                new FlinkRowData(new JoinedRow(taskId, row)))));
+                                                new FlinkRowData(
+                                                        new JoinedRow(
+                                                                taskId,
+                                                                flattenIndexRow(
+                                                                        indexFieldsExtractor,
+                                                                        row))))));
             }
         }
     }

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/procedure/CreateGlobalIndexProcedure.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/procedure/CreateGlobalIndexProcedure.java
@@ -26,6 +26,7 @@ import org.apache.paimon.partition.PartitionPredicate;
 import org.apache.paimon.predicate.Predicate;
 import org.apache.paimon.table.FileStoreTable;
 import org.apache.paimon.types.DataField;
+import org.apache.paimon.types.ResolvedFieldPath;
 import org.apache.paimon.types.RowType;
 import org.apache.paimon.utils.ParameterUtils;
 
@@ -34,6 +35,7 @@ import org.apache.flink.table.annotation.DataTypeHint;
 import org.apache.flink.table.annotation.ProcedureHint;
 import org.apache.flink.table.procedure.ProcedureContext;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
@@ -100,13 +102,16 @@ public class CreateGlobalIndexProcedure extends ProcedureBase {
                 indexColumns.size() == new HashSet<>(indexColumns).size(),
                 "Duplicate index columns are not allowed: %s",
                 indexColumns);
+        List<ResolvedFieldPath> indexFieldPaths = new ArrayList<>(indexColumns.size());
         for (String col : indexColumns) {
-            checkArgument(
-                    rowType.containsField(col),
-                    "Column '%s' does not exist in table '%s'.",
-                    col,
-                    tableId);
+            ResolvedFieldPath path = ResolvedFieldPath.resolve(rowType, col).orElse(null);
+            checkArgument(path != null, "Column '%s' does not exist in table '%s'.", col, tableId);
+            indexFieldPaths.add(path);
         }
+        List<DataField> indexFields =
+                indexFieldPaths.stream()
+                        .map(ResolvedFieldPath::leafField)
+                        .collect(Collectors.toList());
 
         // Parse partition predicate
         PartitionPredicate partitionPredicate = parsePartitionPredicate(table, partitions);
@@ -118,13 +123,12 @@ public class CreateGlobalIndexProcedure extends ProcedureBase {
         if (indexColumns.size() > 1) {
             // Fail fast before submitting the job: index types that do not support multi-column
             // throw from GlobalIndexerFactory#create, which happens before any indexer side effect.
-            DataField indexField = rowType.getField(indexColumns.get(0));
-            List<DataField> extraFields =
-                    indexColumns.subList(1, indexColumns.size()).stream()
-                            .map(rowType::getField)
-                            .collect(Collectors.toList());
             try {
-                GlobalIndexer.create(indexType, indexField, extraFields, userOptions);
+                GlobalIndexer.create(
+                        indexType,
+                        indexFields.get(0),
+                        indexFields.subList(1, indexFields.size()),
+                        userOptions);
             } catch (UnsupportedOperationException e) {
                 throw new IllegalArgumentException(
                         String.format(

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/procedure/DropGlobalIndexProcedure.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/procedure/DropGlobalIndexProcedure.java
@@ -30,6 +30,7 @@ import org.apache.paimon.table.FileStoreTable;
 import org.apache.paimon.table.sink.CommitMessage;
 import org.apache.paimon.table.sink.CommitMessageImpl;
 import org.apache.paimon.table.sink.TableCommitImpl;
+import org.apache.paimon.types.ResolvedFieldPath;
 import org.apache.paimon.types.RowType;
 import org.apache.paimon.utils.Filter;
 import org.apache.paimon.utils.ParameterUtils;
@@ -95,16 +96,15 @@ public class DropGlobalIndexProcedure extends ProcedureBase {
                         .filter(s -> !s.isEmpty())
                         .collect(Collectors.toList());
         checkArgument(!indexColumns.isEmpty(), "At least one column required.");
+        List<ResolvedFieldPath> indexFieldPaths = new ArrayList<>(indexColumns.size());
         for (String col : indexColumns) {
-            checkArgument(
-                    rowType.containsField(col),
-                    "Column '%s' does not exist in table '%s'.",
-                    col,
-                    tableId);
+            ResolvedFieldPath path = ResolvedFieldPath.resolve(rowType, col).orElse(null);
+            checkArgument(path != null, "Column '%s' does not exist in table '%s'.", col, tableId);
+            indexFieldPaths.add(path);
         }
         final List<Integer> indexFieldIds =
-                indexColumns.stream()
-                        .map(col -> rowType.getField(col).id())
+                indexFieldPaths.stream()
+                        .map(path -> path.leafField().id())
                         .collect(Collectors.toList());
         final String columnsDesc = String.join(",", indexColumns);
 

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/PredicateConverterTest.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/PredicateConverterTest.java
@@ -30,6 +30,7 @@ import org.apache.paimon.predicate.SimpleColStatsTestUtils;
 import org.apache.flink.table.api.DataTypes;
 import org.apache.flink.table.expressions.CallExpression;
 import org.apache.flink.table.expressions.FieldReferenceExpression;
+import org.apache.flink.table.expressions.NestedFieldReferenceExpression;
 import org.apache.flink.table.expressions.ResolvedExpression;
 import org.apache.flink.table.expressions.ValueLiteralExpression;
 import org.apache.flink.table.functions.BuiltInFunctionDefinitions;
@@ -808,6 +809,54 @@ public class PredicateConverterTest {
         DataType structType = DataTypes.ROW(DataTypes.INT()).bridgedTo(Row.class);
         assertThatThrownBy(() -> field(0, structType).accept(converter))
                 .isInstanceOf(PredicateConverter.UnsupportedExpression.class);
+    }
+
+    @Test
+    public void testNestedFieldReferenceExpression() {
+        RowType rowType =
+                RowType.of(
+                        new org.apache.flink.table.types.logical.LogicalType[] {
+                            RowType.of(
+                                    new org.apache.flink.table.types.logical.LogicalType[] {
+                                        new VarCharType(),
+                                        RowType.of(
+                                                new org.apache.flink.table.types.logical.LogicalType
+                                                        [] {new IntType()},
+                                                new String[] {"zip"})
+                                    },
+                                    new String[] {"name", "address"})
+                        },
+                        new String[] {"profile"});
+        NestedFieldReferenceExpression zip =
+                new NestedFieldReferenceExpression(
+                        new String[] {"profile", "address", "zip"},
+                        new int[] {0, 1, 0},
+                        DataTypes.INT());
+        Predicate predicate =
+                call(BuiltInFunctionDefinitions.EQUALS, zip, new ValueLiteralExpression(100))
+                        .accept(new PredicateConverter(rowType));
+        Predicate between =
+                call(
+                                BuiltInFunctionDefinitions.BETWEEN,
+                                zip,
+                                new ValueLiteralExpression(50),
+                                new ValueLiteralExpression(150))
+                        .accept(new PredicateConverter(rowType));
+        Predicate isNull =
+                call(BuiltInFunctionDefinitions.IS_NULL, zip)
+                        .accept(new PredicateConverter(rowType));
+
+        assertThat(predicate.toString()).isEqualTo("Equal(profile.address.zip, 100)");
+        assertThat(predicate.test(GenericRow.of(GenericRow.of("Alice", GenericRow.of(100)))))
+                .isTrue();
+        assertThat(predicate.test(GenericRow.of(GenericRow.of("Alice", GenericRow.of(200)))))
+                .isFalse();
+        assertThat(between.test(GenericRow.of(GenericRow.of("Alice", GenericRow.of(100)))))
+                .isTrue();
+        assertThat(between.test(GenericRow.of(GenericRow.of("Alice", GenericRow.of(200)))))
+                .isFalse();
+        assertThat(isNull.test(GenericRow.of(GenericRow.of("Alice", null)))).isTrue();
+        assertThat(isNull.test(GenericRow.of((Object) null))).isTrue();
     }
 
     // ==================== Nested OR Conversion Tests ====================

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/SortedGlobalIndexITCase.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/SortedGlobalIndexITCase.java
@@ -23,6 +23,7 @@ import org.apache.paimon.index.DataEvolutionIndexSourceMeta;
 import org.apache.paimon.index.IndexFileMeta;
 import org.apache.paimon.manifest.IndexManifestEntry;
 import org.apache.paimon.table.FileStoreTable;
+import org.apache.paimon.types.ResolvedFieldPath;
 
 import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
@@ -72,6 +73,36 @@ public class SortedGlobalIndexITCase extends CatalogITCaseBase {
 
         // assert select with filter
         assertThat(sql("SELECT * FROM T WHERE id = 100")).containsOnly(Row.of(100, "name_100"));
+    }
+
+    @Test
+    public void testNestedBTreeIndex() throws Catalog.TableNotExistException {
+        sql(
+                "CREATE TABLE T_NESTED (id INT, profile ROW<zip INT, city STRING>) WITH ("
+                        + "'global-index.enabled' = 'true', "
+                        + "'row-tracking.enabled' = 'true', "
+                        + "'data-evolution.enabled' = 'true'"
+                        + ")");
+        sql("INSERT INTO T_NESTED VALUES (1, ROW(100, 'a')), (2, ROW(200, 'b'))");
+        sql(
+                "CALL sys.create_global_index(`table` => 'default.T_NESTED', "
+                        + "index_column => 'profile.zip', index_type => 'btree')");
+
+        FileStoreTable table = paimonTable("T_NESTED");
+        List<IndexFileMeta> btreeEntries =
+                table.store().newIndexFileHandler().scanEntries().stream()
+                        .map(IndexManifestEntry::indexFile)
+                        .filter(f -> "btree".equals(f.indexType()))
+                        .collect(Collectors.toList());
+        int zipFieldId =
+                ResolvedFieldPath.resolve(table.rowType(), "profile.zip").get().leafField().id();
+
+        assertThat(btreeEntries).hasSize(1);
+        assertThat(btreeEntries.get(0).rowCount()).isEqualTo(2L);
+        assertThat(btreeEntries.get(0).globalIndexMeta()).isNotNull();
+        assertThat(btreeEntries.get(0).globalIndexMeta().indexFieldId()).isEqualTo(zipFieldId);
+        assertThat(sql("SELECT * FROM T_NESTED WHERE profile.zip = 200"))
+                .containsOnly(Row.of(2, Row.of(200, "b")));
     }
 
     @Test

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/globalindex/SortedIndexTopoBuilderTest.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/globalindex/SortedIndexTopoBuilderTest.java
@@ -18,14 +18,18 @@
 
 package org.apache.paimon.flink.globalindex;
 
+import org.apache.paimon.data.GenericRow;
+import org.apache.paimon.data.InternalRow;
 import org.apache.paimon.flink.globalindex.SortedIndexTopoBuilder.SortedBuildTask;
 import org.apache.paimon.globalindex.GlobalIndexSingleColumnWriter;
+import org.apache.paimon.globalindex.RowIdIndexFieldsExtractor;
 import org.apache.paimon.globalindex.sorted.SortedGlobalIndexScanner;
 import org.apache.paimon.globalindex.sorted.SortedGlobalIndexWriter;
 import org.apache.paimon.options.Options;
 import org.apache.paimon.table.FileStoreTable;
 import org.apache.paimon.table.SpecialFields;
 import org.apache.paimon.types.DataTypes;
+import org.apache.paimon.types.RowType;
 import org.apache.paimon.utils.Range;
 
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
@@ -36,6 +40,7 @@ import java.lang.reflect.Constructor;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
@@ -175,5 +180,30 @@ public class SortedIndexTopoBuilderTest {
     public void testSortColumnsUseRowIdAsTieBreaker() {
         assertThat(SortedIndexTopoBuilder.createSortColumns("task-id", "index-key"))
                 .containsExactly("task-id", "index-key", SpecialFields.ROW_ID.name());
+    }
+
+    @Test
+    public void testFlattenNestedIndexRowBeforeSorting() {
+        RowType addressType = DataTypes.ROW(DataTypes.FIELD(2, "zip", DataTypes.INT()));
+        RowType profileType = DataTypes.ROW(DataTypes.FIELD(1, "address", addressType));
+        RowType readType =
+                SpecialFields.rowTypeWithRowId(
+                        DataTypes.ROW(DataTypes.FIELD(0, "profile", profileType)));
+        RowIdIndexFieldsExtractor extractor =
+                new RowIdIndexFieldsExtractor(
+                        readType, Collections.emptyList(), "profile.address.zip");
+
+        InternalRow flattened =
+                SortedIndexTopoBuilder.flattenIndexRow(
+                        extractor, GenericRow.of(GenericRow.of(GenericRow.of(310000)), 42L));
+        assertThat(flattened.getInt(0)).isEqualTo(310000);
+        assertThat(flattened.getLong(1)).isEqualTo(42L);
+
+        for (InternalRow row :
+                Arrays.asList(
+                        GenericRow.of(null, 43L),
+                        GenericRow.of(GenericRow.of((Object) null), 44L))) {
+            assertThat(SortedIndexTopoBuilder.flattenIndexRow(extractor, row).isNullAt(0)).isTrue();
+        }
     }
 }

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/procedure/FullTextSearchProcedureITCase.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/procedure/FullTextSearchProcedureITCase.java
@@ -23,6 +23,7 @@ import org.apache.paimon.index.DataEvolutionIndexSourceMeta;
 import org.apache.paimon.index.pkfulltext.PkFullTextIndexFile;
 import org.apache.paimon.manifest.IndexManifestEntry;
 import org.apache.paimon.table.FileStoreTable;
+import org.apache.paimon.types.ResolvedFieldPath;
 
 import org.apache.flink.table.api.config.TableConfigOptions;
 import org.apache.flink.types.Row;
@@ -36,6 +37,35 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /** IT cases for {@link FullTextSearchProcedure}. */
 public class FullTextSearchProcedureITCase extends CatalogITCaseBase {
+
+    @Test
+    public void testCreateGlobalIndexForNestedField() throws Exception {
+        sql(
+                "CREATE TABLE T_NESTED (id INT, profile ROW<zip INT, city STRING>) WITH ("
+                        + "'bucket' = '-1', "
+                        + "'row-tracking.enabled' = 'true', "
+                        + "'data-evolution.enabled' = 'true'"
+                        + ")");
+        sql("INSERT INTO T_NESTED VALUES (1, ROW(100, 'a')), (2, ROW(200, 'b'))");
+        sql(
+                "CALL sys.create_global_index(`table` => 'default.T_NESTED', "
+                        + "index_column => 'profile.city', index_type => 'full-text')");
+
+        FileStoreTable table = paimonTable("T_NESTED");
+        List<IndexManifestEntry> entries = table.store().newIndexFileHandler().scan("full-text");
+        int cityFieldId =
+                ResolvedFieldPath.resolve(table.rowType(), "profile.city").get().leafField().id();
+
+        assertThat(entries).isNotEmpty();
+        assertThat(entries.stream().mapToLong(e -> e.indexFile().rowCount()).sum()).isEqualTo(2L);
+        assertThat(entries)
+                .allSatisfy(
+                        entry -> {
+                            assertThat(entry.indexFile().globalIndexMeta()).isNotNull();
+                            assertThat(entry.indexFile().globalIndexMeta().indexFieldId())
+                                    .isEqualTo(cityFieldId);
+                        });
+    }
 
     @Test
     public void testGenericFullTextRefreshesUpdatedDataEvolutionRange() throws Exception {

--- a/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/globalindex/DefaultGlobalIndexBuilder.java
+++ b/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/globalindex/DefaultGlobalIndexBuilder.java
@@ -24,19 +24,19 @@ import org.apache.paimon.globalindex.GlobalIndexMultiColumnWriter;
 import org.apache.paimon.globalindex.GlobalIndexSingleColumnWriter;
 import org.apache.paimon.globalindex.GlobalIndexWriter;
 import org.apache.paimon.globalindex.ResultEntry;
+import org.apache.paimon.globalindex.RowIdIndexFieldsExtractor;
 import org.apache.paimon.index.IndexFileMeta;
 import org.apache.paimon.io.CompactIncrement;
 import org.apache.paimon.io.DataIncrement;
 import org.apache.paimon.options.Options;
 import org.apache.paimon.table.FileStoreTable;
-import org.apache.paimon.table.SpecialFields;
 import org.apache.paimon.table.sink.CommitMessage;
 import org.apache.paimon.table.sink.CommitMessageImpl;
 import org.apache.paimon.types.DataField;
+import org.apache.paimon.types.ResolvedFieldPath;
 import org.apache.paimon.types.RowType;
 import org.apache.paimon.utils.CloseableIterator;
 import org.apache.paimon.utils.LongCounter;
-import org.apache.paimon.utils.ProjectedRow;
 import org.apache.paimon.utils.Range;
 
 import javax.annotation.Nullable;
@@ -139,6 +139,15 @@ public class DefaultGlobalIndexBuilder implements Serializable {
         return fields;
     }
 
+    static RowIdIndexFieldsExtractor createIndexFieldsExtractor(
+            RowType readType, List<DataField> indexedFields) {
+        List<String> indexFieldPaths = new ArrayList<>(indexedFields.size());
+        for (DataField field : indexedFields) {
+            indexFieldPaths.add(ResolvedFieldPath.resolve(readType, field.id()).get().fullName());
+        }
+        return new RowIdIndexFieldsExtractor(readType, Collections.emptyList(), indexFieldPaths);
+    }
+
     public FileStoreTable table() {
         return table;
     }
@@ -170,45 +179,25 @@ public class DefaultGlobalIndexBuilder implements Serializable {
         GlobalIndexWriter indexWriter =
                 createIndexWriter(table, indexType, indexField, extraFields, options);
         boolean multiColumn = !extraFields.isEmpty();
+        RowIdIndexFieldsExtractor indexFieldsExtractor =
+                createIndexFieldsExtractor(readType, indexedFields());
 
         try {
-            if (multiColumn) {
-                GlobalIndexMultiColumnWriter multiWriter =
-                        (GlobalIndexMultiColumnWriter) indexWriter;
-                List<DataField> indexedFields = indexedFields();
-                int[] projection = new int[indexedFields.size()];
-                for (int i = 0; i < indexedFields.size(); i++) {
-                    DataField field = indexedFields.get(i);
-                    projection[i] = readType.getFieldIndex(field.name());
+            while (rows.hasNext()) {
+                InternalRow row = rows.next();
+                long absRowId = indexFieldsExtractor.extractRowId(row);
+                if (absRowId < rowRange.from || absRowId > rowRange.to) {
+                    continue;
                 }
-                ProjectedRow projectedRow = ProjectedRow.from(projection);
-                int rowIdIndex = readType.getFieldIndex(SpecialFields.ROW_ID.name());
-                while (rows.hasNext()) {
-                    InternalRow row = rows.next();
-                    long absRowId = row.getLong(rowIdIndex);
-                    if (absRowId < rowRange.from || absRowId > rowRange.to) {
-                        continue;
-                    }
-                    multiWriter.write(absRowId - rowRange.from, projectedRow.replaceRow(row));
-                    rowCounter.add(1);
+                long localRowId = absRowId - rowRange.from;
+                if (multiColumn) {
+                    ((GlobalIndexMultiColumnWriter) indexWriter)
+                            .write(localRowId, indexFieldsExtractor.extractIndexFields(row));
+                } else {
+                    ((GlobalIndexSingleColumnWriter) indexWriter)
+                            .write(indexFieldsExtractor.extractIndexField(row), localRowId);
                 }
-            } else {
-                GlobalIndexSingleColumnWriter singleWriter =
-                        (GlobalIndexSingleColumnWriter) indexWriter;
-                InternalRow.FieldGetter getter =
-                        InternalRow.createFieldGetter(
-                                indexField.type(), readType.getFieldIndex(indexField.name()));
-                int rowIdIndex = readType.getFieldIndex(SpecialFields.ROW_ID.name());
-                while (rows.hasNext()) {
-                    InternalRow row = rows.next();
-                    long absRowId = row.getLong(rowIdIndex);
-                    if (absRowId < rowRange.from || absRowId > rowRange.to) {
-                        continue;
-                    }
-                    Object indexO = getter.getFieldOrNull(row);
-                    singleWriter.write(indexO, absRowId - rowRange.from);
-                    rowCounter.add(1);
-                }
+                rowCounter.add(1);
             }
             return indexWriter.finish();
         } finally {

--- a/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/globalindex/sorted/SortedIndexTopoBuilder.java
+++ b/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/globalindex/sorted/SortedIndexTopoBuilder.java
@@ -34,12 +34,14 @@ import org.apache.paimon.spark.SparkRow;
 import org.apache.paimon.spark.globalindex.GlobalIndexTopologyBuilder;
 import org.apache.paimon.spark.util.ScanPlanHelper$;
 import org.apache.paimon.table.FileStoreTable;
+import org.apache.paimon.table.SpecialFields;
 import org.apache.paimon.table.sink.CommitMessage;
 import org.apache.paimon.table.sink.CommitMessageImpl;
 import org.apache.paimon.table.sink.CommitMessageSerializer;
 import org.apache.paimon.table.source.DataSplit;
 import org.apache.paimon.table.source.Split;
 import org.apache.paimon.types.DataField;
+import org.apache.paimon.types.ResolvedFieldPath;
 import org.apache.paimon.types.RowType;
 import org.apache.paimon.utils.InstantiationUtil;
 import org.apache.paimon.utils.Range;
@@ -70,6 +72,7 @@ import static org.apache.paimon.globalindex.GlobalIndexBuilderUtils.splitByConti
 /** The {@link GlobalIndexTopologyBuilder} for sorted indexes. */
 public class SortedIndexTopoBuilder implements GlobalIndexTopologyBuilder {
 
+    private static final String INDEX_KEY_FIELD = "_SORTED_INDEX_KEY";
     private static final HashSet<String> SUPPORTED_INDEX_TYPES =
             new HashSet<>(Arrays.asList("btree", "bitmap"));
 
@@ -88,9 +91,11 @@ public class SortedIndexTopoBuilder implements GlobalIndexTopologyBuilder {
             DataField indexField,
             Options options)
             throws IOException {
+        ResolvedFieldPath indexFieldPath =
+                ResolvedFieldPath.resolve(table.rowType(), indexField.id()).get();
         SortedGlobalIndexScanner indexScanner =
                 new SortedGlobalIndexScanner(table, indexType, options)
-                        .withIndexField(indexField.name());
+                        .withIndexField(indexFieldPath.fullName());
         if (partitionPredicate != null) {
             indexScanner = indexScanner.withPartitionPredicate(partitionPredicate);
         }
@@ -113,20 +118,26 @@ public class SortedIndexTopoBuilder implements GlobalIndexTopologyBuilder {
             return Collections.emptyList();
         }
 
-        List<String> selectedColumns = new ArrayList<>(readType.getFieldNames());
+        RowType flattenedReadType =
+                SpecialFields.rowTypeWithRowId(
+                        new RowType(
+                                Collections.singletonList(
+                                        new DataField(
+                                                indexField.id(),
+                                                INDEX_KEY_FIELD,
+                                                indexField.type()))));
 
         // Calculate maximum parallelism bound
         long recordsPerRange = options.get(SortedIndexOptions.SORTED_INDEX_RECORDS_PER_RANGE);
         int maxParallelism = options.get(SortedIndexOptions.SORTED_INDEX_BUILD_MAX_PARALLELISM);
 
         List<CommitMessage> allMessages = new ArrayList<>();
-        List<String> sortColumns = new ArrayList<>();
-        sortColumns.add(indexField.name());
+        List<String> sortColumns = Collections.singletonList(INDEX_KEY_FIELD);
         final int partitionKeyNum = table.partitionKeys().size();
         BinaryRowSerializer binaryRowSerializer = new BinaryRowSerializer(partitionKeyNum);
         SortedGlobalIndexWriter indexWriter =
                 new SortedGlobalIndexWriter(table, indexType, options)
-                        .withIndexField(indexField.name());
+                        .withIndexField(indexFieldPath.fullName());
         for (Map.Entry<BinaryRow, Map<Range, List<Split>>> partitionEntry :
                 partitionRangeSplits.entrySet()) {
             for (Map.Entry<Range, List<Split>> entry : partitionEntry.getValue().entrySet()) {
@@ -146,12 +157,13 @@ public class SortedIndexTopoBuilder implements GlobalIndexTopologyBuilder {
 
                 Dataset<Row> selected =
                         source.select(
-                                selectedColumns.stream()
-                                        .map(functions::col)
-                                        .toArray(Column[]::new));
+                                indexColumn(indexFieldPath).alias(INDEX_KEY_FIELD),
+                                quotedColumn(SpecialFields.ROW_ID.name()));
 
                 Column[] sortFields =
-                        sortColumns.stream().map(functions::col).toArray(Column[]::new);
+                        sortColumns.stream()
+                                .map(SortedIndexTopoBuilder::quotedColumn)
+                                .toArray(Column[]::new);
 
                 Dataset<Row> partitioned =
                         selected.repartitionByRange(partitionNum, sortFields)
@@ -163,7 +175,7 @@ public class SortedIndexTopoBuilder implements GlobalIndexTopologyBuilder {
                 JavaRDD<byte[]> written =
                         partitioned
                                 .javaRDD()
-                                .map(row -> (InternalRow) (new SparkRow(readType, row)))
+                                .map(row -> (InternalRow) (new SparkRow(flattenedReadType, row)))
                                 .mapPartitions(
                                         (FlatMapFunction<Iterator<InternalRow>, byte[]>)
                                                 iter ->
@@ -189,6 +201,19 @@ public class SortedIndexTopoBuilder implements GlobalIndexTopologyBuilder {
                             CompactIncrement.emptyIncrement()));
         }
         return allMessages;
+    }
+
+    static Column indexColumn(ResolvedFieldPath fieldPath) {
+        List<String> fieldNames = fieldPath.fieldNames();
+        Column column = quotedColumn(fieldNames.get(0));
+        for (int i = 1; i < fieldNames.size(); i++) {
+            column = column.getField(fieldNames.get(i));
+        }
+        return column;
+    }
+
+    private static Column quotedColumn(String fieldName) {
+        return functions.col("`" + fieldName.replace("`", "``") + "`");
     }
 
     private static Iterator<byte[]> buildSortedIndex(

--- a/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/procedure/CreateGlobalIndexProcedure.java
+++ b/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/procedure/CreateGlobalIndexProcedure.java
@@ -29,6 +29,7 @@ import org.apache.paimon.table.SpecialFields;
 import org.apache.paimon.table.sink.CommitMessage;
 import org.apache.paimon.table.sink.TableCommitImpl;
 import org.apache.paimon.types.DataField;
+import org.apache.paimon.types.ResolvedFieldPath;
 import org.apache.paimon.types.RowType;
 import org.apache.paimon.utils.ProcedureUtils;
 import org.apache.paimon.utils.StringUtils;
@@ -44,6 +45,7 @@ import org.apache.spark.sql.types.StructType;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -150,12 +152,17 @@ public class CreateGlobalIndexProcedure extends BaseProcedure {
                         // frameworks. Whether multiple columns are supported, and any practical
                         // limit, is decided by each index type (single-column types reject
                         // multi-column via UnsupportedOperationException).
+                        List<ResolvedFieldPath> indexFieldPaths =
+                                new ArrayList<>(indexColumns.size());
                         for (String col : indexColumns) {
+                            ResolvedFieldPath path =
+                                    ResolvedFieldPath.resolve(rowType, col).orElse(null);
                             checkArgument(
-                                    rowType.containsField(col),
+                                    path != null,
                                     "Column '%s' does not exist in table '%s'.",
                                     col,
                                     tableIdent);
+                            indexFieldPaths.add(path);
                         }
                         DataSourceV2Relation relation = createRelation(tableIdent, sparkTable);
                         PartitionPredicate partitionPredicate =
@@ -163,10 +170,11 @@ public class CreateGlobalIndexProcedure extends BaseProcedure {
                                         partitions, table, spark());
 
                         List<DataField> indexFields =
-                                indexColumns.stream()
-                                        .map(rowType::getField)
+                                indexFieldPaths.stream()
+                                        .map(ResolvedFieldPath::leafField)
                                         .collect(Collectors.toList());
-                        RowType projectedRowType = rowType.project(indexColumns);
+                        RowType projectedRowType =
+                                ResolvedFieldPath.projectTopLevel(rowType, indexFieldPaths);
                         RowType readRowType = SpecialFields.rowTypeWithRowId(projectedRowType);
 
                         Options userOptions = createUserOptions(table, optionString);

--- a/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/procedure/DropGlobalIndexProcedure.java
+++ b/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/procedure/DropGlobalIndexProcedure.java
@@ -30,6 +30,7 @@ import org.apache.paimon.table.FileStoreTable;
 import org.apache.paimon.table.sink.CommitMessage;
 import org.apache.paimon.table.sink.CommitMessageImpl;
 import org.apache.paimon.table.sink.TableCommitImpl;
+import org.apache.paimon.types.ResolvedFieldPath;
 import org.apache.paimon.types.RowType;
 import org.apache.paimon.utils.Filter;
 import org.apache.paimon.utils.StringUtils;
@@ -127,16 +128,21 @@ public class DropGlobalIndexProcedure extends BaseProcedure {
                         FileStoreTable table = (FileStoreTable) t;
 
                         RowType rowType = table.rowType();
+                        List<ResolvedFieldPath> indexFieldPaths =
+                                new ArrayList<>(indexColumns.size());
                         for (String col : indexColumns) {
+                            ResolvedFieldPath path =
+                                    ResolvedFieldPath.resolve(rowType, col).orElse(null);
                             checkArgument(
-                                    rowType.containsField(col),
+                                    path != null,
                                     "Column '%s' does not exist in table '%s'.",
                                     col,
                                     tableIdent);
+                            indexFieldPaths.add(path);
                         }
                         List<Integer> indexFieldIds =
-                                indexColumns.stream()
-                                        .map(col -> rowType.getField(col).id())
+                                indexFieldPaths.stream()
+                                        .map(path -> path.leafField().id())
                                         .collect(Collectors.toList());
                         DataSourceV2Relation relation = createRelation(tableIdent);
                         PartitionPredicate partitionPredicate =

--- a/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/PaimonScanBuilder.scala
+++ b/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/PaimonScanBuilder.scala
@@ -24,6 +24,7 @@ import org.apache.paimon.predicate._
 import org.apache.paimon.predicate.SortValue.{NullOrdering, SortDirection}
 import org.apache.paimon.spark.aggregate.AggregatePushDownUtils.tryPushdownAggregation
 import org.apache.paimon.spark.read.{PaimonLocalScan, PaimonSupportsPushDownVariantExtractions, VectorSearchResultUtils}
+import org.apache.paimon.spark.util.SparkExpressionConverter
 import org.apache.paimon.table.{FileStoreTable, InnerTable}
 
 import org.apache.spark.sql.connector.expressions
@@ -53,18 +54,15 @@ class PaimonScanBuilder(val table: InnerTable)
     val sorts: List[SortValue] = orders
       .map(
         order => {
-          val fieldName = order.expression() match {
-            case nr: NamedReference => nr.fieldNames.mkString(".")
+          val fieldRef = order.expression() match {
+            case nr: NamedReference =>
+              try {
+                SparkExpressionConverter.toPaimonFieldRef(nr, table.rowType())
+              } catch {
+                case _: UnsupportedOperationException => return false
+              }
             case _ => return false
           }
-
-          val rowType = table.rowType()
-          if (rowType.notContainsField(fieldName)) {
-            return false
-          }
-
-          val field = rowType.getField(fieldName)
-          val ref = new FieldRef(field.id(), field.name(), field.`type`())
 
           val nullOrdering = order.nullOrdering() match {
             case expressions.NullOrdering.NULLS_LAST => NullOrdering.NULLS_LAST
@@ -78,7 +76,7 @@ class PaimonScanBuilder(val table: InnerTable)
             case _ => return false
           }
 
-          new SortValue(ref, direction, nullOrdering)
+          new SortValue(fieldRef, direction, nullOrdering)
         })
       .toList
 

--- a/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/commands/MergeIntoPaimonDataEvolutionTable.scala
+++ b/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/commands/MergeIntoPaimonDataEvolutionTable.scala
@@ -934,7 +934,7 @@ case class MergeIntoPaimonDataEvolutionTable(
         if (globalIndexMeta == null) {
           false
         } else {
-          val indexedNames = globalIndexMeta.getIndexedFieldNames(rowType).asScala
+          val indexedNames = globalIndexMeta.getIndexedTopLevelFieldNames(rowType).asScala
           affectedParts.contains(entry.partition()) && updateColumns.exists(
             col => indexedNames.contains(col.name))
         }

--- a/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/util/SparkExpressionConverter.scala
+++ b/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/util/SparkExpressionConverter.scala
@@ -22,7 +22,7 @@ import org.apache.paimon.data.{BinaryString, Decimal, Timestamp}
 import org.apache.paimon.predicate._
 import org.apache.paimon.spark.{PaimonImplicits, SparkTypeUtils}
 import org.apache.paimon.spark.util.shim.TypeUtils.treatPaimonTimestampTypeAsSparkTimestampType
-import org.apache.paimon.types.{DecimalType, RowType}
+import org.apache.paimon.types.{DecimalType, ResolvedFieldPath, RowType}
 import org.apache.paimon.types.DataTypeRoot._
 
 import org.apache.spark.sql.catalyst.util.DateTimeUtils
@@ -127,15 +127,13 @@ object SparkExpressionConverter {
     }
   }
 
-  private def toPaimonFieldRef(ref: NamedReference, rowType: RowType): FieldRef = {
-    val fieldName = toFieldName(ref)
-    val f = rowType.getField(fieldName)
-    // Note: here should use fieldIndex instead of fieldId
-    val index = rowType.getFieldIndex(fieldName)
-    if (index == -1) {
-      throw new UnsupportedOperationException(s"Nested field '$fieldName' is unsupported.")
+  private[spark] def toPaimonFieldRef(ref: NamedReference, rowType: RowType): FieldRef = {
+    val fieldNames = ref.fieldNames().toSeq
+    val path = ResolvedFieldPath.resolve(rowType, fieldNames.asJava)
+    if (!path.isPresent) {
+      throw new UnsupportedOperationException(s"Field '${toFieldName(ref)}' does not exist.")
     }
-    new FieldRef(index, f.name(), f.`type`())
+    FieldRef.from(path.get())
   }
 
   private def toFieldName(ref: NamedReference): String = ref.fieldNames().mkString(".")

--- a/paimon-spark/paimon-spark-common/src/test/java/org/apache/paimon/spark/globalindex/DefaultGlobalIndexBuilderTest.java
+++ b/paimon-spark/paimon-spark-common/src/test/java/org/apache/paimon/spark/globalindex/DefaultGlobalIndexBuilderTest.java
@@ -1,0 +1,62 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.spark.globalindex;
+
+import org.apache.paimon.data.GenericRow;
+import org.apache.paimon.data.InternalRow;
+import org.apache.paimon.globalindex.RowIdIndexFieldsExtractor;
+import org.apache.paimon.table.SpecialFields;
+import org.apache.paimon.types.DataField;
+import org.apache.paimon.types.DataTypes;
+import org.apache.paimon.types.ResolvedFieldPath;
+import org.apache.paimon.types.RowType;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Tests for {@link DefaultGlobalIndexBuilder}. */
+class DefaultGlobalIndexBuilderTest {
+
+    @Test
+    void testCreateExtractorFromNestedLeafMetadata() {
+        RowType profileType =
+                DataTypes.ROW(
+                        DataTypes.FIELD(1, "name", DataTypes.STRING()),
+                        DataTypes.FIELD(2, "zip", DataTypes.INT()));
+        RowType tableType = DataTypes.ROW(DataTypes.FIELD(0, "profile", profileType));
+        RowType readType = SpecialFields.rowTypeWithRowId(tableType);
+        List<DataField> indexFields =
+                Arrays.asList(
+                        ResolvedFieldPath.resolve(tableType, "profile.zip").get().leafField(),
+                        ResolvedFieldPath.resolve(tableType, "profile.name").get().leafField());
+
+        RowIdIndexFieldsExtractor extractor =
+                DefaultGlobalIndexBuilder.createIndexFieldsExtractor(readType, indexFields);
+        InternalRow fields =
+                extractor.extractIndexFields(GenericRow.of(GenericRow.of(null, 310000), 42L));
+
+        assertThat(fields.getInt(0)).isEqualTo(310000);
+        assertThat(fields.isNullAt(1)).isTrue();
+        assertThat(extractor.extractRowId(GenericRow.of(null, 43L))).isEqualTo(43L);
+    }
+}

--- a/paimon-spark/paimon-spark-common/src/test/scala/org/apache/paimon/spark/util/SparkExpressionConverterTest.scala
+++ b/paimon-spark/paimon-spark-common/src/test/scala/org/apache/paimon/spark/util/SparkExpressionConverterTest.scala
@@ -1,0 +1,55 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.spark.util
+
+import org.apache.paimon.data.GenericRow
+import org.apache.paimon.predicate.FieldTransform
+import org.apache.paimon.types.DataTypes
+
+import org.apache.spark.sql.connector.expressions.Expressions
+import org.scalatest.funsuite.AnyFunSuite
+
+class SparkExpressionConverterTest extends AnyFunSuite {
+
+  test("convert nested named reference") {
+    val rowType = DataTypes.ROW(
+      DataTypes.FIELD(
+        0,
+        "profile",
+        DataTypes.ROW(
+          DataTypes.FIELD(1, "name", DataTypes.STRING()),
+          DataTypes.FIELD(2, "address", DataTypes.ROW(DataTypes.FIELD(3, "zip", DataTypes.INT()))))
+      ))
+
+    val transform = SparkExpressionConverter
+      .toPaimonTransform(Expressions.column("profile.address.zip"), rowType)
+      .get
+      .asInstanceOf[FieldTransform]
+    val fieldRef = transform.fieldRef()
+
+    assert(fieldRef.name() == "profile.address.zip")
+    assert(fieldRef.index() == 0)
+    assert(fieldRef.nestedIndexes().sameElements(Array(1, 0)))
+    assert(fieldRef.nestedArities().sameElements(Array(2, 1)))
+    assert(
+      transform.transform(
+        GenericRow.of(GenericRow.of("Alice", GenericRow.of(Integer.valueOf(100))))) == 100)
+    assert(transform.transform(GenericRow.of(null)) == null)
+  }
+}


### PR DESCRIPTION
## What changed

- add a reusable resolver for multi-level `ROW` field paths and leaf field IDs
- support nested index columns in Flink and Spark create/drop procedures and generic/sorted index builders
- extract nested values with null propagation and preserve multi-column index order
- route predicate, TopN, metadata, MERGE conflict checks, and incremental refresh through nested leaf metadata
- keep exact top-level dotted field names backward compatible

## Why

Global indexes previously resolved index columns only against top-level fields. Paths such as `profile.zip` could not be built or matched consistently, and parent `ROW` updates could leave nested indexes stale.

## Impact

Global indexes can now target nested `ROW` fields such as `profile.zip`, including multi-level paths and nullable parent rows. `ARRAY` and `MAP` traversal remain out of scope.

## Validation

- non-fast focused Common/Core tests passed for path resolution, predicate/TopN evaluation, metadata, extraction, scanners/writers, and incremental refresh
- non-fast Flink tests passed, including nested full-text index creation and sorted topology coverage
- non-fast Spark common test and Spark 3 compilation passed
- `git diff --check` passed

The nested Flink BTree E2E reaches the sorted build job but is blocked locally by a CodeGenerator `PluginLoader` NPE. The existing top-level BTree E2E reproduces the identical failure in this environment; the nested flattening path is covered by the passing sorted topology tests.
