### PR TITLE
[common] Fix substring transform query failure for non int type

### DIFF
--- a/paimon-common/src/main/java/org/apache/paimon/predicate/SubstringTransform.java
+++ b/paimon-common/src/main/java/org/apache/paimon/predicate/SubstringTransform.java
@@ -107,7 +107,20 @@ public class SubstringTransform implements Transform {
 
     private static int readPosition(Object position, InternalRow row) {
         if (position instanceof FieldRef) {
-            return row.getInt(((FieldRef) position).index());
+            FieldRef ref = (FieldRef) position;
+            switch (ref.type().getTypeRoot()) {
+                case TINYINT:
+                    return row.getByte(ref.index());
+                case SMALLINT:
+                    return row.getShort(ref.index());
+                case INTEGER:
+                    return row.getInt(ref.index());
+                case BIGINT:
+                    return Math.toIntExact(row.getLong(ref.index()));
+                default:
+                    throw new IllegalArgumentException(
+                            "Unsupported substring position type: " + ref.type());
+            }
         }
         return Integer.parseInt(position.toString());
     }

--- a/paimon-common/src/test/java/org/apache/paimon/predicate/SubstringTransformTest.java
+++ b/paimon-common/src/test/java/org/apache/paimon/predicate/SubstringTransformTest.java
@@ -20,11 +20,13 @@ package org.apache.paimon.predicate;
 
 import org.apache.paimon.data.BinaryString;
 import org.apache.paimon.data.GenericRow;
+import org.apache.paimon.types.DataType;
 import org.apache.paimon.types.DataTypes;
 
 import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -98,6 +100,32 @@ class SubstringTransformTest {
                                 2,
                                 3));
         assertThat(result).isEqualTo(BinaryString.fromString("ell"));
+    }
+
+    @Test
+    public void testSubstringRefInputsWithDifferentIntegerTypes() {
+        List<Object> positions = Arrays.asList((byte) 2, (short) 2, 2, 2L);
+        List<DataType> types =
+                Arrays.asList(
+                        DataTypes.TINYINT(),
+                        DataTypes.SMALLINT(),
+                        DataTypes.INT(),
+                        DataTypes.BIGINT());
+
+        for (int i = 0; i < positions.size(); i++) {
+            SubstringTransform transform =
+                    new SubstringTransform(
+                            Arrays.asList(
+                                    new FieldRef(0, "value", DataTypes.STRING()),
+                                    new FieldRef(1, "position", types.get(i)),
+                                    3));
+
+            assertThat(
+                            transform.transform(
+                                    GenericRow.of(
+                                            BinaryString.fromString("hello"), positions.get(i))))
+                    .isEqualTo(BinaryString.fromString("ell"));
+        }
     }
 
     @Test


### PR DESCRIPTION
### Purpose
 - Substring function accepts multiple numeric types for position indexes in argument.
 - However, positions are always read as INT, causing a ClassCastException for types such as bigint, long etc.
 - Ensure we read the position fields with the getter corresponding to their declared type.

### Tests
 - UT