### PR TITLE
[python][ray] Rebase self-merge updates after compaction

### DIFF
--- a/paimon-python/pypaimon/ray/data_evolution_merge_into.py
+++ b/paimon-python/pypaimon/ray/data_evolution_merge_into.py
@@ -506,10 +506,6 @@ def _execute_and_commit(
                     delete_msgs + insert_msgs,
                     num_partitions=num_partitions,
                     ray_remote_args=ray_remote_args,
-                    base_snapshot_uuid=(
-                        base_snapshot.uuid
-                        if base_snapshot is not None else None
-                    ),
                 )
             else:
                 table_commit = None

--- a/paimon-python/pypaimon/ray/data_evolution_merge_into.py
+++ b/paimon-python/pypaimon/ray/data_evolution_merge_into.py
@@ -570,11 +570,21 @@ def _require_ray_join() -> None:
 
 def _reraise_inner(err: BaseException) -> None:
     """Unwrap Ray's RayTaskError so callers see the worker-side exception."""
+    from pypaimon.write.file_store_commit import CommitResultUncertainError
+
     inner = err
-    cause = getattr(err, "cause", None) or getattr(err, "__cause__", None)
-    while cause is not None:
+    while True:
+        if isinstance(inner, CommitResultUncertainError):
+            if inner is err:
+                raise err
+            raise inner from err
+        cause = (
+            getattr(inner, "cause", None)
+            or getattr(inner, "__cause__", None)
+        )
+        if cause is None:
+            break
         inner = cause
-        cause = getattr(inner, "cause", None) or getattr(inner, "__cause__", None)
     if inner is err:
         raise err
     raise inner from err

--- a/paimon-python/pypaimon/ray/data_evolution_merge_into.py
+++ b/paimon-python/pypaimon/ray/data_evolution_merge_into.py
@@ -569,24 +569,22 @@ def _require_ray_join() -> None:
 
 
 def _reraise_inner(err: BaseException) -> None:
-    """Unwrap Ray's RayTaskError so callers see the worker-side exception."""
-    from pypaimon.write.file_store_commit import CommitResultUncertainError
+    """Unwrap only RayTaskError layers and preserve ordinary exception chains."""
+    try:
+        from ray.exceptions import RayTaskError
+    except ImportError:
+        raise err
 
     inner = err
-    while True:
-        if isinstance(inner, CommitResultUncertainError):
-            if inner is err:
-                raise err
-            raise inner from err
-        cause = (
-            getattr(inner, "cause", None)
-            or getattr(inner, "__cause__", None)
-        )
-        if cause is None:
+    while isinstance(inner, RayTaskError):
+        cause = getattr(inner, "cause", None)
+        if cause is None or cause is inner:
             break
         inner = cause
     if inner is err:
         raise err
+    if getattr(inner, "__cause__", None) is not None:
+        raise inner
     raise inner from err
 
 

--- a/paimon-python/pypaimon/ray/data_evolution_merge_into.py
+++ b/paimon-python/pypaimon/ray/data_evolution_merge_into.py
@@ -506,6 +506,10 @@ def _execute_and_commit(
                     delete_msgs + insert_msgs,
                     num_partitions=num_partitions,
                     ray_remote_args=ray_remote_args,
+                    base_snapshot_uuid=(
+                        base_snapshot.uuid
+                        if base_snapshot is not None else None
+                    ),
                 )
             else:
                 table_commit = None

