### PR TITLE
[core] optimize column directives

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/schema/ColumnDirectiveUtils.java
+++ b/paimon-core/src/main/java/org/apache/paimon/schema/ColumnDirectiveUtils.java
@@ -34,9 +34,13 @@ import org.apache.paimon.utils.StringUtils;
 import javax.annotation.Nullable;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 /** Utilities for column comment directives (BLOB / VECTOR type conversion via ADD COLUMN). */
 public final class ColumnDirectiveUtils {
@@ -310,7 +314,18 @@ public final class ColumnDirectiveUtils {
                 }
             }
         }
-        String newValue = existing == null ? fieldName : existing + "," + fieldName;
+
+        Set<String> values = new LinkedHashSet<>();
+        if (existing != null) {
+            values.addAll(
+                    Arrays.stream(existing.split(","))
+                            .map(String::trim)
+                            .filter(str -> !str.isEmpty())
+                            .collect(Collectors.toList()));
+        }
+        values.add(fieldName);
+
+        String newValue = StringUtils.join(values.iterator(), ",");
         options.put(optionKey, newValue);
     }
 

--- a/paimon-core/src/main/java/org/apache/paimon/schema/SchemaManager.java
+++ b/paimon-core/src/main/java/org/apache/paimon/schema/SchemaManager.java
@@ -107,6 +107,7 @@ import static org.apache.paimon.catalog.Identifier.UNKNOWN_DATABASE;
 import static org.apache.paimon.mergetree.compact.PartialUpdateMergeFunction.SEQUENCE_GROUP;
 import static org.apache.paimon.schema.ColumnDirectiveUtils.applyAddColumnDirective;
 import static org.apache.paimon.schema.ColumnDirectiveUtils.applyDirectives;
+import static org.apache.paimon.schema.ColumnDirectiveUtils.parseAddColumnComment;
 import static org.apache.paimon.types.BlobType.isBlobFileField;
 import static org.apache.paimon.utils.DefaultValueUtils.validateDefaultValue;
 import static org.apache.paimon.utils.FileUtils.listVersionedFiles;
@@ -577,6 +578,11 @@ public class SchemaManager implements Serializable {
                         lazyIdentifier);
             } else if (change instanceof UpdateColumnComment) {
                 UpdateColumnComment update = (UpdateColumnComment) change;
+                Preconditions.checkArgument(
+                        parseAddColumnComment(update.newDescription()) == null,
+                        "Should not alter existing field's type through column directives: %s",
+                        update.newDescription());
+
                 updateNestedColumn(
                         newFields,
                         update.fieldNames(),

--- a/paimon-core/src/test/java/org/apache/paimon/schema/ColumnDirectiveUtilsTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/schema/ColumnDirectiveUtilsTest.java
@@ -142,6 +142,20 @@ public class ColumnDirectiveUtilsTest {
     }
 
     @Test
+    public void testBlobDirectiveDeduplicatesExistingOptionAndPreservesOrder() {
+        Map<String, String> opts = new HashMap<>();
+        opts.put(CoreOptions.BLOB_FIELD.key(), "first,pic");
+
+        ColumnDirectiveUtils.applyAddColumnDirective(
+                "__BLOB_FIELD", "pic", DataTypes.BYTES(), opts);
+        assertThat(opts).containsEntry(CoreOptions.BLOB_FIELD.key(), "first,pic");
+
+        ColumnDirectiveUtils.applyAddColumnDirective(
+                "__BLOB_FIELD", "last", DataTypes.BYTES(), opts);
+        assertThat(opts).containsEntry(CoreOptions.BLOB_FIELD.key(), "first,pic,last");
+    }
+
+    @Test
     public void testBareDirectiveWithoutComment() {
         Map<String, String> opts = new HashMap<>();
         ColumnDirectiveUtils.ConvertedColumn result =

--- a/paimon-core/src/test/java/org/apache/paimon/table/SchemaEvolutionTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/table/SchemaEvolutionTest.java
@@ -524,6 +524,7 @@ public class SchemaEvolutionTest {
     @Test
     public void testCreateTableWithCommentDirectives() throws Exception {
         Map<String, String> options = blobEnabledOptions();
+        options.put(CoreOptions.BLOB_FIELD.key(), "pic");
         options.put(CoreOptions.VECTOR_FILE_FORMAT.key(), "json");
         schemaManager.createTable(
                 new Schema(
@@ -575,6 +576,37 @@ public class SchemaEvolutionTest {
         assertThat(latest.options().get(CoreOptions.BLOB_FIELD.key())).isEqualTo("pic");
         assertThat(latest.options().get(CoreOptions.BLOB_VIEW_FIELD.key())).isEqualTo("view_col");
         assertThat(latest.options().get(CoreOptions.VECTOR_FIELD.key())).isEqualTo("embedding");
+    }
+
+    @Test
+    public void testUpdateColumnCommentRejectsDirectives() throws Exception {
+        schemaManager.createTable(
+                Schema.newBuilder().column("pic", DataTypes.BYTES(), "original comment").build());
+
+        for (String directive :
+                Arrays.asList(
+                        "__BLOB_FIELD",
+                        "__BLOB_DESCRIPTOR_FIELD",
+                        "__BLOB_VIEW_FIELD",
+                        "__VECTOR_FIELD;64")) {
+            assertThatThrownBy(
+                            () ->
+                                    schemaManager.commitChanges(
+                                            SchemaChange.updateColumnComment("pic", directive)))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessageContaining(
+                            "Should not alter existing field's type through column directives");
+        }
+
+        TableSchema latest = schemaManager.latest().get();
+        assertThat(latest.fields().get(0).type()).isEqualTo(DataTypes.BYTES());
+        assertThat(latest.fields().get(0).description()).isEqualTo("original comment");
+        assertThat(latest.options())
+                .doesNotContainKeys(
+                        CoreOptions.BLOB_FIELD.key(),
+                        CoreOptions.BLOB_DESCRIPTOR_FIELD.key(),
+                        CoreOptions.BLOB_VIEW_FIELD.key(),
+                        CoreOptions.VECTOR_FIELD.key());
     }
 
     private static Map<String, String> blobEnabledOptions() {


### PR DESCRIPTION
### Purpose
This PR fixes 2 issues:
1. Prevent users from updating comments to column directives(current nothing will happen. I think it's confusing)
2. If users specify both blob-field and column directives, there would be duplicated fields in blob-field, like:

```
    'blob-field' = 'pic, pic'
```

### Tests
