### PR TITLE
Fix data loss when recovering incomplete END_INPUT committables

### DIFF
--- a/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/sink/cdc/FlinkCdcMultiTableSink.java
+++ b/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/sink/cdc/FlinkCdcMultiTableSink.java
@@ -177,6 +177,8 @@ public class FlinkCdcMultiTableSink implements Serializable {
 
     protected CommittableStateManager<WrappedManifestCommittable> createCommittableStateManager() {
         return new RestoreAndFailCommittableStateManager<>(
-                WrappedManifestCommittableSerializer::new, true);
+                WrappedManifestCommittableSerializer::new,
+                true,
+                StoreMultiCommitter.END_INPUT_HANDLER);
     }
 }

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/CombinedTableCompactorSink.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/CombinedTableCompactorSink.java
@@ -208,6 +208,7 @@ public class CombinedTableCompactorSink implements Serializable {
     protected CommittableStateManager<WrappedManifestCommittable> createCommittableStateManager() {
         return new RestoreAndFailCommittableStateManager<>(
                 WrappedManifestCommittableSerializer::new,
-                options.get(PARTITION_MARK_DONE_RECOVER_FROM_STATE));
+                options.get(PARTITION_MARK_DONE_RECOVER_FROM_STATE),
+                StoreMultiCommitter.END_INPUT_HANDLER);
     }
 }

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/CommitterOperator.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/CommitterOperator.java
@@ -47,7 +47,7 @@ public class CommitterOperator<CommitT, GlobalCommitT> extends AbstractStreamOpe
         implements OneInputStreamOperator<CommitT, CommitT>, BoundedOneInput {
 
     private static final long serialVersionUID = 1L;
-    private static final long END_INPUT_CHECKPOINT_ID = Long.MAX_VALUE;
+    static final long END_INPUT_CHECKPOINT_ID = Long.MAX_VALUE;
 
     /** Record all the inputs until commit. */
     private final Deque<CommitT> inputs = new ArrayDeque<>();
@@ -85,7 +85,7 @@ public class CommitterOperator<CommitT, GlobalCommitT> extends AbstractStreamOpe
 
     private transient long currentWatermark;
 
-    private transient boolean endInput;
+    private transient boolean completeEndInput;
 
     private transient String commitUser;
 
@@ -123,7 +123,7 @@ public class CommitterOperator<CommitT, GlobalCommitT> extends AbstractStreamOpe
                 "Committer Operator parallelism in paimon MUST be one.");
 
         this.currentWatermark = Long.MIN_VALUE;
-        this.endInput = false;
+        this.completeEndInput = false;
         // each job can only have one user name and this name must be consistent across restarts
         // we cannot use job id as commit user name here because user may change job id by creating
         // a savepoint, stop the job and then resume from savepoint
@@ -149,7 +149,14 @@ public class CommitterOperator<CommitT, GlobalCommitT> extends AbstractStreamOpe
                                 .getSpillingDirectoriesPaths());
         committer = committerFactory.create(committerContext);
 
-        committableStateManager.initializeState(committerContext, committer);
+        List<GlobalCommitT> pendingEndInputCommittables =
+                committableStateManager.initializeState(committerContext, committer);
+        for (GlobalCommitT committable : pendingEndInputCommittables) {
+            Preconditions.checkState(
+                    !committablesPerCheckpoint.containsKey(END_INPUT_CHECKPOINT_ID),
+                    "State manager returned multiple pending end-input committables.");
+            committablesPerCheckpoint.put(END_INPUT_CHECKPOINT_ID, committable);
+        }
     }
 
     @Override
@@ -170,7 +177,8 @@ public class CommitterOperator<CommitT, GlobalCommitT> extends AbstractStreamOpe
         super.snapshotState(context);
         pollInputs();
         committer.snapshotState();
