### PR TITLE
[python] Fix import deadlock: lazy-resolve package exports, drop custom locks

### DIFF
--- a/paimon-python/pypaimon/__init__.py
+++ b/paimon-python/pypaimon/__init__.py
@@ -17,7 +17,6 @@
 
 import importlib
 import sys
-import threading
 
 if sys.version_info[:2] < (3, 8):
     try:
@@ -53,18 +52,15 @@ _LAZY_EXPORTS = {
     "SQLContext": ("pypaimon_rust.datafusion", "SQLContext"),
 }
 
-# Serialize first-time imports: racing threads can otherwise acquire module
-# locks in opposite orders and fail with _DeadlockError.
-_LAZY_IMPORT_LOCK = threading.RLock()
 
-
+# Resolution stays unlocked: submodules import these names at their top
+# level, so a lock here would deadlock against Python's module locks.
 def __getattr__(name):
     target = _LAZY_EXPORTS.get(name)
     if target is None:
         raise AttributeError(
             "module 'pypaimon' has no attribute {}".format(name))
-    with _LAZY_IMPORT_LOCK:
-        if name not in globals():
-            module = importlib.import_module(target[0])
-            globals()[name] = getattr(module, target[1])
-        return globals()[name]
+    module = importlib.import_module(target[0])
+    value = getattr(module, target[1])
+    globals()[name] = value
+    return value

--- a/paimon-python/pypaimon/common/options/__init__.py
+++ b/paimon-python/pypaimon/common/options/__init__.py
@@ -15,10 +15,15 @@
 # specific language governing permissions and limitations
 # under the License.
 
