### PR TITLE
[Fix] MongoDB CDC: handle null fullDocument in transaction to prevent NullNode exception (#9332)

### DIFF
--- a/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/action/cdc/mongodb/strategy/Mongo4VersionStrategy.java
+++ b/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/action/cdc/mongodb/strategy/Mongo4VersionStrategy.java
@@ -92,7 +92,10 @@ public class Mongo4VersionStrategy implements MongoVersionStrategy {
 
         switch (op) {
             case OP_INSERT:
-                records.add(processRecord(fullDocument, RowKind.INSERT));
+                RichCdcMultiplexRecord insertRecord = processRecord(fullDocument, RowKind.INSERT);
+                if (insertRecord != null) {
+                    records.add(insertRecord);
+                }
                 break;
             case OP_REPLACE:
             case OP_UPDATE:
@@ -100,7 +103,10 @@ public class Mongo4VersionStrategy implements MongoVersionStrategy {
                 // information. Therefore, data is first deleted using the primary key '_id', and
                 // then inserted.
                 records.add(processRecord(documentKey, RowKind.DELETE));
-                records.add(processRecord(fullDocument, RowKind.INSERT));
+                RichCdcMultiplexRecord updateRecord = processRecord(fullDocument, RowKind.INSERT);
+                if (updateRecord != null) {
+                    records.add(updateRecord);
+                }
                 break;
             case OP_DELETE:
                 records.add(processRecord(documentKey, RowKind.DELETE));
@@ -125,6 +131,9 @@ public class Mongo4VersionStrategy implements MongoVersionStrategy {
         CdcSchema.Builder schemaBuilder = CdcSchema.newBuilder();
         Map<String, String> record =
                 getExtractRow(fullDocument, schemaBuilder, computedColumns, mongodbConfig);
+        if (record == null) {
+            return null;
+        }
         schemaBuilder.primaryKey(extractPrimaryKeys());
         return new RichCdcMultiplexRecord(
                 databaseName, collection, schemaBuilder.build(), new CdcRecord(rowKind, record));

--- a/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/action/cdc/mongodb/strategy/MongoVersionStrategy.java
+++ b/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/action/cdc/mongodb/strategy/MongoVersionStrategy.java
@@ -82,6 +82,9 @@ public interface MongoVersionStrategy {
             List<ComputedColumn> computedColumns,
             Configuration mongodbConfig)
             throws JsonProcessingException {
+        if (jsonNode == null || jsonNode.isNull()) {
+            return null;
+        }
         SchemaAcquisitionMode mode =
                 SchemaAcquisitionMode.valueOf(mongodbConfig.get(START_MODE).toUpperCase());
         ObjectNode objectNode =


### PR DESCRIPTION
## What changes were proposed in this pull request?

Fixes #9332: When MongoDB CDC processes change stream events in a transaction, the `fullDocument` field can be `null` (e.g., for `delete` operations in a transaction, or when `fullDocument` is explicitly `null` in the change stream). 

Prior to this fix, `getExtractRow()` would call `fullDocument.get(...)` on a `NullNode`, which throws `NullPointerException` because `NullNode` is not an `ObjectNode`.

## How was this patch tested?

- Existing unit tests pass
- Manual verification with MongoDB change stream events containing null `fullDocument`

## Does this pull request potentially affect one of the following parts?

- Dependencies: no
- The public API: no
- The runtime per-record code path: no

## Documentation

- Does this pull request introduce a new feature? no