### PR TITLE
[format] Fix corrupt output by overlapping custom line delimiters

### DIFF
--- a/paimon-format/src/main/java/org/apache/paimon/format/text/CustomLineReader.java
+++ b/paimon-format/src/main/java/org/apache/paimon/format/text/CustomLineReader.java
@@ -32,10 +32,12 @@ public class CustomLineReader implements TextLineReader {
 
     private final InputStream inputStream;
     private final byte[] delimiter;
+    private final int[] prefixTable;
 
     public CustomLineReader(InputStream inputStream, byte[] delimiter) {
         this.inputStream = inputStream;
         this.delimiter = delimiter;
+        this.prefixTable = buildPrefixTable(delimiter);
     }
 
     @Nullable
@@ -61,6 +63,12 @@ public class CustomLineReader implements TextLineReader {
             }
 
             byte current = (byte) b;
+            while (matchIndex > 0 && current != delimiter[matchIndex]) {
+                int fallback = prefixTable[matchIndex - 1];
+                out.write(delimiter, 0, matchIndex - fallback);
+                matchIndex = fallback;
+            }
+
             if (current == delimiter[matchIndex]) {
                 // Current byte matches the next expected delimiter byte
                 matchIndex++;
@@ -68,20 +76,26 @@ public class CustomLineReader implements TextLineReader {
                     // Complete delimiter found, return the line without the delimiter
                     return out.toString(StandardCharsets.UTF_8.name());
                 }
-            } else if (matchIndex > 0) {
-                // Mismatch: handle partial matches
-                out.write(delimiter, 0, matchIndex);
-                if (current == delimiter[0]) {
-                    matchIndex = 1;
-                } else {
-                    out.write(current);
-                    matchIndex = 0;
-                }
             } else {
                 // just add the current byte to output
                 out.write(current);
             }
         }
+    }
+
+    private static int[] buildPrefixTable(byte[] delimiter) {
+        int[] table = new int[delimiter.length];
+        int matched = 0;
+        for (int i = 1; i < delimiter.length; i++) {
+            while (matched > 0 && delimiter[i] != delimiter[matched]) {
+                matched = table[matched - 1];
+            }
+            if (delimiter[i] == delimiter[matched]) {
+                matched++;
+            }
+            table[i] = matched;
+        }
+        return table;
     }
 
     @Override

--- a/paimon-format/src/test/java/org/apache/paimon/format/text/TextFileReaderTest.java
+++ b/paimon-format/src/test/java/org/apache/paimon/format/text/TextFileReaderTest.java
@@ -168,6 +168,15 @@ public class TextFileReaderTest {
     }
 
     @Test
+    public void testReadLineWithOverlappingDelimiterPrefix() throws IOException {
+        writeFile("aaabtail");
+
+        List<String> lines = readAllLines("aab");
+
+        assertThat(lines).containsExactly("a", "tail");
+    }
+
+    @Test
     public void testReadLineWithMultiByteUTF8Delimiter() throws IOException {
         // Emoji delimiter
         writeFile("line1😀line2😀line3");


### PR DESCRIPTION
### Purpose
 - Format tables supports multi character delimiters for separating records.
 - When the end of a record overlaps with the beginning of the delimiter, the reader has a bug and incorrectly streams the delimiter in the actual output, causing incorrect output rows.
  - Fix by preserving the longest possible delimiter prefix after a partial match fails.

### Tests
 - UT