### PR TITLE
[core] Add Multivalue global index for array membership

### DIFF
--- a/docs/docs/multimodal-table/global-index.mdx
+++ b/docs/docs/multimodal-table/global-index.mdx
@@ -43,7 +43,7 @@ without full-table scans. Paimon supports multiple global index types:
 |---|---|---|
 | BTree | Scalar filters on numeric, string, date, and timestamp columns | Best when predicates are selective, such as equality, IN, range, and null checks. |
 | Bitmap | Enum-like dimensions and tag columns | Best for equality, IN, string prefix match, complement predicates, and null checks over compressed row-id bitmaps. |
-| Multivalue | Membership tests on arrays of supported scalar elements | Best for `ARRAY_CONTAINS(array_column, element)` and array null checks. |
+| Multivalue | Membership tests on arrays of supported scalar elements | Best for `ARRAY_CONTAINS(array_column, element)`. |
 | Vector | Top-K similarity search on embeddings | Uses ANN algorithms. Tune build-time and search-time options to balance recall, latency, and index size. |
 | Full-Text | Keyword search over text columns | Uses full-text scoring and tokenizer configuration stored with each index file. |
 | Hybrid Search | Combining multiple vector routes, multiple full-text routes, or vector and full-text retrieval together | Runs multiple scored routes and merges them with a ranker before reading rows. |
@@ -428,7 +428,7 @@ options, and file format details.
 
 Use Multivalue indexes for element-membership predicates on `ARRAY` columns. See
 [Multivalue Index](./global-index/multivalue) for Data Evolution build examples, Core query usage,
-options, and array null semantics.
+options, and null/empty membership semantics.
 
 ## Vector Index
 

--- a/docs/docs/multimodal-table/global-index.mdx
+++ b/docs/docs/multimodal-table/global-index.mdx
@@ -34,6 +34,7 @@ without full-table scans. Paimon supports multiple global index types:
 
 - **[BTree Index](./global-index/btree)**: A B-tree based index for scalar column lookups. Supports equality, IN, range predicates, and can be combined across multiple columns with AND/OR logic.
 - **[Bitmap Index](./global-index/bitmap)**: A bitmap based index for enum-like scalar dimensions and tag columns. Supports equality, IN, prefix match on string columns, complement predicates, and null checks with compressed row-id bitmaps.
+- **[Multivalue Index](./global-index/multivalue)**: A bitmap-backed index for element-membership predicates on `ARRAY` columns.
 - **[Vector Index](./global-index/vector)**: An approximate nearest neighbor (ANN) index powered by Paimon's vector index library for vector similarity search.
 - **[Full-Text Index](./global-index/full-text)**: A full-text search index backed by the native full-text engine for text retrieval. Supports term matching and relevance scoring.
 - **[Hybrid Search](./global-index/hybrid-search)**: A multi-route search API that combines results from multiple vector routes, multiple full-text routes, or both before reading table rows.
@@ -42,6 +43,7 @@ without full-table scans. Paimon supports multiple global index types:
 |---|---|---|
 | BTree | Scalar filters on numeric, string, date, and timestamp columns | Best when predicates are selective, such as equality, IN, range, and null checks. |
 | Bitmap | Enum-like dimensions and tag columns | Best for equality, IN, string prefix match, complement predicates, and null checks over compressed row-id bitmaps. |
+| Multivalue | Membership tests on arrays of supported scalar elements | Best for `ARRAY_CONTAINS(array_column, element)` and array null checks. |
 | Vector | Top-K similarity search on embeddings | Uses ANN algorithms. Tune build-time and search-time options to balance recall, latency, and index size. |
 | Full-Text | Keyword search over text columns | Uses full-text scoring and tokenizer configuration stored with each index file. |
 | Hybrid Search | Combining multiple vector routes, multiple full-text routes, or vector and full-text retrieval together | Runs multiple scored routes and merges them with a ranker before reading rows. |
