### PR TITLE
[iceberg] Skip an already-deleted manifest list when expiring old metadata

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/iceberg/IcebergCommitCallback.java
+++ b/paimon-core/src/main/java/org/apache/paimon/iceberg/IcebergCommitCallback.java
@@ -1608,6 +1608,13 @@ public class IcebergCommitCallback implements CommitCallback, TagCallback {
                 }
                 expiredManifestLists.add(listName);
 
+                // A retained metadata JSON can reference a list an earlier rebuild already
+                // deleted. Reading it must not fail: we only open it to delete what it
+                // points at, and that earlier pass already did so.
+                if (!table.fileIO().exists(listPath)) {
+                    continue;
+                }
+
                 for (IcebergManifestFileMeta meta : manifestList.read(listName)) {
                     String metaName = new Path(meta.manifestPath()).getName();
                     if (expiredManifestFileMetas.contains(metaName)) {

--- a/paimon-core/src/test/java/org/apache/paimon/iceberg/IcebergCompatibilityTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/iceberg/IcebergCompatibilityTest.java
@@ -464,6 +464,54 @@ public class IcebergCompatibilityTest {
     }
 
     @Test
+    public void testExpireAllBeforeSkipsAlreadyDeletedManifestList() throws Exception {
+        RowType rowType =
+                RowType.of(
+                        new DataType[] {DataTypes.INT(), DataTypes.INT()}, new String[] {"k", "v"});
+        FileStoreTable table =
+                createPaimonTable(rowType, Collections.emptyList(), Collections.emptyList(), -1);
+
+        String commitUser = UUID.randomUUID().toString();
+        TableWriteImpl<?> write = table.newWrite(commitUser);
+        TableCommitImpl commit = table.newCommit(commitUser);
+
+        write.write(GenericRow.of(1, 10));
+        commit.commit(1, write.prepareCommit(false, 1));
+        write.write(GenericRow.of(2, 20));
+        commit.commit(2, write.prepareCommit(false, 2));
+
+        IcebergPathFactory pathFactory =
+                new IcebergPathFactory(new Path(table.location(), "metadata"));
+        long latest = table.latestSnapshot().get().id();
+
+        // v(latest - 1) is retained by previous-versions-max = 1, but an earlier from-scratch
+        // rebuild deletes the manifest lists of every version below the one it rebuilds at.
+        // Reproduce that state: the metadata JSON survives, the list it points at does not.
+        Path retainedMetadataPath = pathFactory.toMetadataPath(latest - 1);
+        IcebergMetadata retained = IcebergMetadata.fromPath(table.fileIO(), retainedMetadataPath);
+        Path danglingListPath = new Path(retained.currentSnapshot().manifestList());
+        table.fileIO().deleteQuietly(danglingListPath);
+        assertThat(table.fileIO().exists(retainedMetadataPath)).isTrue();
+        assertThat(table.fileIO().exists(danglingListPath)).isFalse();
+
+        // Dropping the base metadata sends the next commit down the from-scratch path, which
+        // calls expireAllBefore and so walks the retained JSON above.
+        table.fileIO().deleteQuietly(pathFactory.toMetadataPath(latest));
+
+        write.write(GenericRow.of(3, 30));
+        commit.commit(3, write.prepareCommit(false, 3));
+
+        // The rebuild completed and published a usable Iceberg head.
+        Path rebuiltMetadataPath = pathFactory.toMetadataPath(table.latestSnapshot().get().id());
+        assertThat(table.fileIO().exists(rebuiltMetadataPath)).isTrue();
+        assertThat(getIcebergResult())
+                .containsExactlyInAnyOrder("Record(1, 10)", "Record(2, 20)", "Record(3, 30)");
+
+        write.close();
+        commit.close();
+    }
+
+    @Test
     public void testCommitAfterRollbackDoesNotDuplicateSchemas() throws Exception {
         RowType rowType =
                 RowType.of(


### PR DESCRIPTION
### Purpose

Closes #9342.

`expireAllBefore` reads each expired version's manifest list so it can delete the manifests that list references. The deletes use `deleteQuietly` and tolerate absence, but the read does not — so a list that is already gone fails the commit.

That happens in normal operation, because the two cleanup steps use different windows. `expireAllBefore(N)` deletes the manifest lists of every version below `N`, while `deleteApplicableMetadataFiles(N)` only deletes the metadata JSONs below `N - previous-versions-max`. `v(N-1).metadata.json` is therefore retained after a from-scratch rebuild while the list it points at has just been deleted, and the next rebuild on that table throws:

```
java.lang.RuntimeException: Failed to read snap-1-1f878b70-445c-4332-98a4-73ea0c549437.avro
    at org.apache.paimon.iceberg.IcebergCommitCallback.expireAllBefore(IcebergCommitCallback.java:985)
    at org.apache.paimon.iceberg.IcebergCommitCallback.createMetadataWithoutBase(IcebergCommitCallback.java:386)
    at org.apache.paimon.flink.sink.CommitterOperator.initializeState(CommitterOperator.java:147)
Caused by: java.io.FileNotFoundException: File '.../metadata/snap-1-1f878b70-….avro' not found
```

On Flink this is not just noisy. It surfaces from `initializeState`, so the task dies during state initialisation, no checkpoint completes, the restored committable is never dropped, and recovery replays it until later churn happens to delete the retained JSON. We have seen tables loop for ~12h.

The fix skips a manifest list that no longer exists, since the only reason to open it is to delete what it references and an earlier pass already did that. If there is a case where the read must be strict, I would be glad to hear it — that is the one assumption here.

Seen on 1.4.1 with `metadata.iceberg.storage = rest-catalog` and `previous-versions-max = 1` on Flink 2.0; the code is unchanged on `master`. No API or format change.

### Tests

`IcebergCompatibilityTest#testExpireAllBeforeSkipsAlreadyDeletedManifestList` reproduces the state directly: commit twice, delete the manifest list that the retained `v(N-1).metadata.json` points at, then delete the base metadata JSON so the next commit takes the from-scratch path and walks that retained JSON.

With the production change reverted it fails with exactly the error above, and passes with it. All 42 tests in `IcebergCompatibilityTest` pass, and `spotless:check` and `checkstyle:check` are clean on `paimon-core`.
