### PR TITLE
[flink] Surface a failed asynchronous lookup refresh instead of dropping it

### DIFF
--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/lookup/FullCacheLookupTable.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/lookup/FullCacheLookupTable.java
@@ -259,6 +259,15 @@ public abstract class FullCacheLookupTable implements LookupTable {
 
     @Override
     public void refresh() throws Exception {
+        // Surface a failure from a previous asynchronous refresh. Without this the field is
+        // write-only and the failure is lost: the scan cursor has already moved past the
+        // snapshot whose rows failed to apply, so nothing retries it and the cache keeps
+        // serving what it held before. Same shape as TableCommitImpl.maintain().
+        Exception previousFailure = cachedException.getAndSet(null);
+        if (previousFailure != null) {
+            throw previousFailure;
+        }
+
         if (refreshExecutor == null) {
             doRefresh();
             return;

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/lookup/LookupTableTest.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/lookup/LookupTableTest.java
@@ -57,6 +57,7 @@ import org.junit.jupiter.api.io.TempDir;
 import org.testcontainers.shaded.com.google.common.collect.ImmutableList;
 
 import java.io.IOException;
+import java.lang.reflect.Field;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -69,6 +70,7 @@ import java.util.Random;
 import java.util.Set;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicReference;
 
 import static java.util.Collections.emptyList;
 import static java.util.Collections.singletonList;
@@ -127,6 +129,45 @@ public class LookupTableTest extends TableTestBase {
                 new Schema(rowType.getFields(), partitionKeys, primaryKeys, options.toMap(), null);
         catalog.createTable(identifier, schema, false);
         return (FileStoreTable) catalog.getTable(identifier);
+    }
+
+    /**
+     * An asynchronous refresh records its failure in a field; the next refresh has to surface it.
+     * The scan cursor has already advanced past the snapshot whose rows failed to apply, so if the
+     * failure is dropped nothing ever retries it and the cache serves stale rows with the job still
+     * healthy.
+     */
+    @TestTemplate
+    public void testRefreshRethrowsAFailureFromAnEarlierAsyncRefresh() throws Exception {
+        FileStoreTable storeTable = createTable(singletonList("f0"), new Options());
+        FullCacheLookupTable.Context context =
+                new FullCacheLookupTable.Context(
+                        storeTable,
+                        new int[] {0, 1, 2},
+                        null,
+                        null,
+                        tempDir.toFile(),
+                        singletonList("f0"),
+                        null);
+        table = FullCacheLookupTable.create(context, 0);
+        table.open();
+
+        Exception failure = new IOException("refresh failed while applying a snapshot");
+        AtomicReference<Exception> recorded = cachedExceptionOf(table);
+        recorded.set(failure);
+
+        assertThatThrownBy(() -> table.refresh()).isSameAs(failure);
+
+        // Drained, so the same failure does not block every later refresh.
+        assertThat(recorded.get()).isNull();
+    }
+
+    @SuppressWarnings("unchecked")
+    private static AtomicReference<Exception> cachedExceptionOf(FullCacheLookupTable table)
+            throws Exception {
+        Field field = FullCacheLookupTable.class.getDeclaredField("cachedException");
+        field.setAccessible(true);
+        return (AtomicReference<Exception>) field.get(table);
     }
 
     @TestTemplate


### PR DESCRIPTION
### Purpose

With `lookup.refresh.async = true`, a failed refresh is recorded in a field that nothing ever reads:

```java
refreshExecutor.submit(
        () -> {
            try {
                doRefresh();
            } catch (Exception e) {
                LOG.error("Refresh lookup table {} failed", context.table.name(), e);
                cachedException.set(e);          // FullCacheLookupTable:316
            }
        });
```

`git grep cachedException` over the whole tree returns exactly three hits — the declaration at `:97`, the initialisation at `:149`, and that `set`. There is no `get`, `getAndSet` or `compareAndSet` anywhere, and `git log -S` shows it has had no reader since it was introduced. The `catch` also means the submitted task always completes normally, so the `refreshFuture.get()` at `:300` cannot resurface it either.

### Why the snapshot is lost rather than retried

`doRefresh()` plans a snapshot and then reads it:

```java
List<Split> splits = reader.nextSplits();                       // plans snapshot N
try (RecordReaderIterator<InternalRow> batch = ...) {
    refresh(batch);                                             // applies snapshot N
}
```

`nextSplits()` goes through `DataTableStreamScan.nextPlan()`, which advances the cursor **before** handing the plan back:

```java
SnapshotReader.Plan plan = followUpScanner.scan(snapshot, snapshotReader);
currentWatermark = plan.watermark();
nextSnapshotId++;                                               // :232
if (plan.splits().isEmpty()) { continue; }
return plan;                                                    // :236
```

So if the failure happens *after* planning — a read error while streaming the rows, or an `IOException` from the local KV store inside `refreshRow` — snapshot N is already consumed. `refresh(Iterator)` writes rows one at a time with no transaction, so N is left half-applied, and nothing re-reads it.

The existing backlog guard does not help in that case, because the cursor moved: `latestSnapshotId - nextSnapshotId` stays small, so `refresh()` keeps taking the asynchronous branch and never reaches the synchronous `doRefresh()` at `:302` whose exceptions propagate.

**Failures raised during planning are already handled and are not what this changes.** `OutOfRangeException`, and the `ReopenException` that `LookupDataTableScan.handleOverwriteSnapshot` throws after an `INSERT OVERWRITE`, are both raised before `nextSnapshotId++`. The cursor is pinned, the backlog grows past `lookup.refresh.async.pending-snapshot-count` (default 5), the next `refresh()` takes the synchronous branch, and the exception propagates to `FileStoreLookupFunction.lookup()`'s `catch (OutOfRangeException | ReopenException) { reopen(); }`. That path self-heals today and is unaffected here.

### What the user sees

Only in async mode, and only for a post-planning failure: the rows of that snapshot never enter the cache, the lookup join keeps returning the previous value for those keys, the job stays healthy, and the only trace is one `LOG.error`. In synchronous mode the identical failure propagates out of `lookup()` and the job restarts and rebuilds the cache.

### What changes

Drain the recorded failure at the top of `refresh()` and rethrow it, so the next refresh cycle reports what the previous one hit:

```java
Exception previousFailure = cachedException.getAndSet(null);
if (previousFailure != null) {
    throw previousFailure;
}
```

This is the pattern `TableCommitImpl` already uses for its own asynchronous executor:

```java
// TableCommitImpl:410-412
if (maintainError.get() != null) {
    throw new RuntimeException(maintainError.get());
}
```

`getAndSet` rather than `get` so one failure is reported once rather than blocking every later refresh.

### Blast radius

`refresh()` already declares `throws Exception`; no signature changes. When no async refresh has failed — every ordinary cycle — `getAndSet` returns null and the method continues exactly as before. In synchronous mode (`lookup.refresh.async = false`, the default at `FlinkConnectorOptions:298`) the field is never written, so the drain is a no-op there too.

Worth stating plainly: a job currently running with `lookup.refresh.async = true` and quietly absorbing recurring refresh failures will start failing visibly. That is the intent — it is what synchronous mode already does — but it is a behaviour change for such a deployment.

### Test

`LookupTableTest#testRefreshRethrowsAFailureFromAnEarlierAsyncRefresh` records a failure the way the executor's catch does, then asserts the next `refresh()` throws that exact instance and that the field has been cleared. Removing the drain fails it; `LookupTableTest` as a whole is 48 tests, 0 failures.

The field is private with no accessor, so the test reaches it reflectively — the same approach several existing tests take (`IcebergCommitCallbackTest`, `SortBufferWriteBufferOverflowTest`, `PrimaryKeyIndexWriteTest`). Happy to add a `@VisibleForTesting` accessor instead if you would rather.

### API and Format

No change to any option, on-disk format or public signature.