-        committableStateManager.snapshotState(committables(committablesPerCheckpoint));
+        committableStateManager.snapshotState(
+                committables(committablesPerCheckpoint), completeEndInput);
     }
 
     private List<GlobalCommitT> committables(NavigableMap<Long, GlobalCommitT> map) {
@@ -179,23 +187,24 @@ public class CommitterOperator<CommitT, GlobalCommitT> extends AbstractStreamOpe
 
     @Override
     public void endInput() throws Exception {
-        endInput = true;
         if (endInputWatermark != null) {
             currentWatermark = endInputWatermark;
         }
+
+        pollInputs();
+        completeEndInput = true;
 
         if (streamingCheckpointEnabled) {
             return;
         }
 
-        pollInputs();
         commitUpToCheckpoint(END_INPUT_CHECKPOINT_ID);
     }
 
     @Override
     public void notifyCheckpointComplete(long checkpointId) throws Exception {
         super.notifyCheckpointComplete(checkpointId);
-        commitUpToCheckpoint(endInput ? END_INPUT_CHECKPOINT_ID : checkpointId);
+        commitUpToCheckpoint(completeEndInput ? END_INPUT_CHECKPOINT_ID : checkpointId);
     }
 
     private void commitUpToCheckpoint(long checkpointId) throws Exception {

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/EndInputCommittableHandler.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/EndInputCommittableHandler.java
@@ -19,21 +19,16 @@
 package org.apache.paimon.flink.sink;
 
 import java.io.Serializable;
-import java.util.List;
 
-/**
- * Helper interface for {@link CommitterOperator}. This interface manages operator states about
- * {@link org.apache.paimon.manifest.ManifestCommittable}.
- */
-public interface CommittableStateManager<GlobalCommitT> extends Serializable {
+/** Operations required to keep incomplete end-input committables pending during recovery. */
+public interface EndInputCommittableHandler<GlobalCommitT> extends Serializable {
+
+    /** Returns whether the committable belongs to end input. */
+    boolean isEndInput(GlobalCommitT committable);
 
     /**
-     * Initializes the state and returns restored committables which must remain pending in the
-     * operator.
+     * Merges two restored end-input committables without rebuilding them or refreshing watermark
+     * metadata.
      */
-    List<GlobalCommitT> initializeState(
-            Committer.Context context, Committer<?, GlobalCommitT> committer) throws Exception;
-
-    /** Snapshots pending committables together with the complete end-input state. */
-    void snapshotState(List<GlobalCommitT> committables, boolean completeEndInput) throws Exception;
+    GlobalCommitT merge(GlobalCommitT target, GlobalCommitT source);
 }

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/FlinkWriteSink.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/FlinkWriteSink.java
@@ -66,7 +66,8 @@ public abstract class FlinkWriteSink<T> extends FlinkSink<T> {
         Options options = table.coreOptions().toConfiguration();
         return new RestoreAndFailCommittableStateManager<>(
                 ManifestCommittableSerializer::new,
-                options.get(PARTITION_MARK_DONE_RECOVER_FROM_STATE));
+                options.get(PARTITION_MARK_DONE_RECOVER_FROM_STATE),
+                StoreCommitter.END_INPUT_HANDLER);
     }
 
     protected static OneInputStreamOperatorFactory<InternalRow, Committable>
@@ -89,6 +90,7 @@ public abstract class FlinkWriteSink<T> extends FlinkSink<T> {
         Options options = table.coreOptions().toConfiguration();
         return new RestoreCommittableStateManager<>(
                 ManifestCommittableSerializer::new,
-                options.get(PARTITION_MARK_DONE_RECOVER_FROM_STATE));
+                options.get(PARTITION_MARK_DONE_RECOVER_FROM_STATE),
+                StoreCommitter.END_INPUT_HANDLER);
     }
 }

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/NoopCommittableStateManager.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/NoopCommittableStateManager.java
@@ -20,6 +20,7 @@ package org.apache.paimon.flink.sink;
 
 import org.apache.paimon.manifest.ManifestCommittable;
 
