### PR TITLE
[PAIMON-9337] Support Kerberos proxy user when reading Paimon table via Hive

### DIFF
--- a/paimon-common/src/main/java/org/apache/paimon/security/KerberosLoginProvider.java
+++ b/paimon-common/src/main/java/org/apache/paimon/security/KerberosLoginProvider.java
@@ -73,7 +73,8 @@ public class KerberosLoginProvider {
                 return true;
             }
         } else {
-            throwProxyUserNotSupported();
+            LOG.debug("Login from ProxyUser");
+            return true;
         }
 
         LOG.debug("Login is NOT possible");
@@ -95,12 +96,9 @@ public class KerberosLoginProvider {
             UserGroupInformation.loginUserFromSubject(null);
             LOG.info("Loaded user's ticket cache successfully");
         } else {
-            throwProxyUserNotSupported();
+            // Proxy user: credentials are already provided by the proxy mechanism.
+            LOG.debug("Skipping Kerberos login for proxy user");
         }
-    }
-
-    private void throwProxyUserNotSupported() {
-        throw new UnsupportedOperationException("Proxy user is not supported");
     }
 
     public static boolean isProxyUser(UserGroupInformation ugi) {

--- a/paimon-common/src/test/java/org/apache/paimon/security/KerberosLoginProviderITCase.java
+++ b/paimon-common/src/test/java/org/apache/paimon/security/KerberosLoginProviderITCase.java
@@ -37,6 +37,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.when;
 
 /**
@@ -108,7 +109,7 @@ public class KerberosLoginProviderITCase {
     }
 
     @Test
-    public void isLoginPossibleMustThrowExceptionWithProxyUser() {
+    public void isLoginPossibleMustReturnTrueWithProxyUser() {
         Options options = new Options();
         KerberosLoginProvider kerberosLoginProvider = new KerberosLoginProvider(options);
 
@@ -119,8 +120,7 @@ public class KerberosLoginProviderITCase {
             ugi.when(UserGroupInformation::isSecurityEnabled).thenReturn(true);
             ugi.when(UserGroupInformation::getCurrentUser).thenReturn(userGroupInformation);
 
-            assertThatThrownBy(kerberosLoginProvider::isLoginPossible)
-                    .isInstanceOf(UnsupportedOperationException.class);
+            assertThat(kerberosLoginProvider.isLoginPossible()).isTrue();
         }
     }
 
@@ -158,7 +158,7 @@ public class KerberosLoginProviderITCase {
     }
 
     @Test
-    public void doLoginMustThrowExceptionWithProxyUser() {
+    public void doLoginMustDoNothingWithProxyUser() {
         Options options = new Options();
         KerberosLoginProvider kerberosLoginProvider = new KerberosLoginProvider(options);
 
@@ -168,8 +168,12 @@ public class KerberosLoginProviderITCase {
                     .thenReturn(UserGroupInformation.AuthenticationMethod.PROXY);
             ugi.when(UserGroupInformation::getCurrentUser).thenReturn(userGroupInformation);
 
-            assertThatThrownBy(kerberosLoginProvider::doLogin)
-                    .isInstanceOf(UnsupportedOperationException.class);
+            // proxy user should not trigger any Kerberos login
+            kerberosLoginProvider.doLogin();
+            ugi.verify(() -> UserGroupInformation.loginUserFromSubject(null), never());
+            ugi.verify(
+                    () -> UserGroupInformation.loginUserFromKeytab(anyString(), anyString()),
+                    never());
         }
     }
 }

--- a/paimon-common/src/test/java/org/apache/paimon/security/KerberosLoginProviderITCase.java
+++ b/paimon-common/src/test/java/org/apache/paimon/security/KerberosLoginProviderITCase.java
@@ -33,7 +33,6 @@ import static org.apache.paimon.security.SecurityConfiguration.KERBEROS_LOGIN_KE
 import static org.apache.paimon.security.SecurityConfiguration.KERBEROS_LOGIN_PRINCIPAL;
 import static org.apache.paimon.security.SecurityConfiguration.KERBEROS_LOGIN_USETICKETCACHE;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;


### PR DESCRIPTION
Fixes #9337 (https://github.com/apache/paimon/issues/9337)

## What does this PR do?

When querying a Paimon table from Hive via HiveServer2 with a Kerberos proxy user
(`hive.server2.proxy.user`), the query fails with:

```
UnsupportedOperationException: Proxy user is not supported
```

This happens because `KerberosLoginProvider` throws unconditionally when the current
`UserGroupInformation` has auth method `PROXY`, both in `isLoginPossible()` and `doLogin()`.

Unlike Spark/Flink, Hive cannot pass a keytab directly — HiveServer2 itself holds the
Kerberos credentials and proxies requests on behalf of the business user. In this case,
Paimon should simply skip its own Kerberos login and let the existing proxy credentials
work.

## Changes

This fix targets the scenario where a Paimon table is read from Hive via HiveServer2
with a Kerberos proxy user (`hive.server2.proxy.user`).

- `isLoginPossible()`: proxy user now returns `true` instead of throwing
  `UnsupportedOperationException`.
- `doLogin()`: proxy user branch skips login (credentials already provided by the proxy
  mechanism) instead of throwing.
- Remove the now-unreachable private method `throwProxyUserNotSupported()`.
- Update `KerberosLoginProviderITCase` to reflect the new behavior:
  - `isLoginPossibleMustReturnTrueWithProxyUser` (was: `mustThrowException`)
  - `doLoginMustDoNothingWithProxyUser` (was: `mustThrowException`)

## Verifying this change

Run the existing ITCase:

```bash
mvn test -pl paimon-common -Dtest=KerberosLoginProviderITCase
```

Manual verification: after rebuilding the Hive connector, a Hive query via HiveServer2
proxy user on a Paimon table returns results normally. Ranger authorization still works
as expected (proxy user must still have the required privileges).

## Does this PR introduce any user-facing change?

Yes. Hive queries on Paimon tables via HiveServer2 Kerberos proxy user no longer fail
with `UnsupportedOperationException`.

## Does this PR introduce any breaking change?

No.
