### PR TITLE
[core] Read expire_tags older_than as a wall clock, not as an instant

### DIFF
--- a/paimon-flink/paimon-flink-1.18/src/main/java/org/apache/paimon/flink/procedure/ExpireTagsProcedure.java
+++ b/paimon-flink/paimon-flink-1.18/src/main/java/org/apache/paimon/flink/procedure/ExpireTagsProcedure.java
@@ -29,7 +29,6 @@ import org.apache.flink.table.procedure.ProcedureContext;
 import java.time.LocalDateTime;
 import java.util.Collections;
 import java.util.List;
-import java.util.TimeZone;
 
 /** A procedure to expire tags by time. */
 public class ExpireTagsProcedure extends ProcedureBase {
@@ -51,9 +50,7 @@ public class ExpireTagsProcedure extends ProcedureBase {
         TagTimeExpire tagTimeExpire =
                 fileStoreTable.store().newTagAutoManager(fileStoreTable).getTagTimeExpire();
         if (olderThanStr != null) {
-            LocalDateTime olderThanTime =
-                    DateTimeUtils.parseTimestampData(olderThanStr, 3, TimeZone.getDefault())
-                            .toLocalDateTime();
+            LocalDateTime olderThanTime = DateTimeUtils.toLocalDateTime(olderThanStr, 3);
             tagTimeExpire.withOlderThanTime(olderThanTime);
         }
         List<String> expired = tagTimeExpire.expire();

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/procedure/ExpireTagsProcedure.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/procedure/ExpireTagsProcedure.java
@@ -35,7 +35,6 @@ import javax.annotation.Nullable;
 import java.time.LocalDateTime;
 import java.util.Collections;
 import java.util.List;
-import java.util.TimeZone;
 
 /** A procedure to expire tags by time. */
 public class ExpireTagsProcedure extends ProcedureBase {
@@ -61,9 +60,7 @@ public class ExpireTagsProcedure extends ProcedureBase {
         TagTimeExpire tagTimeExpire =
                 fileStoreTable.store().newTagAutoManager(fileStoreTable).getTagTimeExpire();
         if (olderThanStr != null) {
-            LocalDateTime olderThanTime =
-                    DateTimeUtils.parseTimestampData(olderThanStr, 3, TimeZone.getDefault())
-                            .toLocalDateTime();
+            LocalDateTime olderThanTime = DateTimeUtils.toLocalDateTime(olderThanStr, 3);
             tagTimeExpire.withOlderThanTime(olderThanTime);
         }
         List<String> expired = tagTimeExpire.expire();

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/action/ExpireTagsActionTest.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/action/ExpireTagsActionTest.java
@@ -18,7 +18,6 @@
 
 package org.apache.paimon.flink.action;
 
-import org.apache.paimon.data.Timestamp;
 import org.apache.paimon.table.FileStoreTable;
 
 import org.junit.jupiter.api.BeforeEach;
@@ -29,6 +28,7 @@ import org.junit.jupiter.params.provider.ValueSource;
 
 import java.nio.file.Path;
 import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
 import java.util.concurrent.ThreadLocalRandom;
 
 import static org.apache.paimon.flink.util.ReadWriteTableTestUtil.bEnv;
@@ -128,8 +128,8 @@ public class ExpireTagsActionTest extends ActionITCaseBase {
 
         // tag-3 as the base older_than time
         LocalDateTime olderThanTime = table.tagManager().getOrThrow("tag-3").getTagCreateTime();
-        java.sql.Timestamp timestamp =
-                new java.sql.Timestamp(Timestamp.fromLocalDateTime(olderThanTime).getMillisecond());
+        String timestamp =
+                DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss.SSS").format(olderThanTime);
 
         createAction(
                         ExpireTagsAction.class,
@@ -141,7 +141,7 @@ public class ExpireTagsActionTest extends ActionITCaseBase {
                         "--table",
                         "T",
                         "--older_than",
-                        timestamp.toString(),
+                        timestamp,
                         "--force_start_flink_job",
                         Boolean.toString(forceStartFlinkJob))
                 .run();

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/procedure/ExpireTagsProcedureITCase.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/procedure/ExpireTagsProcedureITCase.java
@@ -18,7 +18,6 @@
 
 package org.apache.paimon.flink.procedure;
 
-import org.apache.paimon.data.Timestamp;
 import org.apache.paimon.flink.CatalogITCaseBase;
 import org.apache.paimon.table.FileStoreTable;
 import org.apache.paimon.utils.SnapshotManager;
@@ -28,6 +27,7 @@ import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
 import java.util.List;
 import java.util.concurrent.ThreadLocalRandom;
 
@@ -106,13 +106,11 @@ public class ExpireTagsProcedureITCase extends CatalogITCaseBase {
         // tag-2 as the base older_than time.
         // tag-1 expired by its file creation time.
         LocalDateTime olderThanTime1 = table.tagManager().getOrThrow("tag-2").getTagCreateTime();
-        java.sql.Timestamp timestamp1 =
-                new java.sql.Timestamp(
-                        Timestamp.fromLocalDateTime(olderThanTime1).getMillisecond());
+        String timestamp1 = WALL_CLOCK.format(olderThanTime1);
         assertThat(
                         sql(
                                 "CALL sys.expire_tags(`table` => 'default.T', older_than => '"
-                                        + timestamp1.toString()
+                                        + timestamp1
                                         + "')"))
                 .containsExactlyInAnyOrder(Row.of("tag-1"));
 
@@ -123,18 +121,20 @@ public class ExpireTagsProcedureITCase extends CatalogITCaseBase {
         // tag-4 as the base older_than time.
         // tag-2,tag-3,tag-5 expired, tag-5 reached its tagTimeRetained.
         LocalDateTime olderThanTime2 = table.tagManager().getOrThrow("tag-4").getTagCreateTime();
-        java.sql.Timestamp timestamp2 =
-                new java.sql.Timestamp(
-                        Timestamp.fromLocalDateTime(olderThanTime2).getMillisecond());
+        String timestamp2 = WALL_CLOCK.format(olderThanTime2);
         assertThat(
                         sql(
                                 "CALL sys.expire_tags(`table` => 'default.T', older_than => '"
-                                        + timestamp2.toString()
+                                        + timestamp2
                                         + "')"))
                 .containsExactlyInAnyOrder(Row.of("tag-2"), Row.of("tag-3"), Row.of("tag-5"));
 
         assertThat(sql("select tag_name from `T$tags`")).containsExactly(Row.of("tag-4"));
     }
+
+    /** The plain wall clock a user types, as the documented example does. */
+    private static final DateTimeFormatter WALL_CLOCK =
+            DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss.SSS");
 
     private void checkSnapshots(SnapshotManager sm, int earliest, int latest) throws IOException {
         assertThat(sm.snapshotCount()).isEqualTo(latest - earliest + 1);

--- a/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/procedure/ExpireTagsProcedure.java
+++ b/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/procedure/ExpireTagsProcedure.java
@@ -34,7 +34,6 @@ import org.apache.spark.unsafe.types.UTF8String;
 import java.time.LocalDateTime;
 import java.util.Collections;
 import java.util.List;
-import java.util.TimeZone;
 
 import static org.apache.spark.sql.types.DataTypes.StringType;
 
@@ -86,9 +85,7 @@ public class ExpireTagsProcedure extends BaseProcedure {
                                     .getTagTimeExpire();
                     if (olderThanStr != null) {
                         LocalDateTime olderThanTime =
-                                DateTimeUtils.parseTimestampData(
-                                                olderThanStr, 3, TimeZone.getDefault())
-                                        .toLocalDateTime();
+                                DateTimeUtils.toLocalDateTime(olderThanStr, 3);
                         tagTimeExpire.withOlderThanTime(olderThanTime);
                     }
                     List<String> expired = tagTimeExpire.expire();

--- a/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/procedure/ExpireTagsProcedureTest.scala
+++ b/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/procedure/ExpireTagsProcedureTest.scala
@@ -18,7 +18,6 @@
 
 package org.apache.paimon.spark.procedure;
 
-import org.apache.paimon.data.Timestamp
 import org.apache.paimon.spark.PaimonSparkTestBase
 import org.apache.paimon.utils.SnapshotManager
 
@@ -26,6 +25,9 @@ import org.apache.spark.sql.Row
 import org.assertj.core.api.Assertions.assertThat
 
 class ExpireTagsProcedureTest extends PaimonSparkTestBase {
+
+  /** The plain wall clock a user types, as the documented example does. */
+  private val WALL_CLOCK = java.time.format.DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss.SSS")
 
   test("Paimon procedure: expire tags that reached its timeRetained") {
     val tagTimeExpireEnabled = scala.util.Random.nextBoolean()
@@ -100,11 +102,9 @@ class ExpireTagsProcedureTest extends PaimonSparkTestBase {
     // tag-2 as the base older_than time.
     // tag-1 expired by its file creation time.
     val olderThanTime1 = table.tagManager().getOrThrow("tag-2").getTagCreateTime
-    val timestamp1 =
-      new java.sql.Timestamp(Timestamp.fromLocalDateTime(olderThanTime1).getMillisecond)
+    val timestamp1 = WALL_CLOCK.format(olderThanTime1)
     checkAnswer(
-      spark.sql(
-        s"CALL paimon.sys.expire_tags(table => 'test.T', older_than => '${timestamp1.toString}')"),
+      spark.sql(s"CALL paimon.sys.expire_tags(table => 'test.T', older_than => '$timestamp1')"),
       Row("tag-1") :: Nil
     )
 
@@ -115,11 +115,9 @@ class ExpireTagsProcedureTest extends PaimonSparkTestBase {
     // tag-4 as the base older_than time.
     // tag-2,tag-3,tag-5 expired, tag-5 reached its tagTimeRetained.
     val olderThanTime2 = table.tagManager().getOrThrow("tag-4").getTagCreateTime
-    val timestamp2 =
-      new java.sql.Timestamp(Timestamp.fromLocalDateTime(olderThanTime2).getMillisecond)
+    val timestamp2 = WALL_CLOCK.format(olderThanTime2)
     checkAnswer(
-      spark.sql(
-        s"CALL paimon.sys.expire_tags(table => 'test.T', older_than => '${timestamp2.toString}')"),
+      spark.sql(s"CALL paimon.sys.expire_tags(table => 'test.T', older_than => '$timestamp2')"),
       Row("tag-2") :: Row("tag-3") :: Row("tag-5") :: Nil
     )
 


### PR DESCRIPTION
### Purpose

`expire_tags`'s `older_than` argument is shifted by the JVM's UTC offset, so on any non-UTC deployment the cutoff is not the time the user typed.

```java
LocalDateTime olderThanTime =
        DateTimeUtils.parseTimestampData(olderThanStr, 3, TimeZone.getDefault())
                .toLocalDateTime();
tagTimeExpire.withOlderThanTime(olderThanTime);
```

The two halves disagree about what the value is:

* `parseTimestampData(s, p, tz)` is `Timestamp.fromInstant(local.atZone(tz).toInstant())` (`DateTimeUtils:547-552`), so the resulting `Timestamp` holds a **true epoch milli**;
* `Timestamp.toLocalDateTime()` (`Timestamp:92-103`) divides that milli by `MILLIS_PER_DAY` with no zone at all — it renders the instant as a **UTC** wall clock. It is the exact inverse of `fromLocalDateTime`, not of `fromInstant`.

What it is compared against is a **local** wall clock: tags are created with `LocalDateTime.now()` (`TagManager:168`), the fallback create time is `DateTimeUtils.toLocalDateTime(modificationTime)` = `atZone(systemDefault())` (`TagTimeExpire:81`), and the sibling retention check uses `LocalDateTime.now()` (`:88`). The comparison is `olderThanTime.isAfter(createTime)` at `:89`.

Measured, for the documented example `older_than => '2024-09-06 11:00:00'` (`docs/flink/procedures.md`):

| JVM timezone | cutoff actually used |
|---|---|
| UTC | `2024-09-06 11:00` |
| America/New_York | **`2024-09-06 15:00`** |
| Asia/Shanghai | **`2024-09-06 03:00`** |

It is wrong in both directions: west of UTC it deletes tags the user asked to keep — and once a tag's snapshot has expired, `TagManager.deleteTag` falls through to cleaning the data files, so that is not recoverable. East of UTC it keeps tags the user asked to expire, which is quieter but still not what was requested.

### What changes

Three call sites — `paimon-flink-common`, `paimon-flink-1.18` and `paimon-spark-common` — parse the argument as the wall clock it is:

```java
LocalDateTime olderThanTime = DateTimeUtils.toLocalDateTime(olderThanStr, 3);
```

`DateTimeUtils.toLocalDateTime(String, int)` (`:563`) is `fromTemporalAccessor(...)` with no zone conversion, so the parsed wall clock is compared against wall clocks.

**Deliberately not touched**: the other `parseTimestampData(..., TimeZone.getDefault())` call sites are correct, because they keep the instant rather than re-rendering it — `ProcedureUtils:91` takes `.getMillisecond()` and subtracts it from `System.currentTimeMillis()`, and `OrphanFilesClean:477` compares the `Timestamp` against `Timestamp.fromEpochMillis(System.currentTimeMillis())`. Both sides are epoch millis there. The defect is specifically `parseTimestampData(..., tz)` followed by `.toLocalDateTime()`.

### Why the existing tests did not catch it

`ExpireTagsProcedureITCase` and `ExpireTagsActionTest` do not pass the procedure a wall clock. They take a tag's create time and put it through a round-trip that happens to cancel the bug out:

```java
LocalDateTime olderThanTime = table.tagManager().getOrThrow("tag-2").getTagCreateTime();
java.sql.Timestamp timestamp =
        new java.sql.Timestamp(Timestamp.fromLocalDateTime(olderThanTime).getMillisecond());
```

`fromLocalDateTime(...).getMillisecond()` encodes a local wall clock **as if it were UTC**, and `java.sql.Timestamp.toString()` then renders that instant back **in the local zone** — so the string handed to the procedure is already pre-shifted by exactly the offset the procedure re-applies. Measured, the composition returns the original `11:00` in UTC, `America/New_York` and `Asia/Shanghai` alike.

A user typing the documented form does not do that dance, so the tests were green while the feature was wrong. The Spark suite's `ExpireTagsProcedureTest` does the same thing. All three are updated here to pass the plain wall clock, which is what the procedure's argument is.

This is not a case of CI having no chance. The unit-test workflows already run under a **random** JVM timezone — `jvm_timezone=$(random_timezone)` then `-Duser.timezone=$jvm_timezone`, in `utitcase-flink-1.x-common.yml:68-72`, `utitcase-spark-3.x.yml:70-77` and their siblings — and the Spark UT suite reports `America/Los_Angeles` whatever `-Duser.timezone` is passed. So these tests have been running west of UTC, the direction in which tags are deleted early, all along. The randomisation could not see the defect because the tests cancelled it out before it reached the procedure.

### Test evidence

Flink, `ExpireTagsProcedureITCase` and `ExpireTagsActionTest`:

| | UTC | Asia/Shanghai |
|---|---|---|
| this branch | 5 tests, 0 failures | 5 tests, 0 failures |
| `master` behaviour restored, tests as updated | — | **1 failure**, the wrong tags expired |

The failure names the symptom directly — `expire_tags` returned tags that the assertion lists under "elements not expected".

Spark, `ExpireTagsProcedureTest`, which runs in `America/Los_Angeles`:

| | result |
|---|---|
| this branch | 2 tests, 0 failures |
| updated test against the published `master` snapshot jar | **1 failure** — `Row("tag-1")` expected, `No expired tags.` returned |

The second row is the mutation control and it is not synthetic: the first CI run of this PR produced exactly that failure, because the Spark test had not been updated yet. Under UTC the change is a no-op in both engines, so a UTC-only run proves nothing either way — which is why the table above is the non-UTC one.

### API and Format

No change to any option, on-disk format or public signature. The interpretation of `older_than` changes on non-UTC JVMs, which is the point; a caller that had empirically compensated for the shift would need to stop doing so.
