### PR TITLE
[flink] Fix literal conversion for BETWEEN predicates

### DIFF
--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/PredicateConverter.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/PredicateConverter.java
@@ -116,8 +116,11 @@ public class PredicateConverter implements ExpressionVisitor<Predicate> {
         } else if (func == BuiltInFunctionDefinitions.BETWEEN) {
             FieldReferenceExpression fieldRefExpr =
                     extractFieldReference(children.get(0)).orElseThrow(UnsupportedExpression::new);
+            DataType fieldType = fieldRefExpr.getOutputDataType();
             return builder.between(
-                    builder.indexOf(fieldRefExpr.getName()), children.get(1), children.get(2));
+                    builder.indexOf(fieldRefExpr.getName()),
+                    extractLiteral(fieldType, children.get(1)),
+                    extractLiteral(fieldType, children.get(2)));
         } else if (func == BuiltInFunctionDefinitions.LIKE) {
             FieldReferenceExpression fieldRefExpr =
                     extractFieldReference(children.get(0)).orElseThrow(UnsupportedExpression::new);

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/PredicateConverterTest.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/PredicateConverterTest.java
@@ -273,6 +273,47 @@ public class PredicateConverterTest {
                         BUILDER.equal(3, false)));
     }
 
+    @Test
+    public void testBetweenWithImplicitNumericConversion() {
+        Predicate predicate =
+                call(
+                                BuiltInFunctionDefinitions.BETWEEN,
+                                field(0, DataTypes.BIGINT()),
+                                literal(10),
+                                literal(20))
+                        .accept(new PredicateConverter(RowType.of(new BigIntType())));
+
+        assertThat(predicate.test(GenericRow.of(9L))).isFalse();
+        assertThat(predicate.test(GenericRow.of(10L))).isTrue();
+        assertThat(predicate.test(GenericRow.of(15L))).isTrue();
+        assertThat(predicate.test(GenericRow.of(20L))).isTrue();
+        assertThat(predicate.test(GenericRow.of(21L))).isFalse();
+        assertThat(predicate.test(GenericRow.of((Object) null))).isFalse();
+    }
+
+    @Test
+    public void testBetweenWithNullBounds() {
+        PredicateConverter converter = new PredicateConverter(RowType.of(new BigIntType()));
+        FieldReferenceExpression field = field(0, DataTypes.BIGINT());
+        Predicate nullLowerBound =
+                call(
+                                BuiltInFunctionDefinitions.BETWEEN,
+                                field,
+                                literal(null, DataTypes.BIGINT()),
+                                literal(20))
+                        .accept(converter);
+        Predicate nullUpperBound =
+                call(
+                                BuiltInFunctionDefinitions.BETWEEN,
+                                field,
+                                literal(10),
+                                literal(null, DataTypes.BIGINT()))
+                        .accept(converter);
+
+        assertThat(nullLowerBound.test(GenericRow.of(15L))).isFalse();
+        assertThat(nullUpperBound.test(GenericRow.of(15L))).isFalse();
+    }
+
     @MethodSource("provideLikeExpressions")
     @ParameterizedTest
     public void testStartsWith(


### PR DESCRIPTION
### Purpose

`PredicateConverter` passed `BETWEEN` bounds directly as Flink expression objects instead of converting them to typed Paimon literal values. This could produce predicates with incompatible bound types, especially when implicit type conversion or null bounds were involved.

Convert both bounds using the referenced field type before building the predicate.

### Tests

  - Added coverage for implicit numeric conversion, inclusive boundaries, null input, and null bounds.
  - Passed `PredicateConverterTest` with both Flink 1 and Flink 2 profiles.