### PR TITLE
[core] Support aggregation for partial-update sequence groups

### DIFF
--- a/docs/docs/primary-key-table/merge-engine/partial-update.md
+++ b/docs/docs/primary-key-table/merge-engine/partial-update.md
@@ -205,6 +205,31 @@ SELECT *
 FROM t; -- output 1, 2, 1, 2, 3
 ```
 
+You can assign the same aggregation function to all fields protected by a sequence group by adding
+`.aggregate-function` to the sequence-group option key:
+
+```sql
+CREATE TABLE t
+(
+    k   INT,
+    seq INT,
+    a   INT,
+    b   INT,
+    c   INT,
+    PRIMARY KEY (k) NOT ENFORCED
+) WITH (
+      'merge-engine' = 'partial-update',
+      'fields.seq.sequence-group' = 'a,b,c',
+      'fields.seq.sequence-group.aggregate-function' = 'sum'
+      );
+```
+
+For a sequence group with multiple ordering fields, use the corresponding key, for example
+`fields.seq1,seq2.sequence-group.aggregate-function`. The aggregation function resolution order is
+a single-field option, then the sequence-group option, and finally
+`fields.default-aggregate-function`. A single-field option can therefore override the function for
+one protected field. Sequence ordering fields and primary-key fields are not aggregated.
+
 You can also configure an aggregation function for a `sequence-group` within multiple sorted fields.
 
 See example:

--- a/docs/docs/primary-key-table/merge-engine/partial-update.md
+++ b/docs/docs/primary-key-table/merge-engine/partial-update.md
@@ -205,6 +205,12 @@ SELECT *
 FROM t; -- output 1, 2, 1, 2, 3
 ```
 
+:::note
+
+Sequence-group aggregate functions are supported since Paimon 2.1.
+
+:::
+
 You can assign the same aggregation function to all fields protected by a sequence group by adding
 `.aggregate-function` to the sequence-group option key:
 

--- a/paimon-api/src/main/java/org/apache/paimon/CoreOptions.java
+++ b/paimon-api/src/main/java/org/apache/paimon/CoreOptions.java
@@ -3207,6 +3207,43 @@ public class CoreOptions implements Serializable {
                         .noDefaultValue());
     }
 