+import java.util.Collections;
 import java.util.List;
 
 /**
@@ -32,14 +33,15 @@ import java.util.List;
 public class NoopCommittableStateManager implements CommittableStateManager<ManifestCommittable> {
 
     @Override
-    public void initializeState(
+    public List<ManifestCommittable> initializeState(
             Committer.Context context, Committer<?, ManifestCommittable> committer)
             throws Exception {
-        // nothing to do
+        return Collections.emptyList();
     }
 
     @Override
-    public void snapshotState(List<ManifestCommittable> committables) throws Exception {
+    public void snapshotState(List<ManifestCommittable> committables, boolean completeEndInput)
+            throws Exception {
         // nothing to do
     }
 }

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/RestoreAndFailCommittableStateManager.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/RestoreAndFailCommittableStateManager.java
@@ -41,8 +41,9 @@ public class RestoreAndFailCommittableStateManager<GlobalCommitT>
 
     public RestoreAndFailCommittableStateManager(
             SerializableSupplier<VersionedSerializer<GlobalCommitT>> committableSerializer,
-            boolean partitionMarkDoneRecoverFromState) {
-        super(committableSerializer, partitionMarkDoneRecoverFromState);
+            boolean partitionMarkDoneRecoverFromState,
+            EndInputCommittableHandler<GlobalCommitT> endInputHandler) {
+        super(committableSerializer, partitionMarkDoneRecoverFromState, endInputHandler);
     }
 
     @Override

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/RestoreCommittableStateManager.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/RestoreCommittableStateManager.java
@@ -25,16 +25,19 @@ import org.apache.paimon.utils.SerializableSupplier;
 
 import org.apache.flink.api.common.state.ListState;
 import org.apache.flink.api.common.state.ListStateDescriptor;
+import org.apache.flink.api.common.typeutils.base.BooleanSerializer;
 import org.apache.flink.api.common.typeutils.base.array.BytePrimitiveArraySerializer;
 import org.apache.flink.streaming.api.operators.util.SimpleVersionedListState;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 /**
  * A {@link CommittableStateManager} which stores uncommitted {@link ManifestCommittable}s in state.
  *
- * <p>When the job restarts, these {@link ManifestCommittable}s will be restored and committed.
+ * <p>When the job restarts, regular checkpoint committables are restored and committed. An
+ * incomplete END_INPUT committable remains pending until the operator receives complete end input.
  */
 public class RestoreCommittableStateManager<GlobalCommitT>
         implements CommittableStateManager<GlobalCommitT> {
@@ -46,19 +49,41 @@ public class RestoreCommittableStateManager<GlobalCommitT>
 
     private final boolean partitionMarkDoneRecoverFromState;
 
+    private final EndInputCommittableHandler<GlobalCommitT> endInputHandler;
+
     /** GlobalCommitT state of this job. Used to filter out previous successful commits. */
     private ListState<GlobalCommitT> streamingCommitterState;
 
+    /** Whether every committer operator completed end input before the restored checkpoint. */
+    private ListState<Boolean> completeEndInputState;
+
     public RestoreCommittableStateManager(
             SerializableSupplier<VersionedSerializer<GlobalCommitT>> committableSerializer,
-            boolean partitionMarkDoneRecoverFromState) {
+            boolean partitionMarkDoneRecoverFromState,
+            EndInputCommittableHandler<GlobalCommitT> endInputHandler) {
         this.committableSerializer = committableSerializer;
         this.partitionMarkDoneRecoverFromState = partitionMarkDoneRecoverFromState;
+        this.endInputHandler = endInputHandler;
     }
 
     @Override
-    public void initializeState(Committer.Context context, Committer<?, GlobalCommitT> committer)
-            throws Exception {
+    public List<GlobalCommitT> initializeState(
+            Committer.Context context, Committer<?, GlobalCommitT> committer) throws Exception {
+        completeEndInputState =
+                context.stateStore()
+                        .getUnionListState(
+                                new ListStateDescriptor<>(
+                                        "streaming_committer_complete_end_input_state",
+                                        BooleanSerializer.INSTANCE));
+        boolean hasCompleteEndInputState = false;
+        boolean restoredCompleteEndInput = true;
+        for (Boolean value : completeEndInputState.get()) {
+            hasCompleteEndInputState = true;
+            restoredCompleteEndInput &= Boolean.TRUE.equals(value);
+        }
+        restoredCompleteEndInput &= hasCompleteEndInputState;
+        completeEndInputState.clear();
+
         streamingCommitterState =
                 new SimpleVersionedListState<>(
                         context.stateStore()
@@ -70,7 +95,26 @@ public class RestoreCommittableStateManager<GlobalCommitT>
         List<GlobalCommitT> restored = new ArrayList<>();
         streamingCommitterState.get().forEach(restored::add);
         streamingCommitterState.clear();
+
+        List<GlobalCommitT> pendingEndInput = new ArrayList<>();
+        if (!restoredCompleteEndInput) {
+            restored.removeIf(
+                    committable -> {
+                        if (endInputHandler.isEndInput(committable)) {
+                            if (pendingEndInput.isEmpty()) {
+                                pendingEndInput.add(committable);
+                            } else {
+                                pendingEndInput.set(
+                                        0,
+                                        endInputHandler.merge(pendingEndInput.get(0), committable));
+                            }
+                            return true;
+                        }
+                        return false;
+                    });
+        }
         recover(restored, committer);
+        return pendingEndInput;
     }
 
     protected int recover(List<GlobalCommitT> committables, Committer<?, GlobalCommitT> committer)
@@ -79,7 +123,9 @@ public class RestoreCommittableStateManager<GlobalCommitT>
     }
 
     @Override
-    public void snapshotState(List<GlobalCommitT> committables) throws Exception {
+    public void snapshotState(List<GlobalCommitT> committables, boolean completeEndInput)
+            throws Exception {
         streamingCommitterState.update(committables);
+        completeEndInputState.update(Collections.singletonList(completeEndInput));
     }
 }

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/StoreCommitter.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/StoreCommitter.java
@@ -41,8 +41,31 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import static org.apache.paimon.utils.Preconditions.checkArgument;
+
 /** {@link Committer} for dynamic store. */
 public class StoreCommitter implements Committer<Committable, ManifestCommittable> {
+
+    public static final EndInputCommittableHandler<ManifestCommittable> END_INPUT_HANDLER =
+            new EndInputCommittableHandler<ManifestCommittable>() {
+                private static final long serialVersionUID = 1L;
+
+                @Override
+                public boolean isEndInput(ManifestCommittable committable) {
+                    return committable.identifier() == CommitterOperator.END_INPUT_CHECKPOINT_ID;
+                }
+
+                @Override
+                public ManifestCommittable merge(
+                        ManifestCommittable target, ManifestCommittable source) {
+                    checkArgument(
+                            target.identifier() == source.identifier(),
+                            "Cannot merge committables from different checkpoints %s and %s.",
+                            target.identifier(),
+                            source.identifier());
+                    return mergeManifestCommittables(target, source);
+                }
+            };
 
     private final TableCommitImpl commit;
     @Nullable private final CommitterMetrics committerMetrics;
@@ -104,6 +127,15 @@ public class StoreCommitter implements Committer<Committable, ManifestCommittabl
             manifestCommittable.addFileCommittable(file);
         }
         return manifestCommittable;
+    }
+
+    static ManifestCommittable mergeManifestCommittables(
+            ManifestCommittable target, ManifestCommittable source) {
+        for (CommitMessage commitMessage : source.fileCommittables()) {
+            target.addFileCommittable(commitMessage);
+        }
+        source.properties().forEach(target::addProperty);
+        return target;
     }
 
     @Override

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/StoreMultiCommitter.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/StoreMultiCommitter.java
@@ -39,6 +39,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
+import static org.apache.paimon.utils.Preconditions.checkArgument;
+
 /**
  * {@link StoreMultiCommitter} for multiple dynamic store. During the commit process, it will group
  * the WrappedManifestCommittables by their table identifier and use different committers to commit
@@ -46,6 +48,37 @@ import java.util.stream.Collectors;
  */
 public class StoreMultiCommitter
         implements Committer<MultiTableCommittable, WrappedManifestCommittable> {
+
+    public static final EndInputCommittableHandler<WrappedManifestCommittable> END_INPUT_HANDLER =
+            new EndInputCommittableHandler<WrappedManifestCommittable>() {
+                private static final long serialVersionUID = 1L;
+
+                @Override
+                public boolean isEndInput(WrappedManifestCommittable committable) {
+                    return committable.checkpointId() == CommitterOperator.END_INPUT_CHECKPOINT_ID;
+                }
+
+                @Override
+                public WrappedManifestCommittable merge(
+                        WrappedManifestCommittable target, WrappedManifestCommittable source) {
+                    checkArgument(
+                            target.checkpointId() == source.checkpointId(),
+                            "Cannot merge committables from different checkpoints %s and %s.",
+                            target.checkpointId(),
+                            source.checkpointId());
+                    for (Map.Entry<Identifier, ManifestCommittable> entry :
+                            source.manifestCommittables().entrySet()) {
+                        ManifestCommittable previous =
+                                target.manifestCommittables().get(entry.getKey());
+                        if (previous == null) {
+                            target.putManifestCommittable(entry.getKey(), entry.getValue());
+                        } else {
+                            StoreCommitter.mergeManifestCommittables(previous, entry.getValue());
+                        }
+                    }
+                    return target;
+                }
+            };
 
     private final Catalog catalog;
     private final Context context;

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/state/OperatorBackendStateStore.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/state/OperatorBackendStateStore.java
@@ -35,4 +35,9 @@ public class OperatorBackendStateStore implements StateStore {
     public <T> ListState<T> getListState(ListStateDescriptor<T> descriptor) throws Exception {
         return delegate.getListState(descriptor);
     }
+
+    @Override
+    public <T> ListState<T> getUnionListState(ListStateDescriptor<T> descriptor) throws Exception {
+        return delegate.getUnionListState(descriptor);
+    }
 }

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/state/StateStore.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/state/StateStore.java
@@ -37,4 +37,12 @@ public interface StateStore {
      * (subtask or coordinator) and is checkpointed together with that component.
      */
     <T> ListState<T> getListState(ListStateDescriptor<T> descriptor) throws Exception;
+
+    /**
+     * Returns union list state. Coordinator-side implementations do not rescale and may use regular
+     * list-state semantics.
+     */
+    default <T> ListState<T> getUnionListState(ListStateDescriptor<T> descriptor) throws Exception {
+        return getListState(descriptor);
+    }
 }

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/sink/BatchWriteGeneratorTagOperatorTest.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/sink/BatchWriteGeneratorTagOperatorTest.java
@@ -67,7 +67,9 @@ public class BatchWriteGeneratorTagOperatorTest extends CommitterOperatorTest {
                         table,
                         initialCommitUser,
                         new RestoreAndFailCommittableStateManager<>(
-                                ManifestCommittableSerializer::new, true));
+                                ManifestCommittableSerializer::new,
+                                true,
+                                StoreCommitter.END_INPUT_HANDLER));
 
         OneInputStreamOperator<Committable, Committable> committerOperator =
                 committerOperatorFactory.createStreamOperator(
@@ -143,7 +145,9 @@ public class BatchWriteGeneratorTagOperatorTest extends CommitterOperatorTest {
                         table,
                         initialCommitUser,
                         new RestoreAndFailCommittableStateManager<>(
-                                ManifestCommittableSerializer::new, true));
+                                ManifestCommittableSerializer::new,
+                                true,
+                                StoreCommitter.END_INPUT_HANDLER));
 
         OneInputStreamOperator<Committable, Committable> committerOperator =
                 committerOperatorFactory.createStreamOperator(

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/sink/CommitterOperatorTest.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/sink/CommitterOperatorTest.java
@@ -134,6 +134,59 @@ public class CommitterOperatorTest extends CommitterOperatorTestBase {
     }
 
     @Test
+    public void testPartialEndInputMergedBeforeOldCheckpointNotification() throws Exception {
+        FileStoreTable table = createFileStoreTable();
+        long timestamp = 1;
+
+        // Only one writer has reached endInput. Its END_INPUT committable must remain pending
+        // until the commit operator itself receives endInput.
+        OneInputStreamOperatorTestHarness<Committable, Committable> testHarness =
+                createRecoverableTestHarness(table);
+        testHarness.open();
+        StreamTableWrite writer1 =
+                table.newStreamWriteBuilder().withCommitUser(initialCommitUser).newWrite();
+        writer1.write(GenericRow.of(1, 10L));
+        for (CommitMessage message : writer1.prepareCommit(true, Long.MAX_VALUE)) {
+            testHarness.processElement(new Committable(Long.MAX_VALUE, message), timestamp++);
+        }
+
+        OperatorSubtaskState checkpoint = testHarness.snapshot(2, timestamp++);
+        testHarness.notifyOfCompletedCheckpoint(2);
+        assertResults(table);
+        testHarness.close();
+
+        // Recovery must keep the partial END_INPUT committable pending. There is nothing to commit,
+        // so RestoreAndFailCommittableStateManager must not trigger an intentional failure.
+        testHarness = createRecoverableTestHarness(table);
+        testHarness.initializeState(checkpoint);
+        testHarness.open();
+        assertResults(table);
+
+        // A second writer emits a different committable with the same identifier. It must be
+        // merged with the restored END_INPUT committable before the final commit.
+        StreamTableWrite writer2 =
+                table.newStreamWriteBuilder().withCommitUser(initialCommitUser).newWrite();
+        writer2.write(GenericRow.of(2, 20L));
+        for (CommitMessage message : writer2.prepareCommit(true, Long.MAX_VALUE)) {
+            testHarness.processElement(new Committable(Long.MAX_VALUE, message), timestamp++);
+        }
+
+        testHarness.endInput();
+
+        // A completion notification for the restored checkpoint may arrive before another
+        // snapshot. endInput must have drained inputs first, otherwise this notification commits
+        // only the restored partial MAX_VALUE committable and permanently filters writer2's data.
+        testHarness.notifyOfCompletedCheckpoint(2);
+        assertResults(table, "1, 10", "2, 20");
+
+        testHarness.snapshot(3, timestamp++);
+        testHarness.notifyOfCompletedCheckpoint(3);
+        testHarness.close();
+
+        assertResults(table, "1, 10", "2, 20");
+    }
+
+    @Test
     public void testCheckpointAbort() throws Exception {
         FileStoreTable table = createFileStoreTable();
         OneInputStreamOperatorTestHarness<Committable, Committable> testHarness =
@@ -467,6 +520,23 @@ public class CommitterOperatorTest extends CommitterOperatorTestBase {
         return snapshot;
     }
 
+    private static OperatorSubtaskState writeEndInputAndSnapshot(
+            FileStoreTable table,
+            String commitUser,
+            long timestamp,
+            long checkpoint,
+            OneInputStreamOperatorTestHarness<Committable, Committable> testHarness)
+            throws Exception {
+        StreamTableWrite write =
+                table.newStreamWriteBuilder().withCommitUser(commitUser).newWrite();
+        write.write(GenericRow.of(1, 10L));
+        for (CommitMessage committable : write.prepareCommit(true, checkpoint)) {
+            testHarness.processElement(new Committable(checkpoint, committable), ++timestamp);
+        }
+        testHarness.endInput();
+        return testHarness.snapshot(checkpoint, ++timestamp);
+    }
+
     @Test
     public void testWatermarkCommit() throws Exception {
         FileStoreTable table = createFileStoreTable();
@@ -549,7 +619,7 @@ public class CommitterOperatorTest extends CommitterOperatorTestBase {
                 createRecoverableTestHarness(table, false);
         testHarness.open();
         OperatorSubtaskState snapshotState =
-                writeAndSnapshot(table, "commitUser", 1, Long.MAX_VALUE, testHarness);
+                writeEndInputAndSnapshot(table, "commitUser", 1, Long.MAX_VALUE, testHarness);
         testHarness.close();
 
         testHarness = createRecoverableTestHarness(table, false);
@@ -567,12 +637,46 @@ public class CommitterOperatorTest extends CommitterOperatorTestBase {
                                     + "writers can start writing based on these new commits.");
         }
 
-        testHarness.notifyOfCompletedCheckpoint(Long.MAX_VALUE);
         Snapshot snapshot = table.snapshotManager().latestSnapshot();
         assertThat(snapshot).isNotNull();
 
         Path successFile = new Path(table.location(), "b=10/_SUCCESS");
         assertThat(table.fileIO().exists(successFile)).isEqualTo(false);
+    }
+
+    @Test
+    public void testTriggerPartitionMarkDownWhenRecoverFromCompleteEndInputState()
+            throws Exception {
+        FileStoreTable table =
+                createFileStoreTable(
+                        options -> {
+                            options.set(CoreOptions.COMMIT_FORCE_CREATE_SNAPSHOT.key(), "true");
+                            options.set(
+                                    CoreOptions.PARTITION_MARK_DONE_WHEN_END_INPUT.key(), "true");
+                            options.set(
+                                    FlinkConnectorOptions.PARTITION_IDLE_TIME_TO_DONE.key(), "1h");
+                        },
+                        Collections.singletonList("b"));
+
+        OneInputStreamOperatorTestHarness<Committable, Committable> testHarness =
+                createRecoverableTestHarness(table, true);
+        testHarness.open();
+        OperatorSubtaskState snapshotState =
+                writeEndInputAndSnapshot(table, "commitUser", 1, Long.MAX_VALUE, testHarness);
+        testHarness.close();
+
+        testHarness = createRecoverableTestHarness(table, true);
+        try {
+            testHarness.initializeState(snapshotState);
+            testHarness.open();
+            fail("Expecting intentional exception");
+        } catch (Exception e) {
+            assertThat(e).hasMessageContaining("This exception is intentionally thrown");
+        }
+
+        assertThat(table.snapshotManager().latestSnapshot()).isNotNull();
+        Path successFile = new Path(table.location(), "b=10/_SUCCESS");
+        assertThat(table.fileIO().exists(successFile)).isTrue();
     }
 
     @Test
@@ -678,7 +782,9 @@ public class CommitterOperatorTest extends CommitterOperatorTestBase {
                         table,
                         null,
                         new RestoreAndFailCommittableStateManager<>(
-                                ManifestCommittableSerializer::new, true));
+                                ManifestCommittableSerializer::new,
+                                true,
+                                StoreCommitter.END_INPUT_HANDLER));
         OneInputStreamOperatorTestHarness<Committable, Committable> testHarness =
                 createTestHarness(operatorFactory);
         testHarness.open();
