### PR TITLE
[spark] Fix timestamp precision in key dynamic writes

### DIFF
--- a/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/commands/BucketProcessor.scala
+++ b/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/commands/BucketProcessor.scala
@@ -22,7 +22,7 @@ import org.apache.paimon.CoreOptions
 import org.apache.paimon.bucket.BucketFunction
 import org.apache.paimon.codegen.CodeGenUtils
 import org.apache.paimon.crosspartition.{GlobalIndexAssigner, KeyPartOrRow}
-import org.apache.paimon.data.{BinaryRow, GenericRow, InternalRow => PaimonInternalRow, JoinedRow}
+import org.apache.paimon.data.{BinaryRow, InternalRow => PaimonInternalRow}
 import org.apache.paimon.disk.IOManager
 import org.apache.paimon.index.HashBucketAssigner
 import org.apache.paimon.schema.TableSchema
@@ -31,7 +31,6 @@ import org.apache.paimon.spark.SparkUtils.createIOManager
 import org.apache.paimon.spark.util.EncoderUtils
 import org.apache.paimon.table.FileStoreTable
 import org.apache.paimon.table.sink.RowPartitionKeyExtractor
-import org.apache.paimon.types.RowType
 import org.apache.paimon.utils.{CloseableIterator, SerializationUtils}
 
 import org.apache.spark.TaskContext
@@ -39,6 +38,7 @@ import org.apache.spark.sql.Row
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.encoders.ExpressionEncoder
 import org.apache.spark.sql.catalyst.encoders.ExpressionEncoder.{Deserializer, Serializer}
+import org.apache.spark.sql.catalyst.expressions.{GenericInternalRow, JoinedRow => SparkJoinedRow}
 import org.apache.spark.sql.types.StructType
 
 import java.util.UUID
