### PR TITLE
[common] Correct local dependency for string conversion

### DIFF
--- a/paimon-common/src/main/java/org/apache/paimon/data/BinaryString.java
+++ b/paimon-common/src/main/java/org/apache/paimon/data/BinaryString.java
@@ -28,6 +28,7 @@ import javax.annotation.Nullable;
 import java.io.UnsupportedEncodingException;
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
+import java.util.Locale;
 
 import static org.apache.paimon.memory.MemorySegmentUtils.allocateReuseBytes;
 import static org.apache.paimon.memory.MemorySegmentUtils.allocateReuseChars;
@@ -535,7 +536,7 @@ public final class BinaryString extends BinarySection implements Comparable<Bina
     }
 
     private BinaryString javaToUpperCase() {
-        return fromString(toString().toUpperCase());
+        return fromString(toString().toUpperCase(Locale.ROOT));
     }
 
     /**
@@ -569,7 +570,7 @@ public final class BinaryString extends BinarySection implements Comparable<Bina
     }
 
     private BinaryString javaToLowerCase() {
-        return fromString(toString().toLowerCase());
+        return fromString(toString().toLowerCase(Locale.ROOT));
     }
 
     // ------------------------------------------------------------------------------------------

--- a/paimon-common/src/test/java/org/apache/paimon/data/BinaryStringTest.java
+++ b/paimon-common/src/test/java/org/apache/paimon/data/BinaryStringTest.java
@@ -30,6 +30,7 @@ import java.math.BigDecimal;
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Locale;
 import java.util.Random;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
@@ -344,6 +345,18 @@ public class BinaryStringTest {
         assertThat(row.getString(3).toLowerCase()).isEqualTo(fromString("abcdefg"));
         assertThat(row.getString(5).toUpperCase()).isEqualTo(fromString("!@#$%^*"));
         assertThat(row.getString(5).toLowerCase()).isEqualTo(fromString("!@#$%^*"));
+    }
+
+    @TestTemplate
+    public void testLocaleIndependentUpperLowerCase() {
+        Locale originalLocale = Locale.getDefault();
+        try {
+            Locale.setDefault(new Locale("tr", "TR"));
+            assertThat(fromString("äi").toUpperCase()).isEqualTo(fromString("ÄI"));
+            assertThat(fromString("ÄI").toLowerCase()).isEqualTo(fromString("äi"));
+        } finally {
+            Locale.setDefault(originalLocale);
+        }
     }
 
     @TestTemplate


### PR DESCRIPTION
### Purpose
 - Case change for non ascii strings uses JVM default locale.
 - This produces different results for the same input jvm configured locale (inconsistent results for non ascii chars)
-  Use a language neutral locale for non ascii and preserve the existing conversion for ascii path.

### Tests
 - UT