### PR TITLE
[core] Fix incorrect substring result for unicode characters

### DIFF
--- a/paimon-common/src/main/java/org/apache/paimon/predicate/SubstringTransform.java
+++ b/paimon-common/src/main/java/org/apache/paimon/predicate/SubstringTransform.java
@@ -75,21 +75,21 @@ public class SubstringTransform implements Transform {
             return null;
         }
 
-        String sourceJavaString = sourceString.toString();
+        int sourceLength = sourceString.numChars();
         int beginIndex = readPosition(inputs.get(1), row);
-        if (beginIndex > sourceJavaString.length()) {
+        if (beginIndex > sourceLength) {
             return BinaryString.EMPTY_UTF8;
         }
 
-        int endIndex = sourceJavaString.length();
+        int endIndex = sourceLength;
         if (hasLength) {
             endIndex = beginIndex + readPosition(inputs.get(2), row) - 1;
         }
-        endIndex = Math.min(endIndex, sourceJavaString.length());
+        endIndex = Math.min(endIndex, sourceLength);
         beginIndex--;
         checkArgument(beginIndex < endIndex);
 
-        return BinaryString.fromString(sourceJavaString.substring(beginIndex, endIndex));
+        return sourceString.substring(beginIndex, endIndex);
     }
 
     private static boolean isNullPosition(Object position, InternalRow row) {

--- a/paimon-common/src/test/java/org/apache/paimon/predicate/SubstringTransformTest.java
+++ b/paimon-common/src/test/java/org/apache/paimon/predicate/SubstringTransformTest.java
@@ -83,6 +83,14 @@ class SubstringTransformTest {
     }
 
     @Test
+    public void testSubstringWithSupplementaryCharacter() {
+        SubstringTransform transform =
+                new SubstringTransform(Arrays.asList(BinaryString.fromString("A😀B"), 2, 1));
+
+        assertThat(transform.transform(GenericRow.of())).isEqualTo(BinaryString.fromString("😀"));
+    }
+
+    @Test
     public void testSubstringRefInputs() {
         List<Object> inputs = new ArrayList<>();
         inputs.add(new FieldRef(1, "f1", DataTypes.STRING()));

--- a/paimon-common/src/test/java/org/apache/paimon/predicate/SubstringTransformTest.java
+++ b/paimon-common/src/test/java/org/apache/paimon/predicate/SubstringTransformTest.java
@@ -25,6 +25,7 @@ import org.apache.paimon.types.DataTypes;
 import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;


### PR DESCRIPTION
### Purpose
 - Substring operations use UTF-16 indexes, which count certain unicode characters as two positions.
 - This splits 2 character positions incorrectly (such as emojis) and return an invalid result.
 - Fix this by counting and extracting complete unicode characters.

### Tests
 - UT
