### PR TITLE
[arrow] Fix nanosecond timestamp conversion for pre-epoch values

### DIFF
--- a/paimon-arrow/src/main/java/org/apache/paimon/arrow/converter/Arrow2PaimonVectorConverter.java
+++ b/paimon-arrow/src/main/java/org/apache/paimon/arrow/converter/Arrow2PaimonVectorConverter.java
@@ -462,7 +462,8 @@ public interface Arrow2PaimonVectorConverter {
             } else if (precision >= 4 && precision <= 6) {
                 return Timestamp.fromMicros(value);
             } else {
-                return Timestamp.fromEpochMillis(value / 1_000_000, (int) (value % 1_000_000));
+                return Timestamp.fromEpochMillis(
+                        Math.floorDiv(value, 1_000_000L), (int) Math.floorMod(value, 1_000_000L));
             }
         }
 

--- a/paimon-arrow/src/test/java/org/apache/paimon/arrow/vector/ArrowFormatWriterTest.java
+++ b/paimon-arrow/src/test/java/org/apache/paimon/arrow/vector/ArrowFormatWriterTest.java
@@ -53,6 +53,8 @@ import org.apache.arrow.vector.IntVector;
 import org.apache.arrow.vector.TimeMicroVector;
 import org.apache.arrow.vector.TimeNanoVector;
 import org.apache.arrow.vector.TimeSecVector;
+import org.apache.arrow.vector.TimeStampNanoTZVector;
+import org.apache.arrow.vector.TimeStampNanoVector;
 import org.apache.arrow.vector.VarBinaryVector;
 import org.apache.arrow.vector.VarCharVector;
 import org.apache.arrow.vector.VectorSchemaRoot;
@@ -583,6 +585,43 @@ public class ArrowFormatWriterTest {
                 assertThat(row.getInt(1)).isEqualTo(12345);
                 assertThat(row.getInt(2)).isEqualTo(12345);
                 assertThat(row.getBinary(3)).containsExactly(binary);
+            }
+        }
+    }
+
+    @Test
+    public void testArrowBundleRecordsWithPreEpochNanoTimestamps() {
+        RowType rowType =
+                RowType.of(
+                        new DataField(0, "ts_nano", DataTypes.TIMESTAMP(9)),
+                        new DataField(
+                                1, "ts_ltz_nano", DataTypes.TIMESTAMP_WITH_LOCAL_TIME_ZONE(9)));
+
+        // 1969-12-31T23:59:59.999999999, i.e. one nanosecond before the epoch
+        long nanos = -1L;
+
+        try (RootAllocator allocator = new RootAllocator()) {
+            TimeStampNanoVector tsVector = new TimeStampNanoVector("ts_nano", allocator);
+            tsVector.allocateNew(1);
+            tsVector.setSafe(0, nanos);
+            tsVector.setValueCount(1);
+
+            TimeStampNanoTZVector tsLtzVector =
+                    new TimeStampNanoTZVector("ts_ltz_nano", allocator, "UTC");
+            tsLtzVector.allocateNew(1);
+            tsLtzVector.setSafe(0, nanos);
+            tsLtzVector.setValueCount(1);
+
+            List<FieldVector> vectors = Arrays.asList(tsVector, tsLtzVector);
+            try (VectorSchemaRoot vectorSchemaRoot = new VectorSchemaRoot(vectors)) {
+                vectorSchemaRoot.setRowCount(1);
+
+                Iterator<InternalRow> iterator =
+                        new ArrowBundleRecords(vectorSchemaRoot, rowType, true).iterator();
+                InternalRow row = iterator.next();
+                Timestamp expected = Timestamp.fromEpochMillis(-1, 999_999);
+                assertThat(row.getTimestamp(0, 9)).isEqualTo(expected);
+                assertThat(row.getTimestamp(1, 9)).isEqualTo(expected);
             }
         }
     }


### PR DESCRIPTION
### Purpose

`convertEpochToTimestamp` splits a nanosecond epoch with `/` and `%`, which truncate toward
zero, so a pre-epoch value yields a negative nano-of-millisecond and `Timestamp`'s constructor
rejects it with a message-less `IllegalArgumentException`. `Timestamp#fromMicros` and the
Parquet reader both use `Math.floorDiv`.

`TIMESTAMP(9)` value `-1` through `ArrowBundleRecords`:

```
was  IllegalArgumentException
now  1969-12-31T23:59:59.999999999
```

This is the shared Arrow read path for lance, mosaic and vortex.

### Tests

`ArrowFormatWriterTest#testArrowBundleRecordsWithPreEpochNanoTimestamps`.

Written with Claude Code; reasoning and verification are mine.
