### PR TITLE
[core] Match the lookup high level record by position, not by identity

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/mergetree/compact/LookupMergeFunction.java
+++ b/paimon-core/src/main/java/org/apache/paimon/mergetree/compact/LookupMergeFunction.java
@@ -42,6 +42,9 @@ public class LookupMergeFunction implements MergeFunction<KeyValue> {
     private boolean containLevel0;
     private InternalRow currentKey;
 
+    /** Position of the record {@link #pickHighLevel} chose, -1 when there is none. */
+    private int highLevelIndex = -1;
+
     public LookupMergeFunction(
             MergeFunction<KeyValue> mergeFunction,
             CoreOptions options,
@@ -57,6 +60,7 @@ public class LookupMergeFunction implements MergeFunction<KeyValue> {
         candidates.reset();
         currentKey = null;
         containLevel0 = false;
+        highLevelIndex = -1;
     }
 
     @Override
@@ -75,19 +79,22 @@ public class LookupMergeFunction implements MergeFunction<KeyValue> {
     @Nullable
     public KeyValue pickHighLevel() {
         KeyValue highLevel = null;
+        highLevelIndex = -1;
+        int index = 0;
         try (CloseableIterator<KeyValue> iterator = candidates.iterator()) {
             while (iterator.hasNext()) {
                 KeyValue kv = iterator.next();
                 // records that has not been stored on the disk yet, such as the data in the write
                 // buffer being at level -1
-                if (kv.level() <= 0) {
-                    continue;
+                if (kv.level() > 0) {
+                    // For high-level comparison logic (not involving Level 0), only the value of
+                    // the minimum Level should be selected
+                    if (highLevel == null || kv.level() < highLevel.level()) {
+                        highLevel = kv;
+                        highLevelIndex = index;
+                    }
                 }
-                // For high-level comparison logic (not involving Level 0), only the value of the
-                // minimum Level should be selected
-                if (highLevel == null || kv.level() < highLevel.level()) {
-                    highLevel = kv;
-                }
+                index++;
             }
         } catch (Exception e) {
             throw new RuntimeException(e);
@@ -106,15 +113,20 @@ public class LookupMergeFunction implements MergeFunction<KeyValue> {
     @Override
     public KeyValue getResult() {
         mergeFunction.reset();
-        KeyValue highLevel = pickHighLevel();
+        // match the high level record by its position: once the candidates have spilled, every
+        // iteration deserializes fresh KeyValue instances, so the one picked above is never the
+        // same object as the one seen here
+        pickHighLevel();
+        int index = 0;
         try (CloseableIterator<KeyValue> iterator = candidates.iterator()) {
             while (iterator.hasNext()) {
                 KeyValue kv = iterator.next();
                 // records that has not been stored on the disk yet, such as the data in the write
                 // buffer being at level -1
-                if (kv.level() <= 0 || kv == highLevel) {
+                if (kv.level() <= 0 || index == highLevelIndex) {
                     mergeFunction.add(kv);
                 }
+                index++;
             }
         } catch (Exception e) {
             throw new RuntimeException(e);

--- a/paimon-core/src/test/java/org/apache/paimon/mergetree/compact/LookupMergeFunctionTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/mergetree/compact/LookupMergeFunctionTest.java
@@ -18,9 +18,19 @@
 
 package org.apache.paimon.mergetree.compact;
 
+import org.apache.paimon.CoreOptions;
 import org.apache.paimon.KeyValue;
+import org.apache.paimon.disk.IOManager;
+import org.apache.paimon.options.Options;
+import org.apache.paimon.types.DataTypes;
+import org.apache.paimon.types.RowType;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import javax.annotation.Nullable;
+
+import java.nio.file.Path;
 
 import static org.apache.paimon.io.DataFileTestUtils.row;
 import static org.apache.paimon.types.RowKind.INSERT;
@@ -56,5 +66,61 @@ class LookupMergeFunctionTest {
         KeyValue kv = function.getResult();
         assertThat(kv).isNotNull();
         assertThat(kv.value().getInt(0)).isEqualTo(1);
+    }
+
+    @TempDir Path tempDir;
+
+    /**
+     * Same scenario as {@link #testKeepLowestHighLevel()}, but with the candidates spilled: every
+     * iteration over a spilled buffer deserializes fresh instances, so an identity check against
+     * the record picked by a previous iteration can never match.
+     */
+    @Test
+    public void testKeepLowestHighLevelWhenCandidatesHaveSpilled() {
+        for (boolean withIoManager : new boolean[] {false, true}) {
+            LookupMergeFunction function = spillingFunction(withIoManager);
+            function.reset();
+            function.add(new KeyValue().replace(row(1), 1, INSERT, row(2)).setLevel(1));
+            function.add(new KeyValue().replace(row(1), 1, INSERT, row(1)).setLevel(2));
+            KeyValue kv = function.getResult();
+            assertThat(kv).as("spilled, ioManager=%s", withIoManager).isNotNull();
+            assertThat(kv.value().getInt(0)).isEqualTo(2);
+        }
+    }
+
+    /**
+     * The lowest high level record is not simply the first or the last one, so this also covers the
+     * position bookkeeping rather than only "some high level record was merged".
+     */
+    @Test
+    public void testPicksTheLowestHighLevelFromTheMiddleWhenCandidatesHaveSpilled() {
+        for (boolean withIoManager : new boolean[] {false, true}) {
+            LookupMergeFunction function = spillingFunction(withIoManager);
+            function.reset();
+            function.add(new KeyValue().replace(row(1), 1, INSERT, row(30)).setLevel(3));
+            function.add(new KeyValue().replace(row(1), 2, INSERT, row(10)).setLevel(1));
+            function.add(new KeyValue().replace(row(1), 3, INSERT, row(20)).setLevel(2));
+            KeyValue kv = function.getResult();
+            assertThat(kv).as("spilled, ioManager=%s", withIoManager).isNotNull();
+            assertThat(kv.value().getInt(0)).isEqualTo(10);
+        }
+    }
+
+    private LookupMergeFunction spillingFunction(boolean withIoManager) {
+        Options options = new Options();
+        // spill as soon as there is more than one candidate for the key
+        options.set(CoreOptions.LOOKUP_MERGE_RECORDS_THRESHOLD, 1);
+        RowType keyType = RowType.builder().field("k", DataTypes.INT()).build();
+        RowType valueType = RowType.builder().field("v", DataTypes.INT()).build();
+        LookupMergeFunction.Factory factory =
+                (LookupMergeFunction.Factory)
+                        LookupMergeFunction.wrap(
+                                DeduplicateMergeFunction.factory(),
+                                new CoreOptions(options),
+                                keyType,
+                                valueType);
+        @Nullable IOManager ioManager = withIoManager ? IOManager.create(tempDir.toString()) : null;
+        factory.withIOManager(ioManager);
+        return (LookupMergeFunction) factory.create();
     }
 }


### PR DESCRIPTION
### Purpose

`LookupMergeFunction.getResult` scans the candidate buffer twice and re-identifies the high level record by object identity:

```java
// LookupMergeFunction:107-118
public KeyValue getResult() {
    mergeFunction.reset();
    KeyValue highLevel = pickHighLevel();          // first scan
    try (CloseableIterator<KeyValue> iterator = candidates.iterator()) {   // second scan
        while (iterator.hasNext()) {
            KeyValue kv = iterator.next();
            if (kv.level() <= 0 || kv == highLevel) {
                mergeFunction.add(kv);
            }
        }
    }
    ...
```

The candidates are held in a `KeyValueBuffer.HybridBuffer`, which keeps them in an `ArrayList` until there are more than `lookup.merge-records-threshold` of them for the key and then spills to a `BinaryBuffer` (`KeyValueBuffer:91`). A spilled buffer hands out a new object on every call:

```java
// KeyValueBuffer:192
return kvSerializer.fromRow(iterator.getRow().copy());
```

So after the spill the second scan never sees the object the first scan returned. `kv == highLevel` is false for every record, and the high level record is dropped from the merge.

The threshold counts candidates for a **single key** in one merge, so this needs a key with more than `lookup.merge-records-threshold` records across the files being merged — 1024 by default, lower for anyone who has tuned the option down to bound memory.

### What it does

`LookupMergeFunctionTest.testKeepLowestHighLevel` — two high level records, expecting the lower level to win — is the shape that breaks. Run unchanged except that the candidates spill, it returns **null** instead of the level-1 value: neither record is level 0 and neither matches by identity, so nothing at all reaches the wrapped merge function.

In the pipeline this runs through `LookupChangelogMergeFunctionWrapper.getResult` (`:104-146`), and the two halves then disagree. The wrapper holds its own non-null `highLevel` from its own `pickHighLevel()` call at `:106` and passes it to `setChangelog` as the *before* image at `:142`, while the *after* image it is compared against was merged without that record. For a merge engine that folds the persisted row into the result — partial-update, aggregation — the merged row loses the columns that only the high level record carried, and the changelog describes an update against a base row that was never part of it.

### What changes

Match the record by its position in the buffer instead of by object identity. `pickHighLevel` records the index of the record it chose, and `getResult` compares indices on the second scan:

```java
if (kv.level() > 0) {
    if (highLevel == null || kv.level() < highLevel.level()) {
        highLevel = kv;
        highLevelIndex = index;
    }
}
index++;
```

```java
pickHighLevel();
int index = 0;
...
    if (kv.level() <= 0 || index == highLevelIndex) {
        mergeFunction.add(kv);
    }
    index++;
```

Both scans walk the same buffer with no intervening writes, and the buffer iterates in insertion order: `ListBuffer` over an `ArrayList`, and `BinaryBuffer` over a `RowBuffer` whose `newIterator()` builds a fresh `RandomAccessInputView` from the start of the record segments and reads forward (`InMemoryBuffer:119-127`). Both spilled flavours are covered by the tests below rather than only by that reading. `highLevelIndex` is reset in `reset()` alongside the other per-key state.

That same code is why identity can never hold once spilled: the iterator's `getRow()` returns a reused `BinaryRow`, so `BinaryBuffer` has to `copy()` it before deserialising.

This is deliberately not a value comparison: two candidates for one key can share a level, and comparing on `(level, sequenceNumber)` would rest on an assumption about sequence numbers that the position does not need.

### Test evidence

Two tests, each run against both spilled buffer flavours — `ioManager == null`, which spills to an `InMemoryBuffer`, and a real `IOManager`, which spills to an `ExternalBuffer`:

* `testKeepLowestHighLevelWhenCandidatesHaveSpilled` — the existing `testKeepLowestHighLevel` scenario with `lookup.merge-records-threshold = 1`.
* `testPicksTheLowestHighLevelFromTheMiddleWhenCandidatesHaveSpilled` — levels 3, 1, 2 inserted in that order, so the answer is neither the first nor the last candidate and an off-by-one in the index bookkeeping would not pass.

Mutation control, on a forced clean rebuild of `paimon-core` (`rm -rf target/classes target/test-classes`) so this is not an incremental-build artefact: with the tests kept and `LookupMergeFunction` reverted, **both new tests fail** — `Expecting actual not to be null` — while the two pre-existing tests in the class stay green, which is the point: they do not spill.

Wider run: `*Lookup*Test`, `*MergeTree*Test`, `*MergeFunction*Test`, `KeyValueBufferTest` and `*Compact*Test` across `paimon-core` — 286 tests, 0 failures.

### API and Format

No change to any option, on-disk format or public signature. Below the spill threshold the two scans return the same objects and the behaviour is byte-for-byte what it was.
