### PR TITLE
[Fix] Support KEY_DYNAMIC bucket mode in CompactorSinkBuilder

### DIFF
--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/CompactorSinkBuilder.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/CompactorSinkBuilder.java
@@ -66,6 +66,7 @@ public class CompactorSinkBuilder {
         switch (bucketMode) {
             case HASH_FIXED:
             case HASH_DYNAMIC:
+            case KEY_DYNAMIC:
                 return buildForBucketAware();
             default:
                 throw new UnsupportedOperationException("Unsupported bucket mode: " + bucketMode);


### PR DESCRIPTION
## Which issues does this PR fix?

Closes #9256.

## What changes are included in this PR?

When using KEY_DYNAMIC bucket mode (bucket = -1 with crossPartitionUpdate), the `CALL sys.compact` procedure would throw:

```
UnsupportedOperationException: Unsupported bucket mode: KEY_DYNAMIC
```

The `CompactorSinkBuilder` only handled `HASH_FIXED` and `HASH_DYNAMIC` bucket modes, but `KEY_DYNAMIC` is also a bucket-aware mode that should use the same `buildForBucketAware()` path.

## Root Cause

In `CompactorSinkBuilder.build()`, the switch statement on `BucketMode` only had cases for `HASH_FIXED` and `HASH_DYNAMIC`. The `KEY_DYNAMIC` case was missing, causing it to fall through to the default branch which throws an `UnsupportedOperationException`.

## Fix

Add `KEY_DYNAMIC` to the case statement alongside `HASH_DYNAMIC` so that it also routes to `buildForBucketAware()`.

## How was this patch tested?

The change is a one-line addition of a case statement. The `FlinkSinkBuilder` already handles `KEY_DYNAMIC` by routing to `buildDynamicBucketSink(input, true)`, confirming that KEY_DYNAMIC is a valid bucket-aware mode that should be supported in the compaction path.