### PR TITLE
[core] Keep tied nulls in range bitmap TopN for multi-key sorts

### DIFF
--- a/paimon-common/src/main/java/org/apache/paimon/fileindex/rangebitmap/RangeBitmap.java
+++ b/paimon-common/src/main/java/org/apache/paimon/fileindex/rangebitmap/RangeBitmap.java
@@ -285,7 +285,11 @@ public class RangeBitmap {
             @Nullable RoaringBitmap32 foundSet,
             boolean strict) {
         return fillNulls(
-                k, nullOrdering, foundSet, (l, r) -> getBitSliceIndexBitmap().topK(l, r, strict));
+                k,
+                nullOrdering,
+                foundSet,
+                (l, r) -> getBitSliceIndexBitmap().topK(l, r, strict),
+                strict);
     }
 
     public RoaringBitmap32 bottomK(
@@ -297,14 +301,16 @@ public class RangeBitmap {
                 k,
                 nullOrdering,
                 foundSet,
-                (l, r) -> getBitSliceIndexBitmap().bottomK(l, r, strict));
+                (l, r) -> getBitSliceIndexBitmap().bottomK(l, r, strict),
+                strict);
     }
 
     private RoaringBitmap32 fillNulls(
             int k,
             SortValue.NullOrdering nullOrdering,
             @Nullable RoaringBitmap32 foundSet,
-            BiFunction<Integer, RoaringBitmap32, RoaringBitmap32> function) {
+            BiFunction<Integer, RoaringBitmap32, RoaringBitmap32> function,
+            boolean strict) {
         if (cardinality <= 0) {
             return rid > 0 ? RoaringBitmap32.bitmapOfRange(0, rid) : new RoaringBitmap32();
         }
@@ -316,12 +322,14 @@ public class RangeBitmap {
             if (cardinality >= k) {
                 return bitmap;
             }
-            bitmap.or(isNull(foundSet).limit((int) (k - cardinality)));
+            // Nulls are all tied, so keep the whole group when duplicates are allowed.
+            RoaringBitmap32 nulls = isNull(foundSet);
+            bitmap.or(strict ? nulls.limit((int) (k - cardinality)) : nulls);
         } else {
             bitmap = isNull(foundSet);
             long cardinality = bitmap.getCardinality();
             if (cardinality >= k) {
-                return bitmap.limit(k);
+                return strict ? bitmap.limit(k) : bitmap;
             }
             bitmap.or(function.apply((int) (k - cardinality), foundSet));
         }

--- a/paimon-common/src/test/java/org/apache/paimon/fileindex/rangebitmap/RangeBitmapFileIndexTest.java
+++ b/paimon-common/src/test/java/org/apache/paimon/fileindex/rangebitmap/RangeBitmapFileIndexTest.java
@@ -512,6 +512,59 @@ public class RangeBitmapFileIndexTest {
     }
 
     @Test
+    public void testTopNWithMultipleColumnsKeepsNullTies() {
+        IntType intType = new IntType();
+        FieldRef fieldRef1 = new FieldRef(0, "col1", intType);
+        FieldRef fieldRef2 = new FieldRef(1, "col2", intType);
+
+        RangeBitmapFileIndex bitmapFileIndex = new RangeBitmapFileIndex(intType, new Options());
+        FileIndexWriter writer = bitmapFileIndex.createWriter();
+
+        writer.writeRecord(null);
+        writer.writeRecord(null);
+        writer.writeRecord(null);
+        writer.writeRecord(7);
+        writer.writeRecord(8);
+
+        byte[] bytes = writer.serializedBytes();
+        ByteArraySeekableStream stream = new ByteArraySeekableStream(bytes);
+        FileIndexReader reader = bitmapFileIndex.createReader(stream, 0, bytes.length);
+        RoaringBitmap32 foundSet = RoaringBitmap32.bitmapOf(0, 1, 2, 3, 4);
+
+        // col2 decides among the tied nulls, so all of them must survive the index selection
+        List<SortValue> multiple =
+                Arrays.asList(
+                        new SortValue(fieldRef1, ASCENDING, NULLS_FIRST),
+                        new SortValue(fieldRef2, DESCENDING, NULLS_FIRST));
+        FileIndexResult result =
+                reader.visitTopN(new TopN(multiple, 2), new BitmapIndexResult(() -> foundSet));
+        assertThat(((BitmapIndexResult) result).get()).isEqualTo(RoaringBitmap32.bitmapOf(0, 1, 2));
+
+        // a single order is exact, so the null group is still trimmed to the limit
+        List<SortValue> single = Arrays.asList(new SortValue(fieldRef1, ASCENDING, NULLS_FIRST));
+        result = reader.visitTopN(new TopN(single, 2), new BitmapIndexResult(() -> foundSet));
+        assertThat(((BitmapIndexResult) result).get()).isEqualTo(RoaringBitmap32.bitmapOf(0, 1));
+
+        // nulls sort last, so they tie while filling up the remaining limit
+        List<SortValue> multipleNullsLast =
+                Arrays.asList(
+                        new SortValue(fieldRef1, ASCENDING, NULLS_LAST),
+                        new SortValue(fieldRef2, DESCENDING, NULLS_LAST));
+        result =
+                reader.visitTopN(
+                        new TopN(multipleNullsLast, 3), new BitmapIndexResult(() -> foundSet));
+        assertThat(((BitmapIndexResult) result).get())
+                .isEqualTo(RoaringBitmap32.bitmapOf(0, 1, 2, 3, 4));
+
+        List<SortValue> singleNullsLast =
+                Arrays.asList(new SortValue(fieldRef1, ASCENDING, NULLS_LAST));
+        result =
+                reader.visitTopN(
+                        new TopN(singleNullsLast, 3), new BitmapIndexResult(() -> foundSet));
+        assertThat(((BitmapIndexResult) result).get()).isEqualTo(RoaringBitmap32.bitmapOf(0, 3, 4));
+    }
+
+    @Test
     public void testAllowDuplicatesAscBoundary() {
         IntType intType = new IntType();
         FieldRef fieldRef1 = new FieldRef(0, "col1", intType);


### PR DESCRIPTION
### Purpose

`RangeBitmapFileIndex#visitTopN` sets `strict = orders.size() == 1`: with more orders the
index only prunes, so rows tied on the first key must survive for the engine to break the
tie. #6178 threaded `strict` into `BitSliceIndexBitmap` but not into `fillNulls`, so a tied
null group is still trimmed. Value ties already keep the group.

`ORDER BY col1 ASC NULLS FIRST, col2 DESC LIMIT 2`, `col1 = [null,null,null,7,8]`:

```
was  {0,1}    -> engine can only answer rows 1,0
now  {0,1,2}  -> rows 2,1, correct
```

### Tests

`RangeBitmapFileIndexTest#testTopNWithMultipleColumnsKeepsNullTies`, also pinning that a
single order still trims.

Written with Claude Code; reasoning and verification are mine.
