### PR TITLE
[paimon-vector] Upgrade paimon-vector-index to 0.4.0

### DIFF
--- a/docs/docs/multimodal-table/global-index/vector.mdx
+++ b/docs/docs/multimodal-table/global-index/vector.mdx
@@ -124,7 +124,7 @@ print(added_files)
 ```
 
 PyPaimon vector index build supports the paimon-vindex 0.3.0 identifiers `ivf-flat`, `ivf-pq`,
-`ivf-sq`, `ivf-rq`, and `diskann`. Install `paimon-vindex==0.3.0` or `pypaimon[vindex]` before
+`ivf-sq`, `ivf-rq`, and `diskann`. Install `paimon-vindex==0.4.0` or `pypaimon[vindex]` before
 building or querying paimon-vindex indexes from Python.
 
 </TabItem>

--- a/paimon-python/dev/requirements-dev.txt
+++ b/paimon-python/dev/requirements-dev.txt
@@ -33,6 +33,6 @@ datafusion>=52; python_version >= "3.10"
 # Lumina vector search (optional, for lumina index tests)
 lumina-data>=0.1.0
 # paimon-vindex vector search (optional, for vindex index tests)
-paimon-vindex==0.3.0; python_version >= "3.9"
+paimon-vindex==0.4.0; python_version >= "3.9"
 # paimon-ftindex full-text search (optional, for full-text index tests)
 paimon-ftindex==0.1.0; python_version >= "3.8"

--- a/paimon-python/dev/run_mixed_tests.sh
+++ b/paimon-python/dev/run_mixed_tests.sh
@@ -660,14 +660,14 @@ ensure_paimon_vindex() {
     fi
 
     echo "Installing Python paimon-vindex dependency..."
-    if python -m pip install 'paimon-vindex==0.3.0'; then
+    if python -m pip install 'paimon-vindex==0.4.0'; then
         return 0
     fi
 
     echo -e "${YELLOW}Direct pip install failed; installing paimon-vindex into a temporary target directory...${NC}"
     local target_dir="${TMPDIR:-/tmp}/paimon-vindex-site"
     rm -rf "$target_dir"
-    if python -m pip install --target "$target_dir" 'paimon-vindex==0.3.0'; then
+    if python -m pip install --target "$target_dir" 'paimon-vindex==0.4.0'; then
         export PYTHONPATH="$target_dir:${PYTHONPATH:-}"
         return 0
     fi
@@ -675,7 +675,7 @@ ensure_paimon_vindex() {
     if python -c "import numpy" >/dev/null 2>&1; then
         echo -e "${YELLOW}Dependency install failed but numpy is already available; retrying paimon-vindex without dependencies...${NC}"
         rm -rf "$target_dir"
-        if python -m pip install --target "$target_dir" --no-deps 'paimon-vindex==0.3.0'; then
+        if python -m pip install --target "$target_dir" --no-deps 'paimon-vindex==0.4.0'; then
             export PYTHONPATH="$target_dir:${PYTHONPATH:-}"
             return 0
         fi

--- a/paimon-python/pypaimon/globalindex/vindex/vindex_vector_global_index_reader.py
+++ b/paimon-python/pypaimon/globalindex/vindex/vindex_vector_global_index_reader.py
@@ -160,7 +160,7 @@ class VindexVectorGlobalIndexReader(GlobalIndexReader):
             except ImportError as e:
                 raise ImportError(
                     "paimon-vindex is required to read vindex vector indexes. "
-                    "Install paimon-vindex==0.3.0 or pypaimon[vindex].") from e
+                    "Install paimon-vindex==0.4.0 or pypaimon[vindex].") from e
 
             file_path = (self._io_meta.external_path
                          if self._io_meta.external_path

--- a/paimon-python/pypaimon/globalindex/vindex/vindex_vector_index_writer.py
+++ b/paimon-python/pypaimon/globalindex/vindex/vindex_vector_index_writer.py
@@ -102,7 +102,7 @@ class VindexVectorIndexWriter:
             except ImportError as e:
                 raise ImportError(
                     "paimon-vindex is required to build vindex vector indexes. "
-                    "Install paimon-vindex==0.3.0 or pypaimon[vindex].") from e
+                    "Install paimon-vindex==0.4.0 or pypaimon[vindex].") from e
 
             self._close_temp_files()
             self._file_io.check_or_mkdirs(self._index_path)

--- a/paimon-python/setup.py
+++ b/paimon-python/setup.py
@@ -263,7 +263,7 @@ setup(
             'lumina-data>=0.1.0'
         ],
         'vindex': [
-            'paimon-vindex==0.3.0; python_version>="3.9"',
+            'paimon-vindex==0.4.0; python_version>="3.9"',
         ],
         'full-text': [
             'paimon-ftindex==0.1.0; python_version>="3.8"',

--- a/paimon-vector/pom.xml
+++ b/paimon-vector/pom.xml
@@ -32,7 +32,7 @@ under the License.
     <name>Paimon : Vector Index</name>
 
     <properties>
-        <paimon-vector-index-java.version>0.3.0</paimon-vector-index-java.version>
+        <paimon-vector-index-java.version>0.4.0</paimon-vector-index-java.version>
     </properties>
 
     <dependencies>


### PR DESCRIPTION
### Purpose

Upgrade the `paimon-vector-index` dependency to the newly released `0.4.0` version. `paimon-vector-index` 0.4.0 has been published to Maven Central (`paimon-vector-index-java`), crates.io (`paimon-vindex-core`), and PyPI (`paimon-vindex`).

This PR upgrades the Java and Python artifacts consumed by the paimon repository:

| Artifact | Registry | Old version | New version |
|---|---|---|---|
| `paimon-vector-index-java` | Maven Central | 0.3.0 | 0.4.0 |
| `paimon-vindex` | PyPI | 0.3.0 | 0.4.0 |

### Tests

- `mvn -pl paimon-vector -am compile -DskipTests` → BUILD SUCCESS

Files updated:
- `paimon-vector/pom.xml` — Java dependency version property
- `paimon-python/setup.py` — Python `vindex` extra
- `paimon-python/dev/requirements-dev.txt` — dev dependency
- `paimon-python/dev/run_mixed_tests.sh` — test install commands
- `paimon-python/pypaimon/globalindex/vindex/*.py` — install hint in error messages
- `docs/docs/multimodal-table/global-index/vector.mdx` — doc install hint