-from .config_option import ConfigOption, Description
-from .config_options import ConfigOptions
-from .options import Options
-from .core_options import CoreOptions
+import importlib
+import sys
+
+if sys.version_info[:2] < (3, 7):
+    # Module-level __getattr__ is unavailable before Python 3.7.
+    from .config_option import ConfigOption, Description
+    from .config_options import ConfigOptions
+    from .options import Options
+    from .core_options import CoreOptions
 
 __all__ = [
     'ConfigOption',
@@ -27,3 +32,24 @@ __all__ = [
     'Options',
     'CoreOptions'
 ]
+
+_MODULE_BY_EXPORT = {
+    'ConfigOption': 'pypaimon.common.options.config_option',
+    'Description': 'pypaimon.common.options.config_option',
+    'ConfigOptions': 'pypaimon.common.options.config_options',
+    'Options': 'pypaimon.common.options.options',
+    'CoreOptions': 'pypaimon.common.options.core_options',
+}
+
+
+# This package is imported by name from many modules that its own eager
+# exports pull in, so eager imports here deadlock concurrent importers.
+def __getattr__(name):
+    module_name = _MODULE_BY_EXPORT.get(name)
+    if module_name is None:
+        raise AttributeError(
+            "module 'pypaimon.common.options' has no attribute {}".format(
+                name))
+    value = getattr(importlib.import_module(module_name), name)
+    globals()[name] = value
+    return value

--- a/paimon-python/pypaimon/common/options/core_options.py
+++ b/paimon-python/pypaimon/common/options/core_options.py
@@ -24,7 +24,7 @@ from typing import Dict, List, Optional
 from urllib.parse import urlparse
 
 from pypaimon.common.memory_size import MemorySize
-from pypaimon.common.options import Options
+from pypaimon.common.options.options import Options
 from pypaimon.common.options.config_option import ConfigOption
 from pypaimon.common.options.config_options import ConfigOptions
 from pypaimon.common.options.options_utils import OptionsUtils

--- a/paimon-python/pypaimon/common/options/options.py
+++ b/paimon-python/pypaimon/common/options/options.py
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
-from pypaimon.common.options import ConfigOption
+from pypaimon.common.options.config_option import ConfigOption
 from pypaimon.common.options.options_utils import OptionsUtils
 
 

--- a/paimon-python/pypaimon/data/__init__.py
+++ b/paimon-python/pypaimon/data/__init__.py
@@ -15,9 +15,14 @@
 # specific language governing permissions and limitations
 # under the License.
 
-from pypaimon.data.timestamp import Timestamp
-from pypaimon.data.decimal import Decimal
-from pypaimon.data.variant_path import variant_get, variant_replace
+import importlib
+import sys
+
+if sys.version_info[:2] < (3, 7):
+    # Module-level __getattr__ is unavailable before Python 3.7.
+    from pypaimon.data.timestamp import Timestamp
+    from pypaimon.data.decimal import Decimal
+    from pypaimon.data.variant_path import variant_get, variant_replace
 
 __all__ = [
     'Timestamp',
@@ -25,3 +30,22 @@ __all__ = [
     'variant_get',
     'variant_replace',
 ]
+
+_MODULE_BY_EXPORT = {
+    'Timestamp': 'pypaimon.data.timestamp',
+    'Decimal': 'pypaimon.data.decimal',
+    'variant_get': 'pypaimon.data.variant_path',
+    'variant_replace': 'pypaimon.data.variant_path',
+}
+
+
+# Eager sibling imports here let one thread hold this package's module lock
+# while waiting on a sibling that another thread is already importing.
+def __getattr__(name):
+    module_name = _MODULE_BY_EXPORT.get(name)
+    if module_name is None:
+        raise AttributeError(
+            "module 'pypaimon.data' has no attribute {}".format(name))
+    value = getattr(importlib.import_module(module_name), name)
+    globals()[name] = value
+    return value

--- a/paimon-python/pypaimon/globalindex/__init__.py
+++ b/paimon-python/pypaimon/globalindex/__init__.py
@@ -17,7 +17,6 @@
 
 import importlib
 import sys
-import threading
 
 if sys.version_info[:2] < (3, 7):
     # Module-level __getattr__ is unavailable before Python 3.7.
@@ -107,18 +106,15 @@ _MODULE_BY_EXPORT = {
     'Range': 'pypaimon.utils.range',
 }
 
-# Eager exports would cycle: index_file_meta initializes this package while
-# create_global_index imports it back. The lock serializes racing imports.
-_LAZY_IMPORT_LOCK = threading.RLock()
 
-
+# Lazy resolution breaks the eager cycle where index_file_meta initializes
+# this package while create_global_index imports it back. Python's own
+# module locks make this thread-safe; an extra lock here would deadlock.
 def __getattr__(name):
     module_name = _MODULE_BY_EXPORT.get(name)
     if module_name is None:
         raise AttributeError(
             "module 'pypaimon.globalindex' has no attribute {}".format(name))
-    with _LAZY_IMPORT_LOCK:
-        if name not in globals():
-            module = importlib.import_module(module_name)
-            globals()[name] = getattr(module, name)
-        return globals()[name]
+    value = getattr(importlib.import_module(module_name), name)
+    globals()[name] = value
+    return value

--- a/paimon-python/pypaimon/tag/__init__.py
+++ b/paimon-python/pypaimon/tag/__init__.py
@@ -17,7 +17,6 @@
 
 import importlib
 import sys
-import threading
 
 if sys.version_info[:2] < (3, 7):
     # Module-level __getattr__ is unavailable before Python 3.7.
@@ -31,18 +30,15 @@ _MODULE_BY_EXPORT = {
     "TagManager": "pypaimon.tag.tag_manager",
 }
 
-# Eager sibling imports let threads lock tag and tag_manager in opposite
-# orders and fail with _DeadlockError. The lock serializes racing imports.
-_LAZY_IMPORT_LOCK = threading.RLock()
 
-
+# Lazy resolution avoids the eager sibling imports that let threads lock
+# tag and tag_manager in opposite orders. Python's own module locks make
+# this thread-safe; an extra lock here would deadlock against them.
 def __getattr__(name):
     module_name = _MODULE_BY_EXPORT.get(name)
     if module_name is None:
         raise AttributeError(
             "module 'pypaimon.tag' has no attribute {}".format(name))
-    with _LAZY_IMPORT_LOCK:
-        if name not in globals():
-            module = importlib.import_module(module_name)
-            globals()[name] = getattr(module, name)
-        return globals()[name]
+    value = getattr(importlib.import_module(module_name), name)
+    globals()[name] = value
+    return value

--- a/paimon-python/pypaimon/tests/concurrent_import_test.py
+++ b/paimon-python/pypaimon/tests/concurrent_import_test.py
@@ -155,6 +155,66 @@ if errors:
                 "attempt {}: {}".format(attempt, result.stdout),
             )
 
+    @unittest.skipIf(
+        sys.version_info[:2] < (3, 7),
+        "module-level lazy attributes require Python 3.7+",
+    )
+    def test_concurrent_leaf_imports_and_top_level_export(self):
+        # Racing leaf imports against top-level exports deadlocks whenever a
+        # package init eagerly imports siblings that import the package back.
+        script = r"""
+import sys
+import threading
+
+sys.setswitchinterval(1e-6)
+statements = [
+    "import pypaimon.manifest.schema.data_file_meta",
+    "import pypaimon.manifest.schema.simple_stats",
+    "from pypaimon import Schema",
+    "from pypaimon import CatalogFactory",
+    "import pypaimon.multimodal.connection",
+    "import pypaimon.read.query_auth_split",
+    "import pypaimon.write.table_delete",
+    "import pypaimon.index.index_file_meta",
+]
+barrier = threading.Barrier(len(statements))
+errors = []
+
+
+def resolve(statement):
+    try:
+        barrier.wait()
+        exec(statement)
+    except BaseException as error:
+        errors.append(repr(error))
+
+
+threads = [
+    threading.Thread(target=resolve, args=(statement,))
+    for statement in statements
+]
+for thread in threads:
+    thread.start()
+for thread in threads:
+    thread.join(15)
+if errors:
+    print("\n".join(sorted(set(errors))))
+    raise SystemExit(1)
+"""
+        for attempt in range(8):
+            result = subprocess.run(
+                [sys.executable, "-c", script],
+                env=os.environ.copy(),
+                stdout=subprocess.PIPE,
+                stderr=subprocess.STDOUT,
+                universal_newlines=True,
+                timeout=30,
+            )
+            self.assertEqual(
+                0, result.returncode,
+                "attempt {}: {}".format(attempt, result.stdout),
+            )
+
     def test_fresh_import_of_cycle_prone_leaf_modules(self):
         # Each module must import cleanly as a process's first pypaimon
         # import, without a package init pulling a circular chain.


### PR DESCRIPTION
## What

Follow-up to #9250. The concurrent-import fix added a `threading.RLock` around `importlib.import_module()` in three package `__init__`s (`pypaimon`, `pypaimon.tag`, `pypaimon.globalindex`) to serialize lazy resolution. That lock introduced a **new** deadlock path, flagged as P1 in the #9250 review.

## Why the lock deadlocks

Production code does top-level `from pypaimon import Schema` (e.g. `pypaimon/multimodal/connection.py`). With the root RLock in place:

- Thread A holds the root RLock, then imports a leaf module → waits on that leaf's module lock.
- Thread B holds the leaf module lock (importing the leaf directly), then resolves a top-level export → waits on the root RLock.

Classic lock-ordering inversion → `_DeadlockError` / `partially initialized module` on concurrent cold-start imports (new Ray workers, parallel split deserialization). Probabilistic, so CI easily misses it.

## Fix

Remove all three custom locks. Once the eager-init cycles are broken, Python's own per-module import locks make `import_module` thread-safe and idempotent, and the `globals()` assignment is atomic — the extra lock was both redundant and the source of the new deadlock.

Removing the locks alone re-surfaces deadlocks in two more packages whose eager sibling imports were previously masked by the lock, so those are also converted to lazy `__getattr__`:

- `pypaimon.data` — lazy `__getattr__` (was 3/200 without it)
- `pypaimon.common.options` — lazy `__getattr__`, plus break the `core_options`/`options` self-cycles via direct module imports (the package is imported by name from many modules its own eager exports pull in)

## Test

New regression `test_concurrent_leaf_imports_and_top_level_export` races leaf imports (`DataFileMeta`, `SimpleStats`, `query_auth_split`, `index_file_meta`, `table_delete`, `multimodal.connection`) against top-level exports (`Schema`, `CatalogFactory`) across 8 fresh processes with a 1e-6 switch interval.

## Stress (8-way, 400 fresh processes)

| | failures |
|---|---|
| master (#9250, with root lock) | 115/400 |
| this PR | 0/400 |

Master failures deadlock on `_ModuleLock('pypaimon.common.options.core_options')` — the exact cycle broken by the `common.options` lazy conversion.

## Verification

- `concurrent_import_test` + schema/options suite: 76 passed
- flake8 (`dev/cfg.ini`): clean
- Broad suite: 3661 passed, 63 skipped. The 13 failed / 14 collection errors are all missing optional deps (`lance`, `mosaic`, `ray`, `parameterized`, `_datasketches`, zstd) — confirmed identical on master.

Draft until CI confirms.