+    public String partialUpdateFieldAggFunc(String fieldName) {
+        String fieldAggFunc = fieldAggFunc(fieldName);
+        String optionPrefix = FIELDS_PREFIX + ".";
+        String optionSuffix = ".sequence-group." + AGG_FUNCTION;
+        String aggFunctionSuffix = "." + AGG_FUNCTION;
+        String matchedOption = null;
+        String sequenceGroupAggFunc = null;
+        for (Map.Entry<String, String> entry : options.toMap().entrySet()) {
+            String optionKey = entry.getKey();
+            if (!optionKey.startsWith(optionPrefix) || !optionKey.endsWith(optionSuffix)) {
+                continue;
+            }
+
+            String sequenceGroupOption =
+                    optionKey.substring(0, optionKey.length() - aggFunctionSuffix.length());
+            String protectedFields = options.get(sequenceGroupOption);
+            checkArgument(
+                    protectedFields != null,
+                    "Sequence group aggregate function option '%s' requires sequence group option '%s'.",
+                    optionKey,
+                    sequenceGroupOption);
+            if (!Arrays.asList(protectedFields.split(FIELDS_SEPARATOR)).contains(fieldName)) {
+                continue;
+            }
+
+            checkArgument(
+                    matchedOption == null,
+                    "Field %s is defined repeatedly by multiple sequence group aggregate functions: %s and %s.",
+                    fieldName,
+                    matchedOption,
+                    optionKey);
+            matchedOption = optionKey;
+            sequenceGroupAggFunc = entry.getValue();
+        }
+        return fieldAggFunc == null ? sequenceGroupAggFunc : fieldAggFunc;
+    }
+
     public boolean fieldAggIgnoreRetract(String fieldName) {
         return options.get(
                 key(FIELDS_PREFIX + "." + fieldName + "." + IGNORE_RETRACT)

--- a/paimon-core/src/main/java/org/apache/paimon/mergetree/compact/PartialUpdateMergeFunction.java
+++ b/paimon-core/src/main/java/org/apache/paimon/mergetree/compact/PartialUpdateMergeFunction.java
@@ -711,7 +711,7 @@ public class PartialUpdateMergeFunction implements MergeFunction<KeyValue> {
             return FieldPrimaryKeyAggFactory.NAME;
         }
 
-        String aggFuncName = options.fieldAggFunc(fieldName);
+        String aggFuncName = options.partialUpdateFieldAggFunc(fieldName);
         if (aggFuncName == null) {
             aggFuncName = options.fieldsDefaultFunc();
         }

--- a/paimon-core/src/main/java/org/apache/paimon/schema/SchemaManager.java
+++ b/paimon-core/src/main/java/org/apache/paimon/schema/SchemaManager.java
@@ -898,20 +898,24 @@ public class SchemaManager implements Serializable {
             }
         }
 
-        // case 3: both option key and option value may contain field names
+        // case 3: compound field-scoped options whose keys, and sometimes values, contain field
+        // names
+        String sequenceGroupAggFunction = SEQUENCE_GROUP + "." + AGG_FUNCTION;
         for (String key : options.keySet()) {
             if (key.startsWith(FIELDS_PREFIX)) {
                 String matchedSuffix = null;
-                if (key.endsWith(SEQUENCE_GROUP)) {
+                boolean renameValueFields = false;
+                if (key.endsWith("." + sequenceGroupAggFunction)) {
+                    matchedSuffix = sequenceGroupAggFunction;
+                } else if (key.endsWith(SEQUENCE_GROUP)) {
                     matchedSuffix = SEQUENCE_GROUP;
+                    renameValueFields = true;
                 } else if (key.endsWith(NESTED_KEY)) {
                     matchedSuffix = NESTED_KEY;
+                    renameValueFields = true;
                 }
 
                 if (matchedSuffix != null) {
-                    // Both the key and value may contain field names. If we were to perform a
-                    // "match then replace" operation, the conditions would become quite complex.
-                    // Instead, we directly make a replacement across all instances
                     String keyFieldsStr =
                             key.substring(
                                     FIELDS_PREFIX.length() + 1,
@@ -920,17 +924,21 @@ public class SchemaManager implements Serializable {
                     List<String> newKeyFields =
                             applyNotNestedColumnRename(keyFields, renameMappings);
 
-                    String valueFieldsStr = newOptions.remove(key);
-                    List<String> valueFields = Arrays.asList(valueFieldsStr.split(","));
-                    List<String> newValueFields =
-                            applyNotNestedColumnRename(valueFields, renameMappings);
+                    String optionValue = newOptions.remove(key);
+                    if (renameValueFields) {
+                        List<String> valueFields = Arrays.asList(optionValue.split(","));
+                        optionValue =
+                                String.join(
+                                        ",",
+                                        applyNotNestedColumnRename(valueFields, renameMappings));
+                    }
                     newOptions.put(
                             FIELDS_PREFIX
                                     + "."
                                     + String.join(",", newKeyFields)
                                     + "."
                                     + matchedSuffix,
-                            String.join(",", newValueFields));
+                            optionValue);
                 }
             }
         }

--- a/paimon-core/src/main/java/org/apache/paimon/schema/SchemaValidation.java
+++ b/paimon-core/src/main/java/org/apache/paimon/schema/SchemaValidation.java
@@ -1342,8 +1342,12 @@ public class SchemaValidation {
                                 "Sequence field: '%s' can not be found in table schema.",
                                 field);
 
+                        String aggFuncName =
+                                options.mergeEngine() == MergeEngine.PARTIAL_UPDATE
+                                        ? options.partialUpdateFieldAggFunc(field)
+                                        : options.fieldAggFunc(field);
                         checkArgument(
-                                options.fieldAggFunc(field) == null,
+                                aggFuncName == null,
                                 "Should not define aggregation on sequence field: '%s'.",
                                 field);
 
@@ -1433,7 +1437,10 @@ public class SchemaValidation {
 
         for (int i = 0; i < schema.logicalRowType().getFieldNames().size(); i++) {
             String fieldName = schema.logicalRowType().getFieldNames().get(i);
-            String aggFuncName = options.fieldAggFunc(fieldName);
+            String aggFuncName =
+                    options.mergeEngine() == MergeEngine.PARTIAL_UPDATE
+                            ? options.partialUpdateFieldAggFunc(fieldName)
+                            : options.fieldAggFunc(fieldName);
             aggFuncName = aggFuncName == null ? options.fieldsDefaultFunc() : aggFuncName;
             if (aggFuncName != null) {
                 FactoryUtil.discoverFactory(
@@ -1628,7 +1635,7 @@ public class SchemaValidation {
                 if (!fieldsProtectedBySequenceGroup.contains(field)) {
                     continue;
                 }
-                String aggregateFunction = options.fieldAggFunc(field);
+                String aggregateFunction = options.partialUpdateFieldAggFunc(field);
                 if (aggregateFunction == null) {
                     aggregateFunction = options.fieldsDefaultFunc();
                 }

--- a/paimon-core/src/test/java/org/apache/paimon/CoreOptionsTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/CoreOptionsTest.java
@@ -117,6 +117,36 @@ public class CoreOptionsTest {
     }
 
     @Test
+    public void testSequenceGroupAggregateFunction() {
+        Options conf = new Options();
+        conf.set(CoreOptions.MERGE_ENGINE, CoreOptions.MergeEngine.PARTIAL_UPDATE);
+        conf.setString("fields.seq1,seq2.sequence-group", "a,b");
+        conf.setString("fields.seq1,seq2.sequence-group.aggregate-function", "sum");
+        conf.setString("fields.b.aggregate-function", "max");
+
+        CoreOptions options = new CoreOptions(conf);
+        assertThat(options.fieldAggFunc("a")).isNull();
+        assertThat(options.partialUpdateFieldAggFunc("a")).isEqualTo("sum");
+        assertThat(options.partialUpdateFieldAggFunc("b")).isEqualTo("max");
+        assertThat(options.partialUpdateFieldAggFunc("c")).isNull();
+        assertThat(options.partialUpdateFieldAggFunc("seq1")).isNull();
+        assertThat(options.partialUpdateFieldAggFunc("seq2")).isNull();
+    }
+
+    @Test
+    public void testSequenceGroupAggregateFunctionWithoutGroup() {
+        Options conf = new Options();
+        conf.set(CoreOptions.MERGE_ENGINE, CoreOptions.MergeEngine.PARTIAL_UPDATE);
+        conf.setString("fields.seq.sequence-group.aggregate-function", "sum");
+
+        CoreOptions options = new CoreOptions(conf);
+        assertThatThrownBy(() -> options.partialUpdateFieldAggFunc("a"))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("fields.seq.sequence-group.aggregate-function")
+                .hasMessageContaining("fields.seq.sequence-group");
+    }
+
+    @Test
     public void testIgnoreGlobalIndexColumnUpdateAction() {
         Options conf = new Options();
         conf.setString(CoreOptions.GLOBAL_INDEX_COLUMN_UPDATE_ACTION.key(), "IGNORE");

--- a/paimon-core/src/test/java/org/apache/paimon/mergetree/compact/PartialUpdateMergeFunctionTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/mergetree/compact/PartialUpdateMergeFunctionTest.java
@@ -652,6 +652,33 @@ public class PartialUpdateMergeFunctionTest {
     }
 
     @Test
+    public void testSequenceGroupAggregateFunction() {
+        Options options = new Options();
+        options.set("fields.f1.sequence-group", "f2,f3,f4");
+        options.set("fields.f1.sequence-group.aggregate-function", "sum");
+        options.set("fields.f4.aggregate-function", "max");
+        RowType rowType =
+                RowType.of(
+                        DataTypes.INT(),
+                        DataTypes.INT(),
+                        DataTypes.INT(),
+                        DataTypes.INT(),
+                        DataTypes.INT());
+        MergeFunction<KeyValue> func =
+                PartialUpdateMergeFunction.factory(options, rowType, ImmutableList.of("f0"))
+                        .create();
+
+        func.reset();
+        add(func, 1, 1, 1, 2, 3);
+        add(func, 1, 2, 3, 4, 2);
+        validate(func, 1, 2, 4, 6, 3);
+
+        // Older records still participate in aggregation while the sequence value is not advanced.
+        add(func, 1, 1, 5, 6, 7);
+        validate(func, 1, 2, 9, 12, 7);
+    }
+
+    @Test
     public void testPartialUpdateWithAggregation() {
         Options options = new Options();
         options.set("fields.f1.sequence-group", "f2,f3,f4");

--- a/paimon-core/src/test/java/org/apache/paimon/schema/SchemaManagerTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/schema/SchemaManagerTest.java
@@ -569,6 +569,42 @@ public class SchemaManagerTest {
     }
 
     @Test
+    public void testRenameColumnInSequenceGroupAggregateFunction() throws Exception {
+        Map<String, String> options = new HashMap<>();
+        options.put(CoreOptions.MERGE_ENGINE.key(), "partial-update");
+        options.put(CoreOptions.BUCKET.key(), "1");
+        options.put("fields.seq.sequence-group", "a,b");
+        options.put("fields.seq.sequence-group.aggregate-function", "sum");
+        Schema schema =
+                new Schema(
+                        Arrays.asList(
+                                new DataField(0, "f0", DataTypes.INT()),
+                                new DataField(1, "a", DataTypes.INT()),
+                                new DataField(2, "b", DataTypes.INT()),
+                                new DataField(3, "seq", DataTypes.INT())),
+                        Collections.emptyList(),
+                        Collections.singletonList("f0"),
+                        options,
+                        "");
+
+        retryArtificialException(() -> manager.createTable(schema));
+        retryArtificialException(
+                () ->
+                        manager.commitChanges(
+                                Arrays.asList(
+                                        SchemaChange.renameColumn("a", "renamed_a"),
+                                        SchemaChange.renameColumn("seq", "renamed_seq"))));
+
+        Optional<TableSchema> latest = retryArtificialException(() -> manager.latest());
+        assertThat(latest).isPresent();
+        assertThat(latest.get().options())
+                .doesNotContainKeys(
+                        "fields.seq.sequence-group", "fields.seq.sequence-group.aggregate-function")
+                .containsEntry("fields.renamed_seq.sequence-group", "renamed_a,b")
+                .containsEntry("fields.renamed_seq.sequence-group.aggregate-function", "sum");
+    }
+
+    @Test
     public void testConcurrentCommit() throws Exception {
         retryArtificialException(
                 () ->


### PR DESCRIPTION
### Purpose

Allow Partial Update tables to configure one aggregate function for every value field protected by a sequence group, using a sequence-centered option:

```sql
'fields.seq.sequence-group' = 'a,b,c',
'fields.seq.sequence-group.aggregate-function' = 'sum'
```

Per-field aggregate functions still take precedence, followed by the sequence-group aggregate function and then the default aggregate function. Ordering and primary-key fields are never aggregated.

This change also validates orphan sequence-group aggregate options, preserves the option during column renames, and documents the new syntax.

### Tests

- `mvn -pl paimon-core -am -DfailIfNoTests=false -DwildcardSuites=none -Dtest='CoreOptionsTest#testSequenceGroupAggregateFunction+testSequenceGroupAggregateFunctionWithoutGroup,SchemaManagerTest#testRenameColumnInSequenceGroupAggregateFunction' test`
- The new merge behavior test and the broader related test classes passed on the implementation baseline. On current `master`, local execution of both the new test and the existing `PartialUpdateMergeFunctionTest#testSequenceGroup` is blocked by the same JDK 8 `CodeGenLoader` / `URLClassPath` NPE before merge assertions run.