@@ -173,32 +173,27 @@ case class DynamicBucketProcessor(
 
 case class GlobalDynamicBucketProcessor(
     fileStoreTable: FileStoreTable,
-    rowType: RowType,
     numAssigners: Integer,
     encoderGroup: EncoderSerDeGroup)
   extends BucketProcessor[(KeyPartOrRow, Array[Byte])] {
 
   override def processPartition(
       rowIterator: Iterator[(KeyPartOrRow, Array[Byte])]): Iterator[Row] = {
-    new GlobalIndexAssignerIterator(
-      rowIterator,
-      fileStoreTable,
-      rowType,
-      numAssigners,
-      encoderGroup)
+    new GlobalIndexAssignerIterator(rowIterator, fileStoreTable, numAssigners, encoderGroup)
   }
 }
 
 class GlobalIndexAssignerIterator(
     rowIterator: Iterator[(KeyPartOrRow, Array[Byte])],
     fileStoreTable: FileStoreTable,
-    rowType: RowType,
     numAssigners: Integer,
     encoderGroup: EncoderSerDeGroup)
   extends Iterator[Row]
   with AutoCloseable {
 
   private val queue = mutable.Queue[Row]()
+
+  private val dataRowType = fileStoreTable.rowType()
 
   val ioManager: IOManager = createIOManager
 
@@ -215,12 +210,11 @@ class GlobalIndexAssignerIterator(
       numAssigners,
       TaskContext.getPartitionId(),
       (row, bucket) => {
-        val extraRow: GenericRow = new GenericRow(2)
-        extraRow.setField(0, row.getRowKind.toByteValue)
-        extraRow.setField(1, bucket)
-        queue.enqueue(
-          encoderGroup.internalToRow(
-            DataConverter.fromPaimon(new JoinedRow(row, extraRow), rowType)))
+        val dataRow = DataConverter.fromPaimon(row, dataRowType)
+        val extraRow = new GenericInternalRow(2)
+        extraRow.setByte(0, row.getRowKind.toByteValue)
+        extraRow.setInt(1, bucket)
+        queue.enqueue(encoderGroup.internalToRow(new SparkJoinedRow(dataRow, extraRow)))
       }
     )
     rowIterator.foreach {

--- a/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/commands/PaimonSparkWriter.scala
+++ b/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/commands/PaimonSparkWriter.scala
@@ -30,7 +30,7 @@ import org.apache.paimon.fs.Path
 import org.apache.paimon.index.{BucketAssigner, SimpleHashBucketAssigner}
 import org.apache.paimon.io.{CompactIncrement, DataIncrement}
 import org.apache.paimon.manifest.FileKind
-import org.apache.paimon.spark.{SparkPostponeStagedCommitter, SparkRow, SparkTypeUtils}
+import org.apache.paimon.spark.{SparkPostponeStagedCommitter, SparkRow}
 import org.apache.paimon.spark.catalog.functions.BucketFunction
 import org.apache.paimon.spark.schema.SparkSystemColumns.{BUCKET_COL, ROW_KIND_COL}
 import org.apache.paimon.spark.sort.TableSorter
@@ -40,7 +40,7 @@ import org.apache.paimon.spark.write.{PaimonDataWrite, WriteHelper, WriteTaskRes
 import org.apache.paimon.table.{FileStoreTable, SpecialFields}
 import org.apache.paimon.table.BucketMode._
 import org.apache.paimon.table.sink._
-import org.apache.paimon.types.{RowKind, RowType}
+import org.apache.paimon.types.RowKind
 import org.apache.paimon.utils.{SerializationUtils, UriReaderFactory}
 
 import org.apache.spark.{Partitioner, TaskContext}
@@ -247,7 +247,6 @@ case class PaimonSparkWriter(
     val written: Dataset[_ <: WriteTaskResult] = bucketMode match {
       case KEY_DYNAMIC =>
         // Topology: input -> bootstrap -> shuffle by key hash -> bucket-assigner -> shuffle by partition & bucket
-        val rowType = SparkTypeUtils.toPaimonType(withInitBucketCol.schema).asInstanceOf[RowType]
         val assignerParallelism = Option(coreOptions.dynamicBucketAssignerParallelism)
           .map(_.toInt)
           .getOrElse(sparkParallelism)
@@ -259,11 +258,7 @@ case class PaimonSparkWriter(
             uriReaderFactory)
 
         val globalDynamicBucketProcessor =
-          GlobalDynamicBucketProcessor(
-            table,
-            rowType,
-            assignerParallelism,
-            encoderGroupWithBucketCol)
+          GlobalDynamicBucketProcessor(table, assignerParallelism, encoderGroupWithBucketCol)
         val repartitioned = repartitionByPartitionsAndBucket(
           sparkSession.createDataFrame(
             bootstrapped.mapPartitions(globalDynamicBucketProcessor.processPartition),

--- a/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/sql/DynamicBucketTableTest.scala
+++ b/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/sql/DynamicBucketTableTest.scala
@@ -18,7 +18,10 @@
 
 package org.apache.paimon.spark.sql
 
+import org.apache.paimon.catalog.Identifier
+import org.apache.paimon.schema.Schema
 import org.apache.paimon.spark.PaimonSparkTestBase
+import org.apache.paimon.types.DataTypes
 
 import org.apache.spark.sql.Row
 
@@ -219,6 +222,26 @@ class DynamicBucketTableTest extends PaimonSparkTestBase {
         sql("SELECT c0, c1, c2, pt from t"),
         Row("c0", "c1", "c2", "pt")
       )
+    }
+  }
+
+  test("Paimon cross partition table: write timestamp with precision 3") {
+    withTable("t") {
+      val schema = Schema.newBuilder
+        .column("etl_dt", DataTypes.DATE.notNull)
+        .column("order_id", DataTypes.BIGINT.notNull)
+        .column("despatch_end", DataTypes.TIMESTAMP(3))
+        .partitionKeys("etl_dt")
+        .primaryKey("order_id")
+        .option("bucket", "-1")
+        .option("deletion-vectors.enabled", "true")
+        .option("dynamic-bucket.assigner-parallelism", "1")
+        .build
+      paimonCatalog.createTable(Identifier.create(dbName0, "t"), schema, false)
+
+      sql("INSERT INTO t VALUES (DATE '2026-08-14', 1L, TIMESTAMP '2026-08-14 10:00:00')")
+
+      checkAnswer(sql("SELECT order_id FROM t"), Row(1L))
     }
   }
 }


### PR DESCRIPTION
### Purpose

Fix Spark key-dynamic writes for Paimon tables containing timestamps whose precision cannot be represented in Spark schemas.

The bootstrap path serializes rows with the table's original `RowType`, while the global-index output was decoded with a `RowType` reconstructed from the Spark schema. Spark loses the Paimon timestamp precision, so a `TIMESTAMP(3)` binary row was decoded as `TIMESTAMP(6)` and failed.

Decode global-index data rows with `fileStoreTable.rowType()` and append the Spark row-kind and bucket columns separately.

### Tests

- Added a cross-partition dynamic-bucket regression test using `TIMESTAMP(3)` and deletion vectors.
- Spark 3 `DynamicBucketTableTest`: 8 tests passed.
- Spark 4 shared sources compiled successfully.