@@ -781,7 +887,8 @@ public class CommitterOperatorTest extends CommitterOperatorTestBase {
                         null,
                         new RestoreAndFailCommittableStateManager<>(
                                 ManifestCommittableSerializer::new,
-                                partitionMarkDownRecoverFromState));
+                                partitionMarkDownRecoverFromState,
+                                StoreCommitter.END_INPUT_HANDLER));
         return createTestHarness(operatorFactory);
     }
 

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/sink/StoreMultiCommitterTest.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/sink/StoreMultiCommitterTest.java
@@ -31,6 +31,7 @@ import org.apache.paimon.data.InternalRow;
 import org.apache.paimon.flink.utils.TestingMetricUtils;
 import org.apache.paimon.fs.Path;
 import org.apache.paimon.fs.local.LocalFileIO;
+import org.apache.paimon.manifest.ManifestCommittable;
 import org.apache.paimon.manifest.WrappedManifestCommittable;
 import org.apache.paimon.options.CatalogOptions;
 import org.apache.paimon.options.Options;
@@ -158,6 +159,43 @@ class StoreMultiCommitterTest {
     // ------------------------------------------------------------------------
     //  Recoverable operator tests
     // ------------------------------------------------------------------------
+
+    @Test
+    public void testMergeEndInputCommittables() throws Exception {
+        StoreMultiCommitter committer =
+                new StoreMultiCommitter(
+                        catalogLoader,
+                        Committer.createContext(initialCommitUser, null, true, true, null, 1, 0));
+        try {
+            long checkpointId = Long.MAX_VALUE;
+            WrappedManifestCommittable target =
+                    new WrappedManifestCommittable(checkpointId, Long.MIN_VALUE);
+            ManifestCommittable targetTableCommittable =
+                    new ManifestCommittable(checkpointId, Long.MIN_VALUE);
+            targetTableCommittable.addProperty("target", "value");
+            target.putManifestCommittable(firstTable, targetTableCommittable);
+
+            WrappedManifestCommittable source =
+                    new WrappedManifestCommittable(checkpointId, Long.MIN_VALUE);
+            ManifestCommittable sourceFirstTableCommittable =
+                    new ManifestCommittable(checkpointId, Long.MIN_VALUE);
+            sourceFirstTableCommittable.addProperty("source", "value");
+            source.putManifestCommittable(firstTable, sourceFirstTableCommittable);
+            source.putManifestCommittable(
+                    secondTable, new ManifestCommittable(checkpointId, Long.MIN_VALUE));
+
+            WrappedManifestCommittable merged =
+                    StoreMultiCommitter.END_INPUT_HANDLER.merge(target, source);
+
+            assertThat(merged).isSameAs(target);
+            assertThat(merged.manifestCommittables()).containsOnlyKeys(firstTable, secondTable);
+            assertThat(merged.manifestCommittables().get(firstTable).properties())
+                    .containsEntry("target", "value")
+                    .containsEntry("source", "value");
+        } finally {
+            committer.close();
+        }
+    }
 
     @SuppressWarnings("CatchMayIgnoreException")
     @Test
@@ -617,7 +655,9 @@ class StoreMultiCommitterTest {
                         initialCommitUser,
                         context -> new StoreMultiCommitter(catalogLoader, context),
                         new RestoreAndFailCommittableStateManager<>(
-                                WrappedManifestCommittableSerializer::new, true));
+                                WrappedManifestCommittableSerializer::new,
+                                true,
+                                StoreMultiCommitter.END_INPUT_HANDLER));
         return createTestHarness(operator);
     }
 