@@ -66,6 +68,7 @@ Create a table with the required properties:
 CREATE TABLE my_table (
     id INT,
     name STRING,
+    tags ARRAY<STRING>,
     embedding ARRAY<FLOAT>,
     content STRING
 ) TBLPROPERTIES (
@@ -89,6 +92,7 @@ schema = Schema.from_pyarrow_schema(
     pa.schema([
         pa.field("id", pa.int32()),
         pa.field("name", pa.string()),
+        pa.field("tags", pa.list_(pa.string())),
         pa.field("embedding", pa.list_(pa.float32())),
         pa.field("content", pa.string()),
     ]),
@@ -395,12 +399,12 @@ These table options affect global index build and read behavior:
 |---|---|---|
 | `global-index.enabled` | `true` | Whether scans can use global indexes. |
 | `global-index.search-mode` | Not set | Legacy fallback search mode for global-index queries. Family-specific options take precedence. |
-| `scalar-index.search-mode` | `fast` | Search mode for BTree and Bitmap queries. |
+| `scalar-index.search-mode` | `fast` | Search mode for BTree, Bitmap, and Multivalue queries. |
 | `vector-index.search-mode` | `fast` | Search mode for vector queries. |
 | `full-text-index.search-mode` | `fast` | Search mode for full-text queries. |
 | `global-index.external-path` | Not set | Root directory for global index files. If not set, files are stored under the table index directory. |
 | `global-index.column-update-action` | `THROW_ERROR` | Action for updates to indexed columns. `THROW_ERROR` rejects the update, `DROP_PARTITION_INDEX` drops affected partition indexes, and `IGNORE` keeps existing index files unchanged during the update and causes the next incremental index build to scan active data manifests and rebuild affected row ranges. Index files created before source metadata was introduced are not refreshed automatically. |
-| `sorted-index.records-per-range` | `10000000` | Expected number of records per sorted global index file for BTree and Bitmap builds. |
+| `sorted-index.records-per-range` | `10000000` | Expected number of records per sorted global index file for BTree, Bitmap, and Multivalue builds. |
 | `sorted-index.build.max-parallelism` | `4096` | Maximum Flink or Spark parallelism for building sorted global indexes. |
 | `global-index.row-count-per-shard` | `100000` | Target row count per shard for non-sorted global index builds such as vector and full-text indexes. |
 | `global-index.build.max-shard` | `32` | Preferred maximum shard count for global index builds. |
@@ -419,6 +423,12 @@ for build and query examples.
 Use Bitmap indexes for enum-like dimensions and tag columns queried by equality, IN, string prefix
 match, complement, or null predicates. See [Bitmap Index](./global-index/bitmap) for build examples,
 options, and file format details.
+
+## Multivalue Index
+
+Use Multivalue indexes for element-membership predicates on `ARRAY` columns. See
+[Multivalue Index](./global-index/multivalue) for Data Evolution build examples, Core query usage,
+options, and array null semantics.
 
 ## Vector Index
 

--- a/docs/docs/multimodal-table/global-index/bitmap.mdx
+++ b/docs/docs/multimodal-table/global-index/bitmap.mdx
@@ -171,7 +171,7 @@ print(matched_files)
 
 | Option | Default | Description |
 |---|---|---|
-| `sorted-index.records-per-range` | `10000000` | Expected number of records per sorted global index file for BTree and Bitmap builds. |
+| `sorted-index.records-per-range` | `10000000` | Expected number of records per sorted global index file for BTree, Bitmap, and Multivalue builds. |
 | `sorted-index.build.max-parallelism` | `4096` | Maximum Flink or Spark parallelism for building sorted global indexes. |
 | `bitmap-index.dictionary-block-size` | `16 kb` | Target size of dictionary blocks in bitmap global index files. Smaller blocks reduce dictionary read amplification for high-cardinality columns; larger blocks reduce dictionary block index size. |
 | `bitmap-index.compression` | `none` | Compression algorithm for bitmap dictionary blocks and the dictionary block index. Supported values are the same block codecs as BTree index, such as `none`, `lz4`, `lzo`, and `zstd`. |

--- a/docs/docs/multimodal-table/global-index/btree.mdx
+++ b/docs/docs/multimodal-table/global-index/btree.mdx
@@ -147,7 +147,7 @@ print(matched_files)
 
 | Option | Default | Description |
 |---|---|---|
-| `sorted-index.records-per-range` | `10000000` | Expected number of records per sorted global index file for BTree and Bitmap builds. |
+| `sorted-index.records-per-range` | `10000000` | Expected number of records per sorted global index file for BTree, Bitmap, and Multivalue builds. |
 | `sorted-index.build.max-parallelism` | `4096` | Maximum Flink or Spark parallelism for building sorted global indexes. |
 | `btree-index.block-size` | `64 kb` | Block size used by BTree index files. |
 | `btree-index.cache-size` | `128 mb` | Cache size used by BTree index readers. |

--- a/docs/docs/multimodal-table/global-index/multivalue.mdx
+++ b/docs/docs/multimodal-table/global-index/multivalue.mdx
@@ -31,9 +31,8 @@ array as one scalar key.
 The index preserves these array semantics:
 
 - Duplicate elements in one array contribute the row ID only once.
-- A null array is different from an empty array.
+- An empty array is non-null but contributes no element to the index.
 - Null elements inside a non-null array are ignored for membership lookup.
-- Array `IS NULL` and `IS NOT NULL` use dedicated row bitmaps.
 
 The indexed column must be an `ARRAY` whose element type is supported by the global-index key
 serializer. A Multivalue index is single-column.

--- a/docs/docs/multimodal-table/global-index/multivalue.mdx
+++ b/docs/docs/multimodal-table/global-index/multivalue.mdx
@@ -28,11 +28,11 @@ A Multivalue index maps every distinct non-null element of an `ARRAY` column to 
 64-bit row-id bitmap. It accelerates element-membership predicates without treating the complete
 array as one scalar key.
 
-The index preserves these array semantics:
+For membership lookup, the index has these semantics:
 
 - Duplicate elements in one array contribute the row ID only once.
-- An empty array is non-null but contributes no element to the index.
-- Null elements inside a non-null array are ignored for membership lookup.
+- Null arrays, empty arrays, and null elements contribute no posting. The index does not
+  distinguish those cases and does not accelerate array `IS NULL` or `IS NOT NULL` predicates.
 
 The indexed column must be an `ARRAY` whose element type is supported by the global-index key
 serializer. A Multivalue index is single-column.
@@ -64,9 +64,11 @@ CALL sys.create_global_index(
 );
 ```
 
-The Multivalue writer does not require arrays to be ordered. Flink and Spark distribute build
-records by row ID, while each writer sorts its distinct element dictionary before writing the
-bitmap index file.
+Arrays do not need to be ordered. Flink and Spark first assign source rows to stable row-id ranges,
+expand every non-null element into an `(element, row-id)` entry, and sort those entries with their
+spillable sort paths. The writer then streams the sorted entries into bitmap posting lists while
+retaining the original source-row count for index coverage, including ranges containing only null
+or empty arrays.
 
 Build the procedure again after appending rows to cover newly added row-id ranges. The
 `scalar-index.search-mode` option controls whether an indexed scan includes uncovered rows:
@@ -111,6 +113,6 @@ CALL sys.drop_global_index(
 | `multivalue-index.compression` | `none` | Compression algorithm for dictionary blocks. |
 | `multivalue-index.compression-level` | `1` | Compression level used by codecs which support levels. |
 
-Each writer currently buffers the distinct-element posting lists for its source group in memory.
-Use Multivalue first for arrays with low or moderate element cardinality, and control per-writer
-input with `sorted-index.records-per-range` when necessary.
+The expanded entries use the engine's spillable sort, and the writer keeps only the current
+element's posting list in memory. `sorted-index.records-per-range` bounds the source-row range—and
+therefore the largest posting list—owned by one Data Evolution index file.

--- a/docs/docs/multimodal-table/global-index/multivalue.mdx
+++ b/docs/docs/multimodal-table/global-index/multivalue.mdx
@@ -1,0 +1,117 @@
+---
+title: "Multivalue Index"
+sidebar_position: 3
+---
+
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+# Multivalue Index
+
+A Multivalue index maps every distinct non-null element of an `ARRAY` column to a compressed
+64-bit row-id bitmap. It accelerates element-membership predicates without treating the complete
+array as one scalar key.
+
+The index preserves these array semantics:
+
+- Duplicate elements in one array contribute the row ID only once.
+- A null array is different from an empty array.
+- Null elements inside a non-null array are ignored for membership lookup.
+- Array `IS NULL` and `IS NOT NULL` use dedicated row bitmaps.
+
+The indexed column must be an `ARRAY` whose element type is supported by the global-index key
+serializer. A Multivalue index is single-column.
+
+## Build on a Data Evolution Table
+
+Create a table with the regular global-index prerequisites:
+
+```sql
+CREATE TABLE my_table (
+    id INT,
+    tags ARRAY<STRING>
+) TBLPROPERTIES (
+    'bucket' = '-1',
+    'row-tracking.enabled' = 'true',
+    'data-evolution.enabled' = 'true',
+    'global-index.enabled' = 'true'
+);
+```
+
+Flink and Spark can build the index with `create_global_index`:
+
+```sql
+CALL sys.create_global_index(
+    table => 'db.my_table',
+    index_column => 'tags',
+    index_type => 'multivalue',
+    options => 'sorted-index.records-per-range=10000000'
+);
+```
+
+The Multivalue writer does not require arrays to be ordered. Flink and Spark distribute build
+records by row ID, while each writer sorts its distinct element dictionary before writing the
+bitmap index file.
+
+Build the procedure again after appending rows to cover newly added row-id ranges. The
+`scalar-index.search-mode` option controls whether an indexed scan includes uncovered rows:
+`fast` returns indexed coverage only, while `full` and `detail` retain their regular global-index
+coverage behavior.
+
+## Query Through Paimon Core
+
+The Core predicate API exposes array membership directly:
+
+```java
+int tagsFieldIndex = table.rowType().getFieldIndex("tags");
+Predicate predicate = new PredicateBuilder(table.rowType())
+        .arrayContains(tagsFieldIndex, BinaryString.fromString("blue"));
+
+ReadBuilder readBuilder = table.newReadBuilder().withFilter(predicate);
+TableScan.Plan plan = readBuilder.newScan().plan();
+```
+
+Paimon automatically uses matching Multivalue global index files and maps their row IDs to Data
+Evolution splits. SQL engines use the index after their connector translates an array-membership
+expression to Paimon's `ARRAY_CONTAINS` predicate; that connector translation is separate from the
+Core index implementation.
+
+## Drop the Index
+
+```sql
+CALL sys.drop_global_index(
+    table => 'db.my_table',
+    index_column => 'tags',
+    index_type => 'multivalue'
+);
+```
+
+## Options
+
+| Option | Default | Description |
+|---|---|---|
+| `sorted-index.records-per-range` | `10000000` | Expected number of source records per generated Multivalue index file. |
+| `sorted-index.build.max-parallelism` | `4096` | Maximum Flink or Spark parallelism for building the index. |
+| `multivalue-index.dictionary-block-size` | `16 kb` | Target size of the block-indexed element dictionary. |
+| `multivalue-index.compression` | `none` | Compression algorithm for dictionary blocks. |
+| `multivalue-index.compression-level` | `1` | Compression level used by codecs which support levels. |
+
+Each writer currently buffers the distinct-element posting lists for its source group in memory.
+Use Multivalue first for arrays with low or moderate element cardinality, and control per-writer
+input with `sorted-index.records-per-range` when necessary.

--- a/docs/docs/multimodal-table/index.mdx
+++ b/docs/docs/multimodal-table/index.mdx
@@ -38,7 +38,7 @@ Key capabilities:
 - **[Variant Storage](./variant)**: Store and query schema-flexible semi-structured data with optional typed sub-column shredding.
 - **[Blob Storage](./blob)**: Store large binary objects (images, videos, audio) in dedicated `.blob` files with efficient column projection.
 - **[Vector Storage](./vector)**: Store and manage vector embeddings in dedicated Vortex-format files optimized for vector workloads.
-- **[Global Index](./global-index)**: Build BTree, Bitmap, vector, and full-text indexes for efficient lookups and similarity search.
+- **[Global Index](./global-index)**: Build BTree, Bitmap, Multivalue, vector, and full-text indexes for efficient lookups and similarity search.
 
 Data Evolution, Blob Storage, Vector Storage, and Global Index require the following table properties.
 Variant Storage can also be used in a regular Paimon table without these properties:

--- a/docs/docs/primary-key-table/global-index.mdx
+++ b/docs/docs/primary-key-table/global-index.mdx
@@ -66,7 +66,8 @@ See [Bitmap Index](../multimodal-table/global-index/bitmap) for predicate and fo
 
 Use Multivalue for element-membership predicates on an `ARRAY` column. It stores one compressed
 bitmap posting list per distinct non-null element and accelerates Paimon Core `ARRAY_CONTAINS`
-predicates. Null arrays, empty arrays, and null elements retain distinct semantics.
+predicates. Null arrays, empty arrays, and null elements produce no membership posting; array null
+checks fall back to the ordinary data path.
 
 The Core predicate and index pushdown are available independently of SQL connectors. A connector
 uses this index after it translates its array-membership expression to Paimon's `ARRAY_CONTAINS`
@@ -322,7 +323,7 @@ become full-text searchable only after compaction publishes an eligible data fil
 BTree, Bitmap, and Multivalue indexes are applied automatically to snapshot-scoped Core batch
 scans after a supported predicate reaches Paimon. BTree and Bitmap can accelerate equality, `IN`,
 null checks, comparisons and ranges, complement predicates, and supported string predicates.
-Multivalue accelerates `ARRAY_CONTAINS(array_column, element)` and array null checks.
+Multivalue accelerates `ARRAY_CONTAINS(array_column, element)`.
 
 The Java/Core predicate can be constructed directly:
 
@@ -555,8 +556,8 @@ create a table with the desired definition and migrate the data.
 
 - BTree, Bitmap, and Multivalue definitions are single-column indexes.
 - Multivalue supports arrays of scalar element types accepted by the global-index key serializer.
-  Null elements are not indexed. It is currently intended for low-to-moderate element cardinality,
-  because one build buffers the distinct-element posting lists for its source group in memory.
+  Null elements are not indexed. Higher array and element cardinality increases the expanded-sort
+  I/O and index-file size.
 - Exactly one vector index column is currently supported per table.
 - Exactly one full-text index column is currently supported per table.
 - Only `FLOAT` vectors are supported.

--- a/docs/docs/primary-key-table/global-index.mdx
+++ b/docs/docs/primary-key-table/global-index.mdx
@@ -27,10 +27,10 @@ under the License.
 
 # Primary-Key Indexes
 
-Primary-key tables can maintain Vector, Full Text, BTree, and Bitmap indexes together with compact
-data files. These indexes are bucket-local and source-backed: every index group records its source data
-files and maps matches back to physical row positions. Deletion vectors are applied when indexed
-rows are read, so updates and deletes remain exact.
+Primary-key tables can maintain Vector, Full Text, BTree, Bitmap, and Multivalue indexes together
+with compact data files. These indexes are bucket-local and source-backed: every index group records
+its source data files and maps matches back to physical row positions. Deletion vectors are applied
+when indexed rows are read, so updates and deletes remain exact.
 
 Primary-key indexes differ from indexes created with `create_global_index`. A regular
 [Global Index](../multimodal-table/global-index) addresses table-wide row IDs and is built
@@ -62,6 +62,21 @@ See [Bitmap Index](../multimodal-table/global-index/bitmap) for predicate and fo
 
 </TabItem>
 
+<TabItem value="multivalue" label="Multivalue">
+
+Use Multivalue for element-membership predicates on an `ARRAY` column. It stores one compressed
+bitmap posting list per distinct non-null element and accelerates Paimon Core `ARRAY_CONTAINS`
+predicates. Null arrays, empty arrays, and null elements retain distinct semantics.
+
+The Core predicate and index pushdown are available independently of SQL connectors. A connector
+uses this index after it translates its array-membership expression to Paimon's `ARRAY_CONTAINS`
+predicate.
+
+For an append-only or Data Evolution table whose Multivalue index is built independently, see
+[Global Multivalue Index](../multimodal-table/global-index/multivalue).
+
+</TabItem>
+
 <TabItem value="vector" label="Vector">
 
 Use Vector for approximate nearest-neighbor (ANN) Top-K search on embeddings that are updated with
@@ -87,8 +102,8 @@ For an append-only or Data Evolution table whose full-text index is built indepe
 </Tabs>
 
 Different columns in one table can use different index families. One column can occur in at most
-one of `pk-vector.index.columns`, `pk-full-text.index.columns`, `pk-btree.index.columns`, and
-`pk-bitmap.index.columns`.
+one of `pk-vector.index.columns`, `pk-full-text.index.columns`, `pk-btree.index.columns`,
+`pk-bitmap.index.columns`, and `pk-multivalue.index.columns`.
 
 ## Requirements
 
@@ -104,16 +119,17 @@ supported by this configuration.
 
 <Tabs groupId="primary-key-index-requirements">
 
-<TabItem value="scalar" label="BTree and Bitmap">
+<TabItem value="sorted" label="BTree, Bitmap, and Multivalue">
 
-BTree and Bitmap additionally require:
+BTree, Bitmap, and Multivalue additionally require:
 
 - `deletion-vectors.enabled = true`.
 - `deletion-vectors.merge-on-read = false`.
-- A supported scalar column type.
+- A supported scalar column type for BTree and Bitmap, or an `ARRAY` of supported scalar elements
+  for Multivalue.
 
-Each entry creates an independent single-column index. Multiple BTree and Bitmap columns are
-supported as long as a column is not listed by another primary-key index family.
+Each entry creates an independent single-column index. Multiple columns are supported as long as a
+column is not listed by another primary-key index family.
 
 </TabItem>
 
@@ -149,8 +165,8 @@ Exactly one full-text column is currently supported per table.
 
 ## Create a Table
 
-The following table uses all four families on different columns: Vector for `embedding`, Full
-Text for `content`, BTree for `amount`, and Bitmap for `status`.
+The following table uses all five families on different columns: Vector for `embedding`, Full Text
+for `content`, BTree for `amount`, Bitmap for `status`, and Multivalue for `tags`.
 
 <Tabs groupId="primary-key-index-create-table">
 
@@ -161,6 +177,7 @@ CREATE TABLE items (
     id BIGINT,
     status STRING,
     amount DECIMAL(12, 2),
+    tags ARRAY<STRING>,
     content STRING,
     embedding ARRAY<FLOAT> COMMENT '__VECTOR_FIELD;3',
     PRIMARY KEY (id) NOT ENFORCED
@@ -176,7 +193,9 @@ CREATE TABLE items (
     'pk-btree.index.columns' = 'amount',
     'fields.amount.pk-btree.index.options' = '{"block-size":"64 kb"}',
     'pk-bitmap.index.columns' = 'status',
-    'fields.status.pk-bitmap.index.options' = '{"dictionary-block-size":"16 kb"}'
+    'fields.status.pk-bitmap.index.options' = '{"dictionary-block-size":"16 kb"}',
+    'pk-multivalue.index.columns' = 'tags',
+    'fields.tags.pk-multivalue.index.options' = '{"dictionary-block-size":"16 kb"}'
 );
 ```
 
@@ -193,6 +212,7 @@ CREATE TABLE items (
     id BIGINT,
     status STRING,
     amount DECIMAL(12, 2),
+    tags ARRAY<STRING>,
     content STRING,
     embedding ARRAY<FLOAT> COMMENT '__VECTOR_FIELD;3'
 ) USING paimon
@@ -209,7 +229,9 @@ TBLPROPERTIES (
     'pk-btree.index.columns' = 'amount',
     'fields.amount.pk-btree.index.options' = '{"block-size":"64 kb"}',
     'pk-bitmap.index.columns' = 'status',
-    'fields.status.pk-bitmap.index.options' = '{"dictionary-block-size":"16 kb"}'
+    'fields.status.pk-bitmap.index.options' = '{"dictionary-block-size":"16 kb"}',
+    'pk-multivalue.index.columns' = 'tags',
+    'fields.tags.pk-multivalue.index.options' = '{"dictionary-block-size":"16 kb"}'
 );
 ```
 
@@ -234,6 +256,11 @@ schema validation.
 | `fields.<column>.pk-btree.index.options` | Not set | JSON object containing BTree build options. Unqualified keys are scoped to `btree-index`. |
 | `pk-bitmap.index.columns` | Not set | Comma-separated columns which own independent Bitmap indexes. |
 | `fields.<column>.pk-bitmap.index.options` | Not set | JSON object containing Bitmap build options. Unqualified keys are scoped to `bitmap-index`. |
+| `pk-multivalue.index.columns` | Not set | Comma-separated `ARRAY` columns which own independent Multivalue indexes. |
+| `fields.<column>.pk-multivalue.index.options` | Not set | JSON object containing Multivalue build options. Unqualified keys are scoped to `multivalue-index`. |
+| `multivalue-index.dictionary-block-size` | `16 kb` | Target dictionary block size. |
+| `multivalue-index.compression` | `none` | Dictionary-block compression algorithm. |
+| `multivalue-index.compression-level` | `1` | Dictionary-block compression level. |
 | `global-index.search-mode` | Not set | Legacy fallback search mode. Family-specific options take precedence. |
 | `vector-index.search-mode` | `fast` | Search mode for primary-key Vector queries. `full` and `detail` search uncovered files exactly. |
 | `full-text-index.search-mode` | `fast` | Search mode for primary-key Full Text queries. Only `fast` is currently supported. |
@@ -279,8 +306,8 @@ Coverage behavior depends on the index family and search mode. `vector-index.sea
 queries search only data covered by an active index group. Uncovered files are not searched, so
 partial coverage can make results incomplete.
 
-- BTree and Bitmap scans always read uncovered files through the ordinary data path. Partial
-  coverage affects their acceleration, not result completeness. The original scalar predicate and
+- BTree, Bitmap, and Multivalue scans always read uncovered files through the ordinary data path.
+  Partial coverage affects their acceleration, not result completeness. The original predicate and
   deletion vectors are applied after index pruning.
 - Vector search in `full` or `detail` mode evaluates files without an active ANN group exactly and
   merges those results with ANN candidates. In the default `fast` mode, those files are omitted.
@@ -290,13 +317,26 @@ persistent archives and ignores uncovered files; `full` and `detail` are rejecte
 merge-aware logical-row fallback is not implemented. Consequently, newly appended Level-0 rows
 become full-text searchable only after compaction publishes an eligible data file and archive.
 
-## BTree and Bitmap Queries
+## BTree, Bitmap, and Multivalue Queries
 
-BTree and Bitmap indexes are applied automatically to snapshot-scoped batch scans. They can
-accelerate equality, `IN`, null checks, comparisons and ranges, complement predicates, and
-supported string predicates.
+BTree, Bitmap, and Multivalue indexes are applied automatically to snapshot-scoped Core batch
+scans after a supported predicate reaches Paimon. BTree and Bitmap can accelerate equality, `IN`,
+null checks, comparisons and ranges, complement predicates, and supported string predicates.
+Multivalue accelerates `ARRAY_CONTAINS(array_column, element)` and array null checks.
 
-Paimon combines indexed scalar results as follows:
+The Java/Core predicate can be constructed directly:
+
+```java
+Predicate predicate = new PredicateBuilder(rowType)
+        .arrayContains(tagsFieldIndex, BinaryString.fromString("blue"));
+ReadBuilder readBuilder = table.newReadBuilder().withFilter(predicate);
+TableScan.Plan plan = readBuilder.newScan().plan();
+```
+
+SQL engines need a connector-specific expression conversion before their `array_contains` or
+equivalent function reaches this Core predicate.
+
+Paimon combines indexed predicate results as follows:
 
 - For `AND`, any usable indexed child can narrow a source file; unindexed children remain residual
   filters.
@@ -513,7 +553,10 @@ create a table with the desired definition and migrate the data.
 
 ## Limitations
 
-- BTree and Bitmap definitions are single-column indexes.
+- BTree, Bitmap, and Multivalue definitions are single-column indexes.
+- Multivalue supports arrays of scalar element types accepted by the global-index key serializer.
+  Null elements are not indexed. It is currently intended for low-to-moderate element cardinality,
+  because one build buffers the distinct-element posting lists for its source group in memory.
 - Exactly one vector index column is currently supported per table.
 - Exactly one full-text index column is currently supported per table.
 - Only `FLOAT` vectors are supported.

--- a/docs/generated/core_configuration.html
+++ b/docs/generated/core_configuration.html
@@ -1291,6 +1291,12 @@ For an internal format table in a REST catalog, it also makes the catalog own th
             <td>Comma-separated character columns indexed by primary-key full-text indexes. The first release supports exactly one column.</td>
         </tr>
         <tr>
+            <td><h5>pk-multivalue.index.columns</h5></td>
+            <td style="word-wrap: break-word;">(none)</td>
+            <td>String</td>
+            <td>Comma-separated ARRAY columns indexed by primary-key Multivalue indexes.</td>
+        </tr>
+        <tr>
             <td><h5>pk-vector.index.columns</h5></td>
             <td style="word-wrap: break-word;">(none)</td>
             <td>String</td>

--- a/docs/sidebars.js
+++ b/docs/sidebars.js
@@ -128,6 +128,7 @@ const sidebars = {
         "items": [
           "multimodal-table/global-index/btree",
           "multimodal-table/global-index/bitmap",
+          "multimodal-table/global-index/multivalue",
           "multimodal-table/global-index/vector",
           "multimodal-table/global-index/full-text",
           "multimodal-table/global-index/hybrid-search"

--- a/paimon-api/src/main/java/org/apache/paimon/CoreOptions.java
+++ b/paimon-api/src/main/java/org/apache/paimon/CoreOptions.java
@@ -2952,6 +2952,13 @@ public class CoreOptions implements Serializable {
                     .withDescription(
                             "Comma-separated columns indexed by primary-key Bitmap indexes.");
 
+    public static final ConfigOption<String> PK_MULTIVALUE_INDEX_COLUMNS =
+            key("pk-multivalue.index.columns")
+                    .stringType()
+                    .noDefaultValue()
+                    .withDescription(
+                            "Comma-separated ARRAY columns indexed by primary-key Multivalue indexes.");
+
     public static final ConfigOption<String> PK_FULL_TEXT_INDEX_COLUMNS =
             key("pk-full-text.index.columns")
                     .stringType()
@@ -4605,6 +4612,10 @@ public class CoreOptions implements Serializable {
         return primaryKeyIndexColumns(PK_BITMAP_INDEX_COLUMNS);
     }
 
+    public List<String> primaryKeyMultiValueIndexColumns() {
+        return primaryKeyIndexColumns(PK_MULTIVALUE_INDEX_COLUMNS);
+    }
+
     public List<String> primaryKeyFullTextIndexColumns() {
         return primaryKeyIndexColumns(PK_FULL_TEXT_INDEX_COLUMNS);
     }
@@ -4623,6 +4634,10 @@ public class CoreOptions implements Serializable {
 
     public Options primaryKeyBitmapIndexOptions(String column) {
         return primaryKeySortedIndexOptions(column, "pk-bitmap", "bitmap-index.");
+    }
+
+    public Options primaryKeyMultiValueIndexOptions(String column) {
+        return primaryKeySortedIndexOptions(column, "pk-multivalue", "multivalue-index.");
     }
 
     public Options primaryKeyFullTextIndexOptions(String column) {

--- a/paimon-common/src/main/java/org/apache/paimon/globalindex/GlobalIndexer.java
+++ b/paimon-common/src/main/java/org/apache/paimon/globalindex/GlobalIndexer.java
@@ -30,6 +30,11 @@ import java.util.concurrent.ExecutorService;
 /** Abstract base class for global indexers. */
 public interface GlobalIndexer {
 
+    /** Whether the writer requires records to be ordered by the indexed field. */
+    default boolean requiresSortedInput() {
+        return true;
+    }
+
     GlobalIndexWriter createWriter(GlobalIndexFileWriter fileWriter) throws IOException;
 
     /**

--- a/paimon-common/src/main/java/org/apache/paimon/globalindex/GlobalIndexer.java
+++ b/paimon-common/src/main/java/org/apache/paimon/globalindex/GlobalIndexer.java
@@ -30,11 +30,6 @@ import java.util.concurrent.ExecutorService;
 /** Abstract base class for global indexers. */
 public interface GlobalIndexer {
 
-    /** Whether the writer requires records to be ordered by the indexed field. */
-    default boolean requiresSortedInput() {
-        return true;
-    }
-
     GlobalIndexWriter createWriter(GlobalIndexFileWriter fileWriter) throws IOException;
 
     /**

--- a/paimon-common/src/main/resources/META-INF/services/org.apache.paimon.globalindex.GlobalIndexerFactory
+++ b/paimon-common/src/main/resources/META-INF/services/org.apache.paimon.globalindex.GlobalIndexerFactory
@@ -15,3 +15,4 @@
 
 org.apache.paimon.globalindex.btree.BTreeGlobalIndexerFactory
 org.apache.paimon.globalindex.bitmap.BitmapGlobalIndexerFactory
+org.apache.paimon.globalindex.bitmap.MultiValueGlobalIndexerFactory

--- a/paimon-common/src/test/java/org/apache/paimon/globalindex/bitmap/MultiValueBitmapIndexReaderTest.java
+++ b/paimon-common/src/test/java/org/apache/paimon/globalindex/bitmap/MultiValueBitmapIndexReaderTest.java
@@ -30,6 +30,7 @@ import org.apache.paimon.globalindex.GlobalIndexReader;
 import org.apache.paimon.globalindex.GlobalIndexResult;
 import org.apache.paimon.globalindex.GlobalIndexSingleColumnWriter;
 import org.apache.paimon.globalindex.GlobalIndexer;
+import org.apache.paimon.globalindex.GlobalIndexerFactoryUtils;
 import org.apache.paimon.globalindex.ResultEntry;
 import org.apache.paimon.globalindex.SortedGlobalIndexer;
 import org.apache.paimon.globalindex.SortedIndexFileMeta;
@@ -206,10 +207,8 @@ class MultiValueBitmapIndexReaderTest {
 
     @Test
     void testFactoryAndTypeValidation() throws Exception {
-        MultiValueGlobalIndexerFactory factory = new MultiValueGlobalIndexerFactory();
-        assertThat(factory.identifier()).isEqualTo(MultiValueGlobalIndexerFactory.IDENTIFIER);
-        assertThat(factory.create(dataField, new Options()))
-                .isInstanceOf(MultiValueGlobalIndexer.class);
+        assertThat(GlobalIndexerFactoryUtils.load(MultiValueGlobalIndexerFactory.IDENTIFIER))
+                .isInstanceOf(MultiValueGlobalIndexerFactory.class);
         assertThat(globalIndexer).isInstanceOf(SortedGlobalIndexer.class);
         GlobalIndexKeyExtractor extractor = ((SortedGlobalIndexer) globalIndexer).keyExtractor();
         assertThat(extractor.keyType()).isEqualTo(DataTypes.STRING());

--- a/paimon-core/src/main/java/org/apache/paimon/KeyValueFileStore.java
+++ b/paimon-core/src/main/java/org/apache/paimon/KeyValueFileStore.java
@@ -187,7 +187,8 @@ public class KeyValueFileStore extends AbstractFileStore<KeyValue> {
         if (writeOptions.primaryKeyVectorIndexEnabled()
                 || writeOptions.primaryKeyFullTextIndexEnabled()
                 || !writeOptions.primaryKeyBTreeIndexColumns().isEmpty()
-                || !writeOptions.primaryKeyBitmapIndexColumns().isEmpty()) {
+                || !writeOptions.primaryKeyBitmapIndexColumns().isEmpty()
+                || !writeOptions.primaryKeyMultiValueIndexColumns().isEmpty()) {
             primaryKeyIndexMaintainerFactory =
                     BucketedPrimaryKeyIndexMaintainer.Factory.create(
                             newIndexFileHandler(), newReaderFactoryBuilder(), schema);

--- a/paimon-core/src/main/java/org/apache/paimon/globalindex/GlobalIndexBuilderUtils.java
+++ b/paimon-core/src/main/java/org/apache/paimon/globalindex/GlobalIndexBuilderUtils.java
@@ -275,6 +275,55 @@ public class GlobalIndexBuilderUtils {
         return result;
     }
 
+    /** Splits contiguous build ranges into globally aligned, source-row bounded shards. */
+    public static Map<Range, List<Split>> shardSplitsByRowRange(
+            Map<Range, List<Split>> rangeSplits, long rowsPerShard) {
+        checkArgument(rowsPerShard > 0, "Rows per sorted-index shard must be positive.");
+        Map<Range, List<Split>> result = new LinkedHashMap<>();
+        for (Map.Entry<Range, List<Split>> entry : rangeSplits.entrySet()) {
+            Range buildRange = entry.getKey();
+            checkArgument(
+                    buildRange.from >= 0,
+                    "Sorted-index row IDs must be non-negative, but range starts at %s.",
+                    buildRange.from);
+            long shardStart = (buildRange.from / rowsPerShard) * rowsPerShard;
+            while (shardStart <= buildRange.to) {
+                long unboundedShardEnd = shardStart + rowsPerShard - 1;
+                long shardEnd = unboundedShardEnd < shardStart ? Long.MAX_VALUE : unboundedShardEnd;
+                Range shardRange =
+                        new Range(
+                                Math.max(buildRange.from, shardStart),
+                                Math.min(buildRange.to, shardEnd));
+                List<Split> shardSplits = new ArrayList<>();
+                for (Split split : entry.getValue()) {
+                    DataSplit dataSplit;
+                    List<Range> splitRanges;
+                    if (split instanceof IndexedSplit) {
+                        IndexedSplit indexedSplit = (IndexedSplit) split;
+                        dataSplit = indexedSplit.dataSplit();
+                        splitRanges = indexedSplit.rowRanges();
+                    } else {
+                        dataSplit = (DataSplit) split;
+                        splitRanges = calcRowRanges(Collections.singletonList(dataSplit));
+                    }
+                    List<Range> intersections =
+                            Range.and(splitRanges, Collections.singletonList(shardRange));
+                    if (!intersections.isEmpty()) {
+                        shardSplits.add(new IndexedSplit(dataSplit, intersections, null));
+                    }
+                }
+                if (!shardSplits.isEmpty()) {
+                    result.put(shardRange, shardSplits);
+                }
+                if (shardEnd == Long.MAX_VALUE) {
+                    break;
+                }
+                shardStart = shardEnd + 1;
+            }
+        }
+        return result;
+    }
+
     private static List<DataSplit> splitByContiguousRowRange(DataSplit split) {
         List<DataFileMeta> input = split.dataFiles();
         RangeHelper<DataFileMeta> rangeHelper = new RangeHelper<>(DataFileMeta::nonNullRowIdRange);

--- a/paimon-core/src/main/java/org/apache/paimon/globalindex/sorted/SortedGlobalIndexScanner.java
+++ b/paimon-core/src/main/java/org/apache/paimon/globalindex/sorted/SortedGlobalIndexScanner.java
@@ -22,6 +22,8 @@ import org.apache.paimon.CoreOptions;
 import org.apache.paimon.Snapshot;
 import org.apache.paimon.globalindex.DataEvolutionGlobalIndexRefreshPlanner;
 import org.apache.paimon.globalindex.ScanResult;
+import org.apache.paimon.globalindex.bitmap.MultiValueIndexFileMeta;
+import org.apache.paimon.index.GlobalIndexMeta;
 import org.apache.paimon.manifest.IndexManifestEntry;
 import org.apache.paimon.options.Options;
 import org.apache.paimon.partition.PartitionPredicate;
@@ -29,6 +31,7 @@ import org.apache.paimon.table.FileStoreTable;
 import org.apache.paimon.table.Table;
 import org.apache.paimon.table.source.DataSplit;
 import org.apache.paimon.table.source.snapshot.SnapshotReader;
+import org.apache.paimon.types.ArrayType;
 import org.apache.paimon.types.DataField;
 import org.apache.paimon.types.RowType;
 import org.apache.paimon.utils.Preconditions;
@@ -133,25 +136,34 @@ public class SortedGlobalIndexScanner implements Serializable {
         snapshotReader = withManifestEntryFilter(snapshotReader.withSnapshot(snapshot));
 
         Preconditions.checkArgument(indexField != null, "indexField must be set before scan.");
-        List<IndexManifestEntry> currentIndexes =
+        List<IndexManifestEntry> allCurrentIndexes =
                 currentIndexEntries(
                         table,
                         snapshot,
                         indexType,
                         Collections.singletonList(indexField),
                         partitionPredicate);
+        List<IndexManifestEntry> currentIndexes = new ArrayList<>();
+        List<IndexManifestEntry> deletedIndexEntries = new ArrayList<>();
+        for (IndexManifestEntry entry : allCurrentIndexes) {
+            if (hasCompatibleIndexKeyType(entry)) {
+                currentIndexes.add(entry);
+            } else {
+                deletedIndexEntries.add(entry);
+            }
+        }
         List<Range> rangesToBuild = new ArrayList<>(unindexedRowRanges(snapshot, currentIndexes));
-        List<IndexManifestEntry> deletedIndexEntries = Collections.emptyList();
         if (detectDataFileChange()) {
             // Scans data manifests through reusable binary views without materializing entries.
-            deletedIndexEntries =
+            List<IndexManifestEntry> refreshedIndexes =
                     DataEvolutionGlobalIndexRefreshPlanner.findIndexesToRefresh(
                             table,
                             snapshot,
                             partitionPredicate,
                             currentIndexes,
                             Collections.singletonList(indexField));
-            for (IndexManifestEntry entry : deletedIndexEntries) {
+            deletedIndexEntries.addAll(refreshedIndexes);
+            for (IndexManifestEntry entry : refreshedIndexes) {
                 rangesToBuild.add(entry.indexFile().globalIndexMeta().rowRange());
             }
         }
@@ -167,6 +179,17 @@ public class SortedGlobalIndexScanner implements Serializable {
                         RowRangeIndex.create(rangesToBuild),
                         snapshotReader.read().dataSplits(),
                         deletedIndexEntries));
+    }
+
+    private boolean hasCompatibleIndexKeyType(IndexManifestEntry entry) {
+        if (!"multivalue".equals(indexType)) {
+            return true;
+        }
+        GlobalIndexMeta indexMeta = entry.indexFile().globalIndexMeta();
+        return indexMeta != null
+                && indexField.type() instanceof ArrayType
+                && MultiValueIndexFileMeta.hasCompatibleElementType(
+                        indexMeta.indexMeta(), ((ArrayType) indexField.type()).getElementType());
     }
 
     private boolean detectDataFileChange() {

--- a/paimon-core/src/main/java/org/apache/paimon/globalindex/sorted/SortedGlobalIndexScanner.java
+++ b/paimon-core/src/main/java/org/apache/paimon/globalindex/sorted/SortedGlobalIndexScanner.java
@@ -22,8 +22,6 @@ import org.apache.paimon.CoreOptions;
 import org.apache.paimon.Snapshot;
 import org.apache.paimon.globalindex.DataEvolutionGlobalIndexRefreshPlanner;
 import org.apache.paimon.globalindex.ScanResult;
-import org.apache.paimon.globalindex.bitmap.MultiValueIndexFileMeta;
-import org.apache.paimon.index.GlobalIndexMeta;
 import org.apache.paimon.manifest.IndexManifestEntry;
 import org.apache.paimon.options.Options;
 import org.apache.paimon.partition.PartitionPredicate;
@@ -31,7 +29,6 @@ import org.apache.paimon.table.FileStoreTable;
 import org.apache.paimon.table.Table;
 import org.apache.paimon.table.source.DataSplit;
 import org.apache.paimon.table.source.snapshot.SnapshotReader;
-import org.apache.paimon.types.ArrayType;
 import org.apache.paimon.types.DataField;
 import org.apache.paimon.types.RowType;
 import org.apache.paimon.utils.Preconditions;
@@ -136,34 +133,25 @@ public class SortedGlobalIndexScanner implements Serializable {
         snapshotReader = withManifestEntryFilter(snapshotReader.withSnapshot(snapshot));
 
         Preconditions.checkArgument(indexField != null, "indexField must be set before scan.");
-        List<IndexManifestEntry> allCurrentIndexes =
+        List<IndexManifestEntry> currentIndexes =
                 currentIndexEntries(
                         table,
                         snapshot,
                         indexType,
                         Collections.singletonList(indexField),
                         partitionPredicate);
-        List<IndexManifestEntry> currentIndexes = new ArrayList<>();
-        List<IndexManifestEntry> deletedIndexEntries = new ArrayList<>();
-        for (IndexManifestEntry entry : allCurrentIndexes) {
-            if (hasCompatibleIndexKeyType(entry)) {
-                currentIndexes.add(entry);
-            } else {
-                deletedIndexEntries.add(entry);
-            }
-        }
         List<Range> rangesToBuild = new ArrayList<>(unindexedRowRanges(snapshot, currentIndexes));
+        List<IndexManifestEntry> deletedIndexEntries = Collections.emptyList();
         if (detectDataFileChange()) {
             // Scans data manifests through reusable binary views without materializing entries.
-            List<IndexManifestEntry> refreshedIndexes =
+            deletedIndexEntries =
                     DataEvolutionGlobalIndexRefreshPlanner.findIndexesToRefresh(
                             table,
                             snapshot,
                             partitionPredicate,
                             currentIndexes,
                             Collections.singletonList(indexField));
-            deletedIndexEntries.addAll(refreshedIndexes);
-            for (IndexManifestEntry entry : refreshedIndexes) {
+            for (IndexManifestEntry entry : deletedIndexEntries) {
                 rangesToBuild.add(entry.indexFile().globalIndexMeta().rowRange());
             }
         }
@@ -179,17 +167,6 @@ public class SortedGlobalIndexScanner implements Serializable {
                         RowRangeIndex.create(rangesToBuild),
                         snapshotReader.read().dataSplits(),
                         deletedIndexEntries));
-    }
-
-    private boolean hasCompatibleIndexKeyType(IndexManifestEntry entry) {
-        if (!"multivalue".equals(indexType)) {
-            return true;
-        }
-        GlobalIndexMeta indexMeta = entry.indexFile().globalIndexMeta();
-        return indexMeta != null
-                && indexField.type() instanceof ArrayType
-                && MultiValueIndexFileMeta.hasCompatibleElementType(
-                        indexMeta.indexMeta(), ((ArrayType) indexField.type()).getElementType());
     }
 
     private boolean detectDataFileChange() {

--- a/paimon-core/src/main/java/org/apache/paimon/globalindex/sorted/SortedGlobalIndexWriter.java
+++ b/paimon-core/src/main/java/org/apache/paimon/globalindex/sorted/SortedGlobalIndexWriter.java
@@ -21,9 +21,12 @@ package org.apache.paimon.globalindex.sorted;
 import org.apache.paimon.data.BinaryRow;
 import org.apache.paimon.data.InternalRow;
 import org.apache.paimon.data.InternalRow.FieldGetter;
+import org.apache.paimon.globalindex.GlobalIndexKeyExtractor;
 import org.apache.paimon.globalindex.GlobalIndexSingleColumnWriter;
 import org.apache.paimon.globalindex.GlobalIndexWriter;
+import org.apache.paimon.globalindex.GlobalIndexer;
 import org.apache.paimon.globalindex.ResultEntry;
+import org.apache.paimon.globalindex.SortedGlobalIndexer;
 import org.apache.paimon.index.DataEvolutionIndexSourceMeta;
 import org.apache.paimon.index.IndexFileMeta;
 import org.apache.paimon.io.CompactIncrement;
@@ -35,6 +38,7 @@ import org.apache.paimon.table.sink.CommitMessage;
 import org.apache.paimon.table.sink.CommitMessageImpl;
 import org.apache.paimon.types.DataField;
 import org.apache.paimon.types.RowType;
+import org.apache.paimon.utils.IOUtils;
 import org.apache.paimon.utils.Range;
 
 import java.io.IOException;
@@ -61,6 +65,7 @@ public class SortedGlobalIndexWriter implements Serializable {
     private final long recordsPerRange;
 
     private DataField indexField;
+    private GlobalIndexKeyExtractor keyExtractor;
 
     public SortedGlobalIndexWriter(Table table, String indexType) {
         this(table, indexType, ((FileStoreTable) table).coreOptions().toConfiguration());
@@ -82,7 +87,17 @@ public class SortedGlobalIndexWriter implements Serializable {
                 indexField,
                 table.fullName());
         this.indexField = rowType.getField(indexField);
+        GlobalIndexer indexer = GlobalIndexer.create(indexType, this.indexField, options);
+        checkArgument(
+                indexer instanceof SortedGlobalIndexer,
+                "Index algorithm %s does not expose sorted index keys.",
+                indexType);
+        this.keyExtractor = ((SortedGlobalIndexer) indexer).keyExtractor();
         return this;
+    }
+
+    public GlobalIndexKeyExtractor keyExtractor() {
+        return keyExtractor;
     }
 
     public long recordsPerRange() {
@@ -92,7 +107,33 @@ public class SortedGlobalIndexWriter implements Serializable {
     public List<CommitMessage> buildForSinglePartition(
             Range rowRange, BinaryRow partition, Iterator<InternalRow> data, long scanSnapshotId)
             throws IOException {
-        FieldGetter indexFieldGetter = InternalRow.createFieldGetter(indexField.type(), 0);
+        if (keyExtractor.isIdentity()) {
+            return buildIdentityIndex(rowRange, partition, data, scanSnapshotId);
+        }
+
+        FieldGetter indexFieldGetter = InternalRow.createFieldGetter(keyExtractor.keyType(), 0);
+        GlobalIndexSingleColumnWriter writer = createWriter();
+        try {
+            while (data.hasNext()) {
+                InternalRow row = data.next();
+                long localRowId = row.getLong(1) - rowRange.from;
+                writer.write(indexFieldGetter.getFieldOrNull(row), localRowId);
+            }
+
+            return Collections.singletonList(
+                    flushIndex(
+                            rowRange, writer.finish(rowRange.count()), partition, scanSnapshotId));
+        } finally {
+            if (writer instanceof AutoCloseable) {
+                IOUtils.closeQuietly((AutoCloseable) writer);
+            }
+        }
+    }
+
+    private List<CommitMessage> buildIdentityIndex(
+            Range rowRange, BinaryRow partition, Iterator<InternalRow> data, long scanSnapshotId)
+            throws IOException {
+        FieldGetter indexFieldGetter = InternalRow.createFieldGetter(keyExtractor.keyType(), 0);
         try (SortedSingleColumnIndexWriter writer =
                 new SortedSingleColumnIndexWriter(recordsPerRange, this::createWriter)) {
             while (data.hasNext()) {

--- a/paimon-core/src/main/java/org/apache/paimon/globalindex/sorted/SortedGlobalIndexWriter.java
+++ b/paimon-core/src/main/java/org/apache/paimon/globalindex/sorted/SortedGlobalIndexWriter.java
@@ -38,7 +38,6 @@ import org.apache.paimon.table.sink.CommitMessage;
 import org.apache.paimon.table.sink.CommitMessageImpl;
 import org.apache.paimon.types.DataField;
 import org.apache.paimon.types.RowType;
-import org.apache.paimon.utils.IOUtils;
 import org.apache.paimon.utils.Range;
 
 import java.io.IOException;
@@ -107,35 +106,8 @@ public class SortedGlobalIndexWriter implements Serializable {
     public List<CommitMessage> buildForSinglePartition(
             Range rowRange, BinaryRow partition, Iterator<InternalRow> data, long scanSnapshotId)
             throws IOException {
-        if (keyExtractor.isIdentity()) {
-            return buildIdentityIndex(rowRange, partition, data, scanSnapshotId);
-        }
-
         FieldGetter indexFieldGetter = InternalRow.createFieldGetter(keyExtractor.keyType(), 0);
-        GlobalIndexSingleColumnWriter writer = createWriter();
-        try {
-            while (data.hasNext()) {
-                InternalRow row = data.next();
-                long localRowId = row.getLong(1) - rowRange.from;
-                writer.write(indexFieldGetter.getFieldOrNull(row), localRowId);
-            }
-
-            return Collections.singletonList(
-                    flushIndex(
-                            rowRange, writer.finish(rowRange.count()), partition, scanSnapshotId));
-        } finally {
-            if (writer instanceof AutoCloseable) {
-                IOUtils.closeQuietly((AutoCloseable) writer);
-            }
-        }
-    }
-
-    private List<CommitMessage> buildIdentityIndex(
-            Range rowRange, BinaryRow partition, Iterator<InternalRow> data, long scanSnapshotId)
-            throws IOException {
-        FieldGetter indexFieldGetter = InternalRow.createFieldGetter(keyExtractor.keyType(), 0);
-        try (SortedSingleColumnIndexWriter writer =
-                new SortedSingleColumnIndexWriter(recordsPerRange, this::createWriter)) {
+        try (SortedSingleColumnIndexWriter writer = createTaskWriter(rowRange)) {
             while (data.hasNext()) {
                 InternalRow row = data.next();
                 long localRowId = row.getLong(1) - rowRange.from;
@@ -148,6 +120,14 @@ public class SortedGlobalIndexWriter implements Serializable {
             }
             return commitMessages;
         }
+    }
+
+    /** Creates a task writer which owns file rotation and source-row coverage semantics. */
+    public SortedSingleColumnIndexWriter createTaskWriter(Range rowRange) throws IOException {
+        if (keyExtractor.isIdentity()) {
+            return new SortedSingleColumnIndexWriter(recordsPerRange, this::createWriter);
+        }
+        return SortedSingleColumnIndexWriter.forSourceRowCount(rowRange.count(), createWriter());
     }
 
     public GlobalIndexSingleColumnWriter createWriter() throws IOException {

--- a/paimon-core/src/main/java/org/apache/paimon/globalindex/sorted/SortedSingleColumnIndexWriter.java
+++ b/paimon-core/src/main/java/org/apache/paimon/globalindex/sorted/SortedSingleColumnIndexWriter.java
@@ -32,11 +32,12 @@ import java.util.List;
 import static org.apache.paimon.utils.Preconditions.checkArgument;
 import static org.apache.paimon.utils.Preconditions.checkState;
 
-/** Rotates single-column index writers after a configured number of logical records. */
+/** Writes one sorted index task, optionally rotating by source record count. */
 public final class SortedSingleColumnIndexWriter implements Closeable {
 
     private final long recordsPerRange;
-    private final Factory factory;
+    @Nullable private final Factory factory;
+    @Nullable private final Long sourceRowCount;
     private final List<List<ResultEntry>> resultGroups = new ArrayList<>();
 
     @Nullable private GlobalIndexSingleColumnWriter currentWriter;
@@ -47,14 +48,33 @@ public final class SortedSingleColumnIndexWriter implements Closeable {
         checkArgument(recordsPerRange > 0, "Records per range must be positive.");
         this.recordsPerRange = recordsPerRange;
         this.factory = factory;
+        this.sourceRowCount = null;
+    }
+
+    private SortedSingleColumnIndexWriter(
+            long sourceRowCount, GlobalIndexSingleColumnWriter writer) {
+        checkArgument(sourceRowCount >= 0, "Source row count must be non-negative.");
+        this.recordsPerRange = Long.MAX_VALUE;
+        this.factory = null;
+        this.sourceRowCount = sourceRowCount;
+        this.currentWriter = writer;
+    }
+
+    /** Creates a non-rotating task writer with an explicit source-row coverage count. */
+    public static SortedSingleColumnIndexWriter forSourceRowCount(
+            long sourceRowCount, GlobalIndexSingleColumnWriter writer) {
+        return new SortedSingleColumnIndexWriter(sourceRowCount, writer);
     }
 
     public void write(@Nullable Object value, long localRowId) throws IOException {
         checkState(!finished, "Cannot write after the sorted index writer is finished.");
-        if (currentWriter != null && currentRecordCount >= recordsPerRange) {
+        if (sourceRowCount == null
+                && currentWriter != null
+                && currentRecordCount >= recordsPerRange) {
             finishCurrentWriter();
         }
         if (currentWriter == null) {
+            checkState(factory != null, "Cannot create another source-range index writer.");
             currentWriter = factory.create();
         }
         currentWriter.write(value, localRowId);
@@ -92,7 +112,8 @@ public final class SortedSingleColumnIndexWriter implements Closeable {
     }
 
     private void finishCurrentWriter() {
-        resultGroups.add(currentWriter.finish());
+        resultGroups.add(
+                currentWriter.finish(sourceRowCount == null ? currentRecordCount : sourceRowCount));
         currentWriter = null;
         currentRecordCount = 0;
     }

--- a/paimon-core/src/main/java/org/apache/paimon/index/pk/BucketedPrimaryKeyIndexMaintainer.java
+++ b/paimon-core/src/main/java/org/apache/paimon/index/pk/BucketedPrimaryKeyIndexMaintainer.java
@@ -376,6 +376,7 @@ public final class BucketedPrimaryKeyIndexMaintainer {
                         break;
                     case BTREE:
                     case BITMAP:
+                    case MULTI_VALUE:
                         sortedFactories.add(
                                 new SortedDefinitionFactory(
                                         readerFactoryBuilder,

--- a/paimon-core/src/main/java/org/apache/paimon/index/pk/PrimaryKeyIndexDefinition.java
+++ b/paimon-core/src/main/java/org/apache/paimon/index/pk/PrimaryKeyIndexDefinition.java
@@ -28,6 +28,7 @@ public class PrimaryKeyIndexDefinition {
         VECTOR,
         BTREE,
         BITMAP,
+        MULTI_VALUE,
         FULL_TEXT
     }
 

--- a/paimon-core/src/main/java/org/apache/paimon/index/pk/PrimaryKeyIndexDefinitions.java
+++ b/paimon-core/src/main/java/org/apache/paimon/index/pk/PrimaryKeyIndexDefinitions.java
@@ -20,6 +20,7 @@ package org.apache.paimon.index.pk;
 
 import org.apache.paimon.CoreOptions;
 import org.apache.paimon.globalindex.bitmap.BitmapGlobalIndexerFactory;
+import org.apache.paimon.globalindex.bitmap.MultiValueGlobalIndexerFactory;
 import org.apache.paimon.globalindex.btree.BTreeGlobalIndexerFactory;
 import org.apache.paimon.schema.TableSchema;
 import org.apache.paimon.types.DataField;
@@ -46,12 +47,15 @@ public class PrimaryKeyIndexDefinitions {
         List<String> vectorColumns = options.primaryKeyVectorIndexColumns();
         List<String> btreeColumns = options.primaryKeyBTreeIndexColumns();
         List<String> bitmapColumns = options.primaryKeyBitmapIndexColumns();
+        List<String> multiValueColumns = options.primaryKeyMultiValueIndexColumns();
         List<String> fullTextColumns = options.primaryKeyFullTextIndexColumns();
         validateNoDuplicates(vectorColumns, CoreOptions.PK_VECTOR_INDEX_COLUMNS.key());
         validateNoDuplicates(btreeColumns, CoreOptions.PK_BTREE_INDEX_COLUMNS.key());
         validateNoDuplicates(bitmapColumns, CoreOptions.PK_BITMAP_INDEX_COLUMNS.key());
+        validateNoDuplicates(multiValueColumns, CoreOptions.PK_MULTIVALUE_INDEX_COLUMNS.key());
         validateNoDuplicates(fullTextColumns, CoreOptions.PK_FULL_TEXT_INDEX_COLUMNS.key());
-        validateOneIndexPerColumn(vectorColumns, btreeColumns, bitmapColumns, fullTextColumns);
+        validateOneIndexPerColumn(
+                vectorColumns, btreeColumns, bitmapColumns, multiValueColumns, fullTextColumns);
         List<PrimaryKeyIndexDefinition> definitions = new ArrayList<>();
 
         for (DataField field : schema.fields()) {
@@ -72,6 +76,14 @@ public class PrimaryKeyIndexDefinitions {
                                 BitmapGlobalIndexerFactory.IDENTIFIER,
                                 options.primaryKeyBitmapIndexOptions(column),
                                 PrimaryKeyIndexDefinition.Family.BITMAP));
+            } else if (multiValueColumns.contains(column)) {
+                definitions.add(
+                        new PrimaryKeyIndexDefinition(
+                                column,
+                                field.id(),
+                                MultiValueGlobalIndexerFactory.IDENTIFIER,
+                                options.primaryKeyMultiValueIndexOptions(column),
+                                PrimaryKeyIndexDefinition.Family.MULTI_VALUE));
             } else if (vectorColumns.contains(column)) {
                 definitions.add(
                         new PrimaryKeyIndexDefinition(
@@ -109,11 +121,13 @@ public class PrimaryKeyIndexDefinitions {
             List<String> vectorColumns,
             List<String> btreeColumns,
             List<String> bitmapColumns,
+            List<String> multiValueColumns,
             List<String> fullTextColumns) {
         Set<String> indexedColumns = new HashSet<>();
         validateUniqueColumns(indexedColumns, vectorColumns);
         validateUniqueColumns(indexedColumns, btreeColumns);
         validateUniqueColumns(indexedColumns, bitmapColumns);
+        validateUniqueColumns(indexedColumns, multiValueColumns);
         validateUniqueColumns(indexedColumns, fullTextColumns);
     }
 

--- a/paimon-core/src/main/java/org/apache/paimon/index/pksorted/BucketedSortedIndexMaintainer.java
+++ b/paimon-core/src/main/java/org/apache/paimon/index/pksorted/BucketedSortedIndexMaintainer.java
@@ -45,7 +45,7 @@ import java.util.concurrent.Future;
 
 import static org.apache.paimon.utils.Preconditions.checkArgument;
 
-/** Maintains one bucket-local source-backed BTree or Bitmap definition. */
+/** Maintains one bucket-local source-backed sorted-index definition. */
 public class BucketedSortedIndexMaintainer {
 
     private static final Logger LOG = LoggerFactory.getLogger(BucketedSortedIndexMaintainer.class);

--- a/paimon-core/src/main/java/org/apache/paimon/index/pksorted/PkSortedIndexBuilder.java
+++ b/paimon-core/src/main/java/org/apache/paimon/index/pksorted/PkSortedIndexBuilder.java
@@ -23,7 +23,9 @@ import org.apache.paimon.data.BinaryRow;
 import org.apache.paimon.data.GenericRow;
 import org.apache.paimon.data.InternalRow;
 import org.apache.paimon.disk.IOManager;
+import org.apache.paimon.globalindex.GlobalIndexKeyExtractor;
 import org.apache.paimon.globalindex.GlobalIndexer;
+import org.apache.paimon.globalindex.SortedGlobalIndexer;
 import org.apache.paimon.index.IndexFileMeta;
 import org.apache.paimon.index.pk.PrimaryKeyIndexSourceFile;
 import org.apache.paimon.io.DataFileMeta;
@@ -39,16 +41,14 @@ import javax.annotation.Nullable;
 
 import java.io.Closeable;
 import java.io.IOException;
-import java.io.UncheckedIOException;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.Iterator;
 import java.util.List;
-import java.util.NoSuchElementException;
 
 import static org.apache.paimon.utils.Preconditions.checkArgument;
 
-/** Builds source-backed index payloads, sorting physical records when required by the indexer. */
+/** Builds source-backed index payloads by extracting and spill-sorting normalized index keys. */
 public class PkSortedIndexBuilder {
 
     private static final int ROW_ID_FIELD_ID = Integer.MAX_VALUE;
@@ -104,9 +104,12 @@ public class PkSortedIndexBuilder {
             sourceFiles.add(
                     new PrimaryKeyIndexSourceFile(dataFile.fileName(), dataFile.rowCount()));
         }
-        if (!GlobalIndexer.create(indexType, indexField, options).requiresSortedInput()) {
-            return buildWithoutSorting(dataLevel, orderedDataFiles, sourceFiles);
-        }
+        GlobalIndexer indexer = GlobalIndexer.create(indexType, indexField, options);
+        checkArgument(
+                indexer instanceof SortedGlobalIndexer,
+                "Index algorithm %s does not expose sorted index keys.",
+                indexType);
+        GlobalIndexKeyExtractor keyExtractor = ((SortedGlobalIndexer) indexer).keyExtractor();
 
         IOManager actualIOManager = ioManager;
         boolean ownsIOManager = false;
@@ -118,16 +121,18 @@ public class PkSortedIndexBuilder {
         BinaryExternalSortBuffer sortBuffer = null;
         try {
             CoreOptions coreOptions = new CoreOptions(options);
+            DataField keyField =
+                    new DataField(indexField.id(), indexField.name(), keyExtractor.keyType());
             RowType sortRowType =
                     RowType.of(
-                            indexField,
+                            keyField,
                             new DataField(
                                     ROW_ID_FIELD_ID, "_ROW_ID", DataTypes.BIGINT().notNull()));
             sortBuffer =
                     BinaryExternalSortBuffer.create(
                             actualIOManager,
                             sortRowType,
-                            new int[] {0},
+                            new int[] {0, 1},
                             coreOptions.writeBufferSize(),
                             coreOptions.pageSize(),
                             coreOptions.localSortMaxNumFileHandles(),
@@ -143,6 +148,7 @@ public class PkSortedIndexBuilder {
                             reader.rowCount(),
                             dataFile.fileName(),
                             dataFile.rowCount());
+                    long readRows = 0;
                     PkSortedDataFileReader.Entry entry;
                     while ((entry = reader.readNext()) != null) {
                         checkArgument(
@@ -152,11 +158,19 @@ public class PkSortedIndexBuilder {
                                 entry.rowPosition(),
                                 dataFile.fileName(),
                                 dataFile.rowCount());
-                        sortBuffer.write(
-                                GenericRow.of(
-                                        entry.value(),
-                                        Math.addExact(sourceOffset, entry.rowPosition())));
+                        long rowId = Math.addExact(sourceOffset, entry.rowPosition());
+                        BinaryExternalSortBuffer currentSortBuffer = sortBuffer;
+                        keyExtractor.extract(
+                                entry.value(),
+                                key -> currentSortBuffer.write(GenericRow.of(key, rowId)));
+                        readRows++;
                     }
+                    checkArgument(
+                            readRows == dataFile.rowCount(),
+                            "Sorted reader returned %s rows for data file %s, expected %s.",
+                            readRows,
+                            dataFile.fileName(),
+                            dataFile.rowCount());
                 }
                 sourceOffset = Math.addExact(sourceOffset, dataFile.rowCount());
             }
@@ -166,7 +180,7 @@ public class PkSortedIndexBuilder {
                             sortBuffer.sortedIterator(),
                             new BinaryRow(sortRowType.getFieldCount()));
             InternalRow.FieldGetter valueGetter =
-                    InternalRow.createFieldGetter(indexField.type(), 0);
+                    InternalRow.createFieldGetter(keyExtractor.keyType(), 0);
             Iterator<PkSortedIndexFile.Entry> sortedEntries =
                     new Iterator<PkSortedIndexFile.Entry>() {
                         @Override
@@ -193,18 +207,6 @@ public class PkSortedIndexBuilder {
         }
     }
 
-    private IndexFileMeta buildWithoutSorting(
-            int dataLevel,
-            List<DataFileMeta> dataFiles,
-            List<PrimaryKeyIndexSourceFile> sourceFiles)
-            throws IOException {
-        try (UnsortedEntryIterator entries = new UnsortedEntryIterator(readerFactory, dataFiles)) {
-            return indexFile.build(dataLevel, sourceFiles, indexField, indexType, options, entries);
-        } catch (UncheckedIOException e) {
-            throw e.getCause();
-        }
-    }
-
     protected IOManager createTemporaryIOManager() {
         return IOManager.create(System.getProperty("java.io.tmpdir"));
     }
@@ -222,95 +224,5 @@ public class PkSortedIndexBuilder {
     interface ReaderFactory {
 
         Reader create(DataFileMeta dataFile) throws IOException;
-    }
-
-    private static final class UnsortedEntryIterator
-            implements Iterator<PkSortedIndexFile.Entry>, Closeable {
-
-        private final ReaderFactory readerFactory;
-        private final List<DataFileMeta> dataFiles;
-
-        private int fileIndex;
-        private long sourceOffset;
-        @Nullable private Reader currentReader;
-        @Nullable private PkSortedIndexFile.Entry next;
-
-        private UnsortedEntryIterator(ReaderFactory readerFactory, List<DataFileMeta> dataFiles) {
-            this.readerFactory = readerFactory;
-            this.dataFiles = dataFiles;
-        }
-
-        @Override
-        public boolean hasNext() {
-            if (next == null) {
-                loadNext();
-            }
-            return next != null;
-        }
-
-        @Override
-        public PkSortedIndexFile.Entry next() {
-            if (!hasNext()) {
-                throw new NoSuchElementException();
-            }
-            PkSortedIndexFile.Entry result = next;
-            next = null;
-            return result;
-        }
-
-        private void loadNext() {
-            while (fileIndex < dataFiles.size()) {
-                DataFileMeta dataFile = dataFiles.get(fileIndex);
-                if (currentReader == null) {
-                    try {
-                        currentReader = readerFactory.create(dataFile);
-                    } catch (IOException e) {
-                        throw new UncheckedIOException(e);
-                    }
-                    checkArgument(
-                            currentReader.rowCount() == dataFile.rowCount(),
-                            "Sorted reader row count %s does not match data file %s row count %s.",
-                            currentReader.rowCount(),
-                            dataFile.fileName(),
-                            dataFile.rowCount());
-                }
-
-                PkSortedDataFileReader.Entry entry = currentReader.readNext();
-                if (entry != null) {
-                    checkArgument(
-                            entry.rowPosition() >= 0 && entry.rowPosition() < dataFile.rowCount(),
-                            "Row position %s is outside data file %s row range [0, %s).",
-                            entry.rowPosition(),
-                            dataFile.fileName(),
-                            dataFile.rowCount());
-                    next =
-                            new PkSortedIndexFile.Entry(
-                                    entry.value(),
-                                    Math.addExact(sourceOffset, entry.rowPosition()));
-                    return;
-                }
-
-                closeCurrentReader();
-                sourceOffset = Math.addExact(sourceOffset, dataFile.rowCount());
-                fileIndex++;
-            }
-        }
-
-        private void closeCurrentReader() {
-            try {
-                close();
-            } catch (IOException e) {
-                throw new UncheckedIOException(e);
-            }
-        }
-
-        @Override
-        public void close() throws IOException {
-            Reader reader = currentReader;
-            currentReader = null;
-            if (reader != null) {
-                reader.close();
-            }
-        }
     }
 }

--- a/paimon-core/src/main/java/org/apache/paimon/index/pksorted/PkSortedIndexBuilder.java
+++ b/paimon-core/src/main/java/org/apache/paimon/index/pksorted/PkSortedIndexBuilder.java
@@ -23,6 +23,7 @@ import org.apache.paimon.data.BinaryRow;
 import org.apache.paimon.data.GenericRow;
 import org.apache.paimon.data.InternalRow;
 import org.apache.paimon.disk.IOManager;
+import org.apache.paimon.globalindex.GlobalIndexer;
 import org.apache.paimon.index.IndexFileMeta;
 import org.apache.paimon.index.pk.PrimaryKeyIndexSourceFile;
 import org.apache.paimon.io.DataFileMeta;
@@ -38,14 +39,16 @@ import javax.annotation.Nullable;
 
 import java.io.Closeable;
 import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.Iterator;
 import java.util.List;
+import java.util.NoSuchElementException;
 
 import static org.apache.paimon.utils.Preconditions.checkArgument;
 
-/** Sorts physical data files and builds their source-backed scalar index payloads. */
+/** Builds source-backed index payloads, sorting physical records when required by the indexer. */
 public class PkSortedIndexBuilder {
 
     private static final int ROW_ID_FIELD_ID = Integer.MAX_VALUE;
@@ -96,6 +99,15 @@ public class PkSortedIndexBuilder {
                     dataFile.level());
         }
 
+        List<PrimaryKeyIndexSourceFile> sourceFiles = new ArrayList<>();
+        for (DataFileMeta dataFile : orderedDataFiles) {
+            sourceFiles.add(
+                    new PrimaryKeyIndexSourceFile(dataFile.fileName(), dataFile.rowCount()));
+        }
+        if (!GlobalIndexer.create(indexType, indexField, options).requiresSortedInput()) {
+            return buildWithoutSorting(dataLevel, orderedDataFiles, sourceFiles);
+        }
+
         IOManager actualIOManager = ioManager;
         boolean ownsIOManager = false;
         if (actualIOManager == null) {
@@ -122,11 +134,8 @@ public class PkSortedIndexBuilder {
                             coreOptions.spillCompressOptions(),
                             coreOptions.writeBufferSpillDiskSize());
 
-            List<PrimaryKeyIndexSourceFile> sourceFiles = new ArrayList<>();
             long sourceOffset = 0;
             for (DataFileMeta dataFile : orderedDataFiles) {
-                sourceFiles.add(
-                        new PrimaryKeyIndexSourceFile(dataFile.fileName(), dataFile.rowCount()));
                 try (Reader reader = readerFactory.create(dataFile)) {
                     checkArgument(
                             reader.rowCount() == dataFile.rowCount(),
@@ -184,11 +193,23 @@ public class PkSortedIndexBuilder {
         }
     }
 
+    private IndexFileMeta buildWithoutSorting(
+            int dataLevel,
+            List<DataFileMeta> dataFiles,
+            List<PrimaryKeyIndexSourceFile> sourceFiles)
+            throws IOException {
+        try (UnsortedEntryIterator entries = new UnsortedEntryIterator(readerFactory, dataFiles)) {
+            return indexFile.build(dataLevel, sourceFiles, indexField, indexType, options, entries);
+        } catch (UncheckedIOException e) {
+            throw e.getCause();
+        }
+    }
+
     protected IOManager createTemporaryIOManager() {
         return IOManager.create(System.getProperty("java.io.tmpdir"));
     }
 
-    /** Physical source reader used by the sorter. */
+    /** Physical source reader used by the index builder. */
     interface Reader extends Closeable {
 
         long rowCount();
@@ -201,5 +222,95 @@ public class PkSortedIndexBuilder {
     interface ReaderFactory {
 
         Reader create(DataFileMeta dataFile) throws IOException;
+    }
+
+    private static final class UnsortedEntryIterator
+            implements Iterator<PkSortedIndexFile.Entry>, Closeable {
+
+        private final ReaderFactory readerFactory;
+        private final List<DataFileMeta> dataFiles;
+
+        private int fileIndex;
+        private long sourceOffset;
+        @Nullable private Reader currentReader;
+        @Nullable private PkSortedIndexFile.Entry next;
+
+        private UnsortedEntryIterator(ReaderFactory readerFactory, List<DataFileMeta> dataFiles) {
+            this.readerFactory = readerFactory;
+            this.dataFiles = dataFiles;
+        }
+
+        @Override
+        public boolean hasNext() {
+            if (next == null) {
+                loadNext();
+            }
+            return next != null;
+        }
+
+        @Override
+        public PkSortedIndexFile.Entry next() {
+            if (!hasNext()) {
+                throw new NoSuchElementException();
+            }
+            PkSortedIndexFile.Entry result = next;
+            next = null;
+            return result;
+        }
+
+        private void loadNext() {
+            while (fileIndex < dataFiles.size()) {
+                DataFileMeta dataFile = dataFiles.get(fileIndex);
+                if (currentReader == null) {
+                    try {
+                        currentReader = readerFactory.create(dataFile);
+                    } catch (IOException e) {
+                        throw new UncheckedIOException(e);
+                    }
+                    checkArgument(
+                            currentReader.rowCount() == dataFile.rowCount(),
+                            "Sorted reader row count %s does not match data file %s row count %s.",
+                            currentReader.rowCount(),
+                            dataFile.fileName(),
+                            dataFile.rowCount());
+                }
+
+                PkSortedDataFileReader.Entry entry = currentReader.readNext();
+                if (entry != null) {
+                    checkArgument(
+                            entry.rowPosition() >= 0 && entry.rowPosition() < dataFile.rowCount(),
+                            "Row position %s is outside data file %s row range [0, %s).",
+                            entry.rowPosition(),
+                            dataFile.fileName(),
+                            dataFile.rowCount());
+                    next =
+                            new PkSortedIndexFile.Entry(
+                                    entry.value(),
+                                    Math.addExact(sourceOffset, entry.rowPosition()));
+                    return;
+                }
+
+                closeCurrentReader();
+                sourceOffset = Math.addExact(sourceOffset, dataFile.rowCount());
+                fileIndex++;
+            }
+        }
+
+        private void closeCurrentReader() {
+            try {
+                close();
+            } catch (IOException e) {
+                throw new UncheckedIOException(e);
+            }
+        }
+
+        @Override
+        public void close() throws IOException {
+            Reader reader = currentReader;
+            currentReader = null;
+            if (reader != null) {
+                reader.close();
+            }
+        }
     }
 }

--- a/paimon-core/src/main/java/org/apache/paimon/index/pksorted/PkSortedIndexFile.java
+++ b/paimon-core/src/main/java/org/apache/paimon/index/pksorted/PkSortedIndexFile.java
@@ -46,7 +46,7 @@ import java.util.Map;
 
 import static org.apache.paimon.utils.Preconditions.checkArgument;
 
-/** Builds source-backed BTree or Bitmap payloads for ordered physical data files. */
+/** Builds source-backed sorted-index payloads for ordered physical data files. */
 public class PkSortedIndexFile extends IndexFile {
 
     public PkSortedIndexFile(FileIO fileIO, IndexPathFactory pathFactory) {

--- a/paimon-core/src/main/java/org/apache/paimon/index/pksorted/PkSortedIndexFile.java
+++ b/paimon-core/src/main/java/org/apache/paimon/index/pksorted/PkSortedIndexFile.java
@@ -74,7 +74,6 @@ public class PkSortedIndexFile extends IndexFile {
         try {
             writer = createWriter(indexType, indexField, indexOptions, fileWriter);
 
-            long writtenRows = 0;
             while (sortedEntries.hasNext()) {
                 Entry entry = sortedEntries.next();
                 checkArgument(
@@ -83,15 +82,9 @@ public class PkSortedIndexFile extends IndexFile {
                         entry.rowId,
                         sourceRowCount);
                 writer.write(entry.value, entry.rowId);
-                writtenRows++;
             }
-            checkArgument(
-                    writtenRows == sourceRowCount,
-                    "Sorted index input row count %s does not match source row count %s.",
-                    writtenRows,
-                    sourceRowCount);
 
-            List<ResultEntry> results = writer.finish();
+            List<ResultEntry> results = writer.finish(sourceRowCount);
             checkArgument(
                     results.size() == 1,
                     "Sorted index build must produce exactly one payload file, but produced %s.",
@@ -145,7 +138,7 @@ public class PkSortedIndexFile extends IndexFile {
         return (GlobalIndexSingleColumnWriter) writer;
     }
 
-    /** One sorted scalar value and its zero-based ordinal in the ordered source group. */
+    /** One sorted normalized key and its zero-based source-row ordinal. */
     public static final class Entry {
 
         @Nullable private final Object value;

--- a/paimon-core/src/main/java/org/apache/paimon/schema/SchemaManager.java
+++ b/paimon-core/src/main/java/org/apache/paimon/schema/SchemaManager.java
@@ -1015,6 +1015,7 @@ public class SchemaManager implements Serializable {
         if (options.primaryKeyVectorIndexColumns().contains(fieldName)
                 || options.primaryKeyBTreeIndexColumns().contains(fieldName)
                 || options.primaryKeyBitmapIndexColumns().contains(fieldName)
+                || options.primaryKeyMultiValueIndexColumns().contains(fieldName)
                 || options.primaryKeyFullTextIndexColumns().contains(fieldName)) {
             throw new UnsupportedOperationException(
                     String.format(

--- a/paimon-core/src/main/java/org/apache/paimon/schema/SchemaManager.java
+++ b/paimon-core/src/main/java/org/apache/paimon/schema/SchemaManager.java
@@ -1007,15 +1007,23 @@ public class SchemaManager implements Serializable {
 
     private static void assertNotUpdatingPrimaryKeyIndexColumn(
             TableSchema schema, String[] fieldNames, String operation) {
+        String fieldName = fieldNames[0];
+        CoreOptions options = new CoreOptions(schema.options());
+
+        // Updating an ARRAY element is represented as a nested field change. It still changes
+        // the serialized key type of a multivalue index on the top-level column.
+        if (options.primaryKeyMultiValueIndexColumns().contains(fieldName)) {
+            throw new UnsupportedOperationException(
+                    String.format(
+                            "Cannot %s primary-key index column: [%s]", operation, fieldName));
+        }
+
         if (fieldNames.length > 1) {
             return;
         }
-        String fieldName = fieldNames[0];
-        CoreOptions options = new CoreOptions(schema.options());
         if (options.primaryKeyVectorIndexColumns().contains(fieldName)
                 || options.primaryKeyBTreeIndexColumns().contains(fieldName)
                 || options.primaryKeyBitmapIndexColumns().contains(fieldName)
-                || options.primaryKeyMultiValueIndexColumns().contains(fieldName)
                 || options.primaryKeyFullTextIndexColumns().contains(fieldName)) {
             throw new UnsupportedOperationException(
                     String.format(

--- a/paimon-core/src/main/java/org/apache/paimon/schema/SchemaManager.java
+++ b/paimon-core/src/main/java/org/apache/paimon/schema/SchemaManager.java
@@ -1007,23 +1007,15 @@ public class SchemaManager implements Serializable {
 
     private static void assertNotUpdatingPrimaryKeyIndexColumn(
             TableSchema schema, String[] fieldNames, String operation) {
-        String fieldName = fieldNames[0];
-        CoreOptions options = new CoreOptions(schema.options());
-
-        // Updating an ARRAY element is represented as a nested field change. It still changes
-        // the serialized key type of a multivalue index on the top-level column.
-        if (options.primaryKeyMultiValueIndexColumns().contains(fieldName)) {
-            throw new UnsupportedOperationException(
-                    String.format(
-                            "Cannot %s primary-key index column: [%s]", operation, fieldName));
-        }
-
         if (fieldNames.length > 1) {
             return;
         }
+        String fieldName = fieldNames[0];
+        CoreOptions options = new CoreOptions(schema.options());
         if (options.primaryKeyVectorIndexColumns().contains(fieldName)
                 || options.primaryKeyBTreeIndexColumns().contains(fieldName)
                 || options.primaryKeyBitmapIndexColumns().contains(fieldName)
+                || options.primaryKeyMultiValueIndexColumns().contains(fieldName)
                 || options.primaryKeyFullTextIndexColumns().contains(fieldName)) {
             throw new UnsupportedOperationException(
                     String.format(

--- a/paimon-core/src/main/java/org/apache/paimon/schema/SchemaValidation.java
+++ b/paimon-core/src/main/java/org/apache/paimon/schema/SchemaValidation.java
@@ -31,6 +31,7 @@ import org.apache.paimon.fileindex.FileIndexerFactoryUtils;
 import org.apache.paimon.format.FileFormat;
 import org.apache.paimon.globalindex.GlobalIndexer;
 import org.apache.paimon.globalindex.bitmap.BitmapGlobalIndexerFactory;
+import org.apache.paimon.globalindex.bitmap.MultiValueGlobalIndexerFactory;
 import org.apache.paimon.globalindex.btree.BTreeGlobalIndexerFactory;
 import org.apache.paimon.iceberg.IcebergOptions;
 import org.apache.paimon.mergetree.compact.aggregate.FieldAggregator;
@@ -1217,6 +1218,7 @@ public class SchemaValidation {
         List<String> vectorColumns = options.primaryKeyVectorIndexColumns();
         List<String> btreeColumns = options.primaryKeyBTreeIndexColumns();
         List<String> bitmapColumns = options.primaryKeyBitmapIndexColumns();
+        List<String> multiValueColumns = options.primaryKeyMultiValueIndexColumns();
         List<String> fullTextColumns = options.primaryKeyFullTextIndexColumns();
         validateNoDuplicatePrimaryKeyIndexColumns(
                 vectorColumns, CoreOptions.PK_VECTOR_INDEX_COLUMNS.key());
@@ -1225,12 +1227,15 @@ public class SchemaValidation {
         validateNoDuplicatePrimaryKeyIndexColumns(
                 bitmapColumns, CoreOptions.PK_BITMAP_INDEX_COLUMNS.key());
         validateNoDuplicatePrimaryKeyIndexColumns(
+                multiValueColumns, CoreOptions.PK_MULTIVALUE_INDEX_COLUMNS.key());
+        validateNoDuplicatePrimaryKeyIndexColumns(
                 fullTextColumns, CoreOptions.PK_FULL_TEXT_INDEX_COLUMNS.key());
 
         Set<String> indexedColumns = new HashSet<>();
         validateUniquePrimaryKeyIndexColumns(indexedColumns, vectorColumns);
         validateUniquePrimaryKeyIndexColumns(indexedColumns, btreeColumns);
         validateUniquePrimaryKeyIndexColumns(indexedColumns, bitmapColumns);
+        validateUniquePrimaryKeyIndexColumns(indexedColumns, multiValueColumns);
         validateUniquePrimaryKeyIndexColumns(indexedColumns, fullTextColumns);
     }
 
@@ -1255,27 +1260,28 @@ public class SchemaValidation {
 
     private static void validatePrimaryKeySortedIndexes(TableSchema schema, CoreOptions options) {
         if (options.primaryKeyBTreeIndexColumns().isEmpty()
-                && options.primaryKeyBitmapIndexColumns().isEmpty()) {
+                && options.primaryKeyBitmapIndexColumns().isEmpty()
+                && options.primaryKeyMultiValueIndexColumns().isEmpty()) {
             return;
         }
 
         checkArgument(
                 options.deletionVectorsEnabled(),
-                "Primary-key BTree and Bitmap indexes require deletion-vectors.enabled = true.");
+                "Primary-key BTree, Bitmap, and Multivalue indexes require deletion-vectors.enabled = true.");
         checkArgument(
                 !schema.primaryKeys().isEmpty(),
-                "Primary-key BTree and Bitmap indexes require a primary-key table.");
+                "Primary-key BTree, Bitmap, and Multivalue indexes require a primary-key table.");
         checkArgument(
                 options.bucket() > 0 || options.bucket() == BucketMode.POSTPONE_BUCKET,
-                "Primary-key BTree and Bitmap indexes require fixed or postpone bucket mode "
+                "Primary-key BTree, Bitmap, and Multivalue indexes require fixed or postpone bucket mode "
                         + "(bucket > 0 or bucket = -2), but bucket is %s.",
                 options.bucket());
         checkArgument(
                 !options.deletionVectorsMergeOnRead(),
-                "Primary-key BTree and Bitmap indexes require deletion-vectors.merge-on-read = false.");
+                "Primary-key BTree, Bitmap, and Multivalue indexes require deletion-vectors.merge-on-read = false.");
         checkArgument(
                 !options.pkClusteringOverride(),
-                "Primary-key BTree and Bitmap indexes do not support pk-clustering-override.");
+                "Primary-key BTree, Bitmap, and Multivalue indexes do not support pk-clustering-override.");
 
         validatePrimaryKeySortedIndexColumns(
                 schema,
@@ -1285,6 +1291,10 @@ public class SchemaValidation {
                 schema,
                 options.primaryKeyBitmapIndexColumns(),
                 CoreOptions.PK_BITMAP_INDEX_COLUMNS.key());
+        validatePrimaryKeySortedIndexColumns(
+                schema,
+                options.primaryKeyMultiValueIndexColumns(),
+                CoreOptions.PK_MULTIVALUE_INDEX_COLUMNS.key());
 
         Map<String, DataField> fields = schema.nameToFieldMap();
         for (String column : options.primaryKeyBTreeIndexColumns()) {
@@ -1298,6 +1308,12 @@ public class SchemaValidation {
                     BitmapGlobalIndexerFactory.IDENTIFIER,
                     fields.get(column),
                     options.primaryKeyBitmapIndexOptions(column));
+        }
+        for (String column : options.primaryKeyMultiValueIndexColumns()) {
+            GlobalIndexer.create(
+                    MultiValueGlobalIndexerFactory.IDENTIFIER,
+                    fields.get(column),
+                    options.primaryKeyMultiValueIndexOptions(column));
         }
     }
 

--- a/paimon-core/src/main/java/org/apache/paimon/table/source/PrimaryKeyBatchScan.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/source/PrimaryKeyBatchScan.java
@@ -71,7 +71,8 @@ public class PrimaryKeyBatchScan extends AbstractBatchTableScan {
         for (PrimaryKeyIndexDefinition definition :
                 PrimaryKeyIndexDefinitions.create(table.schema()).definitions()) {
             if (definition.family() == PrimaryKeyIndexDefinition.Family.BTREE
-                    || definition.family() == PrimaryKeyIndexDefinition.Family.BITMAP) {
+                    || definition.family() == PrimaryKeyIndexDefinition.Family.BITMAP
+                    || definition.family() == PrimaryKeyIndexDefinition.Family.MULTI_VALUE) {
                 definitions.add(definition);
                 definitionFieldIds.add(definition.fieldId());
             }

--- a/paimon-core/src/main/java/org/apache/paimon/table/source/PrimaryKeySortedIndexScan.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/source/PrimaryKeySortedIndexScan.java
@@ -74,7 +74,7 @@ import static org.apache.paimon.CoreOptions.GLOBAL_INDEX_THREAD_NUM;
 import static org.apache.paimon.utils.Preconditions.checkArgument;
 import static org.apache.paimon.utils.Preconditions.checkNotNull;
 
-/** Plans source-backed scalar index groups in file-local row-position space. */
+/** Plans source-backed sorted-index groups in file-local row-position space. */
 public final class PrimaryKeySortedIndexScan {
 
     private static final Logger LOG = LoggerFactory.getLogger(PrimaryKeySortedIndexScan.class);
@@ -138,7 +138,8 @@ public final class PrimaryKeySortedIndexScan {
         List<PrimaryKeyIndexDefinition> scalarDefinitions = new ArrayList<>();
         for (PrimaryKeyIndexDefinition definition : definitions) {
             if (definition.family() == PrimaryKeyIndexDefinition.Family.BTREE
-                    || definition.family() == PrimaryKeyIndexDefinition.Family.BITMAP) {
+                    || definition.family() == PrimaryKeyIndexDefinition.Family.BITMAP
+                    || definition.family() == PrimaryKeyIndexDefinition.Family.MULTI_VALUE) {
                 scalarDefinitions.add(definition);
             }
         }
@@ -242,7 +243,8 @@ public final class PrimaryKeySortedIndexScan {
         Map<Integer, PrimaryKeyIndexDefinition> definitionsByField = new LinkedHashMap<>();
         for (PrimaryKeyIndexDefinition definition : definitions) {
             if (definition.family() == PrimaryKeyIndexDefinition.Family.BTREE
-                    || definition.family() == PrimaryKeyIndexDefinition.Family.BITMAP) {
+                    || definition.family() == PrimaryKeyIndexDefinition.Family.BITMAP
+                    || definition.family() == PrimaryKeyIndexDefinition.Family.MULTI_VALUE) {
                 definitionsByField.put(definition.fieldId(), definition);
             }
         }
@@ -448,6 +450,14 @@ public final class PrimaryKeySortedIndexScan {
         }
 
         @Override
+        public CompletableFuture<Optional<GlobalIndexResult>> visitArrayContains(
+                FieldRef fieldRef, Object literal) {
+            return query(
+                    QueryKey.of(QueryOperation.ARRAY_CONTAINS, fieldRef, literal),
+                    () -> reader().visitArrayContains(fieldRef, literal));
+        }
+
+        @Override
         public CompletableFuture<Optional<GlobalIndexResult>> visitLike(
                 FieldRef fieldRef, Object literal) {
             return query(
@@ -628,6 +638,7 @@ public final class PrimaryKeySortedIndexScan {
         STARTS_WITH,
         ENDS_WITH,
         CONTAINS,
+        ARRAY_CONTAINS,
         LIKE,
         LESS_THAN,
         GREATER_OR_EQUAL,
@@ -720,6 +731,12 @@ public final class PrimaryKeySortedIndexScan {
         public CompletableFuture<Optional<GlobalIndexResult>> visitContains(
                 FieldRef fieldRef, Object literal) {
             return localize(wrapped.visitContains(fieldRef, literal));
+        }
+
+        @Override
+        public CompletableFuture<Optional<GlobalIndexResult>> visitArrayContains(
+                FieldRef fieldRef, Object literal) {
+            return localize(wrapped.visitArrayContains(fieldRef, literal));
         }
 
         @Override

--- a/paimon-core/src/test/java/org/apache/paimon/globalindex/GlobalIndexBuilderUtilsTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/globalindex/GlobalIndexBuilderUtilsTest.java
@@ -49,6 +49,7 @@ import org.junit.jupiter.api.io.TempDir;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
@@ -277,6 +278,28 @@ class GlobalIndexBuilderUtilsTest {
         assertThat(ranges).containsOnlyKeys(new Range(4750, 4900), new Range(5938, 7599));
         assertIndexedSplitRowRanges(ranges.get(new Range(4750, 4900)), new Range(4750, 4900));
         assertIndexedSplitRowRanges(ranges.get(new Range(5938, 7599)), new Range(5938, 7599));
+    }
+
+    @Test
+    void testShardSplitsUsesStableGlobalRowIdWindows() {
+        DataSplit split =
+                DataSplit.builder()
+                        .withPartition(BinaryRow.EMPTY_ROW)
+                        .withBucket(0)
+                        .withBucketPath("bucket-0")
+                        .withDataFiles(Collections.singletonList(createDataFileMeta(5L, 10L)))
+                        .rawConvertible(false)
+                        .build();
+        Map<Range, List<Split>> input = new LinkedHashMap<>();
+        input.put(new Range(5, 14), Collections.singletonList(split));
+
+        Map<Range, List<Split>> shards = GlobalIndexBuilderUtils.shardSplitsByRowRange(input, 6);
+
+        assertThat(shards.keySet())
+                .containsExactly(new Range(5, 5), new Range(6, 11), new Range(12, 14));
+        for (Map.Entry<Range, List<Split>> shard : shards.entrySet()) {
+            assertIndexedSplitRowRanges(shard.getValue(), shard.getKey());
+        }
     }
 
     private List<ResultEntry> createDummyResultEntries() throws IOException {

--- a/paimon-core/src/test/java/org/apache/paimon/globalindex/sorted/SortedGlobalIndexScannerTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/globalindex/sorted/SortedGlobalIndexScannerTest.java
@@ -191,12 +191,11 @@ public class SortedGlobalIndexScannerTest extends TableTestBase {
         assertThat(entries).isNotEmpty();
         assertThat(entries)
                 .allSatisfy(
-                        entry ->
-                                assertThat(
-                                                DataEvolutionIndexSourceMeta.fromIndexFile(
-                                                                entry.indexFile())
-                                                        .scanSnapshotId())
-                                        .isEqualTo(scanSnapshotId));
+                        entry -> {
+                            DataEvolutionIndexSourceMeta sourceMeta =
+                                    DataEvolutionIndexSourceMeta.fromIndexFile(entry.indexFile());
+                            assertThat(sourceMeta.scanSnapshotId()).isEqualTo(scanSnapshotId);
+                        });
     }
 
     @Test

--- a/paimon-core/src/test/java/org/apache/paimon/globalindex/sorted/SortedGlobalIndexTestUtils.java
+++ b/paimon-core/src/test/java/org/apache/paimon/globalindex/sorted/SortedGlobalIndexTestUtils.java
@@ -21,6 +21,7 @@ package org.apache.paimon.globalindex.sorted;
 import org.apache.paimon.data.GenericRow;
 import org.apache.paimon.data.InternalRow;
 import org.apache.paimon.globalindex.KeySerializer;
+import org.apache.paimon.globalindex.bitmap.MultiValueGlobalIndexerFactory;
 import org.apache.paimon.reader.RecordReader;
 import org.apache.paimon.table.FileStoreTable;
 import org.apache.paimon.table.SpecialFields;
@@ -74,16 +75,21 @@ public final class SortedGlobalIndexTestUtils {
             }
         }
 
-        Comparator<Object> comparator = KeySerializer.create(indexField.type()).createComparator();
-        rows.sort(
-                (left, right) -> {
-                    if (left.getKey() == null) {
-                        return right.getKey() == null ? 0 : -1;
-                    }
-                    return right.getKey() == null
-                            ? 1
-                            : comparator.compare(left.getKey(), right.getKey());
-                });
+        if (MultiValueGlobalIndexerFactory.IDENTIFIER.equals(indexType)) {
+            rows.sort(Comparator.comparingLong(row -> row.getValue()));
+        } else {
+            Comparator<Object> comparator =
+                    KeySerializer.create(indexField.type()).createComparator();
+            rows.sort(
+                    (left, right) -> {
+                        if (left.getKey() == null) {
+                            return right.getKey() == null ? 0 : -1;
+                        }
+                        return right.getKey() == null
+                                ? 1
+                                : comparator.compare(left.getKey(), right.getKey());
+                    });
+        }
 
         List<InternalRow> sortedRows = new ArrayList<>(rows.size());
         for (Pair<Object, Long> row : rows) {

--- a/paimon-core/src/test/java/org/apache/paimon/globalindex/sorted/SortedGlobalIndexTestUtils.java
+++ b/paimon-core/src/test/java/org/apache/paimon/globalindex/sorted/SortedGlobalIndexTestUtils.java
@@ -20,8 +20,8 @@ package org.apache.paimon.globalindex.sorted;
 
 import org.apache.paimon.data.GenericRow;
 import org.apache.paimon.data.InternalRow;
+import org.apache.paimon.globalindex.GlobalIndexKeyExtractor;
 import org.apache.paimon.globalindex.KeySerializer;
-import org.apache.paimon.globalindex.bitmap.MultiValueGlobalIndexerFactory;
 import org.apache.paimon.reader.RecordReader;
 import org.apache.paimon.table.FileStoreTable;
 import org.apache.paimon.table.SpecialFields;
@@ -61,6 +61,7 @@ public final class SortedGlobalIndexTestUtils {
                 SpecialFields.rowTypeWithRowId(table.rowType())
                         .project(Arrays.asList(indexFieldName, SpecialFields.ROW_ID.name()));
         InternalRow.FieldGetter fieldGetter = InternalRow.createFieldGetter(indexField.type(), 0);
+        GlobalIndexKeyExtractor keyExtractor = writer.keyExtractor();
         List<Pair<Object, Long>> rows = new ArrayList<>();
         try (RecordReader<InternalRow> reader =
                         table.newReadBuilder()
@@ -71,25 +72,34 @@ public final class SortedGlobalIndexTestUtils {
             while (iterator.hasNext()) {
                 InternalRow row = iterator.next();
                 Object value = fieldGetter.getFieldOrNull(row);
-                rows.add(Pair.of(InternalRowUtils.copy(value, indexField.type()), row.getLong(1)));
+                long rowId = row.getLong(1);
+                keyExtractor.extract(
+                        value,
+                        key ->
+                                rows.add(
+                                        Pair.of(
+                                                InternalRowUtils.copy(key, keyExtractor.keyType()),
+                                                rowId)));
             }
         }
 
-        if (MultiValueGlobalIndexerFactory.IDENTIFIER.equals(indexType)) {
-            rows.sort(Comparator.comparingLong(row -> row.getValue()));
-        } else {
-            Comparator<Object> comparator =
-                    KeySerializer.create(indexField.type()).createComparator();
-            rows.sort(
-                    (left, right) -> {
-                        if (left.getKey() == null) {
-                            return right.getKey() == null ? 0 : -1;
-                        }
+        Comparator<Object> comparator =
+                KeySerializer.create(keyExtractor.keyType()).createComparator();
+        rows.sort(
+                (left, right) -> {
+                    if (left.getKey() == null) {
                         return right.getKey() == null
-                                ? 1
-                                : comparator.compare(left.getKey(), right.getKey());
-                    });
-        }
+                                ? Long.compare(left.getValue(), right.getValue())
+                                : -1;
+                    }
+                    int comparison =
+                            right.getKey() == null
+                                    ? 1
+                                    : comparator.compare(left.getKey(), right.getKey());
+                    return comparison == 0
+                            ? Long.compare(left.getValue(), right.getValue())
+                            : comparison;
+                });
 
         List<InternalRow> sortedRows = new ArrayList<>(rows.size());
         for (Pair<Object, Long> row : rows) {

--- a/paimon-core/src/test/java/org/apache/paimon/globalindex/sorted/SortedGlobalIndexWriterTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/globalindex/sorted/SortedGlobalIndexWriterTest.java
@@ -49,9 +49,9 @@ public class SortedGlobalIndexWriterTest extends TableTestBase {
     public void testSingleColumnWriterRotationPreservesResultGroups() throws Exception {
         GlobalIndexSingleColumnWriter first = mock(GlobalIndexSingleColumnWriter.class);
         GlobalIndexSingleColumnWriter second = mock(GlobalIndexSingleColumnWriter.class);
-        when(first.finish())
+        when(first.finish(2))
                 .thenReturn(Collections.singletonList(new ResultEntry("index-1", 2, null)));
-        when(second.finish())
+        when(second.finish(1))
                 .thenReturn(Collections.singletonList(new ResultEntry("index-2", 1, null)));
         Queue<GlobalIndexSingleColumnWriter> writers =
                 new ArrayDeque<>(Arrays.asList(first, second));
@@ -69,6 +69,38 @@ public class SortedGlobalIndexWriterTest extends TableTestBase {
         assertThat(results).hasSize(2);
         assertThat(results.get(0)).extracting(ResultEntry::fileName).containsExactly("index-1");
         assertThat(results.get(1)).extracting(ResultEntry::fileName).containsExactly("index-2");
+    }
+
+    @Test
+    public void testSingleColumnWriterPreservesSourceRowCount() throws Exception {
+        GlobalIndexSingleColumnWriter writer = mock(GlobalIndexSingleColumnWriter.class);
+        when(writer.finish(5))
+                .thenReturn(Collections.singletonList(new ResultEntry("index", 5, null)));
+        SortedSingleColumnIndexWriter taskWriter =
+                SortedSingleColumnIndexWriter.forSourceRowCount(5, writer);
+
+        taskWriter.write(10, 0);
+        taskWriter.write(20, 0);
+        List<List<ResultEntry>> results = taskWriter.finish();
+
+        verify(writer).finish(5);
+        assertThat(results).hasSize(1);
+        assertThat(results.get(0)).extracting(ResultEntry::rowCount).containsExactly(5L);
+    }
+
+    @Test
+    public void testSingleColumnWriterPreservesSourceRangeWithoutEntries() {
+        GlobalIndexSingleColumnWriter writer = mock(GlobalIndexSingleColumnWriter.class);
+        when(writer.finish(3))
+                .thenReturn(Collections.singletonList(new ResultEntry("index", 3, null)));
+        SortedSingleColumnIndexWriter taskWriter =
+                SortedSingleColumnIndexWriter.forSourceRowCount(3, writer);
+
+        List<List<ResultEntry>> results = taskWriter.finish();
+
+        verify(writer).finish(3);
+        assertThat(results).hasSize(1);
+        assertThat(results.get(0)).extracting(ResultEntry::rowCount).containsExactly(3L);
     }
 
     @Test

--- a/paimon-core/src/test/java/org/apache/paimon/index/pk/PrimaryKeyIndexDefinitionsTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/index/pk/PrimaryKeyIndexDefinitionsTest.java
@@ -44,25 +44,27 @@ class PrimaryKeyIndexDefinitionsTest {
         options.put("fields.embedding.pk-vector.index.type", "ivf-pq");
         options.put(CoreOptions.PK_BTREE_INDEX_COLUMNS.key(), "name");
         options.put(CoreOptions.PK_BITMAP_INDEX_COLUMNS.key(), "status");
+        options.put(CoreOptions.PK_MULTIVALUE_INDEX_COLUMNS.key(), "tags");
 
         List<PrimaryKeyIndexDefinition> definitions =
                 PrimaryKeyIndexDefinitions.create(schema(options)).definitions();
 
         assertThat(definitions)
                 .extracting(PrimaryKeyIndexDefinition::column)
-                .containsExactly("name", "status", "embedding");
+                .containsExactly("name", "status", "embedding", "tags");
         assertThat(definitions)
                 .extracting(PrimaryKeyIndexDefinition::family)
                 .containsExactly(
                         PrimaryKeyIndexDefinition.Family.BTREE,
                         PrimaryKeyIndexDefinition.Family.BITMAP,
-                        PrimaryKeyIndexDefinition.Family.VECTOR);
+                        PrimaryKeyIndexDefinition.Family.VECTOR,
+                        PrimaryKeyIndexDefinition.Family.MULTI_VALUE);
         assertThat(definitions)
                 .extracting(PrimaryKeyIndexDefinition::fieldId)
-                .containsExactly(1, 2, 3);
+                .containsExactly(1, 2, 3, 4);
         assertThat(definitions)
                 .extracting(PrimaryKeyIndexDefinition::indexType)
-                .containsExactly("btree", "bitmap", "ivf-pq");
+                .containsExactly("btree", "bitmap", "ivf-pq", "multivalue");
     }
 
     @Test
@@ -126,7 +128,8 @@ class PrimaryKeyIndexDefinitionsTest {
                         new DataField(0, "id", DataTypes.INT().notNull()),
                         new DataField(1, "name", DataTypes.STRING()),
                         new DataField(2, "status", DataTypes.INT()),
-                        new DataField(3, "embedding", DataTypes.VECTOR(3, DataTypes.FLOAT()))),
+                        new DataField(3, "embedding", DataTypes.VECTOR(3, DataTypes.FLOAT())),
+                        new DataField(4, "tags", DataTypes.ARRAY(DataTypes.STRING()))),
                 3,
                 Collections.emptyList(),
                 Collections.singletonList("id"),

--- a/paimon-core/src/test/java/org/apache/paimon/index/pksorted/PkSortedIndexBuilderTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/index/pksorted/PkSortedIndexBuilderTest.java
@@ -19,6 +19,7 @@
 package org.apache.paimon.index.pksorted;
 
 import org.apache.paimon.CoreOptions;
+import org.apache.paimon.data.GenericArray;
 import org.apache.paimon.disk.BufferFileWriter;
 import org.apache.paimon.disk.FileIOChannel;
 import org.apache.paimon.disk.IOManager;
@@ -108,6 +109,117 @@ class PkSortedIndexBuilderTest {
             assertThat(PrimaryKeyIndexSourceMeta.fromIndexFile(payload).dataLevel())
                     .isEqualTo(source.level());
         }
+    }
+
+    @Test
+    void testBuildsQueryableMultiValueFromUnsortedArrayRows() throws Exception {
+        DataField tags = new DataField(8, "tags", DataTypes.ARRAY(DataTypes.INT()));
+        List<PkSortedDataFileReader.Entry> entries =
+                Arrays.asList(
+                        entry(new GenericArray(new Integer[] {2, 1}), 0),
+                        entry(null, 1),
+                        entry(new GenericArray(new Integer[0]), 2),
+                        entry(new GenericArray(new Integer[] {3, 2}), 3));
+        DataFileMeta source = dataFile("data-file", entries.size());
+        LocalFileIO fileIO = LocalFileIO.create();
+        IndexPathFactory pathFactory = pathFactory(tempPath);
+        Options options = options();
+        IndexFileMeta payload =
+                new PkSortedIndexBuilder(
+                        ignored -> new ArrayReader(entries),
+                        new PkSortedIndexFile(fileIO, pathFactory),
+                        tags,
+                        "multivalue",
+                        options,
+                        null) {
+                    @Override
+                    protected IOManager createTemporaryIOManager() {
+                        throw new AssertionError(
+                                "Unordered index input must not create a sort buffer.");
+                    }
+                }.build(Collections.singletonList(source));
+
+        List<GlobalIndexIOMeta> ioMetas =
+                Collections.singletonList(
+                        new GlobalIndexIOMeta(
+                                pathFactory.toPath(payload.fileName()),
+                                payload.fileSize(),
+                                payload.globalIndexMeta().indexMeta()));
+        ExecutorService executor = newDirectExecutorService();
+        try (GlobalIndexReader reader =
+                GlobalIndexer.create("multivalue", tags, options)
+                        .createReader(
+                                new GlobalIndexFileReadWrite(fileIO, pathFactory),
+                                ioMetas,
+                                payload.rowCount(),
+                                executor)) {
+            FieldRef fieldRef = new FieldRef(8, "tags", tags.type());
+            assertThat(reader.visitArrayContains(fieldRef, 2).join().get().results())
+                    .containsExactlyInAnyOrder(0L, 3L);
+            assertThat(reader.visitArrayContains(fieldRef, 4).join().get().results()).isEmpty();
+        } finally {
+            executor.shutdownNow();
+        }
+    }
+
+    @Test
+    void testStreamsUnsortedInputInSourceOrdinalOrder() throws Exception {
+        DataField tags = new DataField(8, "tags", DataTypes.ARRAY(DataTypes.INT()));
+        DataFileMeta sourceB = dataFile("data-b", 2);
+        DataFileMeta sourceA = dataFile("data-a", 2);
+        List<PrimaryKeyIndexSourceFile> capturedSources = new ArrayList<>();
+        List<PkSortedIndexFile.Entry> capturedEntries = new ArrayList<>();
+        List<ArrayReader> openedReaders = new ArrayList<>();
+        List<PkSortedDataFileReader.Entry> entriesA =
+                Arrays.asList(
+                        entry(new GenericArray(new Integer[] {3}), 0),
+                        entry(new GenericArray(new Integer[] {1}), 1));
+        List<PkSortedDataFileReader.Entry> entriesB =
+                Arrays.asList(
+                        entry(new GenericArray(new Integer[] {4}), 0),
+                        entry(new GenericArray(new Integer[] {2}), 1));
+        PkSortedIndexFile capturingFile =
+                new PkSortedIndexFile(LocalFileIO.create(), pathFactory(tempPath)) {
+                    @Override
+                    public IndexFileMeta build(
+                            int dataLevel,
+                            List<PrimaryKeyIndexSourceFile> sourceFiles,
+                            DataField indexField,
+                            String indexType,
+                            Options indexOptions,
+                            Iterator<Entry> entries) {
+                        capturedSources.addAll(sourceFiles);
+                        entries.forEachRemaining(capturedEntries::add);
+                        return ignoredPayload();
+                    }
+                };
+
+        new PkSortedIndexBuilder(
+                dataFile -> {
+                    ArrayReader reader =
+                            new ArrayReader(
+                                    dataFile.fileName().equals("data-a") ? entriesA : entriesB);
+                    openedReaders.add(reader);
+                    return reader;
+                },
+                capturingFile,
+                tags,
+                "multivalue",
+                options(),
+                null) {
+            @Override
+            protected IOManager createTemporaryIOManager() {
+                throw new AssertionError("Unordered index input must not create a sort buffer.");
+            }
+        }.build(Arrays.asList(sourceB, sourceA));
+
+        assertThat(capturedSources)
+                .extracting(PrimaryKeyIndexSourceFile::fileName)
+                .containsExactly("data-a", "data-b");
+        assertThat(capturedEntries)
+                .extracting(PkSortedIndexFile.Entry::rowId)
+                .containsExactly(0L, 1L, 2L, 3L);
+        assertThat(openedReaders).allMatch(ArrayReader::isClosed);
     }
 
     @Test
@@ -310,6 +422,7 @@ class PkSortedIndexBuilderTest {
 
         private final List<PkSortedDataFileReader.Entry> entries;
         private int position;
+        private boolean closed;
 
         private ArrayReader(List<PkSortedDataFileReader.Entry> entries) {
             this.entries = entries;
@@ -326,7 +439,13 @@ class PkSortedIndexBuilderTest {
         }
 
         @Override
-        public void close() {}
+        public void close() {
+            closed = true;
+        }
+
+        private boolean isClosed() {
+            return closed;
+        }
     }
 
     private static final class TrackingIOManager extends IOManagerImpl {

--- a/paimon-core/src/test/java/org/apache/paimon/index/pksorted/PkSortedIndexBuilderTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/index/pksorted/PkSortedIndexBuilderTest.java
@@ -126,18 +126,13 @@ class PkSortedIndexBuilderTest {
         Options options = options();
         IndexFileMeta payload =
                 new PkSortedIndexBuilder(
-                        ignored -> new ArrayReader(entries),
-                        new PkSortedIndexFile(fileIO, pathFactory),
-                        tags,
-                        "multivalue",
-                        options,
-                        null) {
-                    @Override
-                    protected IOManager createTemporaryIOManager() {
-                        throw new AssertionError(
-                                "Unordered index input must not create a sort buffer.");
-                    }
-                }.build(Collections.singletonList(source));
+                                ignored -> new ArrayReader(entries),
+                                new PkSortedIndexFile(fileIO, pathFactory),
+                                tags,
+                                "multivalue",
+                                options,
+                                null)
+                        .build(Collections.singletonList(source));
 
         List<GlobalIndexIOMeta> ioMetas =
                 Collections.singletonList(
@@ -163,7 +158,7 @@ class PkSortedIndexBuilderTest {
     }
 
     @Test
-    void testStreamsUnsortedInputInSourceOrdinalOrder() throws Exception {
+    void testExpandsAndSortsMultivalueInputInSourceOrdinalOrder() throws Exception {
         DataField tags = new DataField(8, "tags", DataTypes.ARRAY(DataTypes.INT()));
         DataFileMeta sourceB = dataFile("data-b", 2);
         DataFileMeta sourceA = dataFile("data-a", 2);
@@ -195,31 +190,76 @@ class PkSortedIndexBuilderTest {
                 };
 
         new PkSortedIndexBuilder(
-                dataFile -> {
-                    ArrayReader reader =
-                            new ArrayReader(
-                                    dataFile.fileName().equals("data-a") ? entriesA : entriesB);
-                    openedReaders.add(reader);
-                    return reader;
-                },
-                capturingFile,
-                tags,
-                "multivalue",
-                options(),
-                null) {
-            @Override
-            protected IOManager createTemporaryIOManager() {
-                throw new AssertionError("Unordered index input must not create a sort buffer.");
-            }
-        }.build(Arrays.asList(sourceB, sourceA));
+                        dataFile -> {
+                            ArrayReader reader =
+                                    new ArrayReader(
+                                            dataFile.fileName().equals("data-a")
+                                                    ? entriesA
+                                                    : entriesB);
+                            openedReaders.add(reader);
+                            return reader;
+                        },
+                        capturingFile,
+                        tags,
+                        "multivalue",
+                        options(),
+                        null)
+                .build(Arrays.asList(sourceB, sourceA));
 
         assertThat(capturedSources)
                 .extracting(PrimaryKeyIndexSourceFile::fileName)
                 .containsExactly("data-a", "data-b");
         assertThat(capturedEntries)
+                .extracting(PkSortedIndexFile.Entry::value)
+                .containsExactly(1, 2, 3, 4);
+        assertThat(capturedEntries)
                 .extracting(PkSortedIndexFile.Entry::rowId)
-                .containsExactly(0L, 1L, 2L, 3L);
+                .containsExactly(1L, 3L, 0L, 2L);
         assertThat(openedReaders).allMatch(ArrayReader::isClosed);
+    }
+
+    @Test
+    void testAllEmptyMultivalueRowsStillBuildSourceCoverage() throws Exception {
+        DataField tags = new DataField(8, "tags", DataTypes.ARRAY(DataTypes.INT()));
+        List<PkSortedIndexFile.Entry> capturedEntries = new ArrayList<>();
+        List<PrimaryKeyIndexSourceFile> capturedSources = new ArrayList<>();
+        PkSortedIndexFile capturingFile =
+                new PkSortedIndexFile(LocalFileIO.create(), pathFactory(tempPath)) {
+                    @Override
+                    public IndexFileMeta build(
+                            int dataLevel,
+                            List<PrimaryKeyIndexSourceFile> sourceFiles,
+                            DataField indexField,
+                            String indexType,
+                            Options indexOptions,
+                            Iterator<Entry> entries) {
+                        capturedSources.addAll(sourceFiles);
+                        entries.forEachRemaining(capturedEntries::add);
+                        return ignoredPayload();
+                    }
+                };
+
+        new PkSortedIndexBuilder(
+                        ignored ->
+                                new ArrayReader(
+                                        Arrays.asList(
+                                                entry(null, 0),
+                                                entry(new GenericArray(new Integer[0]), 1),
+                                                entry(
+                                                        new GenericArray(
+                                                                new Integer[] {null, null}),
+                                                        2))),
+                        capturingFile,
+                        tags,
+                        "multivalue",
+                        options(),
+                        null)
+                .build(Collections.singletonList(dataFile("empty-data", 3)));
+
+        assertThat(capturedEntries).isEmpty();
+        assertThat(capturedSources)
+                .extracting(PrimaryKeyIndexSourceFile::rowCount)
+                .containsOnly(3L);
     }
 
     @Test
@@ -275,13 +315,17 @@ class PkSortedIndexBuilderTest {
     }
 
     @Test
-    void testForcedSpillSortsRowsAndClosesTaskOwnedIoManager() throws Exception {
+    void testForcedSpillSortsExpandedMultivalueKeysAndClosesTaskOwnedIoManager() throws Exception {
         int rowCount = 20_000;
         List<PkSortedDataFileReader.Entry> entries = new ArrayList<>(rowCount);
         for (int position = 0; position < rowCount; position++) {
-            entries.add(entry(rowCount - position - 1, position));
+            entries.add(
+                    entry(
+                            new GenericArray(
+                                    new Integer[] {rowCount - position - 1, rowCount + position}),
+                            position));
         }
-        List<Integer> sortedValues = new ArrayList<>(rowCount);
+        List<Integer> sortedValues = new ArrayList<>(rowCount * 2);
         TrackingIOManager ioManager =
                 new TrackingIOManager(tempPath.resolve("owned-spill").toString());
         PkSortedIndexFile capturingFile =
@@ -309,8 +353,8 @@ class PkSortedIndexBuilderTest {
         new PkSortedIndexBuilder(
                 ignored -> new ArrayReader(entries),
                 capturingFile,
-                field(),
-                "btree",
+                new DataField(8, "tags", DataTypes.ARRAY(DataTypes.INT())),
+                "multivalue",
                 options,
                 null) {
             @Override
@@ -321,7 +365,7 @@ class PkSortedIndexBuilderTest {
 
         assertThat(sortedValues)
                 .containsExactlyElementsOf(
-                        LongStream.range(0, rowCount)
+                        LongStream.range(0, rowCount * 2L)
                                 .mapToObj(value -> (int) value)
                                 .collect(Collectors.toList()));
         assertThat(ioManager.createdSpillWriters).isGreaterThan(0);

--- a/paimon-core/src/test/java/org/apache/paimon/index/pksorted/PkSortedIndexFileTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/index/pksorted/PkSortedIndexFileTest.java
@@ -18,6 +18,7 @@
 
 package org.apache.paimon.index.pksorted;
 
+import org.apache.paimon.data.GenericArray;
 import org.apache.paimon.fs.Path;
 import org.apache.paimon.fs.PositionOutputStream;
 import org.apache.paimon.fs.local.LocalFileIO;
@@ -123,6 +124,37 @@ class PkSortedIndexFileTest {
                     .isEqualTo(source);
             assertThat(indexFile.exists(payload)).isTrue();
         }
+    }
+
+    @Test
+    void testBuildsMultiValuePayloadFromArrayRows() throws Exception {
+        PkSortedIndexFile indexFile =
+                new PkSortedIndexFile(LocalFileIO.create(), pathFactory(tempPath));
+        PrimaryKeyIndexSourceFile source = new PrimaryKeyIndexSourceFile("data-file", 4);
+        DataField tags = new DataField(8, "tags", DataTypes.ARRAY(DataTypes.INT()));
+
+        IndexFileMeta payload =
+                indexFile.build(
+                        1,
+                        Collections.singletonList(source),
+                        tags,
+                        "multivalue",
+                        options(),
+                        Arrays.asList(
+                                        new PkSortedIndexFile.Entry(null, 1),
+                                        new PkSortedIndexFile.Entry(
+                                                new GenericArray(new Integer[0]), 2),
+                                        new PkSortedIndexFile.Entry(
+                                                new GenericArray(new Integer[] {2, 1}), 0),
+                                        new PkSortedIndexFile.Entry(
+                                                new GenericArray(new Integer[] {2}), 3))
+                                .iterator());
+
+        assertThat(payload.indexType()).isEqualTo("multivalue");
+        assertThat(payload.rowCount()).isEqualTo(4L);
+        assertThat(payload.globalIndexMeta().indexFieldId()).isEqualTo(8);
+        assertThat(PrimaryKeyIndexSourceMeta.fromIndexFile(payload).sourceFile()).isEqualTo(source);
+        assertThat(indexFile.exists(payload)).isTrue();
     }
 
     @Test

--- a/paimon-core/src/test/java/org/apache/paimon/index/pksorted/PkSortedIndexFileTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/index/pksorted/PkSortedIndexFileTest.java
@@ -18,7 +18,6 @@
 
 package org.apache.paimon.index.pksorted;
 
-import org.apache.paimon.data.GenericArray;
 import org.apache.paimon.fs.Path;
 import org.apache.paimon.fs.PositionOutputStream;
 import org.apache.paimon.fs.local.LocalFileIO;
@@ -141,13 +140,9 @@ class PkSortedIndexFileTest {
                         "multivalue",
                         options(),
                         Arrays.asList(
-                                        new PkSortedIndexFile.Entry(null, 1),
-                                        new PkSortedIndexFile.Entry(
-                                                new GenericArray(new Integer[0]), 2),
-                                        new PkSortedIndexFile.Entry(
-                                                new GenericArray(new Integer[] {2, 1}), 0),
-                                        new PkSortedIndexFile.Entry(
-                                                new GenericArray(new Integer[] {2}), 3))
+                                        new PkSortedIndexFile.Entry(1, 0),
+                                        new PkSortedIndexFile.Entry(2, 0),
+                                        new PkSortedIndexFile.Entry(2, 3))
                                 .iterator());
 
         assertThat(payload.indexType()).isEqualTo("multivalue");

--- a/paimon-core/src/test/java/org/apache/paimon/index/pksorted/PrimaryKeySortedIndexMaintenanceTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/index/pksorted/PrimaryKeySortedIndexMaintenanceTest.java
@@ -73,7 +73,7 @@ import java.util.stream.Collectors;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-/** End-to-end maintenance tests for source-backed BTree and Bitmap indexes. */
+/** End-to-end maintenance tests for source-backed sorted indexes. */
 class PrimaryKeySortedIndexMaintenanceTest {
 
     @TempDir java.nio.file.Path tempDir;

--- a/paimon-core/src/test/java/org/apache/paimon/index/pksorted/PrimaryKeySortedIndexOptionsTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/index/pksorted/PrimaryKeySortedIndexOptionsTest.java
@@ -50,6 +50,17 @@ class PrimaryKeySortedIndexOptionsTest {
     }
 
     @Test
+    void testResolvesMultiValueIndexColumns() {
+        CoreOptions options =
+                new CoreOptions(
+                        Collections.singletonMap(
+                                "pk-multivalue.index.columns", " tags,  categories "));
+
+        assertThat(options.primaryKeyMultiValueIndexColumns())
+                .containsExactly("tags", "categories");
+    }
+
+    @Test
     void testResolvesBTreeIndexAndSortOptions() {
         Map<String, String> values = new HashMap<>();
         values.put("sorted-index.records-per-range", "10");
@@ -79,5 +90,16 @@ class PrimaryKeySortedIndexOptionsTest {
         Options options = new CoreOptions(values).primaryKeyBitmapIndexOptions("status");
 
         assertThat(options.get("bitmap-index.dictionary-block-size")).isEqualTo("8 kb");
+    }
+
+    @Test
+    void testResolvesMultiValueIndexOptions() {
+        Map<String, String> values = new HashMap<>();
+        values.put(
+                "fields.tags.pk-multivalue.index.options", "{\"dictionary-block-size\":\"8 kb\"}");
+
+        Options options = new CoreOptions(values).primaryKeyMultiValueIndexOptions("tags");
+
+        assertThat(options.get("multivalue-index.dictionary-block-size")).isEqualTo("8 kb");
     }
 }

--- a/paimon-core/src/test/java/org/apache/paimon/operation/PrimaryKeyIndexWriteTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/operation/PrimaryKeyIndexWriteTest.java
@@ -52,7 +52,7 @@ import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-/** Tests BTree and Bitmap primary-key index wiring through the file-store writer. */
+/** Tests source-backed primary-key index wiring through the file-store writer. */
 class PrimaryKeyIndexWriteTest {
 
     @TempDir java.nio.file.Path tempDir;
@@ -86,6 +86,30 @@ class PrimaryKeyIndexWriteTest {
 
         assertThat(container.primaryKeyIndexMaintainer).isNotNull();
         assertThat(container.primaryKeyIndexMaintainer.buildNotCompleted()).isFalse();
+        write.close();
+    }
+
+    @Test
+    void testCreatesCoordinatorForMultiValueDefinition() throws Exception {
+        Map<String, String> options = new HashMap<>();
+        options.put(CoreOptions.BUCKET.key(), "10");
+        options.put(CoreOptions.DELETION_VECTORS_ENABLED.key(), "true");
+        options.put(CoreOptions.PK_MULTIVALUE_INDEX_COLUMNS.key(), "tags");
+        List<DataField> fields =
+                new ArrayList<>(TestKeyValueGenerator.DEFAULT_ROW_TYPE.getFields());
+        fields.add(new DataField(7, "tags", DataTypes.ARRAY(DataTypes.STRING())));
+        TestFileStore store = createStore(options, new RowType(fields));
+        KeyValueFileStoreWrite write = (KeyValueFileStoreWrite) store.newWrite();
+        write.withIOManager(ioManager);
+        TestKeyValueGenerator generator = new TestKeyValueGenerator();
+        KeyValue record = generator.next();
+
+        AbstractFileStoreWrite.WriterContainer<KeyValue> container =
+                write.createWriterContainer(generator.getPartition(record), 1);
+
+        assertThat(container.primaryKeyIndexMaintainer).isNotNull();
+        assertThat((List<?>) readField(container.primaryKeyIndexMaintainer, "sortedMaintainers"))
+                .hasSize(1);
         write.close();
     }
 

--- a/paimon-core/src/test/java/org/apache/paimon/schema/PrimaryKeySortedIndexValidationTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/schema/PrimaryKeySortedIndexValidationTest.java
@@ -33,7 +33,7 @@ import static org.apache.paimon.schema.SchemaValidation.validateTableSchema;
 import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-/** Tests for primary-key BTree and Bitmap index validation. */
+/** Tests for source-backed primary-key sorted index validation. */
 class PrimaryKeySortedIndexValidationTest {
 
     @Test
@@ -68,6 +68,34 @@ class PrimaryKeySortedIndexValidationTest {
     }
 
     @Test
+    void testSupportsMultiValueIndexOnArrayColumn() {
+        Map<String, String> options = enabledOptions();
+        options.put(CoreOptions.PK_MULTIVALUE_INDEX_COLUMNS.key(), "tags");
+
+        assertThatCode(() -> validateTableSchema(arraySchema(options))).doesNotThrowAnyException();
+    }
+
+    @Test
+    void testRejectsDuplicateMultiValueIndexColumns() {
+        Map<String, String> options = enabledOptions();
+        options.put(CoreOptions.PK_MULTIVALUE_INDEX_COLUMNS.key(), "tags,tags");
+
+        assertThatThrownBy(() -> validateTableSchema(arraySchema(options)))
+                .hasMessageContaining(CoreOptions.PK_MULTIVALUE_INDEX_COLUMNS.key())
+                .hasMessageContaining("duplicate");
+    }
+
+    @Test
+    void testRejectsMultiValueIndexOnScalarColumn() {
+        Map<String, String> options = enabledOptions();
+        options.put(CoreOptions.PK_MULTIVALUE_INDEX_COLUMNS.key(), "payload");
+
+        assertThatThrownBy(() -> validateTableSchema(schema(options)))
+                .hasMessageContaining("Multivalue index requires an ARRAY column")
+                .hasMessageContaining("payload");
+    }
+
+    @Test
     void testRequiresDeletionVectors() {
         Map<String, String> options = enabledOptions();
         options.put(CoreOptions.DELETION_VECTORS_ENABLED.key(), "false");
@@ -75,7 +103,7 @@ class PrimaryKeySortedIndexValidationTest {
 
         assertThatThrownBy(() -> validateTableSchema(schema(options)))
                 .hasMessageContaining(
-                        "Primary-key BTree and Bitmap indexes require deletion-vectors.enabled = true");
+                        "Primary-key BTree, Bitmap, and Multivalue indexes require deletion-vectors.enabled = true");
     }
 
     @Test
@@ -86,7 +114,7 @@ class PrimaryKeySortedIndexValidationTest {
 
         assertThatThrownBy(() -> validateTableSchema(schema(options, Collections.emptyList())))
                 .hasMessageContaining(
-                        "Primary-key BTree and Bitmap indexes require a primary-key table");
+                        "Primary-key BTree, Bitmap, and Multivalue indexes require a primary-key table");
     }
 
     @Test
@@ -97,7 +125,7 @@ class PrimaryKeySortedIndexValidationTest {
 
         assertThatThrownBy(() -> validateTableSchema(schema(options)))
                 .hasMessageContaining(
-                        "Primary-key BTree and Bitmap indexes require fixed or postpone bucket mode");
+                        "Primary-key BTree, Bitmap, and Multivalue indexes require fixed or postpone bucket mode");
     }
 
     @Test
@@ -117,7 +145,7 @@ class PrimaryKeySortedIndexValidationTest {
 
         assertThatThrownBy(() -> validateTableSchema(schema(options)))
                 .hasMessageContaining(
-                        "Primary-key BTree and Bitmap indexes require deletion-vectors.merge-on-read = false");
+                        "Primary-key BTree, Bitmap, and Multivalue indexes require deletion-vectors.merge-on-read = false");
     }
 
     @Test
@@ -129,7 +157,7 @@ class PrimaryKeySortedIndexValidationTest {
 
         assertThatThrownBy(() -> validateTableSchema(schema(options)))
                 .hasMessageContaining(
-                        "Primary-key BTree and Bitmap indexes do not support pk-clustering-override");
+                        "Primary-key BTree, Bitmap, and Multivalue indexes do not support pk-clustering-override");
     }
 
     @Test
@@ -173,6 +201,19 @@ class PrimaryKeySortedIndexValidationTest {
 
     private static TableSchema schema(Map<String, String> options) {
         return schema(options, Collections.singletonList("id"));
+    }
+
+    private static TableSchema arraySchema(Map<String, String> options) {
+        return new TableSchema(
+                0,
+                Arrays.asList(
+                        new DataField(0, "id", DataTypes.INT().notNull()),
+                        new DataField(1, "tags", DataTypes.ARRAY(DataTypes.STRING()))),
+                0,
+                Collections.emptyList(),
+                Collections.singletonList("id"),
+                options,
+                "");
     }
 
     private static TableSchema schema(

--- a/paimon-core/src/test/java/org/apache/paimon/schema/SchemaManagerTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/schema/SchemaManagerTest.java
@@ -486,6 +486,36 @@ public class SchemaManagerTest {
     }
 
     @Test
+    public void testRejectChangeOfPrimaryKeyMultiValueIndexColumn() throws Exception {
+        Map<String, String> options = new HashMap<>();
+        options.put(CoreOptions.BUCKET.key(), "1");
+        options.put(CoreOptions.DELETION_VECTORS_ENABLED.key(), "true");
+        options.put(CoreOptions.PK_MULTIVALUE_INDEX_COLUMNS.key(), "tags");
+        Schema schema =
+                new Schema(
+                        Arrays.asList(
+                                new DataField(0, "id", DataTypes.INT().notNull()),
+                                new DataField(1, "tags", DataTypes.ARRAY(DataTypes.STRING()))),
+                        Collections.emptyList(),
+                        Collections.singletonList("id"),
+                        options,
+                        "");
+        SchemaManager manager = new SchemaManager(LocalFileIO.create(), path);
+        manager.createTable(schema);
+
+        assertThatThrownBy(() -> manager.commitChanges(SchemaChange.dropColumn("tags")))
+                .isInstanceOf(UnsupportedOperationException.class)
+                .hasMessage("Cannot drop primary-key index column: [tags]");
+        assertThatThrownBy(
+                        () ->
+                                manager.commitChanges(
+                                        SchemaChange.updateColumnType(
+                                                "tags", DataTypes.ARRAY(DataTypes.BIGINT()))))
+                .isInstanceOf(UnsupportedOperationException.class)
+                .hasMessage("Cannot update type of primary-key index column: [tags]");
+    }
+
+    @Test
     public void testResetSequenceGroupForAggregateFunction() throws Exception {
         Map<String, String> options = new HashMap<>();
         options.put(CoreOptions.MERGE_ENGINE.key(), "partial-update");

--- a/paimon-core/src/test/java/org/apache/paimon/schema/SchemaManagerTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/schema/SchemaManagerTest.java
@@ -513,15 +513,6 @@ public class SchemaManagerTest {
                                                 "tags", DataTypes.ARRAY(DataTypes.BIGINT()))))
                 .isInstanceOf(UnsupportedOperationException.class)
                 .hasMessage("Cannot update type of primary-key index column: [tags]");
-        assertThatThrownBy(
-                        () ->
-                                manager.commitChanges(
-                                        SchemaChange.updateColumnType(
-                                                new String[] {"tags", "element"},
-                                                DataTypes.BIGINT(),
-                                                false)))
-                .isInstanceOf(UnsupportedOperationException.class)
-                .hasMessage("Cannot update type of primary-key index column: [tags]");
     }
 
     @Test

--- a/paimon-core/src/test/java/org/apache/paimon/schema/SchemaManagerTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/schema/SchemaManagerTest.java
@@ -513,6 +513,15 @@ public class SchemaManagerTest {
                                                 "tags", DataTypes.ARRAY(DataTypes.BIGINT()))))
                 .isInstanceOf(UnsupportedOperationException.class)
                 .hasMessage("Cannot update type of primary-key index column: [tags]");
+        assertThatThrownBy(
+                        () ->
+                                manager.commitChanges(
+                                        SchemaChange.updateColumnType(
+                                                new String[] {"tags", "element"},
+                                                DataTypes.BIGINT(),
+                                                false)))
+                .isInstanceOf(UnsupportedOperationException.class)
+                .hasMessage("Cannot update type of primary-key index column: [tags]");
     }
 
     @Test

--- a/paimon-core/src/test/java/org/apache/paimon/table/MultiValueGlobalIndexTableTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/table/MultiValueGlobalIndexTableTest.java
@@ -1,0 +1,134 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.table;
+
+import org.apache.paimon.CoreOptions;
+import org.apache.paimon.data.BinaryString;
+import org.apache.paimon.data.GenericArray;
+import org.apache.paimon.data.GenericRow;
+import org.apache.paimon.globalindex.IndexedSplit;
+import org.apache.paimon.globalindex.ScanResult;
+import org.apache.paimon.globalindex.sorted.SortedGlobalIndexScanner;
+import org.apache.paimon.globalindex.sorted.SortedGlobalIndexTestUtils;
+import org.apache.paimon.predicate.Predicate;
+import org.apache.paimon.predicate.PredicateBuilder;
+import org.apache.paimon.schema.Schema;
+import org.apache.paimon.table.sink.BatchTableCommit;
+import org.apache.paimon.table.sink.CommitMessage;
+import org.apache.paimon.table.source.DataSplit;
+import org.apache.paimon.table.source.ReadBuilder;
+import org.apache.paimon.table.source.TableScan;
+import org.apache.paimon.types.DataTypes;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Tests the multivalue global index on Data Evolution tables. */
+public class MultiValueGlobalIndexTableTest extends TableTestBase {
+
+    private static final BinaryString RED = BinaryString.fromString("red");
+    private static final BinaryString BLUE = BinaryString.fromString("blue");
+
+    @Override
+    protected Schema schemaDefault() {
+        return Schema.newBuilder()
+                .column("id", DataTypes.INT())
+                .column("tags", DataTypes.ARRAY(DataTypes.STRING()))
+                .option("bucket", "-1")
+                .option(CoreOptions.ROW_TRACKING_ENABLED.key(), "true")
+                .option(CoreOptions.DATA_EVOLUTION_ENABLED.key(), "true")
+                .option(CoreOptions.GLOBAL_INDEX_ENABLED.key(), "true")
+                .build();
+    }
+
+    @Test
+    public void testCoreScanUsesMultiValueIndexAndPreservesCoverage() throws Exception {
+        createTableDefault();
+        FileStoreTable table = getTableDefault();
+        write(
+                table,
+                GenericRow.of(1, array(RED, BLUE)),
+                GenericRow.of(2, array(BLUE)),
+                GenericRow.of(3, null),
+                GenericRow.of(4, array()),
+                GenericRow.of(5, array(null, RED, RED)));
+
+        buildIndex(table);
+        table = getTableDefault();
+
+        PredicateBuilder builder = new PredicateBuilder(table.rowType());
+        Predicate containsRed = builder.arrayContains(1, RED);
+        assertThat(readIds(table, containsRed)).containsExactlyInAnyOrder(1, 5);
+        assertThat(readIds(table, builder.isNull(1))).containsExactly(3);
+
+        write(table, GenericRow.of(6, array(RED)));
+        table = getTableDefault();
+
+        // Fast search only returns covered rows. Full search retains the uncovered append.
+        assertThat(readIds(table, containsRed)).containsExactlyInAnyOrder(1, 5);
+        FileStoreTable fullSearchTable =
+                table.copy(
+                        Collections.singletonMap(
+                                CoreOptions.GLOBAL_INDEX_SEARCH_MODE.key(), "full"));
+        assertThat(readIds(fullSearchTable, containsRed)).containsExactlyInAnyOrder(1, 5, 6);
+    }
+
+    private void buildIndex(FileStoreTable table) throws Exception {
+        SortedGlobalIndexScanner scanner =
+                new SortedGlobalIndexScanner(table, "multivalue").withIndexField("tags");
+        ScanResult<DataSplit> scanResult =
+                scanner.incrementalScan()
+                        .orElseThrow(
+                                () ->
+                                        new IllegalStateException(
+                                                "Expected data to build multivalue index."));
+        List<CommitMessage> messages = new ArrayList<>();
+        for (DataSplit split : scanResult.entries()) {
+            messages.addAll(
+                    SortedGlobalIndexTestUtils.buildIndex(
+                            table, "multivalue", "tags", split, scanResult.scanSnapshotId()));
+        }
+        try (BatchTableCommit commit = table.newBatchWriteBuilder().newCommit()) {
+            commit.commit(messages);
+        }
+    }
+
+    private List<Integer> readIds(FileStoreTable table, Predicate predicate) throws Exception {
+        ReadBuilder readBuilder = table.newReadBuilder().withFilter(predicate);
+        TableScan.Plan plan = readBuilder.newScan().plan();
+        assertThat(plan.splits()).allMatch(IndexedSplit.class::isInstance);
+
+        List<Integer> ids = new ArrayList<>();
+        readBuilder
+                .newRead()
+                .executeFilter()
+                .createReader(plan)
+                .forEachRemaining(row -> ids.add(row.getInt(0)));
+        return ids;
+    }
+
+    private GenericArray array(BinaryString... elements) {
+        return new GenericArray(elements);
+    }
+}

--- a/paimon-core/src/test/java/org/apache/paimon/table/MultiValueGlobalIndexTableTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/table/MultiValueGlobalIndexTableTest.java
@@ -30,7 +30,6 @@ import org.apache.paimon.io.DataIncrement;
 import org.apache.paimon.predicate.Predicate;
 import org.apache.paimon.predicate.PredicateBuilder;
 import org.apache.paimon.schema.Schema;
-import org.apache.paimon.schema.SchemaChange;
 import org.apache.paimon.table.sink.BatchTableCommit;
 import org.apache.paimon.table.sink.CommitMessage;
 import org.apache.paimon.table.sink.CommitMessageImpl;
@@ -95,43 +94,6 @@ public class MultiValueGlobalIndexTableTest extends TableTestBase {
                         Collections.singletonMap(
                                 CoreOptions.GLOBAL_INDEX_SEARCH_MODE.key(), "full"));
         assertThat(readIds(fullSearchTable, containsRed)).containsExactlyInAnyOrder(1, 5, 6);
-    }
-
-    @Test
-    public void testElementTypeEvolutionFallsBackAndRebuildsIndex() throws Exception {
-        createTableDefault();
-        FileStoreTable table = getTableDefault();
-        write(
-                table,
-                GenericRow.of(1, array(RED, BLUE)),
-                GenericRow.of(2, array(BLUE)),
-                GenericRow.of(3, null));
-        buildIndex(table);
-
-        table.schemaManager()
-                .commitChanges(
-                        SchemaChange.updateColumnType(
-                                new String[] {"tags", "element"}, DataTypes.BIGINT(), false));
-        catalog.invalidateTable(identifier());
-        table = getTableDefault();
-
-        Predicate containsOne = new PredicateBuilder(table.rowType()).arrayContains(1, 1L);
-        assertThat(readIdsWithFallback(table, containsOne)).containsExactly(1);
-
-        ScanResult<DataSplit> rebuild =
-                new SortedGlobalIndexScanner(table, "multivalue")
-                        .withIndexField("tags")
-                        .incrementalScan()
-                        .orElseThrow(
-                                () ->
-                                        new IllegalStateException(
-                                                "Expected incompatible index to be rebuilt."));
-        assertThat(rebuild.deletedIndexEntries()).isNotEmpty();
-        assertThat(rebuild.entries()).extracting(DataSplit::rowCount).containsOnly(3L);
-
-        buildIndex(table);
-        table = getTableDefault();
-        assertThat(readIds(table, containsOne)).containsExactly(1);
     }
 
     private void buildIndex(FileStoreTable table) throws Exception {

--- a/paimon-core/src/test/java/org/apache/paimon/table/MultiValueGlobalIndexTableTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/table/MultiValueGlobalIndexTableTest.java
@@ -19,18 +19,21 @@
 package org.apache.paimon.table;
 
 import org.apache.paimon.CoreOptions;
-import org.apache.paimon.data.BinaryString;
 import org.apache.paimon.data.GenericArray;
 import org.apache.paimon.data.GenericRow;
 import org.apache.paimon.globalindex.IndexedSplit;
 import org.apache.paimon.globalindex.ScanResult;
 import org.apache.paimon.globalindex.sorted.SortedGlobalIndexScanner;
 import org.apache.paimon.globalindex.sorted.SortedGlobalIndexTestUtils;
+import org.apache.paimon.io.CompactIncrement;
+import org.apache.paimon.io.DataIncrement;
 import org.apache.paimon.predicate.Predicate;
 import org.apache.paimon.predicate.PredicateBuilder;
 import org.apache.paimon.schema.Schema;
+import org.apache.paimon.schema.SchemaChange;
 import org.apache.paimon.table.sink.BatchTableCommit;
 import org.apache.paimon.table.sink.CommitMessage;
+import org.apache.paimon.table.sink.CommitMessageImpl;
 import org.apache.paimon.table.source.DataSplit;
 import org.apache.paimon.table.source.ReadBuilder;
 import org.apache.paimon.table.source.TableScan;
@@ -47,14 +50,14 @@ import static org.assertj.core.api.Assertions.assertThat;
 /** Tests the multivalue global index on Data Evolution tables. */
 public class MultiValueGlobalIndexTableTest extends TableTestBase {
 
-    private static final BinaryString RED = BinaryString.fromString("red");
-    private static final BinaryString BLUE = BinaryString.fromString("blue");
+    private static final Integer RED = 1;
+    private static final Integer BLUE = 2;
 
     @Override
     protected Schema schemaDefault() {
         return Schema.newBuilder()
                 .column("id", DataTypes.INT())
-                .column("tags", DataTypes.ARRAY(DataTypes.STRING()))
+                .column("tags", DataTypes.ARRAY(DataTypes.INT()))
                 .option("bucket", "-1")
                 .option(CoreOptions.ROW_TRACKING_ENABLED.key(), "true")
                 .option(CoreOptions.DATA_EVOLUTION_ENABLED.key(), "true")
@@ -94,6 +97,43 @@ public class MultiValueGlobalIndexTableTest extends TableTestBase {
         assertThat(readIds(fullSearchTable, containsRed)).containsExactlyInAnyOrder(1, 5, 6);
     }
 
+    @Test
+    public void testElementTypeEvolutionFallsBackAndRebuildsIndex() throws Exception {
+        createTableDefault();
+        FileStoreTable table = getTableDefault();
+        write(
+                table,
+                GenericRow.of(1, array(RED, BLUE)),
+                GenericRow.of(2, array(BLUE)),
+                GenericRow.of(3, null));
+        buildIndex(table);
+
+        table.schemaManager()
+                .commitChanges(
+                        SchemaChange.updateColumnType(
+                                new String[] {"tags", "element"}, DataTypes.BIGINT(), false));
+        catalog.invalidateTable(identifier());
+        table = getTableDefault();
+
+        Predicate containsOne = new PredicateBuilder(table.rowType()).arrayContains(1, 1L);
+        assertThat(readIdsWithFallback(table, containsOne)).containsExactly(1);
+
+        ScanResult<DataSplit> rebuild =
+                new SortedGlobalIndexScanner(table, "multivalue")
+                        .withIndexField("tags")
+                        .incrementalScan()
+                        .orElseThrow(
+                                () ->
+                                        new IllegalStateException(
+                                                "Expected incompatible index to be rebuilt."));
+        assertThat(rebuild.deletedIndexEntries()).isNotEmpty();
+        assertThat(rebuild.entries()).extracting(DataSplit::rowCount).containsOnly(3L);
+
+        buildIndex(table);
+        table = getTableDefault();
+        assertThat(readIds(table, containsOne)).containsExactly(1);
+    }
+
     private void buildIndex(FileStoreTable table) throws Exception {
         SortedGlobalIndexScanner scanner =
                 new SortedGlobalIndexScanner(table, "multivalue").withIndexField("tags");
@@ -109,6 +149,19 @@ public class MultiValueGlobalIndexTableTest extends TableTestBase {
                     SortedGlobalIndexTestUtils.buildIndex(
                             table, "multivalue", "tags", split, scanResult.scanSnapshotId()));
         }
+        scanResult
+                .deletedIndexEntries()
+                .forEach(
+                        entry ->
+                                messages.add(
+                                        new CommitMessageImpl(
+                                                entry.partition(),
+                                                entry.bucket(),
+                                                null,
+                                                DataIncrement.deleteIndexIncrement(
+                                                        Collections.singletonList(
+                                                                entry.indexFile())),
+                                                CompactIncrement.emptyIncrement())));
         try (BatchTableCommit commit = table.newBatchWriteBuilder().newCommit()) {
             commit.commit(messages);
         }
@@ -143,7 +196,7 @@ public class MultiValueGlobalIndexTableTest extends TableTestBase {
         return ids;
     }
 
-    private GenericArray array(BinaryString... elements) {
+    private GenericArray array(Object... elements) {
         return new GenericArray(elements);
     }
 }

--- a/paimon-core/src/test/java/org/apache/paimon/table/MultiValueGlobalIndexTableTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/table/MultiValueGlobalIndexTableTest.java
@@ -80,7 +80,7 @@ public class MultiValueGlobalIndexTableTest extends TableTestBase {
         PredicateBuilder builder = new PredicateBuilder(table.rowType());
         Predicate containsRed = builder.arrayContains(1, RED);
         assertThat(readIds(table, containsRed)).containsExactlyInAnyOrder(1, 5);
-        assertThat(readIds(table, builder.isNull(1))).containsExactly(3);
+        assertThat(readIdsWithFallback(table, builder.isNull(1))).containsExactly(3);
 
         write(table, GenericRow.of(6, array(RED)));
         table = getTableDefault();
@@ -115,9 +115,24 @@ public class MultiValueGlobalIndexTableTest extends TableTestBase {
     }
 
     private List<Integer> readIds(FileStoreTable table, Predicate predicate) throws Exception {
+        return readIds(table, predicate, true);
+    }
+
+    private List<Integer> readIdsWithFallback(FileStoreTable table, Predicate predicate)
+            throws Exception {
+        return readIds(table, predicate, false);
+    }
+
+    private List<Integer> readIds(
+            FileStoreTable table, Predicate predicate, boolean expectIndexedSplits)
+            throws Exception {
         ReadBuilder readBuilder = table.newReadBuilder().withFilter(predicate);
         TableScan.Plan plan = readBuilder.newScan().plan();
-        assertThat(plan.splits()).allMatch(IndexedSplit.class::isInstance);
+        if (expectIndexedSplits) {
+            assertThat(plan.splits()).allMatch(IndexedSplit.class::isInstance);
+        } else {
+            assertThat(plan.splits()).noneMatch(IndexedSplit.class::isInstance);
+        }
 
         List<Integer> ids = new ArrayList<>();
         readBuilder

--- a/paimon-core/src/test/java/org/apache/paimon/table/source/PrimaryKeySortedIndexReadTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/table/source/PrimaryKeySortedIndexReadTest.java
@@ -22,6 +22,7 @@ import org.apache.paimon.CoreOptions;
 import org.apache.paimon.Snapshot;
 import org.apache.paimon.data.BinaryRow;
 import org.apache.paimon.data.BinaryString;
+import org.apache.paimon.data.GenericArray;
 import org.apache.paimon.data.GenericRow;
 import org.apache.paimon.data.InternalRow;
 import org.apache.paimon.globalindex.IndexedSplit;
@@ -43,7 +44,7 @@ import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-/** End-to-end reads for source-backed scalar indexes, residual filters, and deletion vectors. */
+/** End-to-end reads for source-backed sorted indexes, residual filters, and deletion vectors. */
 class PrimaryKeySortedIndexReadTest extends TableTestBase {
 
     @Override
@@ -199,5 +200,55 @@ class PrimaryKeySortedIndexReadTest extends TableTestBase {
             reader.forEachRemaining(row -> ids.add(row.getInt(0)));
         }
         assertThat(ids).containsExactlyInAnyOrderElementsOf(expectedIds);
+    }
+
+    @Test
+    void testReadWithMultiValueIndex() throws Exception {
+        Schema schema =
+                Schema.newBuilder()
+                        .column("id", DataTypes.INT())
+                        .column("tags", DataTypes.ARRAY(DataTypes.STRING()))
+                        .primaryKey("id")
+                        .option(CoreOptions.BUCKET.key(), "1")
+                        .option(CoreOptions.DELETION_VECTORS_ENABLED.key(), "true")
+                        .option(CoreOptions.PK_MULTIVALUE_INDEX_COLUMNS.key(), "tags")
+                        .build();
+        catalog.createTable(identifier(), schema, false);
+        FileStoreTable table = getTableDefault();
+        BinaryString red = BinaryString.fromString("red");
+        BinaryString blue = BinaryString.fromString("blue");
+        write(
+                table,
+                ioManager,
+                GenericRow.of(1, new GenericArray(new BinaryString[] {red, blue})),
+                GenericRow.of(2, new GenericArray(new BinaryString[] {blue})),
+                GenericRow.of(3, null));
+        write(
+                table,
+                ioManager,
+                GenericRow.of(4, new GenericArray(new BinaryString[0])),
+                GenericRow.of(5, new GenericArray(new BinaryString[] {null, red})));
+        compact(table, BinaryRow.EMPTY_ROW, 0, ioManager, true);
+
+        Snapshot snapshot = table.store().snapshotManager().latestSnapshot();
+        assertThat(
+                        table.store()
+                                .newIndexFileHandler()
+                                .scanSourceIndexes(snapshot, BinaryRow.EMPTY_ROW, 0))
+                .singleElement()
+                .extracting(IndexFileMeta::indexType)
+                .isEqualTo("multivalue");
+
+        Predicate predicate = new PredicateBuilder(table.rowType()).arrayContains(1, red);
+        ReadBuilder readBuilder = table.newReadBuilder().withFilter(predicate);
+        TableScan.Plan plan = readBuilder.newScan().plan();
+        assertThat(plan.splits()).isNotEmpty().allMatch(IndexedSplit.class::isInstance);
+
+        List<Integer> ids = new ArrayList<>();
+        try (RecordReader<InternalRow> reader =
+                readBuilder.newRead().executeFilter().createReader(plan)) {
+            reader.forEachRemaining(row -> ids.add(row.getInt(0)));
+        }
+        assertThat(ids).containsExactlyInAnyOrder(1, 5);
     }
 }

--- a/paimon-core/src/test/java/org/apache/paimon/table/source/PrimaryKeySortedIndexScanTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/table/source/PrimaryKeySortedIndexScanTest.java
@@ -23,6 +23,7 @@ import org.apache.paimon.globalindex.GlobalIndexReader;
 import org.apache.paimon.globalindex.GlobalIndexResult;
 import org.apache.paimon.globalindex.IndexedSplit;
 import org.apache.paimon.globalindex.bitmap.BitmapGlobalIndexerFactory;
+import org.apache.paimon.globalindex.bitmap.MultiValueGlobalIndexerFactory;
 import org.apache.paimon.globalindex.btree.BTreeGlobalIndexerFactory;
 import org.apache.paimon.index.GlobalIndexMeta;
 import org.apache.paimon.index.IndexFileMeta;
@@ -71,7 +72,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-/** Tests source-backed BTree and Bitmap planning in file-local row-position space. */
+/** Tests source-backed sorted-index planning in file-local row-position space. */
 class PrimaryKeySortedIndexScanTest {
 
     @Test
@@ -360,6 +361,63 @@ class PrimaryKeySortedIndexScanTest {
         IndexedSplit secondSplit = (IndexedSplit) result.splits().get(2);
         assertThat(secondSplit.dataSplit().dataFiles()).containsExactly(second);
         assertThat(secondSplit.rowRanges()).containsExactly(new Range(0, 0), new Range(2, 2));
+    }
+
+    @Test
+    void testArrayContainsIsCachedAndLocalized() throws IOException {
+        DataFileMeta first = dataFile("data-1", 2);
+        DataFileMeta second = dataFile("data-2", 3);
+        DataSplit split = dataSplit(11, 0, first, second);
+        PrimaryKeyIndexDefinition definition =
+                definition(
+                        7,
+                        MultiValueGlobalIndexerFactory.IDENTIFIER,
+                        PrimaryKeyIndexDefinition.Family.MULTI_VALUE);
+        IndexFileMeta mergedPayload =
+                payload(
+                        "multivalue-merged",
+                        Arrays.asList(
+                                new PrimaryKeyIndexSourceFile("data-1", 2),
+                                new PrimaryKeyIndexSourceFile("data-2", 3)),
+                        "multivalue",
+                        7,
+                        5);
+        PrimaryKeySortedIndexScan.Plan plan =
+                PrimaryKeySortedIndexScan.plan(
+                        11,
+                        Collections.singletonList(split),
+                        Collections.singletonList(definition),
+                        Collections.singletonList(payloadEntry(0, mergedPayload)));
+        RowType rowType = RowType.of(new DataField(7, "tags", DataTypes.ARRAY(DataTypes.INT())));
+        Predicate predicate = new PredicateBuilder(rowType).arrayContains(0, 42);
+        AtomicInteger queries = new AtomicInteger();
+        GlobalIndexReader reader = mock(GlobalIndexReader.class);
+        when(reader.visitArrayContains(any(), eq(42)))
+                .thenAnswer(
+                        ignored -> {
+                            queries.incrementAndGet();
+                            return completedResult(1, 2, 4);
+                        });
+
+        PrimaryKeySortedIndexScan.EvaluatedPlan evaluated =
+                PrimaryKeySortedIndexScan.evaluate(
+                        plan,
+                        rowType,
+                        predicate,
+                        Collections.singletonList(definition),
+                        (ignoredFile, ignoredDefinition, payloads, totalRowCount) -> {
+                            assertThat(payloads).containsExactly(mergedPayload);
+                            assertThat(totalRowCount).isEqualTo(5);
+                            return reader;
+                        });
+
+        assertThat(queries).hasValue(1);
+        assertThat(evaluated.files()).hasSize(2);
+        assertThat(evaluated.files().get(0).result()).isPresent();
+        assertThat(evaluated.files().get(0).result().get().results()).containsExactly(1L);
+        assertThat(evaluated.files().get(1).result()).isPresent();
+        assertThat(evaluated.files().get(1).result().get().results()).containsExactly(0L, 2L);
+        verify(reader).close();
     }
 
     @Test

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/action/DataEvolutionMergeIntoAction.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/action/DataEvolutionMergeIntoAction.java
@@ -46,10 +46,13 @@ import org.apache.paimon.types.DataTypeRoot;
 import org.apache.paimon.types.RowType;
 import org.apache.paimon.utils.Preconditions;
 
+import org.apache.flink.api.common.functions.OpenContext;
+import org.apache.flink.api.common.functions.RichMapFunction;
 import org.apache.flink.api.common.typeinfo.BasicTypeInfo;
 import org.apache.flink.api.dag.Transformation;
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.api.java.typeutils.TupleTypeInfo;
+import org.apache.flink.configuration.Configuration;
 import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.streaming.api.functions.sink.v2.DiscardingSink;
 import org.apache.flink.streaming.api.operators.StreamFlatMap;
@@ -62,6 +65,7 @@ import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.data.conversion.DataStructureConverter;
 import org.apache.flink.table.data.conversion.DataStructureConverters;
 import org.apache.flink.table.types.logical.LogicalTypeRoot;
+import org.apache.flink.types.Row;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -440,14 +444,36 @@ public class DataEvolutionMergeIntoAction extends TableActionBase {
         return batchTEnv
                 .toDataStream(source)
                 .map(
-                        row -> {
-                            int arity = row.getArity();
-                            GenericRowData rowData = new GenericRowData(row.getKind(), arity);
-                            for (int i = 0; i < arity; i++) {
-                                rowData.setField(
-                                        i, converters.get(i).toInternalOrNull(row.getField(i)));
+                        new RichMapFunction<Row, RowData>() {
+
+                            /**
+                             * Do not annotate with <code>@override</code> here to maintain
+                             * compatibility with Flink 1.18-.
+                             */
+                            public void open(OpenContext openContext) {
+                                open(new Configuration());
                             }
-                            return rowData;
+
+                            /**
+                             * Do not annotate with <code>@override</code> here to maintain
+                             * compatibility with Flink 2.0+.
+                             */
+                            public void open(Configuration parameters) {
+                                ClassLoader classLoader =
+                                        getRuntimeContext().getUserCodeClassLoader();
+                                converters.forEach(converter -> converter.open(classLoader));
+                            }
+
+                            @Override
+                            public RowData map(Row row) {
+                                int arity = row.getArity();
+                                GenericRowData rowData = new GenericRowData(row.getKind(), arity);
+                                for (int i = 0; i < arity; i++) {
+                                    rowData.setField(
+                                            i, converters.get(i).toInternalOrNull(row.getField(i)));
+                                }
+                                return rowData;
+                            }
                         });
     }
 

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/globalindex/SortedIndexTopoBuilder.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/globalindex/SortedIndexTopoBuilder.java
@@ -38,6 +38,7 @@ import org.apache.paimon.flink.utils.BoundedOneInputOperator;
 import org.apache.paimon.flink.utils.JavaTypeInfo;
 import org.apache.paimon.flink.utils.StreamExecutionEnvironmentUtils;
 import org.apache.paimon.globalindex.GlobalIndexSingleColumnWriter;
+import org.apache.paimon.globalindex.GlobalIndexer;
 import org.apache.paimon.globalindex.ScanResult;
 import org.apache.paimon.globalindex.sorted.SortedGlobalIndexScanner;
 import org.apache.paimon.globalindex.sorted.SortedGlobalIndexWriter;
@@ -91,7 +92,7 @@ public class SortedIndexTopoBuilder {
     private static final String BUILD_TASK_ID_FIELD = "_SORTED_INDEX_BUILD_TASK_ID";
     private static final int BUILD_TASK_ID_FIELD_ID = -1;
     private static final HashSet<String> SUPPORTED_INDEX_TYPES =
-            new HashSet<>(Arrays.asList("btree", "bitmap"));
+            new HashSet<>(Arrays.asList("btree", "bitmap", "multivalue"));
 
     public static boolean supports(String indexType) {
         return SUPPORTED_INDEX_TYPES.contains(indexType);
@@ -174,6 +175,10 @@ public class SortedIndexTopoBuilder {
             int indexFieldPos = sortReadType.getFieldIndex(indexColumn);
             int rowIdPos = sortReadType.getFieldIndex(SpecialFields.ROW_ID.name());
             DataType indexFieldType = sortReadType.getTypeAt(indexFieldPos);
+            boolean requiresSortedInput =
+                    GlobalIndexer.create(
+                                    indexType, table.rowType().getField(indexColumn), userOptions)
+                            .requiresSortedInput();
 
             // 3. Calculate maximum parallelism bound
             long recordsPerRange =
@@ -184,7 +189,8 @@ public class SortedIndexTopoBuilder {
             // 4. Build one topology for all contiguous row ranges
             CoreOptions coreOptions = table.coreOptions();
             ReadBuilder readBuilder = table.newReadBuilder().withReadType(dataReadType);
-            List<String> sortColumns = createSortColumns(buildTaskIdField, indexColumn);
+            List<String> sortColumns =
+                    createSortColumns(buildTaskIdField, indexColumn, requiresSortedInput);
             int partitionFieldSize = table.partitionKeys().size();
             BinaryRowSerializer binaryRowSerializer = new BinaryRowSerializer(partitionFieldSize);
             List<SortedBuildTask> buildTasks = new ArrayList<>();
@@ -371,7 +377,11 @@ public class SortedIndexTopoBuilder {
         return (int) Math.min(parallelism, maxParallelism);
     }
 
-    static List<String> createSortColumns(String buildTaskIdField, String indexColumn) {
+    static List<String> createSortColumns(
+            String buildTaskIdField, String indexColumn, boolean requiresSortedInput) {
+        if (!requiresSortedInput) {
+            return Arrays.asList(buildTaskIdField, SpecialFields.ROW_ID.name());
+        }
         // Range shuffle may spread duplicate boundary keys randomly. ROW_ID makes the full sort key
         // unique while keeping equal index keys adjacent, so output file key ranges stay ordered.
         return Arrays.asList(buildTaskIdField, indexColumn, SpecialFields.ROW_ID.name());

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/globalindex/SortedIndexTopoBuilder.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/globalindex/SortedIndexTopoBuilder.java
@@ -22,7 +22,6 @@ import org.apache.paimon.CoreOptions;
 import org.apache.paimon.data.BinaryRow;
 import org.apache.paimon.data.GenericRow;
 import org.apache.paimon.data.InternalRow;
-import org.apache.paimon.data.JoinedRow;
 import org.apache.paimon.data.serializer.BinaryRowSerializer;
 import org.apache.paimon.flink.FlinkRowData;
 import org.apache.paimon.flink.FlinkRowWrapper;
@@ -32,14 +31,18 @@ import org.apache.paimon.flink.sink.CommittableTypeInfo;
 import org.apache.paimon.flink.sink.CommitterOperatorFactory;
 import org.apache.paimon.flink.sink.NoopCommittableStateManager;
 import org.apache.paimon.flink.sink.StoreCommitter;
+import org.apache.paimon.flink.sorter.SortOperator;
 import org.apache.paimon.flink.sorter.TableSortInfo;
 import org.apache.paimon.flink.sorter.TableSorter;
 import org.apache.paimon.flink.utils.BoundedOneInputOperator;
+import org.apache.paimon.flink.utils.InternalTypeInfo;
 import org.apache.paimon.flink.utils.JavaTypeInfo;
 import org.apache.paimon.flink.utils.StreamExecutionEnvironmentUtils;
+import org.apache.paimon.globalindex.GlobalIndexKeyExtractor;
 import org.apache.paimon.globalindex.GlobalIndexSingleColumnWriter;
 import org.apache.paimon.globalindex.GlobalIndexer;
 import org.apache.paimon.globalindex.ScanResult;
+import org.apache.paimon.globalindex.SortedGlobalIndexer;
 import org.apache.paimon.globalindex.sorted.SortedGlobalIndexScanner;
 import org.apache.paimon.globalindex.sorted.SortedGlobalIndexWriter;
 import org.apache.paimon.globalindex.sorted.SortedIndexOptions;
@@ -62,12 +65,12 @@ import org.apache.paimon.types.DataTypes;
 import org.apache.paimon.types.RowType;
 import org.apache.paimon.utils.Range;
 
+import org.apache.flink.api.java.functions.KeySelector;
 import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.streaming.api.operators.OneInputStreamOperatorFactory;
 import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
 import org.apache.flink.table.data.RowData;
-import org.apache.flink.table.runtime.typeutils.InternalTypeInfo;
 
 import java.io.IOException;
 import java.io.Serializable;
@@ -82,6 +85,7 @@ import java.util.Optional;
 import java.util.function.Supplier;
 
 import static org.apache.paimon.globalindex.GlobalIndexBuilderUtils.groupSplitsByRange;
+import static org.apache.paimon.globalindex.GlobalIndexBuilderUtils.shardSplitsByRowRange;
 import static org.apache.paimon.globalindex.GlobalIndexBuilderUtils.splitByContiguousRowRange;
 import static org.apache.paimon.io.CompactIncrement.emptyIncrement;
 import static org.apache.paimon.io.DataIncrement.deleteIndexIncrement;
@@ -170,15 +174,22 @@ public class SortedIndexTopoBuilder {
             RowType dataReadType =
                     SpecialFields.rowTypeWithRowId(table.rowType().project(selectedColumns));
             String buildTaskIdField = buildTaskIdFieldName(dataReadType);
-            RowType sortReadType = withBuildTaskId(dataReadType, buildTaskIdField);
+            GlobalIndexer indexer =
+                    GlobalIndexer.create(
+                            indexType, table.rowType().getField(indexColumn), userOptions);
+            if (!(indexer instanceof SortedGlobalIndexer)) {
+                throw new IllegalArgumentException(
+                        "Index algorithm " + indexType + " does not expose sorted index keys.");
+            }
+            GlobalIndexKeyExtractor keyExtractor = ((SortedGlobalIndexer) indexer).keyExtractor();
+            RowType sortReadType =
+                    normalizedReadType(
+                            dataReadType, buildTaskIdField, indexColumn, keyExtractor.keyType());
             int taskIdPos = sortReadType.getFieldIndex(buildTaskIdField);
             int indexFieldPos = sortReadType.getFieldIndex(indexColumn);
             int rowIdPos = sortReadType.getFieldIndex(SpecialFields.ROW_ID.name());
             DataType indexFieldType = sortReadType.getTypeAt(indexFieldPos);
-            boolean requiresSortedInput =
-                    GlobalIndexer.create(
-                                    indexType, table.rowType().getField(indexColumn), userOptions)
-                            .requiresSortedInput();
+            DataType sourceFieldType = table.rowType().getField(indexColumn).type();
 
             // 3. Calculate maximum parallelism bound
             long recordsPerRange =
@@ -189,8 +200,6 @@ public class SortedIndexTopoBuilder {
             // 4. Build one topology for all contiguous row ranges
             CoreOptions coreOptions = table.coreOptions();
             ReadBuilder readBuilder = table.newReadBuilder().withReadType(dataReadType);
-            List<String> sortColumns =
-                    createSortColumns(buildTaskIdField, indexColumn, requiresSortedInput);
             int partitionFieldSize = table.partitionKeys().size();
             BinaryRowSerializer binaryRowSerializer = new BinaryRowSerializer(partitionFieldSize);
             List<SortedBuildTask> buildTasks = new ArrayList<>();
@@ -199,7 +208,11 @@ public class SortedIndexTopoBuilder {
                     partitionRangeSplits.entrySet()) {
                 BinaryRow partition = partitionEntry.getKey();
                 byte[] partitionBytes = binaryRowSerializer.serializeToBytes(partition);
-                for (Map.Entry<Range, List<Split>> entry : partitionEntry.getValue().entrySet()) {
+                Map<Range, List<Split>> ranges =
+                        keyExtractor.isIdentity()
+                                ? partitionEntry.getValue()
+                                : shardSplitsByRowRange(partitionEntry.getValue(), recordsPerRange);
+                for (Map.Entry<Range, List<Split>> entry : ranges.entrySet()) {
                     Range range = entry.getKey();
                     List<Split> rangeSplits = entry.getValue();
                     if (rangeSplits.isEmpty()) {
@@ -232,7 +245,8 @@ public class SortedIndexTopoBuilder {
                             indexFieldPos,
                             rowIdPos,
                             indexFieldType,
-                            sortColumns,
+                            sourceFieldType,
+                            keyExtractor,
                             coreOptions,
                             sortReadType,
                             recordsPerRange,
@@ -310,7 +324,8 @@ public class SortedIndexTopoBuilder {
             int indexFieldPos,
             int rowIdPos,
             DataType indexFieldType,
-            List<String> sortColumns,
+            DataType sourceFieldType,
+            GlobalIndexKeyExtractor keyExtractor,
             CoreOptions coreOptions,
             RowType readType,
             long recordsPerRange,
@@ -323,27 +338,24 @@ public class SortedIndexTopoBuilder {
                         .name("Global Index Source")
                         .setParallelism(1);
 
-        DataStream<RowData> rowDataStream =
+        DataStream<InternalRow> rowDataStream =
                 sourceStream
                         .transform(
                                 "Read Data",
-                                InternalTypeInfo.of(LogicalTypeConversion.toLogicalType(readType)),
-                                new ReadDataOperator(readBuilder))
+                                InternalTypeInfo.fromRowType(readType),
+                                new ReadDataOperator(readBuilder, keyExtractor, sourceFieldType))
                         .setParallelism(parallelism);
 
-        TableSortInfo sortInfo =
-                new TableSortInfo.Builder()
-                        .setSortColumns(sortColumns)
-                        .setSortStrategy(CoreOptions.OrderType.ORDER)
-                        .setSinkParallelism(parallelism)
-                        .setLocalSampleSize(parallelism * coreOptions.getLocalSampleMagnification())
-                        .setGlobalSampleSize(parallelism * 1000)
-                        .setRangeNumber(parallelism * 10)
-                        .build();
-
-        TableSorter sorter =
-                TableSorter.getSorter(env, rowDataStream, coreOptions, readType, sortInfo);
-        DataStream<RowData> sortedStream = sorter.sort();
+        DataStream<InternalRow> sortedStream =
+                sortRows(
+                        env,
+                        rowDataStream,
+                        keyExtractor.isIdentity(),
+                        taskIdPos,
+                        indexFieldPos,
+                        coreOptions,
+                        readType,
+                        parallelism);
 
         return sortedStream
                 .transform(
@@ -357,7 +369,59 @@ public class SortedIndexTopoBuilder {
                                 taskIdPos,
                                 indexFieldPos,
                                 rowIdPos,
-                                indexFieldType))
+                                indexFieldType,
+                                !keyExtractor.isIdentity(),
+                                indexWriter.recordsPerRange()))
+                .setParallelism(parallelism);
+    }
+
+    private static DataStream<InternalRow> sortRows(
+            StreamExecutionEnvironment env,
+            DataStream<InternalRow> input,
+            boolean identity,
+            int taskIdPos,
+            int indexFieldPos,
+            CoreOptions coreOptions,
+            RowType readType,
+            int parallelism) {
+        if (!identity) {
+            return input.keyBy((KeySelector<InternalRow, Integer>) row -> row.getInt(taskIdPos))
+                    .transform(
+                            "Sort Normalized Index Keys",
+                            InternalTypeInfo.fromRowType(readType),
+                            new SortOperator(
+                                    readType,
+                                    readType,
+                                    coreOptions.writeBufferSize(),
+                                    coreOptions.pageSize(),
+                                    coreOptions.localSortMaxNumFileHandles(),
+                                    coreOptions.spillCompressOptions(),
+                                    parallelism,
+                                    coreOptions.writeBufferSpillDiskSize()))
+                    .setParallelism(parallelism);
+        }
+
+        DataStream<RowData> rowData =
+                input.map(
+                                row -> (RowData) new FlinkRowData(row),
+                                org.apache.flink.table.runtime.typeutils.InternalTypeInfo.of(
+                                        LogicalTypeConversion.toLogicalType(readType)))
+                        .setParallelism(parallelism);
+        TableSortInfo sortInfo =
+                new TableSortInfo.Builder()
+                        .setSortColumns(
+                                createSortColumns(
+                                        readType.getFieldNames().get(taskIdPos),
+                                        readType.getFieldNames().get(indexFieldPos)))
+                        .setSortStrategy(CoreOptions.OrderType.ORDER)
+                        .setSinkParallelism(parallelism)
+                        .setLocalSampleSize(parallelism * coreOptions.getLocalSampleMagnification())
+                        .setGlobalSampleSize(parallelism * 1000)
+                        .setRangeNumber(parallelism * 10)
+                        .build();
+        return TableSorter.getSorter(env, rowData, coreOptions, readType, sortInfo)
+                .sort()
+                .map(FlinkRowWrapper::new, InternalTypeInfo.fromRowType(readType))
                 .setParallelism(parallelism);
     }
 
@@ -377,13 +441,7 @@ public class SortedIndexTopoBuilder {
         return (int) Math.min(parallelism, maxParallelism);
     }
 
-    static List<String> createSortColumns(
-            String buildTaskIdField, String indexColumn, boolean requiresSortedInput) {
-        if (!requiresSortedInput) {
-            return Arrays.asList(buildTaskIdField, SpecialFields.ROW_ID.name());
-        }
-        // Range shuffle may spread duplicate boundary keys randomly. ROW_ID makes the full sort key
-        // unique while keeping equal index keys adjacent, so output file key ranges stay ordered.
+    static List<String> createSortColumns(String buildTaskIdField, String indexColumn) {
         return Arrays.asList(buildTaskIdField, indexColumn, SpecialFields.ROW_ID.name());
     }
 
@@ -395,11 +453,14 @@ public class SortedIndexTopoBuilder {
         return fieldName;
     }
 
-    private static RowType withBuildTaskId(RowType readType, String buildTaskIdField) {
+    private static RowType normalizedReadType(
+            RowType readType, String buildTaskIdField, String indexColumn, DataType keyType) {
         List<DataField> fields = new ArrayList<>();
         fields.add(
                 new DataField(BUILD_TASK_ID_FIELD_ID, buildTaskIdField, DataTypes.INT().notNull()));
-        fields.addAll(readType.getFields());
+        DataField sourceField = readType.getField(indexColumn);
+        fields.add(new DataField(sourceField.id(), sourceField.name(), keyType));
+        fields.add(readType.getField(SpecialFields.ROW_ID.name()));
         return new RowType(readType.isNullable(), fields);
     }
 
@@ -422,41 +483,71 @@ public class SortedIndexTopoBuilder {
 
     /** Operator to read data from splits. */
     private static class ReadDataOperator
-            extends org.apache.flink.table.runtime.operators.TableStreamOperator<RowData>
+            extends org.apache.flink.table.runtime.operators.TableStreamOperator<InternalRow>
             implements org.apache.flink.streaming.api.operators.OneInputStreamOperator<
-                    SortedSplitTask, RowData> {
+                    SortedSplitTask, InternalRow> {
 
         private static final long serialVersionUID = 1L;
 
         private final ReadBuilder readBuilder;
+        private final GlobalIndexKeyExtractor keyExtractor;
+        private final DataType sourceFieldType;
 
         private transient TableRead tableRead;
+        private transient InternalRow.FieldGetter sourceFieldGetter;
 
-        public ReadDataOperator(ReadBuilder readBuilder) {
+        public ReadDataOperator(
+                ReadBuilder readBuilder,
+                GlobalIndexKeyExtractor keyExtractor,
+                DataType sourceFieldType) {
             this.readBuilder = readBuilder;
+            this.keyExtractor = keyExtractor;
+            this.sourceFieldType = sourceFieldType;
         }
 
         @Override
         public void open() throws Exception {
             super.open();
             this.tableRead = readBuilder.newRead();
+            this.sourceFieldGetter = InternalRow.createFieldGetter(sourceFieldType, 0);
         }
 
         @Override
         public void processElement(StreamRecord<SortedSplitTask> element) throws Exception {
             SortedSplitTask buildTask = element.getValue();
-            GenericRow taskId = GenericRow.of(buildTask.taskId);
             try (RecordReader<InternalRow> reader = tableRead.createReader(buildTask.split)) {
-                reader.forEachRemaining(
-                        row ->
+                RecordReader.RecordIterator<InternalRow> batch;
+                while ((batch = reader.readBatch()) != null) {
+                    try {
+                        InternalRow row;
+                        while ((row = batch.next()) != null) {
+                            long rowId = row.getLong(1);
+                            boolean[] emitted = new boolean[1];
+                            keyExtractor.extract(
+                                    sourceFieldGetter.getFieldOrNull(row),
+                                    key -> {
+                                        emitted[0] = true;
+                                        output.collect(
+                                                new StreamRecord<>(
+                                                        GenericRow.of(
+                                                                buildTask.taskId, key, rowId)));
+                                    });
+                            if (!emitted[0]) {
                                 output.collect(
                                         new StreamRecord<>(
-                                                new FlinkRowData(new JoinedRow(taskId, row)))));
+                                                GenericRow.of(buildTask.taskId, null, rowId)));
+                            }
+                        }
+                    } finally {
+                        batch.releaseBatch();
+                    }
+                }
             }
         }
     }
 
-    private static class WriteIndexOperator extends BoundedOneInputOperator<RowData, Committable> {
+    private static class WriteIndexOperator
+            extends BoundedOneInputOperator<InternalRow, Committable> {
 
         private final List<SortedBuildTask> buildTasks;
         private final int partitionFieldSize;
@@ -466,6 +557,8 @@ public class SortedIndexTopoBuilder {
         private final int indexFieldPos;
         private final int rowIdPos;
         private final DataType indexFieldType;
+        private final boolean multipleValues;
+        private final long recordsPerRange;
 
         private transient long counter;
         private transient SortedBuildTask currentTask;
@@ -484,7 +577,9 @@ public class SortedIndexTopoBuilder {
                 int taskIdPos,
                 int indexFieldPos,
                 int rowIdPos,
-                DataType indexFieldType) {
+                DataType indexFieldType,
+                boolean multipleValues,
+                long recordsPerRange) {
             this.buildTasks = buildTasks;
             this.partitionFieldSize = partitionFieldSize;
             this.writer = writer;
@@ -493,6 +588,8 @@ public class SortedIndexTopoBuilder {
             this.indexFieldPos = indexFieldPos;
             this.rowIdPos = rowIdPos;
             this.indexFieldType = indexFieldType;
+            this.multipleValues = multipleValues;
+            this.recordsPerRange = recordsPerRange;
         }
 
         @Override
@@ -508,8 +605,8 @@ public class SortedIndexTopoBuilder {
         }
 
         @Override
-        public void processElement(StreamRecord<RowData> element) throws IOException {
-            InternalRow row = new FlinkRowWrapper(element.getValue());
+        public void processElement(StreamRecord<InternalRow> element) throws IOException {
+            InternalRow row = element.getValue();
             int taskId = row.getInt(taskIdPos);
             SortedBuildTask task = buildTasksById.get(taskId);
             if (task == null) {
@@ -522,16 +619,15 @@ public class SortedIndexTopoBuilder {
                 currentPartition = binaryRowSerializer.deserializeFromBytes(task.partition);
             }
 
-            if (currentWriter != null && counter >= writer.recordsPerRange()) {
+            if (!multipleValues && currentWriter != null && counter >= recordsPerRange) {
                 flushCurrentWriter();
             }
-
-            counter++;
 
             if (currentWriter == null) {
                 currentWriter = writer.createWriter();
             }
 
+            counter++;
             long localRowId = row.getLong(rowIdPos) - currentTask.rowRange.from;
             currentWriter.write(indexFieldGetter.getFieldOrNull(row), localRowId);
         }
@@ -562,11 +658,13 @@ public class SortedIndexTopoBuilder {
         }
 
         private void flushCurrentWriter() throws IOException {
-            if (counter > 0 && currentWriter != null) {
+            if (currentWriter != null) {
                 commitMessages.add(
                         writer.flushIndex(
                                 currentTask.rowRange,
-                                currentWriter.finish(),
+                                multipleValues
+                                        ? currentWriter.finish(currentTask.rowRange.count())
+                                        : currentWriter.finish(),
                                 currentPartition,
                                 scanSnapshotId));
             }

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/globalindex/SortedIndexTopoBuilder.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/globalindex/SortedIndexTopoBuilder.java
@@ -39,13 +39,14 @@ import org.apache.paimon.flink.utils.InternalTypeInfo;
 import org.apache.paimon.flink.utils.JavaTypeInfo;
 import org.apache.paimon.flink.utils.StreamExecutionEnvironmentUtils;
 import org.apache.paimon.globalindex.GlobalIndexKeyExtractor;
-import org.apache.paimon.globalindex.GlobalIndexSingleColumnWriter;
 import org.apache.paimon.globalindex.GlobalIndexer;
+import org.apache.paimon.globalindex.ResultEntry;
 import org.apache.paimon.globalindex.ScanResult;
 import org.apache.paimon.globalindex.SortedGlobalIndexer;
 import org.apache.paimon.globalindex.sorted.SortedGlobalIndexScanner;
 import org.apache.paimon.globalindex.sorted.SortedGlobalIndexWriter;
 import org.apache.paimon.globalindex.sorted.SortedIndexOptions;
+import org.apache.paimon.globalindex.sorted.SortedSingleColumnIndexWriter;
 import org.apache.paimon.manifest.IndexManifestEntry;
 import org.apache.paimon.options.Options;
 import org.apache.paimon.partition.PartitionPredicate;
@@ -369,9 +370,7 @@ public class SortedIndexTopoBuilder {
                                 taskIdPos,
                                 indexFieldPos,
                                 rowIdPos,
-                                indexFieldType,
-                                !keyExtractor.isIdentity(),
-                                indexWriter.recordsPerRange()))
+                                indexFieldType))
                 .setParallelism(parallelism);
     }
 
@@ -557,13 +556,10 @@ public class SortedIndexTopoBuilder {
         private final int indexFieldPos;
         private final int rowIdPos;
         private final DataType indexFieldType;
-        private final boolean multipleValues;
-        private final long recordsPerRange;
 
-        private transient long counter;
         private transient SortedBuildTask currentTask;
         private transient BinaryRow currentPartition;
-        private transient GlobalIndexSingleColumnWriter currentWriter;
+        private transient SortedSingleColumnIndexWriter currentWriter;
         private transient List<CommitMessage> commitMessages;
         private transient Map<Integer, SortedBuildTask> buildTasksById;
         private transient InternalRow.FieldGetter indexFieldGetter;
@@ -577,9 +573,7 @@ public class SortedIndexTopoBuilder {
                 int taskIdPos,
                 int indexFieldPos,
                 int rowIdPos,
-                DataType indexFieldType,
-                boolean multipleValues,
-                long recordsPerRange) {
+                DataType indexFieldType) {
             this.buildTasks = buildTasks;
             this.partitionFieldSize = partitionFieldSize;
             this.writer = writer;
@@ -588,8 +582,6 @@ public class SortedIndexTopoBuilder {
             this.indexFieldPos = indexFieldPos;
             this.rowIdPos = rowIdPos;
             this.indexFieldType = indexFieldType;
-            this.multipleValues = multipleValues;
-            this.recordsPerRange = recordsPerRange;
         }
 
         @Override
@@ -619,15 +611,10 @@ public class SortedIndexTopoBuilder {
                 currentPartition = binaryRowSerializer.deserializeFromBytes(task.partition);
             }
 
-            if (!multipleValues && currentWriter != null && counter >= recordsPerRange) {
-                flushCurrentWriter();
-            }
-
             if (currentWriter == null) {
-                currentWriter = writer.createWriter();
+                currentWriter = writer.createTaskWriter(currentTask.rowRange);
             }
 
-            counter++;
             long localRowId = row.getLong(rowIdPos) - currentTask.rowRange.from;
             currentWriter.write(indexFieldGetter.getFieldOrNull(row), localRowId);
         }
@@ -646,11 +633,10 @@ public class SortedIndexTopoBuilder {
         @Override
         public void close() throws Exception {
             try {
-                GlobalIndexSingleColumnWriter writer = currentWriter;
+                SortedSingleColumnIndexWriter writer = currentWriter;
                 currentWriter = null;
-                counter = 0;
-                if (writer instanceof AutoCloseable) {
-                    ((AutoCloseable) writer).close();
+                if (writer != null) {
+                    writer.close();
                 }
             } finally {
                 super.close();
@@ -659,17 +645,16 @@ public class SortedIndexTopoBuilder {
 
         private void flushCurrentWriter() throws IOException {
             if (currentWriter != null) {
-                commitMessages.add(
-                        writer.flushIndex(
-                                currentTask.rowRange,
-                                multipleValues
-                                        ? currentWriter.finish(currentTask.rowRange.count())
-                                        : currentWriter.finish(),
-                                currentPartition,
-                                scanSnapshotId));
+                for (List<ResultEntry> resultEntries : currentWriter.finish()) {
+                    commitMessages.add(
+                            writer.flushIndex(
+                                    currentTask.rowRange,
+                                    resultEntries,
+                                    currentPartition,
+                                    scanSnapshotId));
+                }
             }
             currentWriter = null;
-            counter = 0;
         }
     }
 

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/procedure/CreateGlobalIndexProcedure.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/procedure/CreateGlobalIndexProcedure.java
@@ -191,6 +191,9 @@ public class CreateGlobalIndexProcedure extends ProcedureBase {
         if ("bitmap".equals(indexType)) {
             return "Bitmap";
         }
+        if ("multivalue".equals(indexType)) {
+            return "Multivalue";
+        }
         return indexType;
     }
 }

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/SortedGlobalIndexITCase.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/SortedGlobalIndexITCase.java
@@ -19,10 +19,16 @@
 package org.apache.paimon.flink;
 
 import org.apache.paimon.catalog.Catalog;
+import org.apache.paimon.data.BinaryString;
+import org.apache.paimon.globalindex.IndexedSplit;
 import org.apache.paimon.index.DataEvolutionIndexSourceMeta;
 import org.apache.paimon.index.IndexFileMeta;
 import org.apache.paimon.manifest.IndexManifestEntry;
+import org.apache.paimon.predicate.Predicate;
+import org.apache.paimon.predicate.PredicateBuilder;
 import org.apache.paimon.table.FileStoreTable;
+import org.apache.paimon.table.source.ReadBuilder;
+import org.apache.paimon.table.source.TableScan;
 
 import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
@@ -105,6 +111,97 @@ public class SortedGlobalIndexITCase extends CatalogITCaseBase {
 
         assertThat(sql("SELECT * FROM T_BITMAP WHERE id = 100"))
                 .containsOnly(Row.of(100, "name_100"));
+    }
+
+    @Test
+    public void testMultiValueIndex() throws Exception {
+        tEnv.getConfig().set(TableConfigOptions.TABLE_DML_SYNC, true);
+        sql(
+                "CREATE TABLE T_MULTIVALUE (id INT, tags ARRAY<STRING>) WITH ("
+                        + "'bucket' = '-1', "
+                        + "'global-index.enabled' = 'true', "
+                        + "'row-tracking.enabled' = 'true', "
+                        + "'data-evolution.enabled' = 'true', "
+                        + "'global-index.column-update-action' = 'IGNORE'"
+                        + ")");
+        sql(
+                "INSERT INTO T_MULTIVALUE VALUES "
+                        + "(1, ARRAY['red', 'blue']), "
+                        + "(2, ARRAY['blue']), "
+                        + "(3, ARRAY['green']), "
+                        + "(4, CAST(NULL AS ARRAY<STRING>)), "
+                        + "(5, ARRAY['red', 'red'])");
+        sql(
+                "CALL sys.create_global_index(`table` => 'default.T_MULTIVALUE', "
+                        + "index_column => 'tags', index_type => 'multivalue', "
+                        + "options => 'sorted-index.records-per-range=2')");
+
+        FileStoreTable table = paimonTable("T_MULTIVALUE");
+        List<IndexFileMeta> entries =
+                table.store().newIndexFileHandler().scanEntries().stream()
+                        .map(IndexManifestEntry::indexFile)
+                        .filter(file -> "multivalue".equals(file.indexType()))
+                        .collect(Collectors.toList());
+        assertThat(entries).hasSizeGreaterThan(1);
+        assertThat(entries).allSatisfy(entry -> assertThat(entry.globalIndexMeta()).isNotNull());
+        assertThat(entries.stream().mapToLong(IndexFileMeta::rowCount).sum()).isEqualTo(5L);
+        Set<String> initialFiles =
+                entries.stream().map(IndexFileMeta::fileName).collect(Collectors.toSet());
+
+        Predicate predicate =
+                new PredicateBuilder(table.rowType())
+                        .arrayContains(1, BinaryString.fromString("red"));
+        ReadBuilder readBuilder = table.newReadBuilder().withFilter(predicate);
+        TableScan.Plan plan = readBuilder.newScan().plan();
+        assertThat(plan.splits()).allMatch(IndexedSplit.class::isInstance);
+        List<Integer> ids = new java.util.ArrayList<>();
+        readBuilder
+                .newRead()
+                .executeFilter()
+                .createReader(plan)
+                .forEachRemaining(row -> ids.add(row.getInt(0)));
+        assertThat(ids).containsExactlyInAnyOrder(1, 5);
+
+        sql("CREATE TABLE S_MULTIVALUE (id INT, tags ARRAY<STRING>)");
+        sql("INSERT INTO S_MULTIVALUE VALUES (2, ARRAY['red'])");
+        sql(
+                "CALL sys.data_evolution_merge_into("
+                        + "'default.T_MULTIVALUE', '', '', 'S_MULTIVALUE', "
+                        + "'T_MULTIVALUE.id=S_MULTIVALUE.id', 'tags=S_MULTIVALUE.tags', 2)");
+        long updateSnapshotId = paimonTable("T_MULTIVALUE").snapshotManager().latestSnapshot().id();
+
+        sql(
+                "CALL sys.create_global_index(`table` => 'default.T_MULTIVALUE', "
+                        + "index_column => 'tags', index_type => 'multivalue', "
+                        + "options => 'sorted-index.records-per-range=2')");
+        table = paimonTable("T_MULTIVALUE");
+        List<IndexFileMeta> refreshed =
+                table.store().newIndexFileHandler().scanEntries().stream()
+                        .map(IndexManifestEntry::indexFile)
+                        .filter(file -> "multivalue".equals(file.indexType()))
+                        .collect(Collectors.toList());
+        assertThat(refreshed.stream().map(IndexFileMeta::fileName).collect(Collectors.toSet()))
+                .doesNotContainAnyElementsOf(initialFiles);
+        assertThat(refreshed)
+                .allSatisfy(
+                        entry ->
+                                assertThat(
+                                                DataEvolutionIndexSourceMeta.fromIndexFile(entry)
+                                                        .scanSnapshotId())
+                                        .isEqualTo(updateSnapshotId));
+
+        predicate =
+                new PredicateBuilder(table.rowType())
+                        .arrayContains(1, BinaryString.fromString("red"));
+        readBuilder = table.newReadBuilder().withFilter(predicate);
+        plan = readBuilder.newScan().plan();
+        ids.clear();
+        readBuilder
+                .newRead()
+                .executeFilter()
+                .createReader(plan)
+                .forEachRemaining(row -> ids.add(row.getInt(0)));
+        assertThat(ids).containsExactlyInAnyOrder(1, 2, 5);
     }
 
     @Test

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/SortedGlobalIndexITCase.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/SortedGlobalIndexITCase.java
@@ -129,8 +129,11 @@ public class SortedGlobalIndexITCase extends CatalogITCaseBase {
                         + "(1, ARRAY['red', 'blue']), "
                         + "(2, ARRAY['blue']), "
                         + "(3, ARRAY['green']), "
-                        + "(4, CAST(NULL AS ARRAY<STRING>)), "
-                        + "(5, ARRAY['red', 'red'])");
+                        + "(4, ARRAY['red', 'red']), "
+                        + "(5, CAST(NULL AS ARRAY<STRING>)), "
+                        + "(6, ARRAY[CAST(NULL AS STRING)]), "
+                        + "(7, ARRAY[CAST(NULL AS STRING)]), "
+                        + "(8, ARRAY['red', CAST(NULL AS STRING)])");
         sql(
                 "CALL sys.create_global_index(`table` => 'default.T_MULTIVALUE', "
                         + "index_column => 'tags', index_type => 'multivalue', "
@@ -144,7 +147,7 @@ public class SortedGlobalIndexITCase extends CatalogITCaseBase {
                         .collect(Collectors.toList());
         assertThat(entries).hasSizeGreaterThan(1);
         assertThat(entries).allSatisfy(entry -> assertThat(entry.globalIndexMeta()).isNotNull());
-        assertThat(entries.stream().mapToLong(IndexFileMeta::rowCount).sum()).isEqualTo(5L);
+        assertThat(entries.stream().mapToLong(IndexFileMeta::rowCount).sum()).isEqualTo(8L);
         Set<String> initialFiles =
                 entries.stream().map(IndexFileMeta::fileName).collect(Collectors.toSet());
 
@@ -160,7 +163,7 @@ public class SortedGlobalIndexITCase extends CatalogITCaseBase {
                 .executeFilter()
                 .createReader(plan)
                 .forEachRemaining(row -> ids.add(row.getInt(0)));
-        assertThat(ids).containsExactlyInAnyOrder(1, 5);
+        assertThat(ids).containsExactlyInAnyOrder(1, 4, 8);
 
         sql("CREATE TABLE S_MULTIVALUE (id INT, tags ARRAY<STRING>)");
         sql("INSERT INTO S_MULTIVALUE VALUES (2, ARRAY['red'])");
@@ -201,7 +204,7 @@ public class SortedGlobalIndexITCase extends CatalogITCaseBase {
                 .executeFilter()
                 .createReader(plan)
                 .forEachRemaining(row -> ids.add(row.getInt(0)));
-        assertThat(ids).containsExactlyInAnyOrder(1, 2, 5);
+        assertThat(ids).containsExactlyInAnyOrder(1, 2, 4, 8);
     }
 
     @Test

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/globalindex/SortedIndexTopoBuilderTest.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/globalindex/SortedIndexTopoBuilderTest.java
@@ -173,7 +173,13 @@ public class SortedIndexTopoBuilderTest {
 
     @Test
     public void testSortColumnsUseRowIdAsTieBreaker() {
-        assertThat(SortedIndexTopoBuilder.createSortColumns("task-id", "index-key"))
+        assertThat(SortedIndexTopoBuilder.createSortColumns("task-id", "index-key", true))
                 .containsExactly("task-id", "index-key", SpecialFields.ROW_ID.name());
+    }
+
+    @Test
+    public void testUnorderedIndexSortsOnlyByTaskAndRowId() {
+        assertThat(SortedIndexTopoBuilder.createSortColumns("task-id", "index-key", false))
+                .containsExactly("task-id", SpecialFields.ROW_ID.name());
     }
 }

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/globalindex/SortedIndexTopoBuilderTest.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/globalindex/SortedIndexTopoBuilderTest.java
@@ -22,6 +22,7 @@ import org.apache.paimon.flink.globalindex.SortedIndexTopoBuilder.SortedBuildTas
 import org.apache.paimon.globalindex.GlobalIndexSingleColumnWriter;
 import org.apache.paimon.globalindex.sorted.SortedGlobalIndexScanner;
 import org.apache.paimon.globalindex.sorted.SortedGlobalIndexWriter;
+import org.apache.paimon.globalindex.sorted.SortedSingleColumnIndexWriter;
 import org.apache.paimon.options.Options;
 import org.apache.paimon.table.FileStoreTable;
 import org.apache.paimon.table.SpecialFields;
@@ -76,9 +77,7 @@ public class SortedIndexTopoBuilderTest {
                         int.class,
                         int.class,
                         int.class,
-                        org.apache.paimon.types.DataType.class,
-                        boolean.class,
-                        long.class);
+                        org.apache.paimon.types.DataType.class);
         constructor.setAccessible(true);
         Object operator =
                 constructor.newInstance(
@@ -89,16 +88,16 @@ public class SortedIndexTopoBuilderTest {
                         0,
                         0,
                         0,
-                        DataTypes.INT(),
-                        false,
-                        1L);
+                        DataTypes.INT());
         GlobalIndexSingleColumnWriter activeWriter =
                 mock(
                         GlobalIndexSingleColumnWriter.class,
                         org.mockito.Mockito.withSettings().extraInterfaces(Closeable.class));
+        SortedSingleColumnIndexWriter taskWriter =
+                SortedSingleColumnIndexWriter.forSourceRowCount(1, activeWriter);
         Field currentWriter = operatorClass.getDeclaredField("currentWriter");
         currentWriter.setAccessible(true);
-        currentWriter.set(operator, activeWriter);
+        currentWriter.set(operator, taskWriter);
 
         Method close = operatorClass.getMethod("close");
         close.invoke(operator);

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/globalindex/SortedIndexTopoBuilderTest.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/globalindex/SortedIndexTopoBuilderTest.java
@@ -53,6 +53,7 @@ public class SortedIndexTopoBuilderTest {
     public void testSupportsBitmapAndBTree() {
         assertThat(SortedIndexTopoBuilder.supports("bitmap")).isTrue();
         assertThat(SortedIndexTopoBuilder.supports("btree")).isTrue();
+        assertThat(SortedIndexTopoBuilder.supports("multivalue")).isTrue();
         assertThat(SortedIndexTopoBuilder.supports("inverted")).isFalse();
     }
 
@@ -75,7 +76,9 @@ public class SortedIndexTopoBuilderTest {
                         int.class,
                         int.class,
                         int.class,
-                        org.apache.paimon.types.DataType.class);
+                        org.apache.paimon.types.DataType.class,
+                        boolean.class,
+                        long.class);
         constructor.setAccessible(true);
         Object operator =
                 constructor.newInstance(
@@ -86,7 +89,9 @@ public class SortedIndexTopoBuilderTest {
                         0,
                         0,
                         0,
-                        DataTypes.INT());
+                        DataTypes.INT(),
+                        false,
+                        1L);
         GlobalIndexSingleColumnWriter activeWriter =
                 mock(
                         GlobalIndexSingleColumnWriter.class,
@@ -172,14 +177,8 @@ public class SortedIndexTopoBuilderTest {
     }
 
     @Test
-    public void testSortColumnsUseRowIdAsTieBreaker() {
-        assertThat(SortedIndexTopoBuilder.createSortColumns("task-id", "index-key", true))
+    public void testNormalizedSortColumnsUseRowIdAsTieBreaker() {
+        assertThat(SortedIndexTopoBuilder.createSortColumns("task-id", "index-key"))
                 .containsExactly("task-id", "index-key", SpecialFields.ROW_ID.name());
-    }
-
-    @Test
-    public void testUnorderedIndexSortsOnlyByTaskAndRowId() {
-        assertThat(SortedIndexTopoBuilder.createSortColumns("task-id", "index-key", false))
-                .containsExactly("task-id", SpecialFields.ROW_ID.name());
     }
 }

--- a/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/globalindex/sorted/SortedIndexTopoBuilder.java
+++ b/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/globalindex/sorted/SortedIndexTopoBuilder.java
@@ -21,6 +21,7 @@ package org.apache.paimon.spark.globalindex.sorted;
 import org.apache.paimon.data.BinaryRow;
 import org.apache.paimon.data.InternalRow;
 import org.apache.paimon.data.serializer.BinaryRowSerializer;
+import org.apache.paimon.globalindex.GlobalIndexer;
 import org.apache.paimon.globalindex.ScanResult;
 import org.apache.paimon.globalindex.sorted.SortedGlobalIndexScanner;
 import org.apache.paimon.globalindex.sorted.SortedGlobalIndexWriter;
@@ -34,6 +35,7 @@ import org.apache.paimon.spark.SparkRow;
 import org.apache.paimon.spark.globalindex.GlobalIndexTopologyBuilder;
 import org.apache.paimon.spark.util.ScanPlanHelper$;
 import org.apache.paimon.table.FileStoreTable;
+import org.apache.paimon.table.SpecialFields;
 import org.apache.paimon.table.sink.CommitMessage;
 import org.apache.paimon.table.sink.CommitMessageImpl;
 import org.apache.paimon.table.sink.CommitMessageSerializer;
@@ -71,7 +73,7 @@ import static org.apache.paimon.globalindex.GlobalIndexBuilderUtils.splitByConti
 public class SortedIndexTopoBuilder implements GlobalIndexTopologyBuilder {
 
     private static final HashSet<String> SUPPORTED_INDEX_TYPES =
-            new HashSet<>(Arrays.asList("btree", "bitmap"));
+            new HashSet<>(Arrays.asList("btree", "bitmap", "multivalue"));
 
     public static boolean supports(String indexType) {
         return SUPPORTED_INDEX_TYPES.contains(indexType);
@@ -121,7 +123,11 @@ public class SortedIndexTopoBuilder implements GlobalIndexTopologyBuilder {
 
         List<CommitMessage> allMessages = new ArrayList<>();
         List<String> sortColumns = new ArrayList<>();
-        sortColumns.add(indexField.name());
+        if (GlobalIndexer.create(indexType, indexField, options).requiresSortedInput()) {
+            sortColumns.add(indexField.name());
+        } else {
+            sortColumns.add(SpecialFields.ROW_ID.name());
+        }
         final int partitionKeyNum = table.partitionKeys().size();
         BinaryRowSerializer binaryRowSerializer = new BinaryRowSerializer(partitionKeyNum);
         SortedGlobalIndexWriter indexWriter =

--- a/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/globalindex/sorted/SortedIndexTopoBuilder.java
+++ b/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/globalindex/sorted/SortedIndexTopoBuilder.java
@@ -19,10 +19,13 @@
 package org.apache.paimon.spark.globalindex.sorted;
 
 import org.apache.paimon.data.BinaryRow;
+import org.apache.paimon.data.GenericRow;
 import org.apache.paimon.data.InternalRow;
 import org.apache.paimon.data.serializer.BinaryRowSerializer;
+import org.apache.paimon.globalindex.GlobalIndexKeyExtractor;
 import org.apache.paimon.globalindex.GlobalIndexer;
 import org.apache.paimon.globalindex.ScanResult;
+import org.apache.paimon.globalindex.SortedGlobalIndexer;
 import org.apache.paimon.globalindex.sorted.SortedGlobalIndexScanner;
 import org.apache.paimon.globalindex.sorted.SortedGlobalIndexWriter;
 import org.apache.paimon.globalindex.sorted.SortedIndexOptions;
@@ -42,6 +45,7 @@ import org.apache.paimon.table.sink.CommitMessageSerializer;
 import org.apache.paimon.table.source.DataSplit;
 import org.apache.paimon.table.source.Split;
 import org.apache.paimon.types.DataField;
+import org.apache.paimon.types.DataTypes;
 import org.apache.paimon.types.RowType;
 import org.apache.paimon.utils.InstantiationUtil;
 import org.apache.paimon.utils.Range;
@@ -60,17 +64,23 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.NoSuchElementException;
 import java.util.Optional;
 
 import static org.apache.paimon.globalindex.GlobalIndexBuilderUtils.groupSplitsByRange;
+import static org.apache.paimon.globalindex.GlobalIndexBuilderUtils.shardSplitsByRowRange;
 import static org.apache.paimon.globalindex.GlobalIndexBuilderUtils.splitByContiguousRowRange;
 
 /** The {@link GlobalIndexTopologyBuilder} for sorted indexes. */
 public class SortedIndexTopoBuilder implements GlobalIndexTopologyBuilder {
+
+    private static final String BUILD_TASK_ID_FIELD = "_SORTED_INDEX_BUILD_TASK_ID";
+    private static final int BUILD_TASK_ID_FIELD_ID = -1;
 
     private static final HashSet<String> SUPPORTED_INDEX_TYPES =
             new HashSet<>(Arrays.asList("btree", "bitmap", "multivalue"));
@@ -115,19 +125,20 @@ public class SortedIndexTopoBuilder implements GlobalIndexTopologyBuilder {
             return Collections.emptyList();
         }
 
-        List<String> selectedColumns = new ArrayList<>(readType.getFieldNames());
-
         // Calculate maximum parallelism bound
         long recordsPerRange = options.get(SortedIndexOptions.SORTED_INDEX_RECORDS_PER_RANGE);
         int maxParallelism = options.get(SortedIndexOptions.SORTED_INDEX_BUILD_MAX_PARALLELISM);
 
         List<CommitMessage> allMessages = new ArrayList<>();
-        List<String> sortColumns = new ArrayList<>();
-        if (GlobalIndexer.create(indexType, indexField, options).requiresSortedInput()) {
-            sortColumns.add(indexField.name());
-        } else {
-            sortColumns.add(SpecialFields.ROW_ID.name());
+        GlobalIndexer indexer = GlobalIndexer.create(indexType, indexField, options);
+        if (!(indexer instanceof SortedGlobalIndexer)) {
+            throw new IllegalArgumentException(
+                    "Index algorithm " + indexType + " does not expose sorted index keys.");
         }
+        GlobalIndexKeyExtractor keyExtractor = ((SortedGlobalIndexer) indexer).keyExtractor();
+        String taskIdField = buildTaskIdFieldName(readType);
+        RowType normalizedReadType =
+                normalizedReadType(readType, taskIdField, indexField, keyExtractor.keyType());
         final int partitionKeyNum = table.partitionKeys().size();
         BinaryRowSerializer binaryRowSerializer = new BinaryRowSerializer(partitionKeyNum);
         SortedGlobalIndexWriter indexWriter =
@@ -141,42 +152,114 @@ public class SortedIndexTopoBuilder implements GlobalIndexTopologyBuilder {
                 if (rangeSplits.isEmpty()) {
                     continue;
                 }
-                int partitionNum = Math.max((int) (range.count() / recordsPerRange), 1);
-                partitionNum = Math.min(partitionNum, maxParallelism);
+
+                final byte[] serializedWriter = InstantiationUtil.serializeObject(indexWriter);
+                final byte[] partitionBytes =
+                        binaryRowSerializer.serializeToBytes(partitionEntry.getKey());
+                if (keyExtractor.isIdentity()) {
+                    int partitionNum = Math.max((int) (range.count() / recordsPerRange), 1);
+                    partitionNum = Math.min(partitionNum, maxParallelism);
+
+                    Dataset<Row> source =
+                            PaimonUtils.createDataset(
+                                    spark,
+                                    ScanPlanHelper$.MODULE$.createNewScanPlan(
+                                            rangeSplits.toArray(new Split[0]), relation));
+                    Dataset<Row> selected =
+                            source.select(
+                                    readType.getFieldNames().stream()
+                                            .map(functions::col)
+                                            .toArray(Column[]::new));
+                    Column[] sortFields =
+                            new Column[] {
+                                functions.col(indexField.name()),
+                                functions.col(SpecialFields.ROW_ID.name())
+                            };
+                    Dataset<Row> partitioned =
+                            selected.repartitionByRange(partitionNum, sortFields)
+                                    .sortWithinPartitions(sortFields);
+                    JavaRDD<byte[]> written =
+                            partitioned
+                                    .javaRDD()
+                                    .map(row -> (InternalRow) (new SparkRow(readType, row)))
+                                    .mapPartitions(
+                                            (FlatMapFunction<Iterator<InternalRow>, byte[]>)
+                                                    iter ->
+                                                            buildSortedIndex(
+                                                                    iter,
+                                                                    serializedWriter,
+                                                                    range,
+                                                                    partitionKeyNum,
+                                                                    partitionBytes,
+                                                                    scanSnapshotId));
+                    allMessages.addAll(CommitMessageSerializer.deserializeAll(written.collect()));
+                    continue;
+                }
+
+                Map<Range, List<Split>> shardedSplits =
+                        shardSplitsByRowRange(
+                                Collections.singletonMap(range, rangeSplits), recordsPerRange);
+                if (shardedSplits.isEmpty()) {
+                    continue;
+                }
+                int partitionNum = Math.min(shardedSplits.size(), maxParallelism);
+                List<Split> splitsToRead = new ArrayList<>();
+                Map<Long, Range> taskRanges = new HashMap<>();
+                for (Map.Entry<Range, List<Split>> shard : shardedSplits.entrySet()) {
+                    splitsToRead.addAll(shard.getValue());
+                    taskRanges.put(shard.getKey().from / recordsPerRange, shard.getKey());
+                }
 
                 Dataset<Row> source =
                         PaimonUtils.createDataset(
                                 spark,
                                 ScanPlanHelper$.MODULE$.createNewScanPlan(
-                                        rangeSplits.toArray(new Split[0]), relation));
+                                        splitsToRead.toArray(new Split[0]), relation));
 
                 Dataset<Row> selected =
                         source.select(
-                                selectedColumns.stream()
-                                        .map(functions::col)
-                                        .toArray(Column[]::new));
+                                        functions.col(indexField.name()),
+                                        functions.col(SpecialFields.ROW_ID.name()))
+                                .withColumn(
+                                        taskIdField,
+                                        functions
+                                                .expr(
+                                                        "`"
+                                                                + SpecialFields.ROW_ID.name()
+                                                                + "` DIV "
+                                                                + recordsPerRange)
+                                                .cast("long"));
+                Dataset<Row> normalized =
+                        selected.select(
+                                functions.col(taskIdField),
+                                functions
+                                        .explode_outer(functions.col(indexField.name()))
+                                        .alias(indexField.name()),
+                                functions.col(SpecialFields.ROW_ID.name()));
 
                 Column[] sortFields =
-                        sortColumns.stream().map(functions::col).toArray(Column[]::new);
+                        new Column[] {
+                            functions.col(taskIdField),
+                            functions.col(indexField.name()),
+                            functions.col(SpecialFields.ROW_ID.name())
+                        };
 
                 Dataset<Row> partitioned =
-                        selected.repartitionByRange(partitionNum, sortFields)
+                        normalized
+                                .repartition(partitionNum, functions.col(taskIdField))
                                 .sortWithinPartitions(sortFields);
 
-                final byte[] serializedWriter = InstantiationUtil.serializeObject(indexWriter);
-                final byte[] partitionBytes =
-                        binaryRowSerializer.serializeToBytes(partitionEntry.getKey());
                 JavaRDD<byte[]> written =
                         partitioned
                                 .javaRDD()
-                                .map(row -> (InternalRow) (new SparkRow(readType, row)))
+                                .map(row -> (InternalRow) (new SparkRow(normalizedReadType, row)))
                                 .mapPartitions(
                                         (FlatMapFunction<Iterator<InternalRow>, byte[]>)
                                                 iter ->
-                                                        buildSortedIndex(
+                                                        buildSortedIndexes(
                                                                 iter,
                                                                 serializedWriter,
-                                                                range,
+                                                                taskRanges,
                                                                 partitionKeyNum,
                                                                 partitionBytes,
                                                                 scanSnapshotId));
@@ -213,5 +296,108 @@ public class SortedIndexTopoBuilder implements GlobalIndexTopologyBuilder {
         return CommitMessageSerializer.serializeAll(
                         writer.buildForSinglePartition(range, partition, input, scanSnapshotId))
                 .iterator();
+    }
+
+    private static Iterator<byte[]> buildSortedIndexes(
+            Iterator<InternalRow> input,
+            byte[] serializedWriter,
+            Map<Long, Range> taskRanges,
+            int partitionKeyNum,
+            byte[] partitionBytes,
+            long scanSnapshotId)
+            throws IOException, ClassNotFoundException {
+        final BinaryRowSerializer binaryRowSerializer = new BinaryRowSerializer(partitionKeyNum);
+        BinaryRow partition = binaryRowSerializer.deserializeFromBytes(partitionBytes);
+        SortedGlobalIndexWriter writer =
+                InstantiationUtil.deserializeObject(
+                        serializedWriter, SortedGlobalIndexWriter.class.getClassLoader());
+        SortedTaskInput taskInput = new SortedTaskInput(input, writer.keyExtractor().keyType());
+        List<byte[]> results = new ArrayList<>();
+        while (taskInput.hasTask()) {
+            long taskId = taskInput.taskId();
+            Range range = taskRanges.get(taskId);
+            if (range == null) {
+                throw new IllegalArgumentException("Unknown sorted index build task id: " + taskId);
+            }
+            results.addAll(
+                    CommitMessageSerializer.serializeAll(
+                            writer.buildForSinglePartition(
+                                    range,
+                                    partition,
+                                    taskInput.consumeTask(taskId),
+                                    scanSnapshotId)));
+        }
+        return results.iterator();
+    }
+
+    private static String buildTaskIdFieldName(RowType readType) {
+        String fieldName = BUILD_TASK_ID_FIELD;
+        while (readType.containsField(fieldName)) {
+            fieldName = "_" + fieldName;
+        }
+        return fieldName;
+    }
+
+    private static RowType normalizedReadType(
+            RowType readType,
+            String taskIdField,
+            DataField sourceField,
+            org.apache.paimon.types.DataType keyType) {
+        return RowType.of(
+                new DataField(BUILD_TASK_ID_FIELD_ID, taskIdField, DataTypes.BIGINT().notNull()),
+                new DataField(sourceField.id(), sourceField.name(), keyType),
+                readType.getField(SpecialFields.ROW_ID.name()));
+    }
+
+    /** Groups a partition already sorted by task id, normalized key and row id. */
+    private static class SortedTaskInput {
+
+        private final Iterator<InternalRow> input;
+        private final InternalRow.FieldGetter keyGetter;
+
+        private InternalRow next;
+
+        private SortedTaskInput(
+                Iterator<InternalRow> input, org.apache.paimon.types.DataType keyType) {
+            this.input = input;
+            this.keyGetter = InternalRow.createFieldGetter(keyType, 1);
+            advance();
+        }
+
+        private boolean hasTask() {
+            return next != null;
+        }
+
+        private long taskId() {
+            if (next == null) {
+                throw new NoSuchElementException();
+            }
+            return next.getLong(0);
+        }
+
+        private Iterator<InternalRow> consumeTask(long taskId) {
+            return new Iterator<InternalRow>() {
+                @Override
+                public boolean hasNext() {
+                    return next != null && next.getLong(0) == taskId;
+                }
+
+                @Override
+                public InternalRow next() {
+                    if (!hasNext()) {
+                        throw new NoSuchElementException();
+                    }
+                    InternalRow row = next;
+                    InternalRow result =
+                            GenericRow.of(keyGetter.getFieldOrNull(row), row.getLong(2));
+                    advance();
+                    return result;
+                }
+            };
+        }
+
+        private void advance() {
+            next = input.hasNext() ? input.next() : null;
+        }
     }
 }

--- a/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/procedure/CreateGlobalIndexProcedureTest.scala
+++ b/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/procedure/CreateGlobalIndexProcedureTest.scala
@@ -260,8 +260,11 @@ class CreateGlobalIndexProcedureTest extends PaimonSparkTestBase with StreamTest
           "(1, array('red', 'blue')), " +
           "(2, array('blue')), " +
           "(3, array('green')), " +
-          "(4, CAST(NULL AS ARRAY<STRING>)), " +
-          "(5, array('red', 'red'))"
+          "(4, array('red', 'red')), " +
+          "(5, CAST(NULL AS ARRAY<STRING>)), " +
+          "(6, CAST(array() AS ARRAY<STRING>)), " +
+          "(7, array(CAST(NULL AS STRING))), " +
+          "(8, array('red', CAST(NULL AS STRING)))"
       )
 
       val output =
@@ -280,7 +283,7 @@ class CreateGlobalIndexProcedureTest extends PaimonSparkTestBase with StreamTest
         .map(_.indexFile())
         .filter(_.indexType() == "multivalue")
       assert(entries.size > 1)
-      assert(entries.map(_.rowCount()).sum == 5L)
+      assert(entries.map(_.rowCount()).sum == 8L)
       entries.foreach(entry => assert(entry.globalIndexMeta() != null))
     }
   }

--- a/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/procedure/CreateGlobalIndexProcedureTest.scala
+++ b/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/procedure/CreateGlobalIndexProcedureTest.scala
@@ -244,6 +244,47 @@ class CreateGlobalIndexProcedureTest extends PaimonSparkTestBase with StreamTest
     }
   }
 
+  test("create multivalue global index") {
+    withTable("T") {
+      spark.sql("""
+                  |CREATE TABLE T (id INT, tags ARRAY<STRING>)
+                  |TBLPROPERTIES (
+                  |  'bucket' = '-1',
+                  |  'global-index.enabled' = 'true',
+                  |  'row-tracking.enabled' = 'true',
+                  |  'data-evolution.enabled' = 'true')
+                  |""".stripMargin)
+
+      spark.sql(
+        "INSERT INTO T VALUES " +
+          "(1, array('red', 'blue')), " +
+          "(2, array('blue')), " +
+          "(3, array('green')), " +
+          "(4, CAST(NULL AS ARRAY<STRING>)), " +
+          "(5, array('red', 'red'))"
+      )
+
+      val output =
+        spark
+          .sql("CALL sys.create_global_index(table => 'test.T', index_column => 'tags', " +
+            "index_type => 'multivalue', options => 'sorted-index.records-per-range=2')")
+          .collect()
+          .head
+
+      assert(output.getBoolean(0))
+      val entries = loadTable("T")
+        .store()
+        .newIndexFileHandler()
+        .scanEntries()
+        .asScala
+        .map(_.indexFile())
+        .filter(_.indexType() == "multivalue")
+      assert(entries.size > 1)
+      assert(entries.map(_.rowCount()).sum == 5L)
+      entries.foreach(entry => assert(entry.globalIndexMeta() != null))
+    }
+  }
+
   test("create btree global index with multiple partitions") {
     withTable("T") {
       spark.sql("""


### PR DESCRIPTION
### Purpose

Integrate the Multivalue global-index primitives introduced by #9288 with Paimon's Data Evolution and Primary Key table paths, including spill-sorted index construction in Flink and Spark.

### Changes

- Register the `multivalue` index SPI now that the sorted builders understand normalized index keys.
- Add Data Evolution build, refresh, coverage, and scan pushdown for `ARRAY_CONTAINS`.
- Add Primary Key table options, validation, maintenance, source localization, and read pushdown.
- Expand arrays into non-null `(element, row-id)` entries and spill-sort them in the PK, Flink, and Spark build paths.
- Preserve source-row coverage independently from expanded entry count, including null and empty arrays.
- Encapsulate scalar file rotation and explicit source-row coverage in the sorted task writer.
- Add user documentation and generated configuration entries.

### User impact

Flink and Spark can build a Multivalue index with `create_global_index`, and Paimon Core scans can use it to prune `ARRAY_CONTAINS` predicates. SQL expression translation to Paimon's predicate remains connector-specific and is outside this PR.

### Validation

- Common Multivalue reader, writer, key-extractor, metadata, and ServiceLoader tests.
- Focused Core tests for Data Evolution, Primary Key, and sorted task-writer behavior.
- 18 focused Flink 1 topology and integration tests.
- Spark 3 `CreateGlobalIndexProcedureTest`: 6 tests.
- Non-fast Checkstyle, Spotless, and Enforcer validation for API/Common/Core, Flink 1, and Spark 3 modules.
- `git diff --check` and exact tree-equivalence verification after rebasing onto #9288.
