### PR TITLE
[core] Fix flaky column type update test

### DIFF
--- a/paimon-core/src/test/java/org/apache/paimon/schema/SchemaManagerTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/schema/SchemaManagerTest.java
@@ -1533,7 +1533,7 @@ public class SchemaManagerTest {
                 .isInstanceOf(NumberFormatException.class);
 
         // the column is untouched, so the table is still writable
-        TableSchema after = manager.latest().get();
+        TableSchema after = retryArtificialException(() -> manager.latest()).get();
         assertThat(after.fields().get(1).type()).isEqualTo(DataTypes.STRING());
         assertThatCode(
                         () ->
@@ -1549,7 +1549,7 @@ public class SchemaManagerTest {
         retryArtificialException(
                 () -> manager.commitChanges(SchemaChange.updateColumnType("c", DataTypes.INT())));
 
-        TableSchema after = manager.latest().get();
+        TableSchema after = retryArtificialException(() -> manager.latest()).get();
         assertThat(after.fields().get(1).type()).isEqualTo(DataTypes.INT());
         assertThat(after.fields().get(1).defaultValue()).isEqualTo("'123'");
         assertThatCode(


### PR DESCRIPTION
### Purpose
- SchemaManagerTest intentionally injects artificial failure to verify retry behavior.
- The existing column update test reads schema without retrying, this causes the injected ArtificialException to fail the tests randomly and CI failure.
- Fix by wrapping the schema reads with a retryArtificialException.

### Tests
 - UT