@@ -631,13 +671,16 @@ class StoreMultiCommitterTest {
                         context -> new StoreMultiCommitter(catalogLoader, context),
                         new CommittableStateManager<WrappedManifestCommittable>() {
                             @Override
-                            public void initializeState(
+                            public List<WrappedManifestCommittable> initializeState(
                                     Committer.Context context,
-                                    Committer<?, WrappedManifestCommittable> committer) {}
+                                    Committer<?, WrappedManifestCommittable> committer) {
+                                return Collections.emptyList();
+                            }
 
                             @Override
                             public void snapshotState(
-                                    List<WrappedManifestCommittable> committables) {}
+                                    List<WrappedManifestCommittable> committables,
+                                    boolean completeEndInput) {}
                         });
         return createTestHarness(operator);
     }


### PR DESCRIPTION
This PR addresses the data-loss issue reported in [#9236](https://github.com/apache/paimon/issues/9236).

The scope of this PR is intentionally limited to preventing an incomplete `END_INPUT` (`Long.MAX_VALUE`) committable from being committed during recovery before global `END_INPUT` is complete. In particular, it fixes the recovery semantics that could otherwise cause later `END_INPUT` committables to be filtered out and result in data loss.

This PR does **not** address the `END_INPUT` watermark semantics discussed in the same issue. Watermark handling has different checkpoint/recovery semantics and will be considered separately to keep this bug fix focused and avoid unnecessarily expanding the commit protocol changes.

### Purpose

Fix a recovery data-loss issue where a partial `Long.MAX_VALUE` END_INPUT committable could be committed before global END_INPUT was complete.

`Long.MAX_VALUE` alone cannot distinguish a writer that has reached END_INPUT from a globally complete END_INPUT. After a checkpoint and failover, the previous recovery path could commit such a partial committable. When the remaining END_INPUT committables later arrived, `filterAndCommit` could filter them as already committed, losing their data.

This change persists a durable `completeEndInput` state. During recovery, END_INPUT committables from an incomplete state are kept pending and merged with subsequent END_INPUT committables; END_INPUT committables from a complete state retain the existing recovery-commit behavior. `endInput()` also drains buffered inputs before publishing `completeEndInput`, so a `Long.MAX_VALUE` commit is only exposed after the logical END_INPUT is complete.

The change preserves normal checkpoint commit behavior and the existing `partition.mark-done.recover-from-state` behavior for complete recovered END_INPUT commits.

### Tests

- `testPartialEndInputMergedBeforeOldCheckpointNotification`: restores a partial END_INPUT committable without committing it, merges the remaining END_INPUT data after recovery, and verifies that a delayed notification for the restored checkpoint commits the complete result without losing data.
- `testNotTriggerPartitionMarkDownWhenRecoverFromState`: verifies that a complete recovered END_INPUT committable is committed with `partition.mark-done.recover-from-state=false`, without creating the partition `_SUCCESS` marker.
- `testTriggerPartitionMarkDownWhenRecoverFromCompleteEndInputState`: verifies that a complete recovered END_INPUT committable still triggers partition mark-done recovery when the option is enabled.
- `testMergeEndInputCommittables`: verifies merging restored multi-table END_INPUT committables, including committables for the same and different tables.