--- a/paimon-python/pypaimon/ray/data_evolution_merge_into.py
+++ b/paimon-python/pypaimon/ray/data_evolution_merge_into.py
@@ -436,6 +436,8 @@ def _execute_and_commit(
     num_deleted = 0
     delete_row_ids = []
     num_inserted = 0
+    insert_msgs: list = []
+    self_merge_update = isinstance(update_ds, _SelfMergeUpdatePlan)
 
     try:
         if update_ds is not None:
@@ -494,20 +496,32 @@ def _execute_and_commit(
 
         all_msgs: list = list(commit_messages)
         if all_msgs:
-            table_commit = None
-            try:
-                table_commit = table.new_batch_write_builder().new_commit()
-                table_commit.commit(all_msgs)
-            finally:
-                if table_commit is not None:
-                    try:
-                        table_commit.close()
-                    except Exception as close_error:
-                        logger.warning(
-                            "Failed to close merge_into commit: %s",
-                            close_error,
-                            exc_info=close_error,
-                        )
+            if self_merge_update and update_msgs:
+                from pypaimon.ray.row_id_conflict_rewriter import (
+                    commit_self_merge_with_compaction_retry,
+                )
+                commit_self_merge_with_compaction_retry(
+                    table,
+                    update_msgs,
+                    delete_msgs + insert_msgs,
+                    num_partitions=num_partitions,
+                    ray_remote_args=ray_remote_args,
+                )
+            else:
+                table_commit = None
+                try:
+                    table_commit = table.new_batch_write_builder().new_commit()
+                    table_commit.commit(all_msgs)
+                finally:
+                    if table_commit is not None:
+                        try:
+                            table_commit.close()
+                        except Exception as close_error:
+                            logger.warning(
+                                "Failed to close merge_into commit: %s",
+                                close_error,
+                                exc_info=close_error,
+                            )
     except Exception as e:
         _reraise_inner(e)
 

--- a/paimon-python/pypaimon/ray/row_id_conflict_rewriter.py
+++ b/paimon-python/pypaimon/ray/row_id_conflict_rewriter.py
@@ -33,6 +33,7 @@ from pypaimon.table.special_fields import SpecialFields
 from pypaimon.utils.range import Range
 from pypaimon.write.commit.conflict_detection import RowIdExistenceConflict
 from pypaimon.write.commit_message import CommitMessage
+from pypaimon.write.file_store_commit import CommitResultUncertainError
 
 logger = logging.getLogger(__name__)
 
@@ -107,6 +108,9 @@ def commit_self_merge_with_compaction_retry(
             # ordinary FileStoreCommit retries remain enabled.
             commit.file_store_commit.rollback = None
             commit.commit(current_updates + other_messages)
+        except CommitResultUncertainError:
+            # An unobservable snapshot may reference these files.
+            raise
         except Exception as error:
             conflict = _find_row_id_conflict(error)
             if conflict is None:

--- a/paimon-python/pypaimon/ray/row_id_conflict_rewriter.py
+++ b/paimon-python/pypaimon/ray/row_id_conflict_rewriter.py
@@ -93,11 +93,14 @@ def commit_self_merge_with_compaction_retry(
                 table.identifier,
             )
 
+    # Match Spark's PaimonSparkWriter: every outer rebase attempt creates a
+    # fresh commit from one write builder, preserving the commit user.
+    write_builder = commit_table.new_batch_write_builder()
     while True:
         commit = None
         conflict = None
         try:
-            commit = commit_table.new_batch_write_builder().new_commit()
+            commit = write_builder.new_commit()
             commit.commit(current_updates + other_messages)
         except Exception as error:
             conflict = _find_row_id_conflict(error)

--- a/paimon-python/pypaimon/ray/row_id_conflict_rewriter.py
+++ b/paimon-python/pypaimon/ray/row_id_conflict_rewriter.py
@@ -72,11 +72,40 @@ def commit_self_merge_with_compaction_retry(
             "0 B",
     })
 
+    base_snapshot_ids = _base_snapshot_ids(current_updates)
+    latest_snapshot = table.snapshot_manager().get_latest_snapshot()
+    if (
+            len(base_snapshot_ids) == 1
+            and latest_snapshot is not None
+            and latest_snapshot.id != next(iter(base_snapshot_ids))
+    ):
+        result = _rewrite_updates(
+            table,
+            current_updates,
+            latest_snapshot,
+            num_partitions=num_partitions,
+            ray_remote_args=ray_remote_args,
+        )
+        if result is not None:
+            current_updates = result.update_messages
+            superseded_messages.extend(result.superseded_messages)
+            logger.info(
+                "Rewrote %d stale self-merge file(s) against snapshot %d "
+                "before committing to table %s.",
+                result.rewritten_file_count,
+                latest_snapshot.id,
+                table.identifier,
+            )
+
     while True:
         commit = None
         conflict = None
         try:
             commit = commit_table.new_batch_write_builder().new_commit()
+            # This layer owns stale row-id layout recovery. Do not enter the
+            # legacy compaction-rollback loop before the distributed rebase;
+            # ordinary FileStoreCommit retries remain enabled.
+            commit.file_store_commit.rollback = None
             commit.commit(current_updates + other_messages)
         except Exception as error:
             conflict = _find_row_id_conflict(error)
@@ -104,7 +133,7 @@ def commit_self_merge_with_compaction_retry(
         elapsed = int(time.time() * 1000) - start_millis
         if (
                 elapsed > table.options.commit_timeout()
-                or retry_count > table.options.commit_max_retries()
+                or retry_count >= table.options.commit_max_retries()
         ):
             raise conflict
 
@@ -162,12 +191,7 @@ def _rewrite_updates(
     ):
         return None
 
-    base_snapshot_ids = {
-        message.check_from_snapshot
-        for message in update_messages
-        if message.check_from_snapshot is not None
-        and message.check_from_snapshot >= 0
-    }
+    base_snapshot_ids = _base_snapshot_ids(update_messages)
     if len(base_snapshot_ids) != 1:
         return None
     base_snapshot = table.snapshot_manager().get_snapshot_by_id(
@@ -305,6 +329,15 @@ def _rewrite_updates(
         superseded_messages=superseded_messages,
         rewritten_file_count=len(candidates),
     )
+
+
+def _base_snapshot_ids(update_messages: Sequence[CommitMessage]):
+    return {
+        message.check_from_snapshot
+        for message in update_messages
+        if message.check_from_snapshot is not None
+        and message.check_from_snapshot >= 0
+    }
 
 
 def _rewrite_group(

--- a/paimon-python/pypaimon/ray/row_id_conflict_rewriter.py
+++ b/paimon-python/pypaimon/ray/row_id_conflict_rewriter.py
@@ -99,10 +99,6 @@ def commit_self_merge_with_compaction_retry(
         conflict = None
         try:
             commit = commit_table.new_batch_write_builder().new_commit()
-            # This layer owns stale row-id layout recovery. Do not enter the
-            # legacy compaction-rollback loop before the distributed rebase;
-            # ordinary FileStoreCommit retries remain enabled.
-            commit.file_store_commit.rollback = None
             commit.commit(current_updates + other_messages)
         except CommitResultUncertainError:
             raise
@@ -146,7 +142,7 @@ def commit_self_merge_with_compaction_retry(
         except Exception as rewrite_error:
             raise RuntimeError(
                 "{} {}".format(conflict, rewrite_error)
-            )
+            ) from conflict
         if result is None:
             raise conflict
 
@@ -272,35 +268,25 @@ def _rewrite_updates(
         groups.setdefault(tuple(candidate.file.write_cols), []).append(
             candidate
         )
-    try:
-        for columns, files in groups.items():
-            messages, rewritten_rows, _ = _rewrite_group(
-                table,
-                list(columns),
-                files,
-                latest_snapshot.id,
-                num_partitions=num_partitions,
-                ray_remote_args=ray_remote_args,
+    for columns, files in groups.items():
+        messages, rewritten_rows, _ = _rewrite_group(
+            table,
+            list(columns),
+            files,
+            latest_snapshot.id,
+            num_partitions=num_partitions,
+            ray_remote_args=ray_remote_args,
+        )
+        expected_rows = sum(item.file.row_count for item in files)
+        if rewritten_rows != expected_rows:
+            raise RuntimeError(
+                "Distributed row-id conflict rewrite read {} rows from "
+                "staged files, expected {}.".format(
+                    rewritten_rows,
+                    expected_rows,
+                )
             )
-            expected_rows = sum(item.file.row_count for item in files)
-            if rewritten_rows != expected_rows:
-                from pypaimon.write.file_store_commit import (
-                    _abort_commit_messages,
-                )
-                _abort_commit_messages(table, messages)
-                raise RuntimeError(
-                    "Distributed row-id conflict rewrite read {} rows from "
-                    "staged files, expected {}.".format(
-                        rewritten_rows,
-                        expected_rows,
-                    )
-                )
-            rewritten_messages.extend(messages)
-    except Exception:
-        if rewritten_messages:
-            from pypaimon.write.file_store_commit import _abort_commit_messages
-            _abort_commit_messages(table, rewritten_messages)
-        raise
+        rewritten_messages.extend(messages)
 
     return _RewriteResult(
         update_messages=remaining_messages + rewritten_messages,

--- a/paimon-python/pypaimon/ray/row_id_conflict_rewriter.py
+++ b/paimon-python/pypaimon/ray/row_id_conflict_rewriter.py
@@ -33,7 +33,6 @@ from pypaimon.table.special_fields import SpecialFields
 from pypaimon.utils.range import Range
 from pypaimon.write.commit.conflict_detection import RowIdExistenceConflict
 from pypaimon.write.commit_message import CommitMessage
-from pypaimon.write.file_store_commit import CommitResultUncertainError
 
 logger = logging.getLogger(__name__)
 
@@ -100,8 +99,6 @@ def commit_self_merge_with_compaction_retry(
         try:
             commit = commit_table.new_batch_write_builder().new_commit()
             commit.commit(current_updates + other_messages)
-        except CommitResultUncertainError:
-            raise
         except Exception as error:
             conflict = _find_row_id_conflict(error)
             if conflict is None:

--- a/paimon-python/pypaimon/ray/row_id_conflict_rewriter.py
+++ b/paimon-python/pypaimon/ray/row_id_conflict_rewriter.py
@@ -31,10 +31,7 @@ from pypaimon.read.split import DataSplit
 from pypaimon.table.row.generic_row import GenericRow
 from pypaimon.table.special_fields import SpecialFields
 from pypaimon.utils.range import Range
-from pypaimon.write.commit.conflict_detection import (
-    RowIdLineageConflict,
-    RowIdRebaseConflict,
-)
+from pypaimon.write.commit.conflict_detection import RowIdExistenceConflict
 from pypaimon.write.commit_message import CommitMessage
 from pypaimon.write.file_store_commit import CommitResultUncertainError
 
@@ -62,13 +59,11 @@ def commit_self_merge_with_compaction_retry(
         *,
         num_partitions: int,
         ray_remote_args=None,
-        base_snapshot_uuid=None,
 ) -> None:
     """Commit self-merge messages, rebasing stale updates when compaction wins."""
     current_updates = list(update_messages)
     other_messages = list(other_messages)
     superseded_messages = []
-    current_base_snapshot_uuid = base_snapshot_uuid
     retry_count = 0
     start_millis = int(time.time() * 1000)
 
@@ -107,12 +102,10 @@ def commit_self_merge_with_compaction_retry(
                 latest_snapshot,
                 num_partitions=num_partitions,
                 ray_remote_args=ray_remote_args,
-                expected_base_snapshot_uuid=current_base_snapshot_uuid,
             )
             if result is not None:
                 current_updates = result.update_messages
                 superseded_messages.extend(result.superseded_messages)
-                current_base_snapshot_uuid = latest_snapshot.uuid
                 logger.info(
                     "Rewrote %d stale self-merge file(s) against snapshot %d "
                     "before committing to table %s.",
@@ -134,10 +127,6 @@ def commit_self_merge_with_compaction_retry(
             # legacy compaction-rollback loop before the distributed rebase;
             # ordinary FileStoreCommit retries remain enabled.
             commit.file_store_commit.rollback = None
-            conflict_detection = commit.file_store_commit.conflict_detection
-            conflict_detection.set_row_id_check_from_snapshot_uuid(
-                current_base_snapshot_uuid
-            )
             commit_attempted = True
             commit.commit(current_updates + other_messages)
         except CommitResultUncertainError:
@@ -145,12 +134,6 @@ def commit_self_merge_with_compaction_retry(
             abort_known_uncommitted(False)
             raise
         except Exception as error:
-            lineage_conflict = _find_error(error, RowIdLineageConflict)
-            if lineage_conflict is not None:
-                abort_known_uncommitted(True)
-                if lineage_conflict is error:
-                    raise
-                raise lineage_conflict from error
             conflict = _find_row_id_conflict(error)
             if conflict is None:
                 abort_known_uncommitted(not commit_attempted)
@@ -190,7 +173,6 @@ def commit_self_merge_with_compaction_retry(
                 latest_snapshot,
                 num_partitions=num_partitions,
                 ray_remote_args=ray_remote_args,
-                expected_base_snapshot_uuid=current_base_snapshot_uuid,
             )
         except Exception as rewrite_error:
             abort_known_uncommitted(True)
@@ -203,7 +185,6 @@ def commit_self_merge_with_compaction_retry(
 
         current_updates = result.update_messages
         superseded_messages.extend(result.superseded_messages)
-        current_base_snapshot_uuid = latest_snapshot.uuid
         elapsed = int(time.time() * 1000) - start_millis
         if elapsed > table.options.commit_timeout():
             abort_known_uncommitted(True)
@@ -231,7 +212,6 @@ def _rewrite_updates(
         *,
         num_partitions: int,
         ray_remote_args=None,
-        expected_base_snapshot_uuid=None,
 ) -> Optional[_RewriteResult]:
     if table.options.deletion_vectors_enabled(False):
         return None
@@ -249,25 +229,6 @@ def _rewrite_updates(
     base_snapshot = table.snapshot_manager().get_snapshot_by_id(
         next(iter(base_snapshot_ids))
     )
-    if (
-            expected_base_snapshot_uuid is not None
-            and (
-                base_snapshot is None
-                or base_snapshot.uuid != expected_base_snapshot_uuid
-            )
-    ):
-        raise RowIdLineageConflict(
-            "Row-id snapshot lineage conflict: snapshot {} no longer has "
-            "the staged UUID {}.".format(
-                next(iter(base_snapshot_ids)),
-                expected_base_snapshot_uuid,
-            )
-        )
-    if base_snapshot is not None and latest_snapshot.id < base_snapshot.id:
-        raise RowIdLineageConflict(
-            "Latest snapshot {} is older than self-merge base snapshot {}."
-            .format(latest_snapshot.id, base_snapshot.id)
-        )
     if (
             base_snapshot is None
             or base_snapshot.schema_id != latest_snapshot.schema_id
@@ -324,20 +285,7 @@ def _rewrite_updates(
         )
     ]
     if not candidates:
-        # The physical files changed but their row-id boundaries did not.
-        # Logical history was validated above, so advancing the baseline is
-        # sufficient and avoids rejecting another same-boundary compaction.
-        return _RewriteResult(
-            update_messages=[
-                replace(
-                    message,
-                    check_from_snapshot=latest_snapshot.id,
-                )
-                for message in update_messages
-            ],
-            superseded_messages=[],
-            rewritten_file_count=0,
-        )
+        return None
     if not _ranges_are_still_covered(current_files, candidates):
         return None
 
@@ -504,16 +452,12 @@ def _validate_no_logical_conflict(
         commit.close()
 
 
-def _find_row_id_conflict(error) -> Optional[RowIdRebaseConflict]:
-    return _find_error(error, RowIdRebaseConflict)
-
-
-def _find_error(error, error_type):
+def _find_row_id_conflict(error) -> Optional[RowIdExistenceConflict]:
     seen = set()
     current = error
     while current is not None and id(current) not in seen:
         seen.add(id(current))
-        if isinstance(current, error_type):
+        if isinstance(current, RowIdExistenceConflict):
             return current
         current = (
             getattr(current, "cause", None)

--- a/paimon-python/pypaimon/ray/row_id_conflict_rewriter.py
+++ b/paimon-python/pypaimon/ray/row_id_conflict_rewriter.py
@@ -48,7 +48,6 @@ class _StagedFile:
 @dataclass(frozen=True)
 class _RewriteResult:
     update_messages: List[CommitMessage]
-    superseded_messages: List[CommitMessage]
     rewritten_file_count: int
 
 
@@ -63,63 +62,40 @@ def commit_self_merge_with_compaction_retry(
     """Commit self-merge messages, rebasing stale updates when compaction wins."""
     current_updates = list(update_messages)
     other_messages = list(other_messages)
-    superseded_messages = []
     retry_count = 0
     start_millis = int(time.time() * 1000)
 
-    def abort_known_uncommitted(include_current):
-        messages = list(superseded_messages)
-        superseded_messages[:] = []
-        if include_current:
-            messages.extend(current_updates)
-            messages.extend(other_messages)
-        if messages:
-            from pypaimon.write.file_store_commit import (
-                _abort_commit_messages,
-            )
-            _abort_commit_messages(table, messages)
-
-    try:
-        # Ray performs the rebase below without the local driver's size limit.
-        commit_table = table.copy_without_time_travel({
-            CoreOptions.DATA_EVOLUTION_ROW_ID_CONFLICT_REWRITE_MAX_SIZE.key():
-                "0 B",
-        })
-        base_snapshot_ids = _base_snapshot_ids(current_updates)
-        latest_snapshot = table.snapshot_manager().get_latest_snapshot()
-    except Exception:
-        abort_known_uncommitted(True)
-        raise
+    # Ray performs the rebase below without the local driver's size limit.
+    commit_table = table.copy_without_time_travel({
+        CoreOptions.DATA_EVOLUTION_ROW_ID_CONFLICT_REWRITE_MAX_SIZE.key():
+            "0 B",
+    })
+    base_snapshot_ids = _base_snapshot_ids(current_updates)
+    latest_snapshot = table.snapshot_manager().get_latest_snapshot()
     if (
             len(base_snapshot_ids) == 1
             and latest_snapshot is not None
             and latest_snapshot.id != next(iter(base_snapshot_ids))
     ):
-        try:
-            result = _rewrite_updates(
-                table,
-                current_updates,
-                latest_snapshot,
-                num_partitions=num_partitions,
-                ray_remote_args=ray_remote_args,
+        result = _rewrite_updates(
+            table,
+            current_updates,
+            latest_snapshot,
+            num_partitions=num_partitions,
+            ray_remote_args=ray_remote_args,
+        )
+        if result is not None:
+            current_updates = result.update_messages
+            logger.info(
+                "Rewrote %d stale self-merge file(s) against snapshot %d "
+                "before committing to table %s.",
+                result.rewritten_file_count,
+                latest_snapshot.id,
+                table.identifier,
             )
-            if result is not None:
-                current_updates = result.update_messages
-                superseded_messages.extend(result.superseded_messages)
-                logger.info(
-                    "Rewrote %d stale self-merge file(s) against snapshot %d "
-                    "before committing to table %s.",
-                    result.rewritten_file_count,
-                    latest_snapshot.id,
-                    table.identifier,
-                )
-        except Exception:
-            abort_known_uncommitted(True)
-            raise
 
     while True:
         commit = None
-        commit_attempted = False
         conflict = None
         try:
             commit = commit_table.new_batch_write_builder().new_commit()
@@ -127,16 +103,12 @@ def commit_self_merge_with_compaction_retry(
             # legacy compaction-rollback loop before the distributed rebase;
             # ordinary FileStoreCommit retries remain enabled.
             commit.file_store_commit.rollback = None
-            commit_attempted = True
             commit.commit(current_updates + other_messages)
         except CommitResultUncertainError:
-            # An unobservable snapshot may reference these files.
-            abort_known_uncommitted(False)
             raise
         except Exception as error:
             conflict = _find_row_id_conflict(error)
             if conflict is None:
-                abort_known_uncommitted(not commit_attempted)
                 raise
         finally:
             if commit is not None:
@@ -150,7 +122,6 @@ def commit_self_merge_with_compaction_retry(
                     )
 
         if conflict is None:
-            abort_known_uncommitted(False)
             return
 
         elapsed = int(time.time() * 1000) - start_millis
@@ -158,12 +129,10 @@ def commit_self_merge_with_compaction_retry(
                 elapsed > table.options.commit_timeout()
                 or retry_count >= table.options.commit_max_retries()
         ):
-            abort_known_uncommitted(True)
             raise conflict
 
         latest_snapshot = table.snapshot_manager().get_latest_snapshot()
         if latest_snapshot is None:
-            abort_known_uncommitted(True)
             raise conflict
 
         try:
@@ -175,19 +144,15 @@ def commit_self_merge_with_compaction_retry(
                 ray_remote_args=ray_remote_args,
             )
         except Exception as rewrite_error:
-            abort_known_uncommitted(True)
             raise RuntimeError(
                 "{} {}".format(conflict, rewrite_error)
             )
         if result is None:
-            abort_known_uncommitted(True)
             raise conflict
 
         current_updates = result.update_messages
-        superseded_messages.extend(result.superseded_messages)
         elapsed = int(time.time() * 1000) - start_millis
         if elapsed > table.options.commit_timeout():
-            abort_known_uncommitted(True)
             raise conflict
 
         logger.info(
@@ -197,11 +162,7 @@ def commit_self_merge_with_compaction_retry(
             latest_snapshot.id,
             table.identifier,
         )
-        try:
-            _retry_wait(table, retry_count)
-        except Exception:
-            abort_known_uncommitted(True)
-            raise
+        _retry_wait(table, retry_count)
         retry_count += 1
 
 
@@ -289,16 +250,10 @@ def _rewrite_updates(
     if not _ranges_are_still_covered(current_files, candidates):
         return None
 
-    candidates_by_message: Dict[int, List[DataFileMeta]] = {}
-    for candidate in candidates:
-        candidates_by_message.setdefault(candidate.message_index, []).append(
-            candidate.file
-        )
     candidate_ids = {id(candidate.file) for candidate in candidates}
 
     remaining_messages = []
-    superseded_messages = []
-    for index, message in enumerate(update_messages):
+    for message in update_messages:
         kept_files = [
             file for file in message.new_files
             if id(file) not in candidate_ids
@@ -310,15 +265,6 @@ def _rewrite_updates(
         )
         if not remaining.is_empty():
             remaining_messages.append(remaining)
-
-        replaced_files = candidates_by_message.get(index, [])
-        if replaced_files:
-            superseded_messages.append(CommitMessage(
-                partition=message.partition,
-                bucket=message.bucket,
-                new_files=replaced_files,
-                total_buckets=message.total_buckets,
-            ))
 
     rewritten_messages = []
     groups: Dict[Tuple[str, ...], List[_StagedFile]] = {}
@@ -358,7 +304,6 @@ def _rewrite_updates(
 
     return _RewriteResult(
         update_messages=remaining_messages + rewritten_messages,
-        superseded_messages=superseded_messages,
         rewritten_file_count=len(candidates),
     )
 

--- a/paimon-python/pypaimon/ray/row_id_conflict_rewriter.py
+++ b/paimon-python/pypaimon/ray/row_id_conflict_rewriter.py
@@ -31,7 +31,10 @@ from pypaimon.read.split import DataSplit
 from pypaimon.table.row.generic_row import GenericRow
 from pypaimon.table.special_fields import SpecialFields
 from pypaimon.utils.range import Range
-from pypaimon.write.commit.conflict_detection import RowIdExistenceConflict
+from pypaimon.write.commit.conflict_detection import (
+    RowIdLineageConflict,
+    RowIdRebaseConflict,
+)
 from pypaimon.write.commit_message import CommitMessage
 from pypaimon.write.file_store_commit import CommitResultUncertainError
 
@@ -59,47 +62,71 @@ def commit_self_merge_with_compaction_retry(
         *,
         num_partitions: int,
         ray_remote_args=None,
+        base_snapshot_uuid=None,
 ) -> None:
     """Commit self-merge messages, rebasing stale updates when compaction wins."""
     current_updates = list(update_messages)
     other_messages = list(other_messages)
     superseded_messages = []
+    current_base_snapshot_uuid = base_snapshot_uuid
     retry_count = 0
     start_millis = int(time.time() * 1000)
 
-    # Ray performs the rebase below without the local driver's size limit.
-    commit_table = table.copy_without_time_travel({
-        CoreOptions.DATA_EVOLUTION_ROW_ID_CONFLICT_REWRITE_MAX_SIZE.key():
-            "0 B",
-    })
+    def abort_known_uncommitted(include_current):
+        messages = list(superseded_messages)
+        superseded_messages[:] = []
+        if include_current:
+            messages.extend(current_updates)
+            messages.extend(other_messages)
+        if messages:
+            from pypaimon.write.file_store_commit import (
+                _abort_commit_messages,
+            )
+            _abort_commit_messages(table, messages)
 
-    base_snapshot_ids = _base_snapshot_ids(current_updates)
-    latest_snapshot = table.snapshot_manager().get_latest_snapshot()
+    try:
+        # Ray performs the rebase below without the local driver's size limit.
+        commit_table = table.copy_without_time_travel({
+            CoreOptions.DATA_EVOLUTION_ROW_ID_CONFLICT_REWRITE_MAX_SIZE.key():
+                "0 B",
+        })
+        base_snapshot_ids = _base_snapshot_ids(current_updates)
+        latest_snapshot = table.snapshot_manager().get_latest_snapshot()
+    except Exception:
+        abort_known_uncommitted(True)
+        raise
     if (
             len(base_snapshot_ids) == 1
             and latest_snapshot is not None
             and latest_snapshot.id != next(iter(base_snapshot_ids))
     ):
-        result = _rewrite_updates(
-            table,
-            current_updates,
-            latest_snapshot,
-            num_partitions=num_partitions,
-            ray_remote_args=ray_remote_args,
-        )
-        if result is not None:
-            current_updates = result.update_messages
-            superseded_messages.extend(result.superseded_messages)
-            logger.info(
-                "Rewrote %d stale self-merge file(s) against snapshot %d "
-                "before committing to table %s.",
-                result.rewritten_file_count,
-                latest_snapshot.id,
-                table.identifier,
+        try:
+            result = _rewrite_updates(
+                table,
+                current_updates,
+                latest_snapshot,
+                num_partitions=num_partitions,
+                ray_remote_args=ray_remote_args,
+                expected_base_snapshot_uuid=current_base_snapshot_uuid,
             )
+            if result is not None:
+                current_updates = result.update_messages
+                superseded_messages.extend(result.superseded_messages)
+                current_base_snapshot_uuid = latest_snapshot.uuid
+                logger.info(
+                    "Rewrote %d stale self-merge file(s) against snapshot %d "
+                    "before committing to table %s.",
+                    result.rewritten_file_count,
+                    latest_snapshot.id,
+                    table.identifier,
+                )
+        except Exception:
+            abort_known_uncommitted(True)
+            raise
 
     while True:
         commit = None
+        commit_attempted = False
         conflict = None
         try:
             commit = commit_table.new_batch_write_builder().new_commit()
@@ -107,13 +134,26 @@ def commit_self_merge_with_compaction_retry(
             # legacy compaction-rollback loop before the distributed rebase;
             # ordinary FileStoreCommit retries remain enabled.
             commit.file_store_commit.rollback = None
+            conflict_detection = commit.file_store_commit.conflict_detection
+            conflict_detection.set_row_id_check_from_snapshot_uuid(
+                current_base_snapshot_uuid
+            )
+            commit_attempted = True
             commit.commit(current_updates + other_messages)
         except CommitResultUncertainError:
             # An unobservable snapshot may reference these files.
+            abort_known_uncommitted(False)
             raise
         except Exception as error:
+            lineage_conflict = _find_error(error, RowIdLineageConflict)
+            if lineage_conflict is not None:
+                abort_known_uncommitted(True)
+                if lineage_conflict is error:
+                    raise
+                raise lineage_conflict from error
             conflict = _find_row_id_conflict(error)
             if conflict is None:
+                abort_known_uncommitted(not commit_attempted)
                 raise
         finally:
             if commit is not None:
@@ -127,11 +167,7 @@ def commit_self_merge_with_compaction_retry(
                     )
 
         if conflict is None:
-            if superseded_messages:
-                from pypaimon.write.file_store_commit import (
-                    _abort_commit_messages,
-                )
-                _abort_commit_messages(table, superseded_messages)
+            abort_known_uncommitted(False)
             return
 
         elapsed = int(time.time() * 1000) - start_millis
@@ -139,10 +175,12 @@ def commit_self_merge_with_compaction_retry(
                 elapsed > table.options.commit_timeout()
                 or retry_count >= table.options.commit_max_retries()
         ):
+            abort_known_uncommitted(True)
             raise conflict
 
         latest_snapshot = table.snapshot_manager().get_latest_snapshot()
         if latest_snapshot is None:
+            abort_known_uncommitted(True)
             raise conflict
 
         try:
@@ -152,20 +190,25 @@ def commit_self_merge_with_compaction_retry(
                 latest_snapshot,
                 num_partitions=num_partitions,
                 ray_remote_args=ray_remote_args,
+                expected_base_snapshot_uuid=current_base_snapshot_uuid,
             )
         except Exception as rewrite_error:
+            abort_known_uncommitted(True)
             raise RuntimeError(
                 "{} {}".format(conflict, rewrite_error)
             )
         if result is None:
-            raise conflict
-
-        elapsed = int(time.time() * 1000) - start_millis
-        if elapsed > table.options.commit_timeout():
+            abort_known_uncommitted(True)
             raise conflict
 
         current_updates = result.update_messages
         superseded_messages.extend(result.superseded_messages)
+        current_base_snapshot_uuid = latest_snapshot.uuid
+        elapsed = int(time.time() * 1000) - start_millis
+        if elapsed > table.options.commit_timeout():
+            abort_known_uncommitted(True)
+            raise conflict
+
         logger.info(
             "Rewrote %d stale self-merge file(s) against snapshot %d "
             "before retrying commit to table %s.",
@@ -173,7 +216,11 @@ def commit_self_merge_with_compaction_retry(
             latest_snapshot.id,
             table.identifier,
         )
-        _retry_wait(table, retry_count)
+        try:
+            _retry_wait(table, retry_count)
+        except Exception:
+            abort_known_uncommitted(True)
+            raise
         retry_count += 1
 
 
@@ -184,6 +231,7 @@ def _rewrite_updates(
         *,
         num_partitions: int,
         ray_remote_args=None,
+        expected_base_snapshot_uuid=None,
 ) -> Optional[_RewriteResult]:
     if table.options.deletion_vectors_enabled(False):
         return None
@@ -201,6 +249,25 @@ def _rewrite_updates(
     base_snapshot = table.snapshot_manager().get_snapshot_by_id(
         next(iter(base_snapshot_ids))
     )
+    if (
+            expected_base_snapshot_uuid is not None
+            and (
+                base_snapshot is None
+                or base_snapshot.uuid != expected_base_snapshot_uuid
+            )
+    ):
+        raise RowIdLineageConflict(
+            "Row-id snapshot lineage conflict: snapshot {} no longer has "
+            "the staged UUID {}.".format(
+                next(iter(base_snapshot_ids)),
+                expected_base_snapshot_uuid,
+            )
+        )
+    if base_snapshot is not None and latest_snapshot.id < base_snapshot.id:
+        raise RowIdLineageConflict(
+            "Latest snapshot {} is older than self-merge base snapshot {}."
+            .format(latest_snapshot.id, base_snapshot.id)
+        )
     if (
             base_snapshot is None
             or base_snapshot.schema_id != latest_snapshot.schema_id
@@ -257,7 +324,20 @@ def _rewrite_updates(
         )
     ]
     if not candidates:
-        return None
+        # The physical files changed but their row-id boundaries did not.
+        # Logical history was validated above, so advancing the baseline is
+        # sufficient and avoids rejecting another same-boundary compaction.
+        return _RewriteResult(
+            update_messages=[
+                replace(
+                    message,
+                    check_from_snapshot=latest_snapshot.id,
+                )
+                for message in update_messages
+            ],
+            superseded_messages=[],
+            rewritten_file_count=0,
+        )
     if not _ranges_are_still_covered(current_files, candidates):
         return None
 
@@ -424,12 +504,16 @@ def _validate_no_logical_conflict(
         commit.close()
 
 
-def _find_row_id_conflict(error) -> Optional[RowIdExistenceConflict]:
+def _find_row_id_conflict(error) -> Optional[RowIdRebaseConflict]:
+    return _find_error(error, RowIdRebaseConflict)
+
+
+def _find_error(error, error_type):
     seen = set()
     current = error
     while current is not None and id(current) not in seen:
         seen.add(id(current))
-        if isinstance(current, RowIdExistenceConflict):
+        if isinstance(current, error_type):
             return current
         current = (
             getattr(current, "cause", None)

--- a/paimon-python/pypaimon/ray/row_id_conflict_rewriter.py
+++ b/paimon-python/pypaimon/ray/row_id_conflict_rewriter.py
@@ -1,0 +1,466 @@
+################################################################################
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing,
+#  software distributed under the License is distributed on an
+#  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+#  KIND, either express or implied.  See the License for the
+#  specific language governing permissions and limitations
+#  under the License.
+################################################################################
+
+"""Rebase Ray self-merge updates after concurrent compaction."""
+
+import logging
+import random
+import time
+from dataclasses import dataclass, replace
+from typing import Dict, List, Optional, Sequence, Tuple
+
+from pypaimon.common.options.core_options import CoreOptions
+from pypaimon.manifest.schema.data_file_meta import DataFileMeta
+from pypaimon.read.split import DataSplit
+from pypaimon.table.row.generic_row import GenericRow
+from pypaimon.table.special_fields import SpecialFields
+from pypaimon.utils.range import Range
+from pypaimon.write.commit.conflict_detection import RowIdExistenceConflict
+from pypaimon.write.commit_message import CommitMessage
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class _StagedFile:
+    message_index: int
+    message: CommitMessage
+    file: DataFileMeta
+
+
+@dataclass(frozen=True)
+class _RewriteResult:
+    update_messages: List[CommitMessage]
+    superseded_messages: List[CommitMessage]
+    rewritten_file_count: int
+
+
+def commit_self_merge_with_compaction_retry(
+        table,
+        update_messages: Sequence[CommitMessage],
+        other_messages: Sequence[CommitMessage],
+        *,
+        num_partitions: int,
+        ray_remote_args=None,
+) -> None:
+    """Commit self-merge messages, rebasing stale updates when compaction wins."""
+    current_updates = list(update_messages)
+    other_messages = list(other_messages)
+    superseded_messages = []
+    retry_count = 0
+    start_millis = int(time.time() * 1000)
+
+    # Ray performs the rebase below without the local driver's size limit.
+    commit_table = table.copy_without_time_travel({
+        CoreOptions.DATA_EVOLUTION_ROW_ID_CONFLICT_REWRITE_MAX_SIZE.key():
+            "0 B",
+    })
+
+    while True:
+        commit = None
+        conflict = None
+        try:
+            commit = commit_table.new_batch_write_builder().new_commit()
+            commit.commit(current_updates + other_messages)
+        except Exception as error:
+            conflict = _find_row_id_conflict(error)
+            if conflict is None:
+                raise
+        finally:
+            if commit is not None:
+                try:
+                    commit.close()
+                except Exception as close_error:
+                    logger.warning(
+                        "Failed to close self-merge commit: %s",
+                        close_error,
+                        exc_info=close_error,
+                    )
+
+        if conflict is None:
+            if superseded_messages:
+                from pypaimon.write.file_store_commit import (
+                    _abort_commit_messages,
+                )
+                _abort_commit_messages(table, superseded_messages)
+            return
+
+        elapsed = int(time.time() * 1000) - start_millis
+        if (
+                elapsed > table.options.commit_timeout()
+                or retry_count > table.options.commit_max_retries()
+        ):
+            raise conflict
+
+        latest_snapshot = table.snapshot_manager().get_latest_snapshot()
+        if latest_snapshot is None:
+            raise conflict
+
+        try:
+            result = _rewrite_updates(
+                table,
+                current_updates,
+                latest_snapshot,
+                num_partitions=num_partitions,
+                ray_remote_args=ray_remote_args,
+            )
+        except Exception as rewrite_error:
+            raise RuntimeError(
+                "{} {}".format(conflict, rewrite_error)
+            )
+        if result is None:
+            raise conflict
+
+        elapsed = int(time.time() * 1000) - start_millis
+        if elapsed > table.options.commit_timeout():
+            raise conflict
+
+        current_updates = result.update_messages
+        superseded_messages.extend(result.superseded_messages)
+        logger.info(
+            "Rewrote %d stale self-merge file(s) against snapshot %d "
+            "before retrying commit to table %s.",
+            result.rewritten_file_count,
+            latest_snapshot.id,
+            table.identifier,
+        )
+        _retry_wait(table, retry_count)
+        retry_count += 1
+
+
+def _rewrite_updates(
+        table,
+        update_messages: List[CommitMessage],
+        latest_snapshot,
+        *,
+        num_partitions: int,
+        ray_remote_args=None,
+) -> Optional[_RewriteResult]:
+    if table.options.deletion_vectors_enabled(False):
+        return None
+    if latest_snapshot.next_row_id is None:
+        return None
+    if any(
+            message.deleted_files or message.changelog_files
+            for message in update_messages
+    ):
+        return None
+
+    base_snapshot_ids = {
+        message.check_from_snapshot
+        for message in update_messages
+        if message.check_from_snapshot is not None
+        and message.check_from_snapshot >= 0
+    }
+    if len(base_snapshot_ids) != 1:
+        return None
+    base_snapshot = table.snapshot_manager().get_snapshot_by_id(
+        next(iter(base_snapshot_ids))
+    )
+    if (
+            base_snapshot is None
+            or base_snapshot.schema_id != latest_snapshot.schema_id
+    ):
+        return None
+
+    # The failed commit already checked for logical conflicts up to the
+    # snapshot it observed. Repeat that check against the snapshot selected
+    # for this rewrite to close the race between those two reads of latest.
+    _validate_no_logical_conflict(
+        table,
+        update_messages,
+        latest_snapshot,
+        min(base_snapshot_ids),
+    )
+
+    scan_table = table.copy_without_time_travel({
+        CoreOptions.SCAN_SNAPSHOT_ID.key(): str(latest_snapshot.id),
+    })
+    scan_plan = scan_table.new_read_builder().new_scan().plan_for_write()
+    if scan_plan.snapshot_id != latest_snapshot.id:
+        return None
+    current_splits = list(scan_plan.splits())
+    current_files = [
+        (split, file)
+        for split in current_splits
+        for file in split.files
+        if _is_normal_row_id_file(file)
+    ]
+    current_exact_ranges = {
+        _range_key(tuple(split.partition.values), split.bucket, file)
+        for split, file in current_files
+    }
+
+    staged = [
+        _StagedFile(index, message, file)
+        for index, message in enumerate(update_messages)
+        for file in message.new_files
+    ]
+    if any(
+            _is_dedicated_file(item.file)
+            and item.file.first_row_id is not None
+            and item.file.first_row_id < latest_snapshot.next_row_id
+            for item in staged
+    ):
+        return None
+
+    candidates = [
+        item for item in staged
+        if _is_rewrite_candidate(
+            item,
+            current_exact_ranges,
+            latest_snapshot.next_row_id,
+        )
+    ]
+    if not candidates:
+        return None
+    if not _ranges_are_still_covered(current_files, candidates):
+        return None
+
+    candidates_by_message: Dict[int, List[DataFileMeta]] = {}
+    for candidate in candidates:
+        candidates_by_message.setdefault(candidate.message_index, []).append(
+            candidate.file
+        )
+    candidate_ids = {id(candidate.file) for candidate in candidates}
+
+    remaining_messages = []
+    superseded_messages = []
+    for index, message in enumerate(update_messages):
+        kept_files = [
+            file for file in message.new_files
+            if id(file) not in candidate_ids
+        ]
+        remaining = replace(
+            message,
+            new_files=kept_files,
+            check_from_snapshot=latest_snapshot.id,
+        )
+        if not remaining.is_empty():
+            remaining_messages.append(remaining)
+
+        replaced_files = candidates_by_message.get(index, [])
+        if replaced_files:
+            superseded_messages.append(CommitMessage(
+                partition=message.partition,
+                bucket=message.bucket,
+                new_files=replaced_files,
+                total_buckets=message.total_buckets,
+            ))
+
+    rewritten_messages = []
+    groups: Dict[Tuple[str, ...], List[_StagedFile]] = {}
+    for candidate in candidates:
+        groups.setdefault(tuple(candidate.file.write_cols), []).append(
+            candidate
+        )
+    try:
+        for columns, files in groups.items():
+            messages, rewritten_rows, _ = _rewrite_group(
+                table,
+                list(columns),
+                files,
+                latest_snapshot.id,
+                num_partitions=num_partitions,
+                ray_remote_args=ray_remote_args,
+            )
+            expected_rows = sum(item.file.row_count for item in files)
+            if rewritten_rows != expected_rows:
+                from pypaimon.write.file_store_commit import (
+                    _abort_commit_messages,
+                )
+                _abort_commit_messages(table, messages)
+                raise RuntimeError(
+                    "Distributed row-id conflict rewrite read {} rows from "
+                    "staged files, expected {}.".format(
+                        rewritten_rows,
+                        expected_rows,
+                    )
+                )
+            rewritten_messages.extend(messages)
+    except Exception:
+        if rewritten_messages:
+            from pypaimon.write.file_store_commit import _abort_commit_messages
+            _abort_commit_messages(table, rewritten_messages)
+        raise
+
+    return _RewriteResult(
+        update_messages=remaining_messages + rewritten_messages,
+        superseded_messages=superseded_messages,
+        rewritten_file_count=len(candidates),
+    )
+
+
+def _rewrite_group(
+        table,
+        columns: List[str],
+        candidates: List[_StagedFile],
+        snapshot_id: int,
+        *,
+        num_partitions: int,
+        ray_remote_args=None,
+):
+    import ray
+
+    from pypaimon.ray.data_evolution_merge_join import (
+        distributed_update_apply,
+    )
+    from pypaimon.read.datasource.ray_datasource import RayDatasource
+    from pypaimon.read.datasource.split_provider import (
+        PreResolvedSplitProvider,
+    )
+
+    read_type = [table.field_dict[name] for name in columns]
+    read_type.append(SpecialFields.ROW_ID)
+    splits = [
+        DataSplit(
+            files=[candidate.file],
+            partition=GenericRow(
+                list(candidate.message.partition),
+                table.partition_keys_fields,
+            ),
+            bucket=candidate.message.bucket,
+            raw_convertible=True,
+        )
+        for candidate in candidates
+    ]
+    provider = PreResolvedSplitProvider(
+        table,
+        splits,
+        read_type,
+    )
+    parallelism = max(1, min(num_partitions, len(splits)))
+    staged_updates = ray.data.read_datasource(
+        RayDatasource(provider),
+        ray_remote_args=ray_remote_args,
+        concurrency=parallelism,
+        override_num_blocks=parallelism,
+    )
+    return distributed_update_apply(
+        staged_updates,
+        table,
+        columns,
+        num_partitions=num_partitions,
+        ray_remote_args=ray_remote_args,
+        base_snapshot_id=snapshot_id,
+    )
+
+
+def _validate_no_logical_conflict(
+        table,
+        update_messages: List[CommitMessage],
+        latest_snapshot,
+        base_snapshot_id: int,
+) -> None:
+    """Reject non-compaction changes before advancing the rewrite baseline."""
+    commit = table.new_batch_write_builder().new_commit()
+    try:
+        file_store_commit = commit.file_store_commit
+        file_store_commit.conflict_detection._row_id_check_from_snapshot = (
+            base_snapshot_id
+        )
+        entries = file_store_commit._collect_manifest_entries(update_messages)
+        conflict = file_store_commit.conflict_detection.check_row_id_from_snapshot(
+            latest_snapshot,
+            entries,
+            check_compaction=False,
+        )
+        if conflict is not None:
+            raise conflict
+    finally:
+        commit.close()
+
+
+def _find_row_id_conflict(error) -> Optional[RowIdExistenceConflict]:
+    seen = set()
+    current = error
+    while current is not None and id(current) not in seen:
+        seen.add(id(current))
+        if isinstance(current, RowIdExistenceConflict):
+            return current
+        current = (
+            getattr(current, "cause", None)
+            or getattr(current, "__cause__", None)
+        )
+    return None
+
+
+def _is_rewrite_candidate(
+        item: _StagedFile,
+        current_exact_ranges,
+        next_row_id: int,
+) -> bool:
+    file = item.file
+    return (
+        _is_normal_row_id_file(file)
+        and file.first_row_id < next_row_id
+        and bool(file.write_cols)
+        and not any(
+            SpecialFields.is_system_field(name)
+            for name in file.write_cols
+        )
+        and _range_key(item.message.partition, item.message.bucket, file)
+        not in current_exact_ranges
+    )
+
+
+def _ranges_are_still_covered(current_files, candidates) -> bool:
+    current_ranges = {}
+    for split, file in current_files:
+        key = (tuple(split.partition.values), split.bucket)
+        current_ranges.setdefault(key, []).append(file.row_id_range())
+    current_ranges = {
+        key: Range.sort_and_merge_overlap(ranges, True, True)
+        for key, ranges in current_ranges.items()
+    }
+    for candidate in candidates:
+        key = (tuple(candidate.message.partition), candidate.message.bucket)
+        if candidate.file.row_id_range().exclude(
+                current_ranges.get(key, [])):
+            return False
+    return True
+
+
+def _range_key(partition, bucket, file):
+    return (
+        tuple(partition),
+        bucket,
+        file.first_row_id,
+        file.row_count,
+    )
+
+
+def _is_normal_row_id_file(file) -> bool:
+    return file.first_row_id is not None and not _is_dedicated_file(file)
+
+
+def _is_dedicated_file(file) -> bool:
+    return (
+        DataFileMeta.is_blob_file(file.file_name)
+        or DataFileMeta.is_vector_file(file.file_name)
+    )
+
+
+def _retry_wait(table, retry_count: int) -> None:
+    wait_millis = min(
+        table.options.commit_min_retry_wait() * (2 ** retry_count),
+        table.options.commit_max_retry_wait(),
+    )
+    jitter = random.randint(0, max(1, int(wait_millis * 0.2)))
+    time.sleep((wait_millis + jitter) / 1000.0)

--- a/paimon-python/pypaimon/tests/file_store_commit_test.py
+++ b/paimon-python/pypaimon/tests/file_store_commit_test.py
@@ -32,7 +32,6 @@ from pypaimon.table.row.generic_row import GenericRow, GenericRowSerializer
 from pypaimon.write.commit.row_id_conflict_rewriter import RowIdRewriteResult
 from pypaimon.write.commit_message import CommitMessage
 from pypaimon.write.file_store_commit import (
-    CommitResultUncertainError,
     FileStoreCommit,
     ManifestMergeResult,
     RetryResult,
@@ -1089,67 +1088,6 @@ class TestFileStoreCommit(unittest.TestCase):
         self.assertIn("with 1 retries", str(ctx.exception))
         self.assertEqual(2, file_store_commit._try_commit_once.call_count)
         file_store_commit._commit_retry_wait.assert_called_once_with(0)
-
-    def test_uncertain_retry_preserves_error_on_prepare_failure(
-            self, mock_manifest_list_manager, mock_manifest_file_manager):
-        file_store_commit = self._create_file_store_commit()
-        file_store_commit.commit_max_retries = 3
-        file_store_commit.commit_timeout = 10 ** 9
-        file_store_commit._commit_retry_wait = Mock()
-        latest_snapshot = Mock(id=7)
-        file_store_commit.snapshot_manager.get_latest_snapshot.return_value = (
-            latest_snapshot
-        )
-        commit_entry = Mock()
-        commit_timeout = TimeoutError('snapshot response was lost')
-        prepare_failure = RuntimeError('manifest preparation failed')
-        file_store_commit._try_commit_once = Mock(side_effect=[
-            RetryResult(
-                latest_snapshot,
-                commit_timeout,
-                commit_result_may_be_uncertain=True,
-            ),
-            prepare_failure,
-        ])
-
-        with self.assertRaises(CommitResultUncertainError) as context:
-            file_store_commit._try_commit(
-                commit_kind='APPEND',
-                commit_identifier=11,
-                commit_entries_plan=lambda snapshot: [commit_entry],
-            )
-
-        self.assertIs(commit_timeout, context.exception.__cause__)
-        self.assertEqual(2, file_store_commit._try_commit_once.call_count)
-
-    def test_uncertain_retry_does_not_exit_on_empty_plan(
-            self, mock_manifest_list_manager, mock_manifest_file_manager):
-        file_store_commit = self._create_file_store_commit()
-        file_store_commit.commit_max_retries = 3
-        file_store_commit.commit_timeout = 10 ** 9
-        file_store_commit._commit_retry_wait = Mock()
-        latest_snapshot = Mock(id=7)
-        file_store_commit.snapshot_manager.get_latest_snapshot.return_value = (
-            latest_snapshot
-        )
-        commit_entry = Mock()
-        plans = iter([[commit_entry], []])
-        commit_timeout = TimeoutError('snapshot response was lost')
-        file_store_commit._try_commit_once = Mock(return_value=RetryResult(
-            latest_snapshot,
-            commit_timeout,
-            commit_result_may_be_uncertain=True,
-        ))
-
-        with self.assertRaises(CommitResultUncertainError) as context:
-            file_store_commit._try_commit(
-                commit_kind='APPEND',
-                commit_identifier=11,
-                commit_entries_plan=lambda snapshot: next(plans),
-            )
-
-        self.assertIs(commit_timeout, context.exception.__cause__)
-        file_store_commit._try_commit_once.assert_called_once()
 
     @staticmethod
     def _to_entries(commit_messages):

--- a/paimon-python/pypaimon/tests/file_store_commit_test.py
+++ b/paimon-python/pypaimon/tests/file_store_commit_test.py
@@ -32,6 +32,7 @@ from pypaimon.table.row.generic_row import GenericRow, GenericRowSerializer
 from pypaimon.write.commit.row_id_conflict_rewriter import RowIdRewriteResult
 from pypaimon.write.commit_message import CommitMessage
 from pypaimon.write.file_store_commit import (
+    CommitResultUncertainError,
     FileStoreCommit,
     ManifestMergeResult,
     RetryResult,
@@ -1088,6 +1089,67 @@ class TestFileStoreCommit(unittest.TestCase):
         self.assertIn("with 1 retries", str(ctx.exception))
         self.assertEqual(2, file_store_commit._try_commit_once.call_count)
         file_store_commit._commit_retry_wait.assert_called_once_with(0)
+
+    def test_uncertain_retry_preserves_error_on_prepare_failure(
+            self, mock_manifest_list_manager, mock_manifest_file_manager):
+        file_store_commit = self._create_file_store_commit()
+        file_store_commit.commit_max_retries = 3
+        file_store_commit.commit_timeout = 10 ** 9
+        file_store_commit._commit_retry_wait = Mock()
+        latest_snapshot = Mock(id=7)
+        file_store_commit.snapshot_manager.get_latest_snapshot.return_value = (
+            latest_snapshot
+        )
+        commit_entry = Mock()
+        commit_timeout = TimeoutError('snapshot response was lost')
+        prepare_failure = RuntimeError('manifest preparation failed')
+        file_store_commit._try_commit_once = Mock(side_effect=[
+            RetryResult(
+                latest_snapshot,
+                commit_timeout,
+                commit_result_may_be_uncertain=True,
+            ),
+            prepare_failure,
+        ])
+
+        with self.assertRaises(CommitResultUncertainError) as context:
+            file_store_commit._try_commit(
+                commit_kind='APPEND',
+                commit_identifier=11,
+                commit_entries_plan=lambda snapshot: [commit_entry],
+            )
+
+        self.assertIs(commit_timeout, context.exception.__cause__)
+        self.assertEqual(2, file_store_commit._try_commit_once.call_count)
+
+    def test_uncertain_retry_does_not_exit_on_empty_plan(
+            self, mock_manifest_list_manager, mock_manifest_file_manager):
+        file_store_commit = self._create_file_store_commit()
+        file_store_commit.commit_max_retries = 3
+        file_store_commit.commit_timeout = 10 ** 9
+        file_store_commit._commit_retry_wait = Mock()
+        latest_snapshot = Mock(id=7)
+        file_store_commit.snapshot_manager.get_latest_snapshot.return_value = (
+            latest_snapshot
+        )
+        commit_entry = Mock()
+        plans = iter([[commit_entry], []])
+        commit_timeout = TimeoutError('snapshot response was lost')
+        file_store_commit._try_commit_once = Mock(return_value=RetryResult(
+            latest_snapshot,
+            commit_timeout,
+            commit_result_may_be_uncertain=True,
+        ))
+
+        with self.assertRaises(CommitResultUncertainError) as context:
+            file_store_commit._try_commit(
+                commit_kind='APPEND',
+                commit_identifier=11,
+                commit_entries_plan=lambda snapshot: next(plans),
+            )
+
+        self.assertIs(commit_timeout, context.exception.__cause__)
+        file_store_commit._try_commit_once.assert_called_once()
 
     @staticmethod
     def _to_entries(commit_messages):

--- a/paimon-python/pypaimon/tests/file_store_commit_test.py
+++ b/paimon-python/pypaimon/tests/file_store_commit_test.py
@@ -32,9 +32,10 @@ from pypaimon.table.row.generic_row import GenericRow, GenericRowSerializer
 from pypaimon.write.commit.row_id_conflict_rewriter import RowIdRewriteResult
 from pypaimon.write.commit_message import CommitMessage
 from pypaimon.write.file_store_commit import (
+    CommitFailRetryResult,
     FileStoreCommit,
     ManifestMergeResult,
-    RetryResult,
+    RollbackRetryResult,
     RewriteResult,
     _abort_commit_messages,
     _try_replace_manifest_files,
@@ -355,6 +356,77 @@ class TestFileStoreCommit(unittest.TestCase):
              for manifest in result.merge_after_manifests],
         )
 
+    def test_conflict_rollback_retry_skips_history_and_rescans_base(
+            self, mock_manifest_list_manager, mock_manifest_file_manager):
+        file_store_commit = self._create_file_store_commit()
+        conflict = RuntimeError("conflicting compaction")
+        read_all = Mock(return_value=[])
+        file_store_commit.commit_scanner.read_all_entries_from_changed_partitions = read_all
+        file_store_commit.conflict_detection.check_conflicts = Mock(
+            return_value=conflict
+        )
+        file_store_commit.rollback = Mock()
+        file_store_commit.rollback.try_to_rollback.return_value = True
+
+        result = file_store_commit._try_commit_once(
+            retry_result=None,
+            commit_kind="APPEND",
+            commit_entries=[Mock()],
+            changelog_entries=[],
+            commit_identifier=11,
+            latest_snapshot=Mock(id=3),
+            detect_conflicts=True,
+            allow_rollback=True,
+        )
+
+        self.assertIsInstance(result, RollbackRetryResult)
+        self.assertIs(result.exception, conflict)
+
+        file_store_commit.snapshot_manager.get_snapshot_by_id.side_effect = (
+            AssertionError("rollback retry must not scan snapshot history")
+        )
+        file_store_commit.commit_scanner.read_incremental_changes = Mock(
+            side_effect=AssertionError(
+                "rollback retry must not reuse the previous conflict base"
+            )
+        )
+        read_all.reset_mock()
+        file_store_commit.conflict_detection.check_conflicts.return_value = (
+            RuntimeError("conflict after rollback retry")
+        )
+
+        with self.assertRaisesRegex(
+                RuntimeError, "conflict after rollback retry"):
+            file_store_commit._try_commit_once(
+                retry_result=result,
+                commit_kind="APPEND",
+                commit_entries=[Mock()],
+                changelog_entries=[],
+                commit_identifier=11,
+                latest_snapshot=Mock(id=2),
+                detect_conflicts=True,
+            )
+
+        file_store_commit.snapshot_manager.get_snapshot_by_id.assert_not_called()
+        file_store_commit.commit_scanner.read_incremental_changes.assert_not_called()
+        read_all.assert_called_once()
+
+    def test_commit_fail_retry_missing_snapshot_still_fails_closed(
+            self, mock_manifest_list_manager, mock_manifest_file_manager):
+        file_store_commit = self._create_file_store_commit()
+        file_store_commit.snapshot_manager.get_snapshot_by_id.return_value = None
+
+        with self.assertRaisesRegex(
+                RuntimeError, "snapshot 1 cannot be found"):
+            file_store_commit._is_duplicate_commit(
+                CommitFailRetryResult(None),
+                Mock(id=3),
+                11,
+                "APPEND",
+            )
+
+        file_store_commit.snapshot_manager.get_snapshot_by_id.assert_called_once_with(1)
+
     def _run_manifest_commit_attempt(self, commit_side_effect=None,
                                      commit_result=None, retry_result=None,
                                      existing_manifests=None,
@@ -429,7 +501,7 @@ class TestFileStoreCommit(unittest.TestCase):
         file_store_commit, result = self._run_manifest_commit_attempt(
             commit_result=False)
 
-        self.assertIsInstance(result, RetryResult)
+        self.assertIsInstance(result, CommitFailRetryResult)
         self.assertIsNone(result.exception)
         self.assertEqual(
             ['before'],
@@ -449,7 +521,7 @@ class TestFileStoreCommit(unittest.TestCase):
         file_store_commit, result = self._run_manifest_commit_attempt(
             commit_side_effect=failure)
 
-        self.assertIsInstance(result, RetryResult)
+        self.assertIsInstance(result, CommitFailRetryResult)
         self.assertIs(failure, result.exception)
         self.assertTrue(result.commit_result_may_be_uncertain)
         self.assertIsNone(result.manifest_merge_result)
@@ -463,7 +535,7 @@ class TestFileStoreCommit(unittest.TestCase):
             self._manifest_meta('before-b'),
         ]
         previous_after = [self._manifest_meta('merged')]
-        retry_result = RetryResult(
+        retry_result = CommitFailRetryResult(
             Mock(id=3),
             manifest_merge_result=ManifestMergeResult(
                 previous_before, previous_after),
@@ -481,7 +553,7 @@ class TestFileStoreCommit(unittest.TestCase):
             existing_manifests=current,
         )
 
-        self.assertIsInstance(result, RetryResult)
+        self.assertIsInstance(result, CommitFailRetryResult)
         self.assertEqual(
             ['prefix', 'before-a', 'before-b', 'suffix'],
             [manifest.file_name for manifest
@@ -507,7 +579,7 @@ class TestFileStoreCommit(unittest.TestCase):
             self._manifest_meta('before-a'),
             self._manifest_meta('before-b'),
         ]
-        retry_result = RetryResult(
+        retry_result = CommitFailRetryResult(
             Mock(id=3),
             manifest_merge_result=ManifestMergeResult(
                 previous_before, [self._manifest_meta('merged')]),
@@ -524,7 +596,7 @@ class TestFileStoreCommit(unittest.TestCase):
             existing_manifests=current,
         )
 
-        self.assertIsInstance(result, RetryResult)
+        self.assertIsInstance(result, CommitFailRetryResult)
         self.assertIsNone(result.manifest_merge_result)
         file_store_commit.manifest_file_merger.merge.assert_not_called()
         base_manifests = (

--- a/paimon-python/pypaimon/tests/overwrite_commit_conflict_test.py
+++ b/paimon-python/pypaimon/tests/overwrite_commit_conflict_test.py
@@ -209,9 +209,9 @@ class OverwriteCommitConflictTest(unittest.TestCase):
         self.assertEqual(sorted(actual[actual['f0'] == 1]['f1'].tolist()), ['new'])
         self.assertEqual(sorted(actual[actual['f0'] == 2]['f1'].tolist()), ['c'])
 
-    def test_falls_back_to_full_scan_when_intermediate_snapshot_missing(self):
-        # A missing intermediate snapshot -> read_incremental_changes returns None
-        # and the retry falls back to a full scan.
+    def test_fails_when_intermediate_snapshot_missing(self):
+        # Match Java SnapshotManager.snapshot: duplicate detection cannot skip
+        # an unavailable snapshot in the retry history.
         K = 1
         missing_id = self.table.snapshot_manager().get_latest_snapshot().id + 1
 
@@ -266,12 +266,15 @@ class OverwriteCommitConflictTest(unittest.TestCase):
 
         fsc.snapshot_commit.commit = patched_cas
 
-        c.commit(messages)
+        with self.assertRaisesRegex(
+                RuntimeError,
+                "snapshot {} cannot be found".format(missing_id)):
+            c.commit(messages)
         c.close()
 
         self.assertEqual(cas['fails'], K, "expected exactly K forced conflicts")
-        self.assertIn(None, incr_results)          # incremental bailed on missing
-        self.assertEqual(full_scans['n'], 2)       # first attempt + fallback
+        self.assertEqual([], incr_results)
+        self.assertEqual(full_scans['n'], 1)
 
     def test_incremental_merge_across_non_append_snapshot(self):
         self._assert_merge_equals_full_scan(self._overwrite_target)

--- a/paimon-python/pypaimon/tests/overwrite_commit_conflict_test.py
+++ b/paimon-python/pypaimon/tests/overwrite_commit_conflict_test.py
@@ -239,8 +239,8 @@ class OverwriteCommitConflictTest(unittest.TestCase):
         fsc.commit_scanner.read_all_entries_from_changed_partitions = spy_full
         fsc.commit_scanner.read_incremental_changes = spy_incr
 
-        # Only the scanner's lookups see missing_id as absent; the commit's own
-        # manager (bound earlier) is untouched.
+        # Both duplicate detection and incremental conflict scanning observe
+        # the expired snapshot.
         real_mgr = fsc.commit_scanner.table.snapshot_manager()
 
         class _Wrap:
@@ -250,7 +250,9 @@ class OverwriteCommitConflictTest(unittest.TestCase):
             def get_snapshot_by_id(self, i):
                 return None if i == missing_id else real_mgr.get_snapshot_by_id(i)
 
-        fsc.commit_scanner.table.snapshot_manager = lambda: _Wrap()
+        wrapped_mgr = _Wrap()
+        fsc.snapshot_manager = wrapped_mgr
+        fsc.commit_scanner.table.snapshot_manager = lambda: wrapped_mgr
 
         orig_cas = fsc.snapshot_commit.commit
         cas = {'fails': 0}

--- a/paimon-python/pypaimon/tests/ray_data_evolution_merge_into_test.py
+++ b/paimon-python/pypaimon/tests/ray_data_evolution_merge_into_test.py
@@ -2352,6 +2352,10 @@ class RayDataEvolutionMergeIntoTest(unittest.TestCase):
         def compact_before_first_retry(_table, retry_count):
             retry_counts.append(retry_count)
             if retry_count == 0:
+                # Change the current row-id boundary before the second
+                # compaction so the next commit observes the same
+                # RowIdExistenceConflict used by Spark's retry loop.
+                self._write(target, self._source(ids=(5, 6)))
                 self._compact_all_data_files(table)
 
         with patch.object(
@@ -2377,88 +2381,13 @@ class RayDataEvolutionMergeIntoTest(unittest.TestCase):
             )
 
         self.assertEqual(result['num_matched'], 4)
-        self.assertEqual(self._read_sorted(target)['age'], [99, 99, 99, 99])
+        output = self._read_sorted(target)
+        self.assertEqual(output['id'], [1, 2, 3, 4, 5, 6])
+        self.assertEqual(output['age'], [99, 99, 99, 99, 10, 10])
         self.assertEqual(retry_counts, [0, 1])
         self.assertEqual(len(rewrite_snapshot_ids), 3)
         self.assertEqual(rewrite_snapshot_ids[0], rewrite_snapshot_ids[1])
         self.assertGreater(rewrite_snapshot_ids[2], rewrite_snapshot_ids[1])
-
-    def test_self_merge_rejects_reused_snapshot_id_after_rollback(self):
-        from pypaimon.ray import data_evolution_merge_into as merge_module
-        from pypaimon.ray import row_id_conflict_rewriter as rewriter_module
-
-        target = self._create_table()
-        self._write(target, self._source(ids=(1, 2)))
-        self._write(target, self._source(ids=(3, 4)))
-        table = self.catalog.get_table(target)
-        real_apply = merge_module.distributed_self_merge_update_apply
-        real_rewrite = rewriter_module._rewrite_updates
-        replaced_lineage = [False]
-        staging_paths = set()
-
-        def remember_paths(messages):
-            for message in messages:
-                for file in message.new_files:
-                    staging_paths.add(file.external_path or file.file_path)
-
-        def stage_then_compact(*args, **kwargs):
-            result = real_apply(*args, **kwargs)
-            remember_paths(result[0])
-            self._compact_all_data_files(table)
-            return result
-
-        def rewrite_then_replace_lineage(*args, **kwargs):
-            latest_snapshot = args[2]
-            result = real_rewrite(*args, **kwargs)
-            if result is not None:
-                remember_paths(result.update_messages)
-            if not replaced_lineage[0]:
-                replaced_lineage[0] = True
-                old_uuid = latest_snapshot.uuid
-                table.rollback_to(1)
-                replacement = pa.Table.from_pydict(
-                    {
-                        'id': pa.array([30, 40], type=pa.int32()),
-                        'name': ['replacement', 'replacement'],
-                        'age': pa.array([30, 40], type=pa.int32()),
-                    },
-                    schema=self.pa_schema,
-                )
-                self._write(target, replacement)
-                self._compact_all_data_files(table)
-                replacement_snapshot = (
-                    table.snapshot_manager().get_latest_snapshot()
-                )
-                self.assertEqual(replacement_snapshot.id, latest_snapshot.id)
-                self.assertNotEqual(replacement_snapshot.uuid, old_uuid)
-            return result
-
-        with patch.object(
-                merge_module,
-                'distributed_self_merge_update_apply',
-                side_effect=stage_then_compact,
-        ), patch.object(
-                rewriter_module,
-                '_rewrite_updates',
-                side_effect=rewrite_then_replace_lineage,
-        ), self.assertRaisesRegex(RuntimeError, 'snapshot lineage'):
-            merge_into(
-                target=target,
-                source=target,
-                catalog_options=self.catalog_options,
-                on=['_ROW_ID'],
-                when_matched=[WhenMatched.update({'age': lit(99)})],
-                num_partitions=_TEST_NUM_PARTITIONS,
-            )
-
-        self.assertTrue(replaced_lineage[0])
-        output = self._read_sorted(target)
-        self.assertEqual(output['id'], [1, 2, 30, 40])
-        self.assertEqual(output['age'], [10, 10, 30, 40])
-        self.assertTrue(staging_paths)
-        self.assertTrue(
-            all(not os.path.exists(path) for path in staging_paths)
-        )
 
     def test_self_merge_rejects_concurrent_overwrite(self):
         from pypaimon.ray import data_evolution_merge_into as merge_module

--- a/paimon-python/pypaimon/tests/ray_data_evolution_merge_into_test.py
+++ b/paimon-python/pypaimon/tests/ray_data_evolution_merge_into_test.py
@@ -2317,6 +2317,285 @@ class RayDataEvolutionMergeIntoTest(unittest.TestCase):
         self.assertEqual(ray_retry_wait.call_args[0][1], 0)
         self.assertEqual(rewrite_calls[0], 2)
 
+    def test_self_merge_rebases_again_after_second_compaction(self):
+        from pypaimon.ray import data_evolution_merge_into as merge_module
+        from pypaimon.ray import row_id_conflict_rewriter as rewriter_module
+
+        target = self._create_table()
+        self._write(target, self._source(ids=(1, 2)))
+        self._write(target, self._source(ids=(3, 4)))
+        table = self.catalog.get_table(target)
+        real_apply = merge_module.distributed_self_merge_update_apply
+        real_rewrite = rewriter_module._rewrite_updates
+
+        def stage_then_compact(*args, **kwargs):
+            result = real_apply(*args, **kwargs)
+            self._compact_all_data_files(table)
+            return result
+
+        rewrite_snapshot_ids = []
+
+        def miss_precommit_race(
+                rewrite_table, messages, latest_snapshot, **kwargs):
+            rewrite_snapshot_ids.append(latest_snapshot.id)
+            if len(rewrite_snapshot_ids) == 1:
+                return None
+            return real_rewrite(
+                rewrite_table,
+                messages,
+                latest_snapshot,
+                **kwargs,
+            )
+
+        retry_counts = []
+
+        def compact_before_first_retry(_table, retry_count):
+            retry_counts.append(retry_count)
+            if retry_count == 0:
+                self._compact_all_data_files(table)
+
+        with patch.object(
+                merge_module,
+                'distributed_self_merge_update_apply',
+                side_effect=stage_then_compact,
+        ), patch.object(
+                rewriter_module,
+                '_rewrite_updates',
+                side_effect=miss_precommit_race,
+        ), patch.object(
+                rewriter_module,
+                '_retry_wait',
+                side_effect=compact_before_first_retry,
+        ):
+            result = merge_into(
+                target=target,
+                source=target,
+                catalog_options=self.catalog_options,
+                on=['_ROW_ID'],
+                when_matched=[WhenMatched.update({'age': lit(99)})],
+                num_partitions=_TEST_NUM_PARTITIONS,
+            )
+
+        self.assertEqual(result['num_matched'], 4)
+        self.assertEqual(self._read_sorted(target)['age'], [99, 99, 99, 99])
+        self.assertEqual(retry_counts, [0, 1])
+        self.assertEqual(len(rewrite_snapshot_ids), 3)
+        self.assertEqual(rewrite_snapshot_ids[0], rewrite_snapshot_ids[1])
+        self.assertGreater(rewrite_snapshot_ids[2], rewrite_snapshot_ids[1])
+
+    def test_self_merge_rejects_reused_snapshot_id_after_rollback(self):
+        from pypaimon.ray import data_evolution_merge_into as merge_module
+        from pypaimon.ray import row_id_conflict_rewriter as rewriter_module
+
+        target = self._create_table()
+        self._write(target, self._source(ids=(1, 2)))
+        self._write(target, self._source(ids=(3, 4)))
+        table = self.catalog.get_table(target)
+        real_apply = merge_module.distributed_self_merge_update_apply
+        real_rewrite = rewriter_module._rewrite_updates
+        replaced_lineage = [False]
+        staging_paths = set()
+
+        def remember_paths(messages):
+            for message in messages:
+                for file in message.new_files:
+                    staging_paths.add(file.external_path or file.file_path)
+
+        def stage_then_compact(*args, **kwargs):
+            result = real_apply(*args, **kwargs)
+            remember_paths(result[0])
+            self._compact_all_data_files(table)
+            return result
+
+        def rewrite_then_replace_lineage(*args, **kwargs):
+            latest_snapshot = args[2]
+            result = real_rewrite(*args, **kwargs)
+            if result is not None:
+                remember_paths(result.update_messages)
+            if not replaced_lineage[0]:
+                replaced_lineage[0] = True
+                old_uuid = latest_snapshot.uuid
+                table.rollback_to(1)
+                replacement = pa.Table.from_pydict(
+                    {
+                        'id': pa.array([30, 40], type=pa.int32()),
+                        'name': ['replacement', 'replacement'],
+                        'age': pa.array([30, 40], type=pa.int32()),
+                    },
+                    schema=self.pa_schema,
+                )
+                self._write(target, replacement)
+                self._compact_all_data_files(table)
+                replacement_snapshot = (
+                    table.snapshot_manager().get_latest_snapshot()
+                )
+                self.assertEqual(replacement_snapshot.id, latest_snapshot.id)
+                self.assertNotEqual(replacement_snapshot.uuid, old_uuid)
+            return result
+
+        with patch.object(
+                merge_module,
+                'distributed_self_merge_update_apply',
+                side_effect=stage_then_compact,
+        ), patch.object(
+                rewriter_module,
+                '_rewrite_updates',
+                side_effect=rewrite_then_replace_lineage,
+        ), self.assertRaisesRegex(RuntimeError, 'snapshot lineage'):
+            merge_into(
+                target=target,
+                source=target,
+                catalog_options=self.catalog_options,
+                on=['_ROW_ID'],
+                when_matched=[WhenMatched.update({'age': lit(99)})],
+                num_partitions=_TEST_NUM_PARTITIONS,
+            )
+
+        self.assertTrue(replaced_lineage[0])
+        output = self._read_sorted(target)
+        self.assertEqual(output['id'], [1, 2, 30, 40])
+        self.assertEqual(output['age'], [10, 10, 30, 40])
+        self.assertTrue(staging_paths)
+        self.assertTrue(
+            all(not os.path.exists(path) for path in staging_paths)
+        )
+
+    def test_self_merge_rejects_concurrent_overwrite(self):
+        from pypaimon.ray import data_evolution_merge_into as merge_module
+
+        target = self._create_table()
+        self._write(target, self._source(ids=(1, 2)))
+        table = self.catalog.get_table(target)
+        real_apply = merge_module.distributed_self_merge_update_apply
+        staging_paths = []
+
+        def stage_then_overwrite(*args, **kwargs):
+            result = real_apply(*args, **kwargs)
+            staging_paths.extend(
+                file.external_path or file.file_path
+                for message in result[0]
+                for file in message.new_files
+            )
+            replacement = pa.Table.from_pydict(
+                {
+                    'id': pa.array([30, 40], type=pa.int32()),
+                    'name': ['replacement', 'replacement'],
+                    'age': pa.array([30, 40], type=pa.int32()),
+                },
+                schema=self.pa_schema,
+            )
+            write_builder = table.new_batch_write_builder().overwrite({})
+            writer = write_builder.new_write()
+            commit = write_builder.new_commit()
+            try:
+                writer.write_arrow(replacement)
+                commit.commit(writer.prepare_commit())
+            finally:
+                writer.close()
+                commit.close()
+            return result
+
+        with patch.object(
+                merge_module,
+                'distributed_self_merge_update_apply',
+                side_effect=stage_then_overwrite,
+        ), self.assertRaises(Exception):
+            merge_into(
+                target=target,
+                source=target,
+                catalog_options=self.catalog_options,
+                on=['_ROW_ID'],
+                when_matched=[WhenMatched.update({'age': lit(99)})],
+                num_partitions=_TEST_NUM_PARTITIONS,
+            )
+
+        output = self._read_sorted(target)
+        self.assertEqual(output['id'], [30, 40])
+        self.assertEqual(output['age'], [30, 40])
+        self.assertTrue(staging_paths)
+        self.assertTrue(
+            all(not os.path.exists(path) for path in staging_paths)
+        )
+
+    @unittest.skipIf(_SKIP_CONDITION, _SKIP_REASON)
+    def test_self_merge_update_and_delete(self):
+        options = dict(self.de_options)
+        options['deletion-vectors.enabled'] = 'true'
+        target = self._create_table(options=options)
+        self._write(target, self._source(ids=(1, 2, 3, 4)))
+
+        result = merge_into(
+            target=target,
+            source=target,
+            catalog_options=self.catalog_options,
+            on=['_ROW_ID'],
+            when_matched=[
+                WhenMatched.update(
+                    {'age': lit(99)}, condition='t.id <= 2',
+                ),
+                WhenMatched.delete(condition='t.id = 3'),
+            ],
+            num_partitions=_TEST_NUM_PARTITIONS,
+        )
+
+        self.assertEqual(result['num_matched'], 3)
+        output = self._read_sorted(target)
+        self.assertEqual(output['id'], [1, 2, 4])
+        self.assertEqual(output['age'], [99, 99, 10])
+
+    @unittest.skipIf(_SKIP_CONDITION, _SKIP_REASON)
+    def test_self_merge_update_delete_does_not_rebase_after_compaction(self):
+        from pypaimon.ray import row_id_conflict_rewriter as rewriter_module
+
+        options = dict(self.de_options)
+        options['deletion-vectors.enabled'] = 'true'
+        target = self._create_table(options=options)
+        self._write(target, self._source(ids=(1, 2, 3, 4)))
+        table = self.catalog.get_table(target)
+        real_commit = (
+            rewriter_module.commit_self_merge_with_compaction_retry
+        )
+        real_rewrite = rewriter_module._rewrite_updates
+        rewrite_results = []
+
+        def compact_then_commit(*args, **kwargs):
+            self._compact_all_data_files(table)
+            return real_commit(*args, **kwargs)
+
+        def assert_rewrite_disabled(*args, **kwargs):
+            result = real_rewrite(*args, **kwargs)
+            rewrite_results.append(result)
+            return result
+
+        with patch.object(
+                rewriter_module,
+                'commit_self_merge_with_compaction_retry',
+                side_effect=compact_then_commit,
+        ), patch.object(
+                rewriter_module,
+                '_rewrite_updates',
+                side_effect=assert_rewrite_disabled,
+        ), self.assertRaises(Exception):
+            merge_into(
+                target=target,
+                source=target,
+                catalog_options=self.catalog_options,
+                on=['_ROW_ID'],
+                when_matched=[
+                    WhenMatched.update(
+                        {'age': lit(99)}, condition='t.id <= 2',
+                    ),
+                    WhenMatched.delete(condition='t.id = 3'),
+                ],
+                num_partitions=_TEST_NUM_PARTITIONS,
+            )
+
+        self.assertTrue(rewrite_results)
+        self.assertTrue(all(result is None for result in rewrite_results))
+        output = self._read_sorted(target)
+        self.assertEqual(output['id'], [1, 2, 3, 4])
+        self.assertEqual(output['age'], [10, 10, 10, 10])
+
     def test_self_merge_compaction_rebase_keeps_logical_conflicts(self):
         from pypaimon.ray import data_evolution_merge_into as merge_module
 

--- a/paimon-python/pypaimon/tests/ray_data_evolution_merge_into_test.py
+++ b/paimon-python/pypaimon/tests/ray_data_evolution_merge_into_test.py
@@ -2252,7 +2252,7 @@ class RayDataEvolutionMergeIntoTest(unittest.TestCase):
         # Match Spark: replaced staging files are left for orphan cleanup.
         self.assertTrue(all(os.path.exists(path) for path in stale_paths))
 
-    def test_self_merge_compaction_retry_is_not_nested(self):
+    def test_self_merge_compaction_retry_checks_core_rollback(self):
         from pypaimon.ray import data_evolution_merge_into as merge_module
         from pypaimon.ray import row_id_conflict_rewriter as rewriter_module
         from pypaimon.write.file_store_commit import FileStoreCommit
@@ -2264,6 +2264,7 @@ class RayDataEvolutionMergeIntoTest(unittest.TestCase):
         real_apply = merge_module.distributed_self_merge_update_apply
         real_rewrite = rewriter_module._rewrite_updates
         real_commit_init = FileStoreCommit.__init__
+        rollbacks = []
 
         def stage_then_compact(*args, **kwargs):
             result = real_apply(*args, **kwargs)
@@ -2281,7 +2282,8 @@ class RayDataEvolutionMergeIntoTest(unittest.TestCase):
         def init_with_rollback(commit, *args, **kwargs):
             real_commit_init(commit, *args, **kwargs)
             commit.rollback = Mock()
-            commit.rollback.try_to_rollback.return_value = True
+            commit.rollback.try_to_rollback.return_value = False
+            rollbacks.append(commit.rollback)
 
         with patch.object(
                 merge_module,
@@ -2314,6 +2316,9 @@ class RayDataEvolutionMergeIntoTest(unittest.TestCase):
         self.assertEqual(result['num_matched'], 4)
         self.assertEqual(self._read_sorted(target)['age'], [99, 99, 99, 99])
         commit_retry_wait.assert_not_called()
+        self.assertTrue(any(
+            rollback.try_to_rollback.called for rollback in rollbacks
+        ))
         ray_retry_wait.assert_called_once()
         self.assertEqual(ray_retry_wait.call_args[0][1], 0)
         self.assertEqual(rewrite_calls[0], 2)

--- a/paimon-python/pypaimon/tests/ray_data_evolution_merge_into_test.py
+++ b/paimon-python/pypaimon/tests/ray_data_evolution_merge_into_test.py
@@ -2249,7 +2249,8 @@ class RayDataEvolutionMergeIntoTest(unittest.TestCase):
             ['imu-yz-negated-v1'] * 4,
         )
         self.assertTrue(stale_paths)
-        self.assertTrue(all(not os.path.exists(path) for path in stale_paths))
+        # Match Spark: replaced staging files are left for orphan cleanup.
+        self.assertTrue(all(os.path.exists(path) for path in stale_paths))
 
     def test_self_merge_compaction_retry_is_not_nested(self):
         from pypaimon.ray import data_evolution_merge_into as merge_module
@@ -2442,8 +2443,9 @@ class RayDataEvolutionMergeIntoTest(unittest.TestCase):
         self.assertEqual(output['id'], [30, 40])
         self.assertEqual(output['age'], [30, 40])
         self.assertTrue(staging_paths)
+        # Match Spark: failed staging files are left for orphan cleanup.
         self.assertTrue(
-            all(not os.path.exists(path) for path in staging_paths)
+            all(os.path.exists(path) for path in staging_paths)
         )
 
     @unittest.skipIf(_SKIP_CONDITION, _SKIP_REASON)

--- a/paimon-python/pypaimon/tests/ray_data_evolution_merge_into_test.py
+++ b/paimon-python/pypaimon/tests/ray_data_evolution_merge_into_test.py
@@ -2362,6 +2362,64 @@ class RayDataEvolutionMergeIntoTest(unittest.TestCase):
         self.assertIn("multiple 'MERGE INTO'", str(ctx.exception))
         self.assertEqual(self._read_sorted(target)['age'][1], 100)
 
+    def test_self_merge_missing_logical_snapshot_fails_closed(self):
+        from pypaimon.ray import data_evolution_merge_into as merge_module
+        from pypaimon.snapshot.snapshot_manager import SnapshotManager
+
+        target = self._create_table()
+        self._write(target, self._source(ids=(1, 2)))
+        self._write(target, self._source(ids=(3, 4)))
+        table = self.catalog.get_table(target)
+        real_apply = merge_module.distributed_self_merge_update_apply
+        real_get_snapshot = SnapshotManager.get_snapshot_by_id
+        hidden_snapshot = {'id': None}
+
+        def get_snapshot_except_hidden(manager, snapshot_id):
+            if snapshot_id == hidden_snapshot['id']:
+                return None
+            return real_get_snapshot(manager, snapshot_id)
+
+        def stage_then_update_and_compact(*args, **kwargs):
+            result = real_apply(*args, **kwargs)
+            write_builder = table.new_batch_write_builder()
+            update = write_builder.new_update()
+            predicate = update.new_predicate_builder().equal('id', 2)
+            messages = update.update_by_predicate(predicate, {'age': 100})
+            write_builder.new_commit().commit(messages)
+            logical_snapshot_id = self._snapshot_id(target)
+            self._compact_all_data_files(table)
+            hidden_snapshot['id'] = logical_snapshot_id
+            return result
+
+        def increment_age(rows):
+            return pc.add(rows['age'], 1)
+
+        with patch.object(
+                merge_module,
+                'distributed_self_merge_update_apply',
+                side_effect=stage_then_update_and_compact,
+        ), patch.object(
+                SnapshotManager,
+                'get_snapshot_by_id',
+                new=get_snapshot_except_hidden,
+        ), self.assertRaisesRegex(
+                RuntimeError,
+                "snapshot .* cannot be found",
+        ):
+            merge_into(
+                target=target,
+                source=target,
+                catalog_options=self.catalog_options,
+                on=['_ROW_ID'],
+                read_columns=['age'],
+                when_matched=[WhenMatched.update({
+                    'age': increment_age,
+                })],
+                num_partitions=_TEST_NUM_PARTITIONS,
+            )
+
+        self.assertEqual(self._read_sorted(target)['age'][1], 100)
+
     def test_self_merge_compaction_rebase_preserves_other_column_update(self):
         from pypaimon.ray import data_evolution_merge_into as merge_module
 

--- a/paimon-python/pypaimon/tests/ray_data_evolution_merge_into_test.py
+++ b/paimon-python/pypaimon/tests/ray_data_evolution_merge_into_test.py
@@ -2251,6 +2251,72 @@ class RayDataEvolutionMergeIntoTest(unittest.TestCase):
         self.assertTrue(stale_paths)
         self.assertTrue(all(not os.path.exists(path) for path in stale_paths))
 
+    def test_self_merge_compaction_retry_is_not_nested(self):
+        from pypaimon.ray import data_evolution_merge_into as merge_module
+        from pypaimon.ray import row_id_conflict_rewriter as rewriter_module
+        from pypaimon.write.file_store_commit import FileStoreCommit
+
+        target = self._create_table()
+        self._write(target, self._source(ids=(1, 2)))
+        self._write(target, self._source(ids=(3, 4)))
+        table = self.catalog.get_table(target)
+        real_apply = merge_module.distributed_self_merge_update_apply
+        real_rewrite = rewriter_module._rewrite_updates
+        real_commit_init = FileStoreCommit.__init__
+
+        def stage_then_compact(*args, **kwargs):
+            result = real_apply(*args, **kwargs)
+            self._compact_all_data_files(table)
+            return result
+
+        rewrite_calls = [0]
+
+        def miss_precommit_race(*args, **kwargs):
+            rewrite_calls[0] += 1
+            if rewrite_calls[0] == 1:
+                return None
+            return real_rewrite(*args, **kwargs)
+
+        def init_with_rollback(commit, *args, **kwargs):
+            real_commit_init(commit, *args, **kwargs)
+            commit.rollback = Mock()
+            commit.rollback.try_to_rollback.return_value = True
+
+        with patch.object(
+                merge_module,
+                'distributed_self_merge_update_apply',
+                side_effect=stage_then_compact,
+        ), patch.object(
+                rewriter_module,
+                '_rewrite_updates',
+                side_effect=miss_precommit_race,
+        ), patch.object(
+                FileStoreCommit,
+                '__init__',
+                new=init_with_rollback,
+        ), patch.object(
+                FileStoreCommit,
+                '_commit_retry_wait',
+        ) as commit_retry_wait, patch.object(
+                rewriter_module,
+                '_retry_wait',
+        ) as ray_retry_wait:
+            result = merge_into(
+                target=target,
+                source=target,
+                catalog_options=self.catalog_options,
+                on=['_ROW_ID'],
+                when_matched=[WhenMatched.update({'age': lit(99)})],
+                num_partitions=_TEST_NUM_PARTITIONS,
+            )
+
+        self.assertEqual(result['num_matched'], 4)
+        self.assertEqual(self._read_sorted(target)['age'], [99, 99, 99, 99])
+        commit_retry_wait.assert_not_called()
+        ray_retry_wait.assert_called_once()
+        self.assertEqual(ray_retry_wait.call_args[0][1], 0)
+        self.assertEqual(rewrite_calls[0], 2)
+
     def test_self_merge_compaction_rebase_keeps_logical_conflicts(self):
         from pypaimon.ray import data_evolution_merge_into as merge_module
 

--- a/paimon-python/pypaimon/tests/ray_data_evolution_merge_into_test.py
+++ b/paimon-python/pypaimon/tests/ray_data_evolution_merge_into_test.py
@@ -114,6 +114,45 @@ class RayDataEvolutionMergeIntoTest(unittest.TestCase):
         snap = table.snapshot_manager().get_latest_snapshot()
         return snap.id if snap is not None else None
 
+    def _compact_all_data_files(self, table):
+        """Replace all current data files with one COMPACT output file."""
+        from pypaimon.table.special_fields import SpecialFields
+
+        read_builder = table.new_read_builder().with_projection(
+            list(table.field_names) + [SpecialFields.ROW_ID.name]
+        )
+        plan = read_builder.new_scan().plan_for_write()
+        old_files = [
+            file for split in plan.splits() for file in split.files
+        ]
+        current = read_builder.new_read().to_arrow(plan.splits()).sort_by(
+            [(SpecialFields.ROW_ID.name, 'ascending')]
+        ).select(list(table.field_names))
+
+        write_builder = table.new_batch_write_builder()
+        writer = write_builder.new_write()
+        writer.write_arrow(current)
+        messages = writer.prepare_commit()
+        self.assertEqual(len(messages), 1)
+        self.assertEqual(len(messages[0].new_files), 1)
+        messages[0].new_files = [
+            messages[0].new_files[0].assign_first_row_id(0)
+        ]
+        messages[0].deleted_files.extend(old_files)
+
+        commit = write_builder.new_commit()
+        file_store_commit = commit.file_store_commit
+        original_try_commit = file_store_commit._try_commit
+        file_store_commit._try_commit = (
+            lambda commit_kind, *args, **kwargs:
+            original_try_commit('COMPACT', *args, **kwargs)
+        )
+        try:
+            commit.commit(messages)
+        finally:
+            writer.close()
+            commit.close()
+
     def _merge_and_capture_self_merge_plan(self, **kwargs):
         from pypaimon.ray.data_evolution_merge_join import (
             build_self_merge_update_plan as real_build_plan,
@@ -2088,6 +2127,227 @@ class RayDataEvolutionMergeIntoTest(unittest.TestCase):
         self.assertEqual(len(plan.file_groups), 2)
         self.assertEqual(result['num_matched'], 4)
         self.assertEqual(self._read_sorted(target)['age'], [99, 99, 99, 99])
+
+    def test_self_merge_rebases_staged_updates_after_compaction(self):
+        from pypaimon.data.generic_variant import GenericVariant
+        from pypaimon.data.variant_path import variant_get, variant_replace
+        from pypaimon.ray import data_evolution_merge_into as merge_module
+
+        options = dict(self.de_options)
+        options.update({
+            'commit.max-retries': '0',
+            'data-evolution.row-id-conflict-rewrite.max-size': '1 B',
+        })
+        variant_type = pa.struct([
+            pa.field('value', pa.binary(), nullable=False),
+            pa.field('metadata', pa.binary(), nullable=False),
+        ])
+        schema = pa.schema([
+            ('id', pa.int32()),
+            ('payload', variant_type),
+            ('topic_schema', pa.string()),
+        ])
+        target = 'default.tbl_{}'.format(uuid.uuid4().hex[:8])
+        self.catalog.create_table(
+            target,
+            Schema.from_pyarrow_schema(schema, options=options),
+            False,
+        )
+
+        def payload(values):
+            return GenericVariant.to_arrow_array([
+                GenericVariant.from_python({
+                    'angular_velocity': {'y': value, 'z': value + 1.0},
+                    'linear_acceleration': {
+                        'y': value + 2.0,
+                        'z': value + 3.0,
+                    },
+                })
+                for value in values
+            ])
+
+        self._write(
+            target,
+            pa.table({
+                'id': pa.array([1, 2], type=pa.int32()),
+                'payload': payload([1.0, 10.0]),
+                'topic_schema': ['old', 'old'],
+            }, schema=schema),
+        )
+        self._write(
+            target,
+            pa.table({
+                'id': pa.array([3, 4], type=pa.int32()),
+                'payload': payload([20.0, 30.0]),
+                'topic_schema': ['old', 'old'],
+            }, schema=schema),
+        )
+        table = self.catalog.get_table(target)
+        real_apply = merge_module.distributed_self_merge_update_apply
+        stale_paths = []
+
+        def stage_then_compact(*args, **kwargs):
+            result = real_apply(*args, **kwargs)
+            stale_paths.extend(
+                file.file_path
+                for message in result[0]
+                for file in message.new_files
+            )
+            self._compact_all_data_files(table)
+            return result
+
+        path_types = {
+            '$.angular_velocity.y': pa.float64(),
+            '$.angular_velocity.z': pa.float64(),
+            '$.linear_acceleration.y': pa.float64(),
+            '$.linear_acceleration.z': pa.float64(),
+        }
+
+        def negate_imu_yz(rows):
+            values = variant_get(rows['payload'], path_types)
+            return variant_replace(
+                rows['payload'],
+                {
+                    path: pc.negate(value)
+                    for path, value in values.items()
+                },
+                strict=True,
+            )
+
+        with patch.object(
+                merge_module,
+                'distributed_self_merge_update_apply',
+                side_effect=stage_then_compact,
+        ), patch(
+                'pypaimon.ray.row_id_conflict_rewriter._retry_wait',
+        ):
+            result = merge_into(
+                target=target,
+                source=target,
+                catalog_options=self.catalog_options,
+                on=['_ROW_ID'],
+                read_columns=['payload'],
+                when_matched=[WhenMatched.update({
+                    'payload': negate_imu_yz,
+                    'topic_schema': lit('imu-yz-negated-v1'),
+                })],
+                num_partitions=_TEST_NUM_PARTITIONS,
+            )
+
+        self.assertEqual(result['num_matched'], 4)
+        output = self._read_sorted(target)
+        decoded = [
+            GenericVariant.from_arrow_struct(value).to_python()
+            for value in output['payload']
+        ]
+        self.assertEqual(
+            [row['angular_velocity']['y'] for row in decoded],
+            [-1.0, -10.0, -20.0, -30.0],
+        )
+        self.assertEqual(
+            output['topic_schema'],
+            ['imu-yz-negated-v1'] * 4,
+        )
+        self.assertTrue(stale_paths)
+        self.assertTrue(all(not os.path.exists(path) for path in stale_paths))
+
+    def test_self_merge_compaction_rebase_keeps_logical_conflicts(self):
+        from pypaimon.ray import data_evolution_merge_into as merge_module
+
+        target = self._create_table()
+        self._write(target, self._source(ids=(1, 2)))
+        self._write(target, self._source(ids=(3, 4)))
+        table = self.catalog.get_table(target)
+        real_apply = merge_module.distributed_self_merge_update_apply
+
+        def stage_then_update_and_compact(*args, **kwargs):
+            result = real_apply(*args, **kwargs)
+            write_builder = table.new_batch_write_builder()
+            update = write_builder.new_update()
+            predicate = update.new_predicate_builder().equal('id', 2)
+            messages = update.update_by_predicate(
+                predicate,
+                {'age': 100},
+            )
+            write_builder.new_commit().commit(messages)
+            self._compact_all_data_files(table)
+            return result
+
+        def increment_age(rows):
+            return pc.add(rows['age'], 1)
+
+        with patch.object(
+                merge_module,
+                'distributed_self_merge_update_apply',
+                side_effect=stage_then_update_and_compact,
+        ), self.assertRaises(Exception) as ctx:
+            merge_into(
+                target=target,
+                source=target,
+                catalog_options=self.catalog_options,
+                on=['_ROW_ID'],
+                read_columns=['age'],
+                when_matched=[WhenMatched.update({
+                    'age': increment_age,
+                })],
+                num_partitions=_TEST_NUM_PARTITIONS,
+            )
+
+        self.assertIn("multiple 'MERGE INTO'", str(ctx.exception))
+        self.assertEqual(self._read_sorted(target)['age'][1], 100)
+
+    def test_self_merge_compaction_rebase_preserves_other_column_update(self):
+        from pypaimon.ray import data_evolution_merge_into as merge_module
+
+        target = self._create_table()
+        self._write(target, self._source(ids=(1, 2)))
+        self._write(target, self._source(ids=(3, 4)))
+        table = self.catalog.get_table(target)
+        real_apply = merge_module.distributed_self_merge_update_apply
+
+        def stage_then_update_and_compact(*args, **kwargs):
+            result = real_apply(*args, **kwargs)
+            self._write(target, self._source(ids=(5,)))
+            write_builder = table.new_batch_write_builder()
+            update = write_builder.new_update()
+            predicate = update.new_predicate_builder().equal('id', 2)
+            messages = update.update_by_predicate(
+                predicate,
+                {'name': 'concurrent'},
+            )
+            write_builder.new_commit().commit(messages)
+            self._compact_all_data_files(table)
+            return result
+
+        def increment_age(rows):
+            return pc.add(rows['age'], 1)
+
+        with patch.object(
+                merge_module,
+                'distributed_self_merge_update_apply',
+                side_effect=stage_then_update_and_compact,
+        ), patch(
+                'pypaimon.ray.row_id_conflict_rewriter._retry_wait',
+        ):
+            result = merge_into(
+                target=target,
+                source=target,
+                catalog_options=self.catalog_options,
+                on=['_ROW_ID'],
+                read_columns=['age'],
+                when_matched=[WhenMatched.update({
+                    'age': increment_age,
+                })],
+                num_partitions=_TEST_NUM_PARTITIONS,
+            )
+
+        self.assertEqual(result['num_matched'], 4)
+        output = self._read_sorted(target)
+        self.assertEqual(output['age'], [11, 11, 11, 11, 10])
+        self.assertEqual(
+            output['name'],
+            ['x', 'concurrent', 'x', 'x', 'x'],
+        )
 
     @unittest.skipIf(_SKIP_CONDITION, _SKIP_REASON)
     def test_self_merge_filters_file_group_in_batches(self):

--- a/paimon-python/pypaimon/tests/ray_data_evolution_merge_into_test.py
+++ b/paimon-python/pypaimon/tests/ray_data_evolution_merge_into_test.py
@@ -2326,6 +2326,7 @@ class RayDataEvolutionMergeIntoTest(unittest.TestCase):
     def test_self_merge_rebases_again_after_second_compaction(self):
         from pypaimon.ray import data_evolution_merge_into as merge_module
         from pypaimon.ray import row_id_conflict_rewriter as rewriter_module
+        from pypaimon.write.write_builder import BatchWriteBuilder
 
         target = self._create_table()
         self._write(target, self._source(ids=(1, 2)))
@@ -2333,6 +2334,17 @@ class RayDataEvolutionMergeIntoTest(unittest.TestCase):
         table = self.catalog.get_table(target)
         real_apply = merge_module.distributed_self_merge_update_apply
         real_rewrite = rewriter_module._rewrite_updates
+        real_new_commit = BatchWriteBuilder.new_commit
+        coordinator_commit_users = []
+
+        def capture_new_commit(write_builder):
+            commit = real_new_commit(write_builder)
+            if (
+                    write_builder.table.options
+                    .data_evolution_row_id_conflict_rewrite_max_size() == 0
+            ):
+                coordinator_commit_users.append(write_builder.commit_user)
+            return commit
 
         def stage_then_compact(*args, **kwargs):
             result = real_apply(*args, **kwargs)
@@ -2373,9 +2385,13 @@ class RayDataEvolutionMergeIntoTest(unittest.TestCase):
                 '_rewrite_updates',
                 side_effect=miss_precommit_race,
         ), patch.object(
-                rewriter_module,
-                '_retry_wait',
-                side_effect=compact_before_first_retry,
+            rewriter_module,
+            '_retry_wait',
+            side_effect=compact_before_first_retry,
+        ), patch.object(
+            BatchWriteBuilder,
+            'new_commit',
+            new=capture_new_commit,
         ):
             result = merge_into(
                 target=target,
@@ -2394,6 +2410,98 @@ class RayDataEvolutionMergeIntoTest(unittest.TestCase):
         self.assertEqual(len(rewrite_snapshot_ids), 3)
         self.assertEqual(rewrite_snapshot_ids[0], rewrite_snapshot_ids[1])
         self.assertGreater(rewrite_snapshot_ids[2], rewrite_snapshot_ids[1])
+        self.assertEqual(len(coordinator_commit_users), 3)
+        self.assertEqual(len(set(coordinator_commit_users)), 1)
+
+    def test_self_merge_uncertain_commit_then_compaction_is_duplicate(self):
+        from pypaimon.ray import row_id_conflict_rewriter as rewriter_module
+        from pypaimon.write.write_builder import BatchWriteBuilder
+
+        target = self._create_table()
+        self._write(target, self._source(ids=(1, 2)))
+        self._write(target, self._source(ids=(3, 4)))
+        table = self.catalog.get_table(target)
+        base_snapshot_id = self._snapshot_id(target)
+        real_new_commit = BatchWriteBuilder.new_commit
+        coordinator_commit_users = []
+        duplicate_results = []
+        atomic_attempts = []
+        injected = [False]
+
+        def inject_uncertain_commit(write_builder):
+            commit = real_new_commit(write_builder)
+            if (
+                    injected[0]
+                    or write_builder.table.options
+                    .data_evolution_row_id_conflict_rewrite_max_size() != 0
+            ):
+                return commit
+
+            injected[0] = True
+            coordinator_commit_users.append(write_builder.commit_user)
+            file_store_commit = commit.file_store_commit
+            real_atomic_commit = file_store_commit.snapshot_commit.commit
+            real_duplicate_check = file_store_commit._is_duplicate_commit
+
+            def track_duplicate(*args, **kwargs):
+                result = real_duplicate_check(*args, **kwargs)
+                duplicate_results.append(result)
+                return result
+
+            def commit_then_compact_and_timeout(
+                    base_uuid, snapshot, statistics):
+                atomic_attempts.append(snapshot.id)
+                self.assertTrue(real_atomic_commit(
+                    base_uuid, snapshot, statistics,
+                ))
+                self._compact_all_data_files(table)
+                raise TimeoutError('lost snapshot commit response')
+
+            file_store_commit._is_duplicate_commit = track_duplicate
+            file_store_commit.snapshot_commit.commit = (
+                commit_then_compact_and_timeout
+            )
+            file_store_commit._commit_retry_wait = Mock()
+            return commit
+
+        with patch.object(
+            BatchWriteBuilder,
+            'new_commit',
+            new=inject_uncertain_commit,
+        ), patch.object(
+            rewriter_module,
+            '_rewrite_updates',
+            wraps=rewriter_module._rewrite_updates,
+        ) as rewrite_updates:
+            result = merge_into(
+                target=target,
+                source=target,
+                catalog_options=self.catalog_options,
+                on=['_ROW_ID'],
+                when_matched=[WhenMatched.update({'age': lit(99)})],
+                num_partitions=_TEST_NUM_PARTITIONS,
+            )
+
+        self.assertTrue(injected[0])
+        self.assertEqual(result['num_matched'], 4)
+        self.assertEqual(self._read_sorted(target)['age'], [99, 99, 99, 99])
+        self.assertEqual(atomic_attempts, [base_snapshot_id + 1])
+        self.assertEqual(duplicate_results, [False, True])
+        self.assertEqual(len(coordinator_commit_users), 1)
+        self.assertEqual(
+            table.snapshot_manager().get_snapshot_by_id(
+                base_snapshot_id + 1
+            ).commit_user,
+            coordinator_commit_users[0],
+        )
+        self.assertEqual(
+            table.snapshot_manager().get_snapshot_by_id(
+                base_snapshot_id + 2
+            ).commit_kind,
+            'COMPACT',
+        )
+        self.assertEqual(self._snapshot_id(target), base_snapshot_id + 2)
+        rewrite_updates.assert_not_called()
 
     def test_self_merge_rejects_concurrent_overwrite(self):
         from pypaimon.ray import data_evolution_merge_into as merge_module

--- a/paimon-python/pypaimon/tests/ray_row_id_conflict_rewriter_test.py
+++ b/paimon-python/pypaimon/tests/ray_row_id_conflict_rewriter_test.py
@@ -20,14 +20,9 @@ from unittest.mock import Mock, patch
 
 from pypaimon.ray.data_evolution_merge_into import _reraise_inner
 from pypaimon.ray.row_id_conflict_rewriter import (
-    _rewrite_updates,
     commit_self_merge_with_compaction_retry,
 )
-from pypaimon.write.commit.conflict_detection import (
-    RowIdExistenceConflict,
-    RowIdLineageConflict,
-    RowIdRebaseConflict,
-)
+from pypaimon.write.commit.conflict_detection import RowIdExistenceConflict
 from pypaimon.write.file_store_commit import CommitResultUncertainError
 
 
@@ -36,6 +31,16 @@ class RayRowIdConflictRewriterTest(unittest.TestCase):
     @staticmethod
     def _message(snapshot_id, name):
         return Mock(check_from_snapshot=snapshot_id, name=name)
+
+    @staticmethod
+    def _conflict(name):
+        entry = Mock(bucket=0)
+        entry.file = Mock(
+            file_name=name,
+            first_row_id=0,
+            row_count=1,
+        )
+        return RowIdExistenceConflict(entry)
 
     @staticmethod
     def _table(commits, snapshots, max_retries=3):
@@ -111,34 +116,6 @@ class RayRowIdConflictRewriterTest(unittest.TestCase):
 
         self.assertIs(uncertain, context.exception)
 
-    def test_rewrite_rejects_latest_snapshot_older_than_base(self):
-        message = Mock(
-            check_from_snapshot=2,
-            deleted_files=[],
-            changelog_files=[],
-        )
-        base_snapshot = Mock(id=2, uuid='uuid-2', schema_id=1)
-        latest_snapshot = Mock(
-            id=1,
-            uuid='uuid-1',
-            schema_id=1,
-            next_row_id=10,
-        )
-        table = Mock()
-        table.options.deletion_vectors_enabled.return_value = False
-        table.snapshot_manager.return_value.get_snapshot_by_id.return_value = (
-            base_snapshot
-        )
-
-        with self.assertRaises(RowIdLineageConflict):
-            _rewrite_updates(
-                table,
-                [message],
-                latest_snapshot,
-                num_partitions=1,
-                expected_base_snapshot_uuid='uuid-2',
-            )
-
     def test_uncertain_final_generation_only_aborts_superseded_messages(self):
         generation_0 = self._message(1, 'generation-0')
         generation_1 = self._message(2, 'generation-1')
@@ -148,8 +125,8 @@ class RayRowIdConflictRewriterTest(unittest.TestCase):
         snapshot_2 = Mock(id=2, uuid='uuid-2')
         snapshot_3 = Mock(id=3, uuid='uuid-3')
         commits = [Mock(), Mock(), Mock()]
-        commits[0].commit.side_effect = RowIdRebaseConflict('compact-1')
-        commits[1].commit.side_effect = RowIdRebaseConflict('compact-2')
+        commits[0].commit.side_effect = self._conflict('compact-1')
+        commits[1].commit.side_effect = self._conflict('compact-2')
         uncertain = CommitResultUncertainError('uncertain final attempt')
         commits[2].commit.side_effect = uncertain
         table = self._table(
@@ -183,7 +160,6 @@ class RayRowIdConflictRewriterTest(unittest.TestCase):
                 [generation_0],
                 [other],
                 num_partitions=1,
-                base_snapshot_uuid='uuid-1',
             )
 
         self.assertIs(uncertain, context.exception)
@@ -199,8 +175,8 @@ class RayRowIdConflictRewriterTest(unittest.TestCase):
         snapshot_1 = Mock(id=1, uuid='uuid-1')
         snapshot_2 = Mock(id=2, uuid='uuid-2')
         commits = [Mock(), Mock()]
-        commits[0].commit.side_effect = RowIdRebaseConflict('compact-1')
-        terminal = RowIdRebaseConflict('compact-2')
+        commits[0].commit.side_effect = self._conflict('compact-1')
+        terminal = self._conflict('compact-2')
         commits[1].commit.side_effect = terminal
         table = self._table(
             commits,
@@ -220,14 +196,13 @@ class RayRowIdConflictRewriterTest(unittest.TestCase):
         ), patch(
             'pypaimon.write.file_store_commit._abort_commit_messages',
         ) as abort_messages, self.assertRaises(
-            RowIdRebaseConflict,
+            RowIdExistenceConflict,
         ) as context:
             commit_self_merge_with_compaction_retry(
                 table,
                 [generation_0],
                 [other],
                 num_partitions=1,
-                base_snapshot_uuid='uuid-1',
             )
 
         self.assertIs(terminal, context.exception)
@@ -243,7 +218,7 @@ class RayRowIdConflictRewriterTest(unittest.TestCase):
         snapshot_1 = Mock(id=1, uuid='uuid-1')
         snapshot_2 = Mock(id=2, uuid='uuid-2')
         commits = [Mock(), Mock()]
-        commits[0].commit.side_effect = RowIdRebaseConflict('compact')
+        commits[0].commit.side_effect = self._conflict('compact')
         unknown = RuntimeError('callback failed after commit')
         commits[1].commit.side_effect = unknown
         table = self._table(commits, [snapshot_1, snapshot_2])
@@ -265,7 +240,6 @@ class RayRowIdConflictRewriterTest(unittest.TestCase):
                 [generation_0],
                 [other],
                 num_partitions=1,
-                base_snapshot_uuid='uuid-1',
             )
 
         self.assertIs(unknown, context.exception)

--- a/paimon-python/pypaimon/tests/ray_row_id_conflict_rewriter_test.py
+++ b/paimon-python/pypaimon/tests/ray_row_id_conflict_rewriter_test.py
@@ -20,13 +20,37 @@ from unittest.mock import Mock, patch
 
 from pypaimon.ray.data_evolution_merge_into import _reraise_inner
 from pypaimon.ray.row_id_conflict_rewriter import (
+    _rewrite_updates,
     commit_self_merge_with_compaction_retry,
 )
-from pypaimon.write.commit.conflict_detection import RowIdExistenceConflict
+from pypaimon.write.commit.conflict_detection import (
+    RowIdExistenceConflict,
+    RowIdLineageConflict,
+    RowIdRebaseConflict,
+)
 from pypaimon.write.file_store_commit import CommitResultUncertainError
 
 
 class RayRowIdConflictRewriterTest(unittest.TestCase):
+
+    @staticmethod
+    def _message(snapshot_id, name):
+        return Mock(check_from_snapshot=snapshot_id, name=name)
+
+    @staticmethod
+    def _table(commits, snapshots, max_retries=3):
+        builder = Mock()
+        builder.new_commit.side_effect = commits
+        commit_table = Mock()
+        commit_table.new_batch_write_builder.return_value = builder
+        table = Mock()
+        table.copy_without_time_travel.return_value = commit_table
+        table.snapshot_manager.return_value.get_latest_snapshot.side_effect = (
+            snapshots
+        )
+        table.options.commit_timeout.return_value = 60_000
+        table.options.commit_max_retries.return_value = max_retries
+        return table
 
     def test_uncertain_commit_is_not_rebased_as_row_id_conflict(self):
         entry = Mock(bucket=0)
@@ -86,6 +110,166 @@ class RayRowIdConflictRewriterTest(unittest.TestCase):
             _reraise_inner(uncertain)
 
         self.assertIs(uncertain, context.exception)
+
+    def test_rewrite_rejects_latest_snapshot_older_than_base(self):
+        message = Mock(
+            check_from_snapshot=2,
+            deleted_files=[],
+            changelog_files=[],
+        )
+        base_snapshot = Mock(id=2, uuid='uuid-2', schema_id=1)
+        latest_snapshot = Mock(
+            id=1,
+            uuid='uuid-1',
+            schema_id=1,
+            next_row_id=10,
+        )
+        table = Mock()
+        table.options.deletion_vectors_enabled.return_value = False
+        table.snapshot_manager.return_value.get_snapshot_by_id.return_value = (
+            base_snapshot
+        )
+
+        with self.assertRaises(RowIdLineageConflict):
+            _rewrite_updates(
+                table,
+                [message],
+                latest_snapshot,
+                num_partitions=1,
+                expected_base_snapshot_uuid='uuid-2',
+            )
+
+    def test_uncertain_final_generation_only_aborts_superseded_messages(self):
+        generation_0 = self._message(1, 'generation-0')
+        generation_1 = self._message(2, 'generation-1')
+        generation_2 = self._message(3, 'generation-2')
+        other = self._message(-1, 'insert')
+        snapshot_1 = Mock(id=1, uuid='uuid-1')
+        snapshot_2 = Mock(id=2, uuid='uuid-2')
+        snapshot_3 = Mock(id=3, uuid='uuid-3')
+        commits = [Mock(), Mock(), Mock()]
+        commits[0].commit.side_effect = RowIdRebaseConflict('compact-1')
+        commits[1].commit.side_effect = RowIdRebaseConflict('compact-2')
+        uncertain = CommitResultUncertainError('uncertain final attempt')
+        commits[2].commit.side_effect = uncertain
+        table = self._table(
+            commits,
+            [snapshot_1, snapshot_2, snapshot_3],
+        )
+
+        with patch(
+            'pypaimon.ray.row_id_conflict_rewriter._rewrite_updates',
+            side_effect=[
+                Mock(
+                    update_messages=[generation_1],
+                    superseded_messages=[generation_0],
+                    rewritten_file_count=1,
+                ),
+                Mock(
+                    update_messages=[generation_2],
+                    superseded_messages=[generation_1],
+                    rewritten_file_count=1,
+                ),
+            ],
+        ), patch(
+            'pypaimon.ray.row_id_conflict_rewriter._retry_wait',
+        ), patch(
+            'pypaimon.write.file_store_commit._abort_commit_messages',
+        ) as abort_messages, self.assertRaises(
+            CommitResultUncertainError,
+        ) as context:
+            commit_self_merge_with_compaction_retry(
+                table,
+                [generation_0],
+                [other],
+                num_partitions=1,
+                base_snapshot_uuid='uuid-1',
+            )
+
+        self.assertIs(uncertain, context.exception)
+        abort_messages.assert_called_once_with(
+            table,
+            [generation_0, generation_1],
+        )
+
+    def test_exhausted_deterministic_conflict_aborts_every_generation(self):
+        generation_0 = self._message(1, 'generation-0')
+        generation_1 = self._message(2, 'generation-1')
+        other = self._message(-1, 'insert')
+        snapshot_1 = Mock(id=1, uuid='uuid-1')
+        snapshot_2 = Mock(id=2, uuid='uuid-2')
+        commits = [Mock(), Mock()]
+        commits[0].commit.side_effect = RowIdRebaseConflict('compact-1')
+        terminal = RowIdRebaseConflict('compact-2')
+        commits[1].commit.side_effect = terminal
+        table = self._table(
+            commits,
+            [snapshot_1, snapshot_2],
+            max_retries=1,
+        )
+
+        with patch(
+            'pypaimon.ray.row_id_conflict_rewriter._rewrite_updates',
+            return_value=Mock(
+                update_messages=[generation_1],
+                superseded_messages=[generation_0],
+                rewritten_file_count=1,
+            ),
+        ), patch(
+            'pypaimon.ray.row_id_conflict_rewriter._retry_wait',
+        ), patch(
+            'pypaimon.write.file_store_commit._abort_commit_messages',
+        ) as abort_messages, self.assertRaises(
+            RowIdRebaseConflict,
+        ) as context:
+            commit_self_merge_with_compaction_retry(
+                table,
+                [generation_0],
+                [other],
+                num_partitions=1,
+                base_snapshot_uuid='uuid-1',
+            )
+
+        self.assertIs(terminal, context.exception)
+        abort_messages.assert_called_once_with(
+            table,
+            [generation_0, generation_1, other],
+        )
+
+    def test_unknown_final_error_only_aborts_superseded_messages(self):
+        generation_0 = self._message(1, 'generation-0')
+        generation_1 = self._message(2, 'generation-1')
+        other = self._message(-1, 'insert')
+        snapshot_1 = Mock(id=1, uuid='uuid-1')
+        snapshot_2 = Mock(id=2, uuid='uuid-2')
+        commits = [Mock(), Mock()]
+        commits[0].commit.side_effect = RowIdRebaseConflict('compact')
+        unknown = RuntimeError('callback failed after commit')
+        commits[1].commit.side_effect = unknown
+        table = self._table(commits, [snapshot_1, snapshot_2])
+
+        with patch(
+            'pypaimon.ray.row_id_conflict_rewriter._rewrite_updates',
+            return_value=Mock(
+                update_messages=[generation_1],
+                superseded_messages=[generation_0],
+                rewritten_file_count=1,
+            ),
+        ), patch(
+            'pypaimon.ray.row_id_conflict_rewriter._retry_wait',
+        ), patch(
+            'pypaimon.write.file_store_commit._abort_commit_messages',
+        ) as abort_messages, self.assertRaises(RuntimeError) as context:
+            commit_self_merge_with_compaction_retry(
+                table,
+                [generation_0],
+                [other],
+                num_partitions=1,
+                base_snapshot_uuid='uuid-1',
+            )
+
+        self.assertIs(unknown, context.exception)
+        abort_messages.assert_called_once_with(table, [generation_0])
 
 
 if __name__ == '__main__':

--- a/paimon-python/pypaimon/tests/ray_row_id_conflict_rewriter_test.py
+++ b/paimon-python/pypaimon/tests/ray_row_id_conflict_rewriter_test.py
@@ -1,0 +1,81 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+import unittest
+from unittest.mock import Mock, patch
+
+from pypaimon.ray.row_id_conflict_rewriter import (
+    commit_self_merge_with_compaction_retry,
+)
+from pypaimon.write.commit.conflict_detection import RowIdExistenceConflict
+from pypaimon.write.file_store_commit import CommitResultUncertainError
+
+
+class RayRowIdConflictRewriterTest(unittest.TestCase):
+
+    def test_uncertain_commit_is_not_rebased_as_row_id_conflict(self):
+        entry = Mock(bucket=0)
+        entry.file = Mock(
+            file_name='data-file.parquet',
+            first_row_id=0,
+            row_count=1,
+        )
+        conflict = RowIdExistenceConflict(entry)
+        uncertain = CommitResultUncertainError(
+            'The snapshot commit result is uncertain.')
+        uncertain.__cause__ = conflict
+
+        commit = Mock()
+        commit.commit.side_effect = [uncertain, None]
+        commit_table = Mock()
+        commit_table.new_batch_write_builder.return_value.new_commit.return_value = (
+            commit)
+        table = Mock()
+        table.copy_without_time_travel.return_value = commit_table
+        table.snapshot_manager.return_value.get_latest_snapshot.return_value = (
+            Mock(id=2))
+
+        with patch(
+            'pypaimon.ray.row_id_conflict_rewriter._find_row_id_conflict',
+            return_value=conflict,
+        ) as find_conflict, patch(
+            'pypaimon.ray.row_id_conflict_rewriter._rewrite_updates',
+            return_value=Mock(
+                update_messages=[],
+                superseded_messages=[object()],
+                rewritten_file_count=1,
+            ),
+        ) as rewrite_updates, patch(
+            'pypaimon.write.file_store_commit._abort_commit_messages',
+        ) as abort_messages:
+            with self.assertRaises(CommitResultUncertainError) as context:
+                commit_self_merge_with_compaction_retry(
+                    table,
+                    [],
+                    [],
+                    num_partitions=1,
+                )
+
+        self.assertIs(uncertain, context.exception)
+        find_conflict.assert_not_called()
+        rewrite_updates.assert_not_called()
+        abort_messages.assert_not_called()
+        commit.close.assert_called_once_with()
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/paimon-python/pypaimon/tests/ray_row_id_conflict_rewriter_test.py
+++ b/paimon-python/pypaimon/tests/ray_row_id_conflict_rewriter_test.py
@@ -24,7 +24,6 @@ from pypaimon.ray.row_id_conflict_rewriter import (
     commit_self_merge_with_compaction_retry,
 )
 from pypaimon.write.commit.conflict_detection import RowIdExistenceConflict
-from pypaimon.write.file_store_commit import CommitResultUncertainError
 
 
 class RayRowIdConflictRewriterTest(unittest.TestCase):
@@ -58,7 +57,7 @@ class RayRowIdConflictRewriterTest(unittest.TestCase):
         table.options.commit_max_retries.return_value = max_retries
         return table
 
-    def test_uncertain_commit_is_not_rebased_as_row_id_conflict(self):
+    def test_nested_row_id_conflict_is_rebased(self):
         entry = Mock(bucket=0)
         entry.file = Mock(
             file_name='data-file.parquet',
@@ -66,45 +65,36 @@ class RayRowIdConflictRewriterTest(unittest.TestCase):
             row_count=1,
         )
         conflict = RowIdExistenceConflict(entry)
-        uncertain = CommitResultUncertainError(
-            'The snapshot commit result is uncertain.')
-        uncertain.__cause__ = conflict
+        commit_error = RuntimeError('commit failed')
+        commit_error.__cause__ = conflict
 
         commit = Mock()
-        commit.commit.side_effect = [uncertain, None]
-        commit_table = Mock()
-        commit_table.new_batch_write_builder.return_value.new_commit.return_value = (
-            commit)
-        table = Mock()
-        table.copy_without_time_travel.return_value = commit_table
-        table.snapshot_manager.return_value.get_latest_snapshot.return_value = (
-            Mock(id=2))
+        commit.commit.side_effect = [commit_error, None]
+        table = self._table(
+            [commit, commit],
+            [Mock(id=1), Mock(id=2)],
+        )
+        rewrite_result = Mock(
+            update_messages=[],
+            rewritten_file_count=1,
+        )
 
         with patch(
-            'pypaimon.ray.row_id_conflict_rewriter._find_row_id_conflict',
-            return_value=conflict,
-        ) as find_conflict, patch(
             'pypaimon.ray.row_id_conflict_rewriter._rewrite_updates',
-            return_value=Mock(
-                update_messages=[],
-                rewritten_file_count=1,
-            ),
+            return_value=rewrite_result,
         ) as rewrite_updates, patch(
-            'pypaimon.write.file_store_commit._abort_commit_messages',
-        ) as abort_messages:
-            with self.assertRaises(CommitResultUncertainError) as context:
-                commit_self_merge_with_compaction_retry(
-                    table,
-                    [],
-                    [],
-                    num_partitions=1,
-                )
+            'pypaimon.ray.row_id_conflict_rewriter._retry_wait',
+        ):
+            commit_self_merge_with_compaction_retry(
+                table,
+                [],
+                [],
+                num_partitions=1,
+            )
 
-        self.assertIs(uncertain, context.exception)
-        find_conflict.assert_not_called()
-        rewrite_updates.assert_not_called()
-        abort_messages.assert_not_called()
-        commit.close.assert_called_once_with()
+        rewrite_updates.assert_called_once()
+        self.assertEqual(2, commit.commit.call_count)
+        self.assertEqual(2, commit.close.call_count)
 
     def test_commit_preserves_file_store_rollback(self):
         rollback = Mock()
@@ -145,16 +135,6 @@ class RayRowIdConflictRewriterTest(unittest.TestCase):
 
         self.assertIs(conflict, context.exception.__cause__)
 
-    def test_public_error_preserves_uncertain_commit(self):
-        conflict = RuntimeError('inner conflict')
-        uncertain = CommitResultUncertainError('uncertain commit')
-        uncertain.__cause__ = conflict
-
-        with self.assertRaises(CommitResultUncertainError) as context:
-            _reraise_inner(uncertain)
-
-        self.assertIs(uncertain, context.exception)
-
     def test_public_error_does_not_unwrap_regular_cause(self):
         timeout = TimeoutError('commit timeout')
         outer = RuntimeError('commit result is uncertain')
@@ -187,33 +167,7 @@ class RayRowIdConflictRewriterTest(unittest.TestCase):
 
         self.assertIs(cause, context.exception)
 
-    @unittest.skipUnless(
-        importlib.util.find_spec('ray') is not None,
-        'Ray is not installed.',
-    )
-    def test_ray_task_error_stops_at_uncertain_commit(self):
-        from ray.exceptions import RayTaskError
-
-        timeout = TimeoutError('commit timeout')
-        uncertain = CommitResultUncertainError('uncertain commit')
-        uncertain.__cause__ = timeout
-        ray_error = RayTaskError(
-            'worker',
-            'Traceback (most recent call last):\n'
-            'CommitResultUncertainError: uncertain commit',
-            uncertain,
-            proctitle='ray::worker',
-            pid=1,
-            ip='127.0.0.1',
-        ).as_instanceof_cause()
-
-        with self.assertRaises(CommitResultUncertainError) as context:
-            _reraise_inner(ray_error)
-
-        self.assertIs(uncertain, context.exception)
-        self.assertIs(timeout, context.exception.__cause__)
-
-    def test_uncertain_final_generation_does_not_abort_messages(self):
+    def test_final_error_after_multiple_rebases_does_not_abort_messages(self):
         generation_0 = self._message(1, 'generation-0')
         generation_1 = self._message(2, 'generation-1')
         generation_2 = self._message(3, 'generation-2')
@@ -224,8 +178,8 @@ class RayRowIdConflictRewriterTest(unittest.TestCase):
         commits = [Mock(), Mock(), Mock()]
         commits[0].commit.side_effect = self._conflict('compact-1')
         commits[1].commit.side_effect = self._conflict('compact-2')
-        uncertain = CommitResultUncertainError('uncertain final attempt')
-        commits[2].commit.side_effect = uncertain
+        terminal = RuntimeError('final attempt failed')
+        commits[2].commit.side_effect = terminal
         table = self._table(
             commits,
             [snapshot_1, snapshot_2, snapshot_3],
@@ -247,9 +201,7 @@ class RayRowIdConflictRewriterTest(unittest.TestCase):
             'pypaimon.ray.row_id_conflict_rewriter._retry_wait',
         ), patch(
             'pypaimon.write.file_store_commit._abort_commit_messages',
-        ) as abort_messages, self.assertRaises(
-            CommitResultUncertainError,
-        ) as context:
+        ) as abort_messages, self.assertRaises(RuntimeError) as context:
             commit_self_merge_with_compaction_retry(
                 table,
                 [generation_0],
@@ -257,7 +209,7 @@ class RayRowIdConflictRewriterTest(unittest.TestCase):
                 num_partitions=1,
             )
 
-        self.assertIs(uncertain, context.exception)
+        self.assertIs(terminal, context.exception)
         abort_messages.assert_not_called()
 
     def test_exhausted_deterministic_conflict_does_not_abort_messages(self):

--- a/paimon-python/pypaimon/tests/ray_row_id_conflict_rewriter_test.py
+++ b/paimon-python/pypaimon/tests/ray_row_id_conflict_rewriter_test.py
@@ -86,7 +86,6 @@ class RayRowIdConflictRewriterTest(unittest.TestCase):
             'pypaimon.ray.row_id_conflict_rewriter._rewrite_updates',
             return_value=Mock(
                 update_messages=[],
-                superseded_messages=[object()],
                 rewritten_file_count=1,
             ),
         ) as rewrite_updates, patch(
@@ -116,7 +115,7 @@ class RayRowIdConflictRewriterTest(unittest.TestCase):
 
         self.assertIs(uncertain, context.exception)
 
-    def test_uncertain_final_generation_only_aborts_superseded_messages(self):
+    def test_uncertain_final_generation_does_not_abort_messages(self):
         generation_0 = self._message(1, 'generation-0')
         generation_1 = self._message(2, 'generation-1')
         generation_2 = self._message(3, 'generation-2')
@@ -139,12 +138,10 @@ class RayRowIdConflictRewriterTest(unittest.TestCase):
             side_effect=[
                 Mock(
                     update_messages=[generation_1],
-                    superseded_messages=[generation_0],
                     rewritten_file_count=1,
                 ),
                 Mock(
                     update_messages=[generation_2],
-                    superseded_messages=[generation_1],
                     rewritten_file_count=1,
                 ),
             ],
@@ -163,12 +160,9 @@ class RayRowIdConflictRewriterTest(unittest.TestCase):
             )
 
         self.assertIs(uncertain, context.exception)
-        abort_messages.assert_called_once_with(
-            table,
-            [generation_0, generation_1],
-        )
+        abort_messages.assert_not_called()
 
-    def test_exhausted_deterministic_conflict_aborts_every_generation(self):
+    def test_exhausted_deterministic_conflict_does_not_abort_messages(self):
         generation_0 = self._message(1, 'generation-0')
         generation_1 = self._message(2, 'generation-1')
         other = self._message(-1, 'insert')
@@ -188,7 +182,6 @@ class RayRowIdConflictRewriterTest(unittest.TestCase):
             'pypaimon.ray.row_id_conflict_rewriter._rewrite_updates',
             return_value=Mock(
                 update_messages=[generation_1],
-                superseded_messages=[generation_0],
                 rewritten_file_count=1,
             ),
         ), patch(
@@ -206,12 +199,9 @@ class RayRowIdConflictRewriterTest(unittest.TestCase):
             )
 
         self.assertIs(terminal, context.exception)
-        abort_messages.assert_called_once_with(
-            table,
-            [generation_0, generation_1, other],
-        )
+        abort_messages.assert_not_called()
 
-    def test_unknown_final_error_only_aborts_superseded_messages(self):
+    def test_unknown_final_error_does_not_abort_messages(self):
         generation_0 = self._message(1, 'generation-0')
         generation_1 = self._message(2, 'generation-1')
         other = self._message(-1, 'insert')
@@ -227,7 +217,6 @@ class RayRowIdConflictRewriterTest(unittest.TestCase):
             'pypaimon.ray.row_id_conflict_rewriter._rewrite_updates',
             return_value=Mock(
                 update_messages=[generation_1],
-                superseded_messages=[generation_0],
                 rewritten_file_count=1,
             ),
         ), patch(
@@ -243,7 +232,7 @@ class RayRowIdConflictRewriterTest(unittest.TestCase):
             )
 
         self.assertIs(unknown, context.exception)
-        abort_messages.assert_called_once_with(table, [generation_0])
+        abort_messages.assert_not_called()
 
 
 if __name__ == '__main__':

--- a/paimon-python/pypaimon/tests/ray_row_id_conflict_rewriter_test.py
+++ b/paimon-python/pypaimon/tests/ray_row_id_conflict_rewriter_test.py
@@ -15,6 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
+import importlib.util
 import unittest
 from unittest.mock import Mock, patch
 
@@ -114,6 +115,64 @@ class RayRowIdConflictRewriterTest(unittest.TestCase):
             _reraise_inner(uncertain)
 
         self.assertIs(uncertain, context.exception)
+
+    def test_public_error_does_not_unwrap_regular_cause(self):
+        timeout = TimeoutError('commit timeout')
+        outer = RuntimeError('commit result is uncertain')
+        outer.__cause__ = timeout
+
+        with self.assertRaises(RuntimeError) as context:
+            _reraise_inner(outer)
+
+        self.assertIs(outer, context.exception)
+
+    @unittest.skipUnless(
+        importlib.util.find_spec('ray') is not None,
+        'Ray is not installed.',
+    )
+    def test_public_error_unwraps_ray_task_error(self):
+        from ray.exceptions import RayTaskError
+
+        cause = ValueError('worker failure')
+        ray_error = RayTaskError(
+            'worker',
+            'Traceback (most recent call last):\nValueError: worker failure',
+            cause,
+            proctitle='ray::worker',
+            pid=1,
+            ip='127.0.0.1',
+        ).as_instanceof_cause()
+
+        with self.assertRaises(ValueError) as context:
+            _reraise_inner(ray_error)
+
+        self.assertIs(cause, context.exception)
+
+    @unittest.skipUnless(
+        importlib.util.find_spec('ray') is not None,
+        'Ray is not installed.',
+    )
+    def test_ray_task_error_stops_at_uncertain_commit(self):
+        from ray.exceptions import RayTaskError
+
+        timeout = TimeoutError('commit timeout')
+        uncertain = CommitResultUncertainError('uncertain commit')
+        uncertain.__cause__ = timeout
+        ray_error = RayTaskError(
+            'worker',
+            'Traceback (most recent call last):\n'
+            'CommitResultUncertainError: uncertain commit',
+            uncertain,
+            proctitle='ray::worker',
+            pid=1,
+            ip='127.0.0.1',
+        ).as_instanceof_cause()
+
+        with self.assertRaises(CommitResultUncertainError) as context:
+            _reraise_inner(ray_error)
+
+        self.assertIs(uncertain, context.exception)
+        self.assertIs(timeout, context.exception.__cause__)
 
     def test_uncertain_final_generation_does_not_abort_messages(self):
         generation_0 = self._message(1, 'generation-0')

--- a/paimon-python/pypaimon/tests/ray_row_id_conflict_rewriter_test.py
+++ b/paimon-python/pypaimon/tests/ray_row_id_conflict_rewriter_test.py
@@ -17,7 +17,6 @@
 
 import importlib.util
 import unittest
-import uuid
 from unittest.mock import Mock, patch
 
 from pypaimon.ray.data_evolution_merge_into import _reraise_inner
@@ -96,59 +95,6 @@ class RayRowIdConflictRewriterTest(unittest.TestCase):
         rewrite_updates.assert_called_once()
         self.assertEqual(2, commit.commit.call_count)
         self.assertEqual(2, commit.close.call_count)
-
-    def test_outer_rebase_reuses_commit_user_after_uncertain_conflict(self):
-        conflict = self._conflict('compact')
-        uncertain_conflict = RuntimeError(
-            'commit retry after uncertain snapshot commit'
-        )
-        uncertain_conflict.__cause__ = conflict
-        builders = []
-        commit_users = []
-
-        class _Builder:
-
-            def __init__(self):
-                self.commit_user = str(uuid.uuid4())
-                builders.append(self)
-
-            def new_commit(self):
-                commit = Mock(commit_user=self.commit_user)
-                commit.commit.side_effect = (
-                    uncertain_conflict if not commit_users else None
-                )
-                commit_users.append(self.commit_user)
-                return commit
-
-        commit_table = Mock()
-        commit_table.new_batch_write_builder.side_effect = _Builder
-        table = Mock()
-        table.copy_without_time_travel.return_value = commit_table
-        table.snapshot_manager.return_value.get_latest_snapshot.side_effect = [
-            Mock(id=1), Mock(id=2),
-        ]
-        table.options.commit_timeout.return_value = 60_000
-        table.options.commit_max_retries.return_value = 3
-
-        with patch(
-            'pypaimon.ray.row_id_conflict_rewriter._rewrite_updates',
-            return_value=Mock(
-                update_messages=[],
-                rewritten_file_count=1,
-            ),
-        ), patch(
-            'pypaimon.ray.row_id_conflict_rewriter._retry_wait',
-        ):
-            commit_self_merge_with_compaction_retry(
-                table,
-                [],
-                [],
-                num_partitions=1,
-            )
-
-        self.assertEqual(1, len(builders))
-        self.assertEqual(2, len(commit_users))
-        self.assertEqual(1, len(set(commit_users)))
 
     def test_commit_preserves_file_store_rollback(self):
         rollback = Mock()

--- a/paimon-python/pypaimon/tests/ray_row_id_conflict_rewriter_test.py
+++ b/paimon-python/pypaimon/tests/ray_row_id_conflict_rewriter_test.py
@@ -17,6 +17,7 @@
 
 import importlib.util
 import unittest
+import uuid
 from unittest.mock import Mock, patch
 
 from pypaimon.ray.data_evolution_merge_into import _reraise_inner
@@ -95,6 +96,59 @@ class RayRowIdConflictRewriterTest(unittest.TestCase):
         rewrite_updates.assert_called_once()
         self.assertEqual(2, commit.commit.call_count)
         self.assertEqual(2, commit.close.call_count)
+
+    def test_outer_rebase_reuses_commit_user_after_uncertain_conflict(self):
+        conflict = self._conflict('compact')
+        uncertain_conflict = RuntimeError(
+            'commit retry after uncertain snapshot commit'
+        )
+        uncertain_conflict.__cause__ = conflict
+        builders = []
+        commit_users = []
+
+        class _Builder:
+
+            def __init__(self):
+                self.commit_user = str(uuid.uuid4())
+                builders.append(self)
+
+            def new_commit(self):
+                commit = Mock(commit_user=self.commit_user)
+                commit.commit.side_effect = (
+                    uncertain_conflict if not commit_users else None
+                )
+                commit_users.append(self.commit_user)
+                return commit
+
+        commit_table = Mock()
+        commit_table.new_batch_write_builder.side_effect = _Builder
+        table = Mock()
+        table.copy_without_time_travel.return_value = commit_table
+        table.snapshot_manager.return_value.get_latest_snapshot.side_effect = [
+            Mock(id=1), Mock(id=2),
+        ]
+        table.options.commit_timeout.return_value = 60_000
+        table.options.commit_max_retries.return_value = 3
+
+        with patch(
+            'pypaimon.ray.row_id_conflict_rewriter._rewrite_updates',
+            return_value=Mock(
+                update_messages=[],
+                rewritten_file_count=1,
+            ),
+        ), patch(
+            'pypaimon.ray.row_id_conflict_rewriter._retry_wait',
+        ):
+            commit_self_merge_with_compaction_retry(
+                table,
+                [],
+                [],
+                num_partitions=1,
+            )
+
+        self.assertEqual(1, len(builders))
+        self.assertEqual(2, len(commit_users))
+        self.assertEqual(1, len(set(commit_users)))
 
     def test_commit_preserves_file_store_rollback(self):
         rollback = Mock()

--- a/paimon-python/pypaimon/tests/ray_row_id_conflict_rewriter_test.py
+++ b/paimon-python/pypaimon/tests/ray_row_id_conflict_rewriter_test.py
@@ -18,6 +18,7 @@
 import unittest
 from unittest.mock import Mock, patch
 
+from pypaimon.ray.data_evolution_merge_into import _reraise_inner
 from pypaimon.ray.row_id_conflict_rewriter import (
     commit_self_merge_with_compaction_retry,
 )
@@ -75,6 +76,16 @@ class RayRowIdConflictRewriterTest(unittest.TestCase):
         rewrite_updates.assert_not_called()
         abort_messages.assert_not_called()
         commit.close.assert_called_once_with()
+
+    def test_public_error_preserves_uncertain_commit(self):
+        conflict = RuntimeError('inner conflict')
+        uncertain = CommitResultUncertainError('uncertain commit')
+        uncertain.__cause__ = conflict
+
+        with self.assertRaises(CommitResultUncertainError) as context:
+            _reraise_inner(uncertain)
+
+        self.assertIs(uncertain, context.exception)
 
 
 if __name__ == '__main__':

--- a/paimon-python/pypaimon/tests/ray_row_id_conflict_rewriter_test.py
+++ b/paimon-python/pypaimon/tests/ray_row_id_conflict_rewriter_test.py
@@ -106,6 +106,45 @@ class RayRowIdConflictRewriterTest(unittest.TestCase):
         abort_messages.assert_not_called()
         commit.close.assert_called_once_with()
 
+    def test_commit_preserves_file_store_rollback(self):
+        rollback = Mock()
+        commit = Mock()
+        commit.file_store_commit.rollback = rollback
+        table = self._table([commit], [Mock(id=1)])
+
+        commit_self_merge_with_compaction_retry(
+            table,
+            [],
+            [],
+            num_partitions=1,
+        )
+
+        self.assertIs(commit.file_store_commit.rollback, rollback)
+
+    def test_rewrite_error_keeps_row_id_conflict_as_cause(self):
+        conflict = self._conflict('compact')
+        rewrite_error = ValueError('rewrite failed')
+        update = self._message(1, 'update')
+        commit = Mock()
+        commit.commit.side_effect = conflict
+        table = self._table(
+            [commit],
+            [Mock(id=1), Mock(id=2)],
+        )
+
+        with patch(
+            'pypaimon.ray.row_id_conflict_rewriter._rewrite_updates',
+            side_effect=rewrite_error,
+        ), self.assertRaises(RuntimeError) as context:
+            commit_self_merge_with_compaction_retry(
+                table,
+                [update],
+                [],
+                num_partitions=1,
+            )
+
+        self.assertIs(conflict, context.exception.__cause__)
+
     def test_public_error_preserves_uncertain_commit(self):
         conflict = RuntimeError('inner conflict')
         uncertain = CommitResultUncertainError('uncertain commit')

--- a/paimon-python/pypaimon/tests/reader_append_only_test.py
+++ b/paimon-python/pypaimon/tests/reader_append_only_test.py
@@ -32,7 +32,7 @@ from pypaimon.common.options.core_options import CoreOptions
 from pypaimon.manifest.schema.manifest_entry import ManifestEntry
 from pypaimon.snapshot.snapshot import BATCH_COMMIT_IDENTIFIER
 from pypaimon.table.row.generic_row import GenericRow
-from pypaimon.write.file_store_commit import RetryResult
+from pypaimon.write.file_store_commit import CommitFailRetryResult
 
 
 class AoReaderTest(unittest.TestCase):
@@ -669,7 +669,7 @@ class AoReaderTest(unittest.TestCase):
                 ))
         # mock retry
         success = table_commit.file_store_commit._try_commit_once(
-            RetryResult(None),
+            CommitFailRetryResult(None),
             "APPEND",
             commit_entries,
             [],

--- a/paimon-python/pypaimon/tests/write/conflict_detection_test.py
+++ b/paimon-python/pypaimon/tests/write/conflict_detection_test.py
@@ -408,6 +408,21 @@ class TestCheckRowIdFromSnapshot(unittest.TestCase):
         self.assertIsNone(
             detection.check_row_id_from_snapshot(compact_snap, self._blob_delta()))
 
+    def test_missing_intermediate_snapshot_fails_closed(self):
+        check_snap = _FakeSnapshot(1, "APPEND", next_row_id=200)
+        latest_snap = _FakeSnapshot(3, "COMPACT", next_row_id=200)
+        detection = self._make_detection(
+            [check_snap, latest_snap], {3: []})
+
+        result = detection.check_row_id_from_snapshot(
+            latest_snap,
+            self._blob_delta(),
+            check_compaction=False,
+        )
+
+        self.assertIsInstance(result, RuntimeError)
+        self.assertIn("snapshot 2 cannot be found", str(result))
+
     def test_compact_no_conflict_when_no_matching_delete(self):
         check_snap = _FakeSnapshot(1, "APPEND", next_row_id=400)
         compact_snap = _FakeSnapshot(2, "COMPACT", next_row_id=400)

--- a/paimon-python/pypaimon/tests/write/conflict_detection_test.py
+++ b/paimon-python/pypaimon/tests/write/conflict_detection_test.py
@@ -414,14 +414,13 @@ class TestCheckRowIdFromSnapshot(unittest.TestCase):
         detection = self._make_detection(
             [check_snap, latest_snap], {3: []})
 
-        result = detection.check_row_id_from_snapshot(
-            latest_snap,
-            self._blob_delta(),
-            check_compaction=False,
-        )
-
-        self.assertIsInstance(result, RuntimeError)
-        self.assertIn("snapshot 2 cannot be found", str(result))
+        with self.assertRaisesRegex(
+                RuntimeError, "snapshot 2 cannot be found"):
+            detection.check_row_id_from_snapshot(
+                latest_snap,
+                self._blob_delta(),
+                check_compaction=False,
+            )
 
     def test_compact_no_conflict_when_no_matching_delete(self):
         check_snap = _FakeSnapshot(1, "APPEND", next_row_id=400)

--- a/paimon-python/pypaimon/tests/write/conflict_detection_test.py
+++ b/paimon-python/pypaimon/tests/write/conflict_detection_test.py
@@ -423,19 +423,6 @@ class TestCheckRowIdFromSnapshot(unittest.TestCase):
         self.assertIsInstance(result, RuntimeError)
         self.assertIn("snapshot 2 cannot be found", str(result))
 
-    def test_missing_base_snapshot_has_specific_error(self):
-        latest_snap = _FakeSnapshot(2, "APPEND", next_row_id=200)
-        detection = self._make_detection([latest_snap], {})
-
-        with self.assertRaisesRegex(
-                RuntimeError,
-                "base snapshot 1 cannot be found",
-        ):
-            detection.check_row_id_from_snapshot(
-                latest_snap,
-                self._blob_delta(),
-            )
-
     def test_compact_no_conflict_when_no_matching_delete(self):
         check_snap = _FakeSnapshot(1, "APPEND", next_row_id=400)
         compact_snap = _FakeSnapshot(2, "COMPACT", next_row_id=400)

--- a/paimon-python/pypaimon/tests/write/conflict_detection_test.py
+++ b/paimon-python/pypaimon/tests/write/conflict_detection_test.py
@@ -423,6 +423,19 @@ class TestCheckRowIdFromSnapshot(unittest.TestCase):
         self.assertIsInstance(result, RuntimeError)
         self.assertIn("snapshot 2 cannot be found", str(result))
 
+    def test_missing_base_snapshot_has_specific_error(self):
+        latest_snap = _FakeSnapshot(2, "APPEND", next_row_id=200)
+        detection = self._make_detection([latest_snap], {})
+
+        with self.assertRaisesRegex(
+                RuntimeError,
+                "base snapshot 1 cannot be found",
+        ):
+            detection.check_row_id_from_snapshot(
+                latest_snap,
+                self._blob_delta(),
+            )
+
     def test_compact_no_conflict_when_no_matching_delete(self):
         check_snap = _FakeSnapshot(1, "APPEND", next_row_id=400)
         compact_snap = _FakeSnapshot(2, "COMPACT", next_row_id=400)

--- a/paimon-python/pypaimon/tests/write/table_write_test.py
+++ b/paimon-python/pypaimon/tests/write/table_write_test.py
@@ -32,7 +32,6 @@ from pypaimon.build_info import full_version as build_full_version
 from pypaimon.common.json_util import JSON
 from pypaimon.common.options.core_options import CoreOptions
 from pypaimon.manifest.manifest_list_manager import ManifestListManager
-from pypaimon.write.file_store_commit import CommitResultUncertainError
 from pypaimon.write.table_write import TableWrite
 from pypaimon.write.writer.append_only_data_writer import AppendOnlyDataWriter
 
@@ -1541,86 +1540,6 @@ class TableWriteTest(unittest.TestCase):
             write_three.close()
             commit_two.close()
             commit_three.close()
-
-    def test_uncertain_commit_with_unavailable_snapshot_fails_closed(self):
-        table = self._create_postpone_table(
-            'default.test_uncertain_commit_with_unavailable_snapshot',
-            pa_schema=self.postpone_pa_schema,
-            partition_keys=['dt'],
-            primary_keys=['id', 'dt'],
-        )
-        builder = table.new_postpone_fixed_bucket_write_builder()
-        write = builder.new_write()
-        commit = builder.new_commit()
-        try:
-            write.write_arrow(pa.Table.from_pydict({
-                'id': [1], 'dt': ['p'], 'value': ['v'],
-            }, schema=self.postpone_pa_schema))
-            messages = write.prepare_commit()
-            data_paths = [
-                file.external_path or file.file_path
-                for message in messages
-                for file in message.new_files
-            ]
-            uncertain_error = TimeoutError('lost commit response')
-            file_store_commit = commit.file_store_commit
-            file_store_commit.commit_max_retries = 1
-            snapshot_commit = file_store_commit.snapshot_commit
-            real_commit = snapshot_commit.commit
-            attempts = 0
-
-            def uncertain_then_cas_failure(base_uuid, snapshot, statistics):
-                nonlocal attempts
-                attempts += 1
-                if attempts == 1:
-                    self.assertTrue(real_commit(base_uuid, snapshot, statistics))
-                    self._commit_arrow(
-                        table,
-                        pa.Table.from_pydict({
-                            'id': [2], 'dt': ['p'], 'value': ['v2'],
-                        }, schema=self.postpone_pa_schema),
-                        fixed_bucket=True,
-                    )
-                    raise uncertain_error
-                return False
-
-            real_get_snapshot = file_store_commit.snapshot_manager.get_snapshot_by_id
-
-            def hide_first_snapshot(snapshot_id):
-                return None if snapshot_id == 1 else real_get_snapshot(snapshot_id)
-
-            # An unavailable committed snapshot must stop conflict handling.
-            with patch.object(
-                snapshot_commit,
-                'commit',
-                side_effect=uncertain_then_cas_failure,
-            ), patch.object(
-                file_store_commit.snapshot_manager,
-                'get_snapshot_by_id',
-                side_effect=hide_first_snapshot,
-            ), patch.object(
-                file_store_commit.conflict_detection,
-                'check_conflicts',
-                return_value=None,
-            ) as check_conflicts, patch.object(
-                file_store_commit,
-                '_commit_retry_wait',
-            ):
-                with self.assertRaises(CommitResultUncertainError) as context:
-                    commit.commit(messages)
-
-            self.assertIs(uncertain_error, context.exception.__cause__)
-            self.assertEqual(1, attempts)
-            # Only the original attempt reaches conflict detection.
-            check_conflicts.assert_called_once()
-            self.assertTrue(all(table.file_io.exists(path) for path in data_paths))
-            read_builder = table.new_read_builder()
-            rows = read_builder.new_read().to_arrow(
-                read_builder.new_scan().plan().splits())
-            self.assertEqual([1, 2], sorted(rows.column('id').to_pylist()))
-        finally:
-            write.close()
-            commit.close()
 
     def test_data_file_prefix_postpone(self):
         """Test that generated data file names follow the expected prefix format."""

--- a/paimon-python/pypaimon/tests/write/table_write_test.py
+++ b/paimon-python/pypaimon/tests/write/table_write_test.py
@@ -32,6 +32,7 @@ from pypaimon.build_info import full_version as build_full_version
 from pypaimon.common.json_util import JSON
 from pypaimon.common.options.core_options import CoreOptions
 from pypaimon.manifest.manifest_list_manager import ManifestListManager
+from pypaimon.write.file_store_commit import CommitResultUncertainError
 from pypaimon.write.table_write import TableWrite
 from pypaimon.write.writer.append_only_data_writer import AppendOnlyDataWriter
 
@@ -1541,9 +1542,9 @@ class TableWriteTest(unittest.TestCase):
             commit_two.close()
             commit_three.close()
 
-    def test_uncertain_commit_then_cas_failure_keeps_files(self):
+    def test_uncertain_commit_with_unavailable_snapshot_fails_closed(self):
         table = self._create_postpone_table(
-            'default.test_uncertain_commit_then_cas_failure',
+            'default.test_uncertain_commit_with_unavailable_snapshot',
             pa_schema=self.postpone_pa_schema,
             partition_keys=['dt'],
             primary_keys=['id', 'dt'],
@@ -1588,7 +1589,7 @@ class TableWriteTest(unittest.TestCase):
             def hide_first_snapshot(snapshot_id):
                 return None if snapshot_id == 1 else real_get_snapshot(snapshot_id)
 
-            # Keep the retry on the CAS path after snapshot 1 becomes unavailable.
+            # An unavailable committed snapshot must stop conflict handling.
             with patch.object(
                 snapshot_commit,
                 'commit',
@@ -1601,16 +1602,22 @@ class TableWriteTest(unittest.TestCase):
                 file_store_commit.conflict_detection,
                 'check_conflicts',
                 return_value=None,
-            ), patch.object(file_store_commit, '_commit_retry_wait'):
-                with self.assertRaises(RuntimeError) as context:
+            ) as check_conflicts, patch.object(
+                file_store_commit,
+                '_commit_retry_wait',
+            ):
+                with self.assertRaises(CommitResultUncertainError) as context:
                     commit.commit(messages)
 
             self.assertIs(uncertain_error, context.exception.__cause__)
-            self.assertEqual(2, attempts)
+            self.assertEqual(1, attempts)
+            # Only the original attempt reaches conflict detection.
+            check_conflicts.assert_called_once()
             self.assertTrue(all(table.file_io.exists(path) for path in data_paths))
-            self.assertEqual(
-                [1, 2], self._read_sorted(table, 'id').column('id').to_pylist()
-            )
+            read_builder = table.new_read_builder()
+            rows = read_builder.new_read().to_arrow(
+                read_builder.new_scan().plan().splits())
+            self.assertEqual([1, 2], sorted(rows.column('id').to_pylist()))
         finally:
             write.close()
             commit.close()

--- a/paimon-python/pypaimon/tests/write/table_write_test.py
+++ b/paimon-python/pypaimon/tests/write/table_write_test.py
@@ -1541,6 +1541,84 @@ class TableWriteTest(unittest.TestCase):
             commit_two.close()
             commit_three.close()
 
+    def test_uncertain_commit_with_unavailable_snapshot_fails_closed(self):
+        table = self._create_postpone_table(
+            'default.test_uncertain_commit_with_unavailable_snapshot',
+            pa_schema=self.postpone_pa_schema,
+            partition_keys=['dt'],
+            primary_keys=['id', 'dt'],
+        )
+        builder = table.new_postpone_fixed_bucket_write_builder()
+        write = builder.new_write()
+        commit = builder.new_commit()
+        try:
+            write.write_arrow(pa.Table.from_pydict({
+                'id': [1], 'dt': ['p'], 'value': ['v'],
+            }, schema=self.postpone_pa_schema))
+            messages = write.prepare_commit()
+            data_paths = [
+                file.external_path or file.file_path
+                for message in messages
+                for file in message.new_files
+            ]
+            uncertain_error = TimeoutError('lost commit response')
+            file_store_commit = commit.file_store_commit
+            file_store_commit.commit_max_retries = 1
+            snapshot_commit = file_store_commit.snapshot_commit
+            real_commit = snapshot_commit.commit
+            attempts = 0
+
+            def uncertain_then_cas_failure(base_uuid, snapshot, statistics):
+                nonlocal attempts
+                attempts += 1
+                if attempts == 1:
+                    self.assertTrue(real_commit(base_uuid, snapshot, statistics))
+                    self._commit_arrow(
+                        table,
+                        pa.Table.from_pydict({
+                            'id': [2], 'dt': ['p'], 'value': ['v2'],
+                        }, schema=self.postpone_pa_schema),
+                        fixed_bucket=True,
+                    )
+                    raise uncertain_error
+                return False
+
+            real_get_snapshot = file_store_commit.snapshot_manager.get_snapshot_by_id
+
+            def hide_first_snapshot(snapshot_id):
+                return None if snapshot_id == 1 else real_get_snapshot(snapshot_id)
+
+            with patch.object(
+                snapshot_commit,
+                'commit',
+                side_effect=uncertain_then_cas_failure,
+            ), patch.object(
+                file_store_commit.snapshot_manager,
+                'get_snapshot_by_id',
+                side_effect=hide_first_snapshot,
+            ), patch.object(
+                file_store_commit.conflict_detection,
+                'check_conflicts',
+                return_value=None,
+            ) as check_conflicts, patch.object(
+                file_store_commit,
+                '_commit_retry_wait',
+            ):
+                with self.assertRaisesRegex(
+                        RuntimeError, 'snapshot 1 cannot be found'):
+                    commit.commit(messages)
+
+            self.assertEqual(1, attempts)
+            check_conflicts.assert_called_once()
+            self.assertTrue(all(table.file_io.exists(path) for path in data_paths))
+            self.assertEqual(
+                [1, 2], self._read_sorted(
+                    table, 'id').column('id').to_pylist()
+            )
+        finally:
+            write.close()
+            commit.close()
+
     def test_data_file_prefix_postpone(self):
         """Test that generated data file names follow the expected prefix format."""
         schema = Schema.from_pyarrow_schema(self.pa_schema, partition_keys=['user_id'], primary_keys=['user_id', 'dt'],

--- a/paimon-python/pypaimon/write/commit/conflict_detection.py
+++ b/paimon-python/pypaimon/write/commit/conflict_detection.py
@@ -696,7 +696,7 @@ class ConflictDetection:
                 latest_snapshot.id + 1):
             snapshot = self.snapshot_manager.get_snapshot_by_id(snapshot_id)
             if snapshot is None:
-                return RuntimeError(
+                raise RuntimeError(
                     "Row-id conflict check cannot continue because snapshot "
                     "{} cannot be found.".format(snapshot_id))
 

--- a/paimon-python/pypaimon/write/commit/conflict_detection.py
+++ b/paimon-python/pypaimon/write/commit/conflict_detection.py
@@ -696,7 +696,9 @@ class ConflictDetection:
                 latest_snapshot.id + 1):
             snapshot = self.snapshot_manager.get_snapshot_by_id(snapshot_id)
             if snapshot is None:
-                continue
+                return RuntimeError(
+                    "Row-id conflict check cannot continue because snapshot "
+                    "{} cannot be found.".format(snapshot_id))
 
             if snapshot.commit_kind == "COMPACT":
                 if check_compaction:

--- a/paimon-python/pypaimon/write/commit/conflict_detection.py
+++ b/paimon-python/pypaimon/write/commit/conflict_detection.py
@@ -149,15 +149,7 @@ class _WriteRange:
         self.field_ids = field_ids
 
 
-class RowIdRebaseConflict(RuntimeError):
-    """A structural row-id conflict eligible for a guarded rebase attempt."""
-
-
-class RowIdLineageConflict(RuntimeError):
-    """A staged row-id update belongs to a different snapshot lineage."""
-
-
-class RowIdExistenceConflict(RowIdRebaseConflict):
+class RowIdExistenceConflict(RuntimeError):
     """A staged row-id file no longer matches the current base-file layout."""
 
     def __init__(self, entry):
@@ -184,7 +176,6 @@ class ConflictDetection:
         self.manifest_list_manager = manifest_list_manager
         self.table = table
         self._row_id_check_from_snapshot = None
-        self._row_id_check_from_snapshot_uuid = None
         self.commit_scanner = commit_scanner
 
     def should_be_overwrite_commit(self, append_file_entries=None, append_index_files=None):
@@ -198,9 +189,6 @@ class ConflictDetection:
 
     def has_row_id_check_from_snapshot(self):
         return self._row_id_check_from_snapshot is not None
-
-    def set_row_id_check_from_snapshot_uuid(self, snapshot_uuid):
-        self._row_id_check_from_snapshot_uuid = snapshot_uuid
 
     @staticmethod
     def has_global_index_additions(index_entries=None):
@@ -220,10 +208,6 @@ class ConflictDetection:
             delta_entries,
             commit_kind,
             delta_index_entries=None):
-        conflict = self.check_row_id_snapshot_lineage(latest_snapshot)
-        if conflict is not None:
-            return conflict
-
         try:
             FileEntry.merge_entries(delta_entries)
         except Exception as e:
@@ -280,37 +264,6 @@ class ConflictDetection:
             return conflict
 
         return self.check_row_id_from_snapshot(latest_snapshot, delta_entries)
-
-    def check_row_id_snapshot_lineage(self, latest_snapshot):
-        expected_uuid = self._row_id_check_from_snapshot_uuid
-        base_snapshot_id = self._row_id_check_from_snapshot
-        if expected_uuid is None or base_snapshot_id is None:
-            return None
-
-        if latest_snapshot is None or latest_snapshot.id < base_snapshot_id:
-            return RowIdLineageConflict(
-                "Row-id snapshot lineage conflict: staged from snapshot {} "
-                "with UUID {}, but the latest snapshot is {}.".format(
-                    base_snapshot_id,
-                    expected_uuid,
-                    latest_snapshot.id if latest_snapshot is not None else None,
-                )
-            )
-
-        base_snapshot = self.snapshot_manager.get_snapshot_by_id(
-            base_snapshot_id
-        )
-        actual_uuid = base_snapshot.uuid if base_snapshot is not None else None
-        if actual_uuid != expected_uuid:
-            return RowIdLineageConflict(
-                "Row-id snapshot lineage conflict: snapshot {} changed "
-                "from UUID {} to {}.".format(
-                    base_snapshot_id,
-                    expected_uuid,
-                    actual_uuid,
-                )
-            )
-        return None
 
     @staticmethod
     def check_bucket_num_conflicts(entries):
@@ -723,11 +676,7 @@ class ConflictDetection:
 
         check_snapshot = self.snapshot_manager.get_snapshot_by_id(
             self._row_id_check_from_snapshot)
-        if check_snapshot is None:
-            raise RuntimeError(
-                "Row-id conflict check base snapshot {} cannot be found."
-                .format(self._row_id_check_from_snapshot))
-        if check_snapshot.next_row_id is None:
+        if check_snapshot is None or check_snapshot.next_row_id is None:
             raise RuntimeError(
                 "Next row id cannot be null for snapshot "
                 "{snapshot}.".format(snapshot=self._row_id_check_from_snapshot))
@@ -805,7 +754,7 @@ class ConflictDetection:
                     continue
                 if not column_checker.conflicts_with(entry.file):
                     continue
-                return RowIdRebaseConflict(
+                return RuntimeError(
                     "Blob/row-id update conflicts with concurrent COMPACT "
                     "(snapshot {sid}): anchor file {name} [{ff}, {ft}] "
                     "was compacted away, overlaps staged delta "

--- a/paimon-python/pypaimon/write/commit/conflict_detection.py
+++ b/paimon-python/pypaimon/write/commit/conflict_detection.py
@@ -149,7 +149,15 @@ class _WriteRange:
         self.field_ids = field_ids
 
 
-class RowIdExistenceConflict(RuntimeError):
+class RowIdRebaseConflict(RuntimeError):
+    """A structural row-id conflict eligible for a guarded rebase attempt."""
+
+
+class RowIdLineageConflict(RuntimeError):
+    """A staged row-id update belongs to a different snapshot lineage."""
+
+
+class RowIdExistenceConflict(RowIdRebaseConflict):
     """A staged row-id file no longer matches the current base-file layout."""
 
     def __init__(self, entry):
@@ -176,6 +184,7 @@ class ConflictDetection:
         self.manifest_list_manager = manifest_list_manager
         self.table = table
         self._row_id_check_from_snapshot = None
+        self._row_id_check_from_snapshot_uuid = None
         self.commit_scanner = commit_scanner
 
     def should_be_overwrite_commit(self, append_file_entries=None, append_index_files=None):
@@ -189,6 +198,9 @@ class ConflictDetection:
 
     def has_row_id_check_from_snapshot(self):
         return self._row_id_check_from_snapshot is not None
+
+    def set_row_id_check_from_snapshot_uuid(self, snapshot_uuid):
+        self._row_id_check_from_snapshot_uuid = snapshot_uuid
 
     @staticmethod
     def has_global_index_additions(index_entries=None):
@@ -208,6 +220,10 @@ class ConflictDetection:
             delta_entries,
             commit_kind,
             delta_index_entries=None):
+        conflict = self.check_row_id_snapshot_lineage(latest_snapshot)
+        if conflict is not None:
+            return conflict
+
         try:
             FileEntry.merge_entries(delta_entries)
         except Exception as e:
@@ -264,6 +280,37 @@ class ConflictDetection:
             return conflict
 
         return self.check_row_id_from_snapshot(latest_snapshot, delta_entries)
+
+    def check_row_id_snapshot_lineage(self, latest_snapshot):
+        expected_uuid = self._row_id_check_from_snapshot_uuid
+        base_snapshot_id = self._row_id_check_from_snapshot
+        if expected_uuid is None or base_snapshot_id is None:
+            return None
+
+        if latest_snapshot is None or latest_snapshot.id < base_snapshot_id:
+            return RowIdLineageConflict(
+                "Row-id snapshot lineage conflict: staged from snapshot {} "
+                "with UUID {}, but the latest snapshot is {}.".format(
+                    base_snapshot_id,
+                    expected_uuid,
+                    latest_snapshot.id if latest_snapshot is not None else None,
+                )
+            )
+
+        base_snapshot = self.snapshot_manager.get_snapshot_by_id(
+            base_snapshot_id
+        )
+        actual_uuid = base_snapshot.uuid if base_snapshot is not None else None
+        if actual_uuid != expected_uuid:
+            return RowIdLineageConflict(
+                "Row-id snapshot lineage conflict: snapshot {} changed "
+                "from UUID {} to {}.".format(
+                    base_snapshot_id,
+                    expected_uuid,
+                    actual_uuid,
+                )
+            )
+        return None
 
     @staticmethod
     def check_bucket_num_conflicts(entries):
@@ -676,7 +723,11 @@ class ConflictDetection:
 
         check_snapshot = self.snapshot_manager.get_snapshot_by_id(
             self._row_id_check_from_snapshot)
-        if check_snapshot is None or check_snapshot.next_row_id is None:
+        if check_snapshot is None:
+            raise RuntimeError(
+                "Row-id conflict check base snapshot {} cannot be found."
+                .format(self._row_id_check_from_snapshot))
+        if check_snapshot.next_row_id is None:
             raise RuntimeError(
                 "Next row id cannot be null for snapshot "
                 "{snapshot}.".format(snapshot=self._row_id_check_from_snapshot))
@@ -754,7 +805,7 @@ class ConflictDetection:
                     continue
                 if not column_checker.conflicts_with(entry.file):
                     continue
-                return RuntimeError(
+                return RowIdRebaseConflict(
                     "Blob/row-id update conflicts with concurrent COMPACT "
                     "(snapshot {sid}): anchor file {name} [{ff}, {ft}] "
                     "was compacted away, overlaps staged delta "

--- a/paimon-python/pypaimon/write/file_store_commit.py
+++ b/paimon-python/pypaimon/write/file_store_commit.py
@@ -180,30 +180,6 @@ class RetryResult(CommitResult):
         return False
 
 
-class CommitResultUncertainError(RuntimeError):
-    """A previous snapshot commit may have succeeded but is not observable."""
-
-
-class _UncertainCommitState:
-    """Retain the first unresolved snapshot-commit attempt across retries."""
-
-    def __init__(self):
-        self.pending = False
-        self.latest_snapshot = None
-        self.exception = None
-
-    def record(self, retry_result: RetryResult) -> None:
-        if not self.pending:
-            self.latest_snapshot = retry_result.latest_snapshot
-            self.exception = retry_result.exception
-        self.pending = True
-
-    def resolve(self) -> None:
-        self.pending = False
-        self.latest_snapshot = None
-        self.exception = None
-
-
 class RewriteResult(CommitResult):
 
     def __init__(self, rewrite: RowIdRewriteResult):
@@ -501,51 +477,37 @@ class FileStoreCommit:
 
         retry_count = 0
         retry_result = None
-        uncertain_commit_state = _UncertainCommitState()
+        commit_result_may_be_uncertain = False
+        uncertain_commit_exception = None
         rewritten_commit_entries = None
         start_time_ms = int(time.time() * 1000)
         while True:
-            try:
-                latest_snapshot = self.snapshot_manager.get_latest_snapshot()
-                commit_entries = (
-                    rewritten_commit_entries
-                    if rewritten_commit_entries is not None
-                    else commit_entries_plan(latest_snapshot)
-                )
+            latest_snapshot = self.snapshot_manager.get_latest_snapshot()
+            commit_entries = (
+                rewritten_commit_entries
+                if rewritten_commit_entries is not None
+                else commit_entries_plan(latest_snapshot)
+            )
 
-                # No entries to commit (e.g. drop_partitions with no matching
-                # data): skip an empty snapshot.
-                if not commit_entries and not index_deletes and not index_adds:
-                    if uncertain_commit_state.pending:
-                        raise CommitResultUncertainError(
-                            "Cannot skip an empty retry while a previous "
-                            "snapshot commit is still uncertain."
-                        ) from uncertain_commit_state.exception
-                    break
+            # No entries to commit (e.g. drop_partitions with no matching
+            # data): skip an empty snapshot.
+            if not commit_entries and not index_deletes and not index_adds:
+                break
 
-                result = self._try_commit_once(
-                    retry_result=retry_result,
-                    commit_kind=commit_kind,
-                    commit_entries=commit_entries,
-                    changelog_entries=changelog_entries or [],
-                    commit_identifier=commit_identifier,
-                    latest_snapshot=latest_snapshot,
-                    detect_conflicts=detect_conflicts,
-                    allow_rollback=allow_rollback,
-                    index_deletes=index_deletes,
-                    index_adds=index_adds,
-                    hash_index_base_snapshot=hash_index_base_snapshot,
-                    uncertain_commit_state=uncertain_commit_state,
-                )
-            except CommitResultUncertainError:
-                raise
-            except Exception:
-                if uncertain_commit_state.pending:
-                    raise CommitResultUncertainError(
-                        "Cannot safely continue after a retry failure while "
-                        "a previous snapshot commit is still uncertain."
-                    ) from uncertain_commit_state.exception
-                raise
+            result = self._try_commit_once(
+                retry_result=retry_result,
+                commit_kind=commit_kind,
+                commit_entries=commit_entries,
+                changelog_entries=changelog_entries or [],
+                commit_identifier=commit_identifier,
+                latest_snapshot=latest_snapshot,
+                detect_conflicts=detect_conflicts,
+                allow_rollback=allow_rollback,
+                index_deletes=index_deletes,
+                index_adds=index_adds,
+                hash_index_base_snapshot=hash_index_base_snapshot,
+                commit_result_may_be_uncertain=commit_result_may_be_uncertain,
+            )
 
             if isinstance(result, RewriteResult):
                 rewritten_commit_entries = result.rewrite.commit_entries
@@ -580,7 +542,9 @@ class FileStoreCommit:
             else:
                 retry_result = result
                 if result.commit_result_may_be_uncertain:
-                    uncertain_commit_state.record(result)
+                    commit_result_may_be_uncertain = True
+                    if uncertain_commit_exception is None:
+                        uncertain_commit_exception = result.exception
 
             elapsed_ms = int(time.time() * 1000) - start_time_ms
             if elapsed_ms > self.commit_timeout or retry_count >= self.commit_max_retries:
@@ -601,24 +565,14 @@ class FileStoreCommit:
                     f"after {elapsed_ms} millis with {retry_count} retries, "
                     f"there maybe exist commit conflicts between multiple jobs."
                 )
-                if uncertain_commit_state.pending:
-                    raise CommitResultUncertainError(
-                        error_msg
-                    ) from uncertain_commit_state.exception
+                if commit_result_may_be_uncertain:
+                    raise RuntimeError(error_msg) from uncertain_commit_exception
                 if retry_result is not None and retry_result.exception:
                     raise RuntimeError(error_msg) from retry_result.exception
                 else:
                     raise RuntimeError(error_msg)
 
-            try:
-                self._commit_retry_wait(retry_count)
-            except Exception:
-                if uncertain_commit_state.pending:
-                    raise CommitResultUncertainError(
-                        "Commit retry was interrupted while a previous "
-                        "snapshot commit is still uncertain."
-                    ) from uncertain_commit_state.exception
-                raise
+            self._commit_retry_wait(retry_count)
             retry_count += 1
 
     def _try_commit_once(self, retry_result: Optional[RetryResult], commit_kind: str,
@@ -631,16 +585,10 @@ class FileStoreCommit:
                          index_deletes=None,
                          index_adds=None,
                          hash_index_base_snapshot=None,
-                         uncertain_commit_state=None) -> CommitResult:
-        if uncertain_commit_state is None:
-            uncertain_commit_state = _UncertainCommitState()
+                         commit_result_may_be_uncertain: bool = False) -> CommitResult:
         start_millis = int(time.time() * 1000)
         if self._is_duplicate_commit(
-                retry_result,
-                latest_snapshot,
-                commit_identifier,
-                commit_kind,
-                uncertain_commit_state):
+                retry_result, latest_snapshot, commit_identifier, commit_kind):
             return SuccessResult()
 
         latest_snapshot_id = latest_snapshot.id if latest_snapshot else 0
@@ -702,13 +650,8 @@ class FileStoreCommit:
             )
 
             if conflict_exception is not None:
-                if uncertain_commit_state.pending:
-                    raise CommitResultUncertainError(
-                        "Cannot safely handle a commit conflict while a "
-                        "previous snapshot commit is still uncertain."
-                    ) from uncertain_commit_state.exception
                 rewrite_result = self._try_rewrite_row_id_conflict(
-                    uncertain_commit_state.pending,
+                    commit_result_may_be_uncertain,
                     conflict_exception,
                     latest_snapshot,
                     base_data_files,
@@ -968,38 +911,15 @@ class FileStoreCommit:
             retry_result,
             latest_snapshot,
             commit_identifier,
-            commit_kind,
-            uncertain_commit_state) -> bool:
-        if (
-                (retry_result is not None or uncertain_commit_state.pending)
-                and latest_snapshot is not None
-        ):
+            commit_kind) -> bool:
+        if retry_result is not None and latest_snapshot is not None:
             start_check_snapshot_id = 1  # Snapshot.FIRST_SNAPSHOT_ID
-            check_from_snapshot = (
-                uncertain_commit_state.latest_snapshot
-                if uncertain_commit_state.pending
-                else retry_result.latest_snapshot
-            )
-            if check_from_snapshot is not None:
-                start_check_snapshot_id = check_from_snapshot.id + 1
+            if retry_result.latest_snapshot is not None:
+                start_check_snapshot_id = retry_result.latest_snapshot.id + 1
 
             for snapshot_id in range(start_check_snapshot_id, latest_snapshot.id + 1):
                 snapshot = self.snapshot_manager.get_snapshot_by_id(snapshot_id)
                 if snapshot is None:
-                    if uncertain_commit_state.pending:
-                        message = (
-                            "Cannot determine whether commit {} by user {} "
-                            "succeeded because snapshot {} is unavailable."
-                        ).format(
-                            commit_identifier,
-                            self.commit_user,
-                            snapshot_id,
-                        )
-                        raise CommitResultUncertainError(
-                            message
-                        ) from uncertain_commit_state.exception
-                    # A deterministic retry has no unresolved snapshot commit.
-                    # Conflict detection handles any history it must read.
                     continue
                 if (snapshot.commit_user == self.commit_user and
                         snapshot.commit_identifier == commit_identifier and
@@ -1009,12 +929,6 @@ class FileStoreCommit:
                         f"user: {self.commit_user}, identifier: {commit_identifier}"
                     )
                     return True
-            if (
-                    uncertain_commit_state.pending
-                    and start_check_snapshot_id <= latest_snapshot.id
-            ):
-                # All later snapshots are visible and exclude this commit.
-                uncertain_commit_state.resolve()
         return False
 
     def _create_dynamic_partition_filter(self, commit_messages: List[CommitMessage]):

--- a/paimon-python/pypaimon/write/file_store_commit.py
+++ b/paimon-python/pypaimon/write/file_store_commit.py
@@ -505,32 +505,47 @@ class FileStoreCommit:
         rewritten_commit_entries = None
         start_time_ms = int(time.time() * 1000)
         while True:
-            latest_snapshot = self.snapshot_manager.get_latest_snapshot()
-            commit_entries = (
-                rewritten_commit_entries
-                if rewritten_commit_entries is not None
-                else commit_entries_plan(latest_snapshot)
-            )
+            try:
+                latest_snapshot = self.snapshot_manager.get_latest_snapshot()
+                commit_entries = (
+                    rewritten_commit_entries
+                    if rewritten_commit_entries is not None
+                    else commit_entries_plan(latest_snapshot)
+                )
 
-            # No entries to commit (e.g. drop_partitions with no matching data): skip commit
-            # to avoid creating manifest/snapshot with empty partition_stats (causes read errors).
-            if not commit_entries and not index_deletes and not index_adds:
-                break
+                # No entries to commit (e.g. drop_partitions with no matching
+                # data): skip an empty snapshot.
+                if not commit_entries and not index_deletes and not index_adds:
+                    if uncertain_commit_state.pending:
+                        raise CommitResultUncertainError(
+                            "Cannot skip an empty retry while a previous "
+                            "snapshot commit is still uncertain."
+                        ) from uncertain_commit_state.exception
+                    break
 
-            result = self._try_commit_once(
-                retry_result=retry_result,
-                commit_kind=commit_kind,
-                commit_entries=commit_entries,
-                changelog_entries=changelog_entries or [],
-                commit_identifier=commit_identifier,
-                latest_snapshot=latest_snapshot,
-                detect_conflicts=detect_conflicts,
-                allow_rollback=allow_rollback,
-                index_deletes=index_deletes,
-                index_adds=index_adds,
-                hash_index_base_snapshot=hash_index_base_snapshot,
-                uncertain_commit_state=uncertain_commit_state,
-            )
+                result = self._try_commit_once(
+                    retry_result=retry_result,
+                    commit_kind=commit_kind,
+                    commit_entries=commit_entries,
+                    changelog_entries=changelog_entries or [],
+                    commit_identifier=commit_identifier,
+                    latest_snapshot=latest_snapshot,
+                    detect_conflicts=detect_conflicts,
+                    allow_rollback=allow_rollback,
+                    index_deletes=index_deletes,
+                    index_adds=index_adds,
+                    hash_index_base_snapshot=hash_index_base_snapshot,
+                    uncertain_commit_state=uncertain_commit_state,
+                )
+            except CommitResultUncertainError:
+                raise
+            except Exception:
+                if uncertain_commit_state.pending:
+                    raise CommitResultUncertainError(
+                        "Cannot safely continue after a retry failure while "
+                        "a previous snapshot commit is still uncertain."
+                    ) from uncertain_commit_state.exception
+                raise
 
             if isinstance(result, RewriteResult):
                 rewritten_commit_entries = result.rewrite.commit_entries
@@ -595,7 +610,15 @@ class FileStoreCommit:
                 else:
                     raise RuntimeError(error_msg)
 
-            self._commit_retry_wait(retry_count)
+            try:
+                self._commit_retry_wait(retry_count)
+            except Exception:
+                if uncertain_commit_state.pending:
+                    raise CommitResultUncertainError(
+                        "Commit retry was interrupted while a previous "
+                        "snapshot commit is still uncertain."
+                    ) from uncertain_commit_state.exception
+                raise
             retry_count += 1
 
     def _try_commit_once(self, retry_result: Optional[RetryResult], commit_kind: str,

--- a/paimon-python/pypaimon/write/file_store_commit.py
+++ b/paimon-python/pypaimon/write/file_store_commit.py
@@ -180,6 +180,30 @@ class RetryResult(CommitResult):
         return False
 
 
+class CommitResultUncertainError(RuntimeError):
+    """A previous snapshot commit may have succeeded but is not observable."""
+
+
+class _UncertainCommitState:
+    """Retain the first unresolved snapshot-commit attempt across retries."""
+
+    def __init__(self):
+        self.pending = False
+        self.latest_snapshot = None
+        self.exception = None
+
+    def record(self, retry_result: RetryResult) -> None:
+        if not self.pending:
+            self.latest_snapshot = retry_result.latest_snapshot
+            self.exception = retry_result.exception
+        self.pending = True
+
+    def resolve(self) -> None:
+        self.pending = False
+        self.latest_snapshot = None
+        self.exception = None
+
+
 class RewriteResult(CommitResult):
 
     def __init__(self, rewrite: RowIdRewriteResult):
@@ -477,8 +501,7 @@ class FileStoreCommit:
 
         retry_count = 0
         retry_result = None
-        commit_result_may_be_uncertain = False
-        uncertain_commit_exception = None
+        uncertain_commit_state = _UncertainCommitState()
         rewritten_commit_entries = None
         start_time_ms = int(time.time() * 1000)
         while True:
@@ -506,7 +529,7 @@ class FileStoreCommit:
                 index_deletes=index_deletes,
                 index_adds=index_adds,
                 hash_index_base_snapshot=hash_index_base_snapshot,
-                commit_result_may_be_uncertain=commit_result_may_be_uncertain,
+                uncertain_commit_state=uncertain_commit_state,
             )
 
             if isinstance(result, RewriteResult):
@@ -542,9 +565,7 @@ class FileStoreCommit:
             else:
                 retry_result = result
                 if result.commit_result_may_be_uncertain:
-                    commit_result_may_be_uncertain = True
-                    if uncertain_commit_exception is None:
-                        uncertain_commit_exception = result.exception
+                    uncertain_commit_state.record(result)
 
             elapsed_ms = int(time.time() * 1000) - start_time_ms
             if elapsed_ms > self.commit_timeout or retry_count >= self.commit_max_retries:
@@ -565,8 +586,10 @@ class FileStoreCommit:
                     f"after {elapsed_ms} millis with {retry_count} retries, "
                     f"there maybe exist commit conflicts between multiple jobs."
                 )
-                if commit_result_may_be_uncertain:
-                    raise RuntimeError(error_msg) from uncertain_commit_exception
+                if uncertain_commit_state.pending:
+                    raise CommitResultUncertainError(
+                        error_msg
+                    ) from uncertain_commit_state.exception
                 if retry_result is not None and retry_result.exception:
                     raise RuntimeError(error_msg) from retry_result.exception
                 else:
@@ -585,9 +608,16 @@ class FileStoreCommit:
                          index_deletes=None,
                          index_adds=None,
                          hash_index_base_snapshot=None,
-                         commit_result_may_be_uncertain: bool = False) -> CommitResult:
+                         uncertain_commit_state=None) -> CommitResult:
+        if uncertain_commit_state is None:
+            uncertain_commit_state = _UncertainCommitState()
         start_millis = int(time.time() * 1000)
-        if self._is_duplicate_commit(retry_result, latest_snapshot, commit_identifier, commit_kind):
+        if self._is_duplicate_commit(
+                retry_result,
+                latest_snapshot,
+                commit_identifier,
+                commit_kind,
+                uncertain_commit_state):
             return SuccessResult()
 
         latest_snapshot_id = latest_snapshot.id if latest_snapshot else 0
@@ -649,8 +679,13 @@ class FileStoreCommit:
             )
 
             if conflict_exception is not None:
+                if uncertain_commit_state.pending:
+                    raise CommitResultUncertainError(
+                        "Cannot safely handle a commit conflict while a "
+                        "previous snapshot commit is still uncertain."
+                    ) from uncertain_commit_state.exception
                 rewrite_result = self._try_rewrite_row_id_conflict(
-                    commit_result_may_be_uncertain,
+                    uncertain_commit_state.pending,
                     conflict_exception,
                     latest_snapshot,
                     base_data_files,
@@ -905,15 +940,43 @@ class FileStoreCommit:
         return self.manifest_file_manager.rolling_write(
             commit_entries, self.manifest_target_size, base_name)
 
-    def _is_duplicate_commit(self, retry_result, latest_snapshot, commit_identifier, commit_kind) -> bool:
-        if retry_result is not None and latest_snapshot is not None:
+    def _is_duplicate_commit(
+            self,
+            retry_result,
+            latest_snapshot,
+            commit_identifier,
+            commit_kind,
+            uncertain_commit_state) -> bool:
+        if (
+                (retry_result is not None or uncertain_commit_state.pending)
+                and latest_snapshot is not None
+        ):
             start_check_snapshot_id = 1  # Snapshot.FIRST_SNAPSHOT_ID
-            if retry_result.latest_snapshot is not None:
-                start_check_snapshot_id = retry_result.latest_snapshot.id + 1
+            check_from_snapshot = (
+                uncertain_commit_state.latest_snapshot
+                if uncertain_commit_state.pending
+                else retry_result.latest_snapshot
+            )
+            if check_from_snapshot is not None:
+                start_check_snapshot_id = check_from_snapshot.id + 1
 
             for snapshot_id in range(start_check_snapshot_id, latest_snapshot.id + 1):
                 snapshot = self.snapshot_manager.get_snapshot_by_id(snapshot_id)
-                if (snapshot and snapshot.commit_user == self.commit_user and
+                if snapshot is None:
+                    message = (
+                        "Cannot determine whether commit {} by user {} "
+                        "succeeded because snapshot {} is unavailable."
+                    ).format(
+                        commit_identifier,
+                        self.commit_user,
+                        snapshot_id,
+                    )
+                    if uncertain_commit_state.pending:
+                        raise CommitResultUncertainError(
+                            message
+                        ) from uncertain_commit_state.exception
+                    raise RuntimeError(message)
+                if (snapshot.commit_user == self.commit_user and
                         snapshot.commit_identifier == commit_identifier and
                         snapshot.commit_kind == commit_kind):
                     logger.info(
@@ -921,6 +984,12 @@ class FileStoreCommit:
                         f"user: {self.commit_user}, identifier: {commit_identifier}"
                     )
                     return True
+            if (
+                    uncertain_commit_state.pending
+                    and start_check_snapshot_id <= latest_snapshot.id
+            ):
+                # All later snapshots are visible and exclude this commit.
+                uncertain_commit_state.resolve()
         return False
 
     def _create_dynamic_partition_filter(self, commit_messages: List[CommitMessage]):

--- a/paimon-python/pypaimon/write/file_store_commit.py
+++ b/paimon-python/pypaimon/write/file_store_commit.py
@@ -963,19 +963,21 @@ class FileStoreCommit:
             for snapshot_id in range(start_check_snapshot_id, latest_snapshot.id + 1):
                 snapshot = self.snapshot_manager.get_snapshot_by_id(snapshot_id)
                 if snapshot is None:
-                    message = (
-                        "Cannot determine whether commit {} by user {} "
-                        "succeeded because snapshot {} is unavailable."
-                    ).format(
-                        commit_identifier,
-                        self.commit_user,
-                        snapshot_id,
-                    )
                     if uncertain_commit_state.pending:
+                        message = (
+                            "Cannot determine whether commit {} by user {} "
+                            "succeeded because snapshot {} is unavailable."
+                        ).format(
+                            commit_identifier,
+                            self.commit_user,
+                            snapshot_id,
+                        )
                         raise CommitResultUncertainError(
                             message
                         ) from uncertain_commit_state.exception
-                    raise RuntimeError(message)
+                    # A deterministic retry has no unresolved snapshot commit.
+                    # Conflict detection handles any history it must read.
+                    continue
                 if (snapshot.commit_user == self.commit_user and
                         snapshot.commit_identifier == commit_identifier and
                         snapshot.commit_kind == commit_kind):

--- a/paimon-python/pypaimon/write/file_store_commit.py
+++ b/paimon-python/pypaimon/write/file_store_commit.py
@@ -920,7 +920,15 @@ class FileStoreCommit:
             for snapshot_id in range(start_check_snapshot_id, latest_snapshot.id + 1):
                 snapshot = self.snapshot_manager.get_snapshot_by_id(snapshot_id)
                 if snapshot is None:
-                    continue
+                    raise RuntimeError(
+                        "Cannot determine whether commit {} by user {} "
+                        "succeeded because snapshot {} cannot be found."
+                        .format(
+                            commit_identifier,
+                            self.commit_user,
+                            snapshot_id,
+                        )
+                    )
                 if (snapshot.commit_user == self.commit_user and
                         snapshot.commit_identifier == commit_identifier and
                         snapshot.commit_kind == commit_kind):

--- a/paimon-python/pypaimon/write/file_store_commit.py
+++ b/paimon-python/pypaimon/write/file_store_commit.py
@@ -150,7 +150,7 @@ class ManifestMergeResult:
 
 
 def _try_reuse_manifest_merge_result(retry_result, current_manifests):
-    if (retry_result is None
+    if (not isinstance(retry_result, CommitFailRetryResult)
             or retry_result.commit_result_may_be_uncertain
             or retry_result.manifest_merge_result is None):
         return None
@@ -178,6 +178,17 @@ class RetryResult(CommitResult):
 
     def is_success(self) -> bool:
         return False
+
+
+class CommitFailRetryResult(RetryResult):
+    """Retry after an atomic snapshot commit failed, matching Java."""
+
+
+class RollbackRetryResult(RetryResult):
+    """Retry after a conflicting compaction was rolled back, matching Java."""
+
+    def __init__(self, exception: Optional[Exception] = None):
+        super().__init__(None, exception)
 
 
 class RewriteResult(CommitResult):
@@ -619,17 +630,22 @@ class FileStoreCommit:
         base_data_files = None
         if detect_conflicts:
             incremental = None
+            commit_fail_retry = (
+                retry_result
+                if isinstance(retry_result, CommitFailRetryResult)
+                else None
+            )
             if (latest_snapshot is not None
-                    and retry_result is not None
-                    and retry_result.latest_snapshot is not None
-                    and retry_result.base_data_files is not None):
+                    and commit_fail_retry is not None
+                    and commit_fail_retry.latest_snapshot is not None
+                    and commit_fail_retry.base_data_files is not None):
                 incremental = self.commit_scanner.read_incremental_changes(
-                    retry_result.latest_snapshot,
+                    commit_fail_retry.latest_snapshot,
                     latest_snapshot,
                     commit_entries,
                     index_entries)
             if incremental is not None:
-                base_data_files = list(retry_result.base_data_files)
+                base_data_files = list(commit_fail_retry.base_data_files)
                 if incremental:
                     base_data_files.extend(incremental)
                     base_data_files = FileEntry.merge_entries(base_data_files)
@@ -666,7 +682,7 @@ class FileStoreCommit:
                     if self.rollback.try_to_rollback(latest_snapshot):
                         # Rolled back: base/snapshot no longer valid; next attempt
                         # re-scans from scratch (matches Java RollbackRetryResult).
-                        return RetryResult(None, conflict_exception)
+                        return RollbackRetryResult(conflict_exception)
                 raise conflict_exception
 
         # Apply row tracking logic after conflict detection (matches Java ordering)
@@ -819,7 +835,7 @@ class FileStoreCommit:
                             merge_after_manifests,
                         )
                     )
-                    return RetryResult(
+                    return CommitFailRetryResult(
                         latest_snapshot,
                         None,
                         base_data_files=base_data_files,
@@ -828,7 +844,7 @@ class FileStoreCommit:
         except Exception as e:
             # Commit exception, not sure about the situation and should not clean up the files
             logger.warning("Retry commit for exception.", exc_info=True)
-            return RetryResult(
+            return CommitFailRetryResult(
                 latest_snapshot,
                 e,
                 base_data_files=base_data_files,
@@ -912,7 +928,8 @@ class FileStoreCommit:
             latest_snapshot,
             commit_identifier,
             commit_kind) -> bool:
-        if retry_result is not None and latest_snapshot is not None:
+        if (isinstance(retry_result, CommitFailRetryResult)
+                and latest_snapshot is not None):
             start_check_snapshot_id = 1  # Snapshot.FIRST_SNAPSHOT_ID
             if retry_result.latest_snapshot is not None:
                 start_check_snapshot_id = retry_result.latest_snapshot.id + 1


### PR DESCRIPTION
## What changed

- Recover Ray self-merge updates when normal forward snapshot progress, such as concurrent compaction, changes row-ID file boundaries after partial-column files are staged.
- Read staged update files with Ray, route them against the latest complete logical file groups, and retry the commit without rerunning the source scan or user callable.
- Reuse one batch write builder across outer rebase attempts so every fresh table commit keeps the same commit user, matching Spark's `PaimonSparkWriter` lifecycle.
- Preserve logical conflict detection and deterministic commit retries.
- Distinguish atomic commit-failure retries from successful compaction-rollback retries: only the former performs duplicate detection, while rollback retries rescan the conflict base, matching Java.
- Follow Spark's existing conflict retry behavior when a commit result may be uncertain; do not add a Python-only terminal exception.
- Fail commit retry when a snapshot required for duplicate detection is unavailable, matching Java.
- Match Spark by leaving replaced or failed staging files for orphan cleanup instead of eagerly aborting rebase generations.

## Why

A compaction between the self-merge read and commit can raise a row-ID existence conflict and fail the whole job. The existing PyPaimon fallback runs on the driver and defaults to a 256 MiB affected-file limit. This adds the distributed Ray equivalent of the Spark self-merge rebase behavior introduced by #9091.

## Behavior alignment and scope

This PR intentionally follows the current Spark behavior: it compares the latest and read snapshot IDs with `!=` when deciding whether to rebase staged updates. It does not add snapshot-lineage or UUID validation.

The supported and tested scope of this PR is normal forward snapshot progress and conflict retry. It does **not** claim to safely handle table rollback, `latest snapshot ID < base snapshot ID`, or equal snapshot IDs with different UUIDs.

The rollback snapshot-ID reuse ABA problem is tracked separately in #9352 and should be fixed for Spark and Python together.

Recovery remains disabled for deletion-vector tables, schema changes, missing row-ID coverage, changelog/deleted-file updates, and existing-row BLOB or VECTOR staged files. Same-column concurrent updates are still rejected.

## Validation

- PR-specific Ray self-merge/rebase scenarios: 18 passed.
- Real filesystem/Ray coverage verifies that an atomic commit which succeeds and then times out is found by core duplicate detection even after a real compaction snapshot; it performs one snapshot CAS and does not enter outer rebase.
- Real repeated-compaction coverage verifies that the initial commit and two outer rebase retries use three fresh commits from one real batch write builder and retain one commit user. Reverting to the old per-attempt builder lifecycle makes this test fail with three distinct commit users.
- File-store commit, overwrite, append-only read, table-write, and conflict suites: 145 passed, 7 subtests passed; 11 optional Lance/Vortex tests were deselected because those local dependencies were not installed.
- Python 3.6 `py_compile`, project-configured flake8, and `git diff --check` passed.
