### PR TITLE
[core] Keep the deletion-vector meta cache when a table is copied

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/table/AbstractFileStoreTable.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/AbstractFileStoreTable.java
@@ -403,6 +403,9 @@ abstract class AbstractFileStoreTable implements FileStoreTable {
         if (statsCache != null) {
             copied.setStatsCache(statsCache);
         }
+        if (dvmetaCache != null) {
+            copied.setDVMetaCache(dvmetaCache);
+        }
         return copied;
     }
 

--- a/paimon-core/src/test/java/org/apache/paimon/table/CopyKeepsCachesTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/table/CopyKeepsCachesTest.java
@@ -1,0 +1,63 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.table;
+
+import org.apache.paimon.CoreOptions;
+import org.apache.paimon.catalog.Identifier;
+import org.apache.paimon.schema.Schema;
+import org.apache.paimon.types.DataTypes;
+import org.apache.paimon.utils.DVMetaCache;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * A caching catalog installs its caches on the table it loads, but engines read through a copy
+ * carrying dynamic options. Every cache has to survive that copy or it is inert in practice.
+ */
+public class CopyKeepsCachesTest extends TableTestBase {
+
+    @Test
+    public void testCopyKeepsTheDeletionVectorMetaCache() throws Exception {
+        Identifier id = identifier("dv_cache");
+        catalog.createTable(
+                id,
+                Schema.newBuilder()
+                        .column("a", DataTypes.INT())
+                        .column("b", DataTypes.INT())
+                        .option(CoreOptions.BUCKET.key(), "-1")
+                        .build(),
+                false);
+        AbstractFileStoreTable table = (AbstractFileStoreTable) catalog.getTable(id);
+
+        DVMetaCache dvMetaCache = new DVMetaCache(100);
+        table.setDVMetaCache(dvMetaCache);
+
+        AbstractFileStoreTable copied =
+                (AbstractFileStoreTable)
+                        table.copy(
+                                Collections.singletonMap(
+                                        CoreOptions.SCAN_MAX_SPLITS_PER_TASK.key(), "7"));
+
+        assertThat(copied.dvmetaCache).isSameAs(dvMetaCache);
+    }
+}


### PR DESCRIPTION
### Purpose

`AbstractFileStoreTable` carries four caches installed by the catalog. `copy(TableSchema)` re-installs three of them onto the new instance and silently drops the fourth:

```java
if (snapshotCache != null)  { copied.setSnapshotCache(snapshotCache); }
if (manifestCache != null)  { copied.setManifestCache(manifestCache); }
if (statsCache != null)     { copied.setStatsCache(statsCache); }
return copied;                                    // dvmetaCache is not carried over
```

The four are declared side by side at `:98-101`, and `CachingCatalog.loadTable` installs `dvMetaCache` alongside the others at `:303`. `cache.deletion-vectors.max-num` defaults to **100_000** (`CatalogOptions:155-159`), so the cache exists by default rather than only when opted in.

### Why this is the normal path, not an edge case

Every copy funnels through this method — `copy(Map)` → `copyInternal` → `copy(TableSchema)`, and `copyWithoutTimeTravel` / `copyWithLatestSchema` likewise. And engines read through a copy: `FileStoreTableFactory:225` ends with

```java
return table.copy(dynamicOptions.toMap());
```

So on a catalog-backed read with any dynamic option, the table that actually serves the scan has `dvmetaCache == null`, while `snapshotCache`, `manifestCache` and `statsCache` survive.

### What the user sees

`AbstractFileStoreTable.newSnapshotReader():285` hands `dvmetaCache` to `SnapshotReaderImpl`, which branches on it at `:661`. With null it degrades gracefully — no failure — but the index manifest and the deletion-vector index metadata are re-read from storage on **every** scan plan, and nothing is ever populated for the next one. The `dvMetaHitCache` / `dvMetaMissedCache` scan metrics stay at zero, which is what makes it easy to miss: the cache is not slow, it is simply never consulted.

So a cache that is on by default does nothing on the main read path. On object storage that is an extra metadata round trip per plan, for the life of the job.

### What changes

Three lines, in the same shape as the three neighbours immediately above:

```java
if (dvmetaCache != null) {
    copied.setDVMetaCache(dvmetaCache);
}
```

### Blast radius

Purely additive. A table with no DV cache installed — the whole non-caching-catalog path, and any catalog with `cache.deletion-vectors.max-num = 0` — takes the null branch and is byte-for-byte unchanged. `org.apache.paimon.table.*Test` is 646 tests, 0 failures.

### Test

`CopyKeepsCachesTest` installs a `DVMetaCache`, copies the table the way `FileStoreTableFactory` does (a dynamic option), and asserts the copy holds the same instance. Removing the three lines fails it:

```
Expecting actual:
  null
and:
  org.apache.paimon.utils.DVMetaCache@4a1c0752
to refer to the same object
```

There was no existing test asserting that any of the four caches survives a copy, which is presumably how the omission went unnoticed; this one is written so that adding a fifth cache and forgetting it would be caught the same way.

### API and Format

No change to any option, on-disk format or public signature.
