### PR TITLE
[core] Fix scan version for fallback branch

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/table/FallbackReadFileStoreTable.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/FallbackReadFileStoreTable.java
@@ -193,6 +193,15 @@ public class FallbackReadFileStoreTable extends DelegatedFileStoreTable {
         // then convert millisecond to other branch snapshot id
         String scanSnapshotIdOptionKey = CoreOptions.SCAN_SNAPSHOT_ID.key();
         String scanSnapshotId = options.get(scanSnapshotIdOptionKey);
+        String scanVersionOptionKey = CoreOptions.SCAN_VERSION.key();
+        String scanVersion = options.get(scanVersionOptionKey);
+        if (scanSnapshotId == null
+                && scanVersion != null
+                && scanVersion.chars().allMatch(Character::isDigit)
+                && !wrapped.tagManager().tagExists(scanVersion)) {
+            scanSnapshotId = scanVersion;
+            result.remove(scanVersionOptionKey);
+        }
         if (scanSnapshotId != null) {
             long id = Long.parseLong(scanSnapshotId);
             long millis = wrapped.snapshotManager().snapshot(id).timeMillis();

--- a/paimon-core/src/test/java/org/apache/paimon/table/FallbackReadFileStoreTableTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/table/FallbackReadFileStoreTableTest.java
@@ -166,6 +166,30 @@ public class FallbackReadFileStoreTableTest {
         assertThat(result).containsExactlyInAnyOrder(Pair.of(1, 1), Pair.of(2, 2));
     }
 
+    @Test
+    public void testScanVersionForFallbackBranch() throws Exception {
+        FileStoreTable mainTable = createTable();
+        writeDataIntoTable(mainTable, 0, rowData(1, 10));
+        mainTable.createTag("base");
+
+        writeDataIntoTable(mainTable, 1, rowData(2, 20));
+        long mainSnapshotTime = mainTable.snapshotManager().snapshot(2).timeMillis();
+        mainTable.createBranch("bc", "base");
+        while (System.currentTimeMillis() <= mainSnapshotTime) {
+            Thread.yield();
+        }
+        FileStoreTable branchTable = mainTable.switchToBranch("bc");
+        writeDataIntoTable(branchTable, 2, rowData(3, 30));
+
+        FallbackReadFileStoreTable table =
+                new FallbackReadFileStoreTable(mainTable, branchTable, true);
+        FileStoreTable versioned =
+                table.copy(Collections.singletonMap(CoreOptions.SCAN_VERSION.key(), "2"));
+
+        assertThat(readAndCollect((FallbackReadFileStoreTable) versioned, scan -> {}))
+                .containsExactlyInAnyOrder(Pair.of(1, 10), Pair.of(2, 20));
+    }
+
     private DataTableScan queryAuthScan(DataTableScan delegate, TableQueryAuthResult authResult) {
         DataTableScan scan =
                 Mockito.mock(DataTableScan.class, AdditionalAnswers.delegatesTo(delegate));


### PR DESCRIPTION
### Purpose
- During reads, when a fallback branch is configured, Paimon forwards the scan.version to the fallback reader.
- However this scan version can represent different commit timestamps across the main and fallback branch causing the wrong snapshot to be picked from fallback branch.
- Fix by mapping scan versions to the fallback snapshot using the main snapshot timestamp.

### Tests
 - UT