### PR TITLE
[spark]to DE insert into path,the target table should also be target splits

### DIFF
--- a/paimon-spark/paimon-spark-4.0/src/main/scala/org/apache/paimon/spark/commands/MergeIntoPaimonDataEvolutionTable.scala
+++ b/paimon-spark/paimon-spark-4.0/src/main/scala/org/apache/paimon/spark/commands/MergeIntoPaimonDataEvolutionTable.scala
@@ -838,7 +838,7 @@ case class MergeIntoPaimonDataEvolutionTable(
       mergeFields.filter(field => targetTable.output.exists(attr => attr.equals(field)))
 
     val targetReadPlan =
-      touchedFileTargetRelation.copy(targetRelation.table, allReadFieldsOnTarget.toSeq)
+      touchedFileTargetRelation.copy(output = allReadFieldsOnTarget.toSeq)
     val sourceReadPlan = persistSourceDss.map(_.queryExecution.logical).getOrElse(sourceTable)
 
     val joinPlan =

--- a/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/commands/MergeIntoPaimonDataEvolutionTable.scala
+++ b/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/commands/MergeIntoPaimonDataEvolutionTable.scala
@@ -837,7 +837,7 @@ case class MergeIntoPaimonDataEvolutionTable(
       mergeFields.filter(field => targetTable.output.exists(attr => attr.equals(field)))
 
     val targetReadPlan =
-      touchedFileTargetRelation.copy(targetRelation.table, allReadFieldsOnTarget.toSeq)
+      touchedFileTargetRelation.copy(output = allReadFieldsOnTarget.toSeq)
     val sourceReadPlan = persistSourceDss.map(_.queryExecution.logical).getOrElse(sourceTable)
 
     val joinPlan =


### PR DESCRIPTION
### Purpose

to DE table, the insert path's left anti join could be more efficence by making the target table be target spltis

### Tests

minor change, no tests,the existing one cove