### PR TITLE
[core] Add field-id.one-based option for strictly positive Iceberg field ids

### DIFF
--- a/docs/generated/core_configuration.html
+++ b/docs/generated/core_configuration.html
@@ -663,6 +663,12 @@ under the License.
             <td>Optional endInput check partition expire used in case of batch mode or bounded stream.</td>
         </tr>
         <tr>
+            <td><h5>field-id.one-based</h5></td>
+            <td style="word-wrap: break-word;">false</td>
+            <td>Boolean</td>
+            <td>Whether to assign field ids starting from 1 instead of 0 when creating a table (ids of all columns, including nested ones, are shifted by one). Paimon historically starts field ids at 0, but some external Iceberg readers (e.g. Snowflake) reject field id 0 in Iceberg metadata. Enable when creating tables with Iceberg compatibility for such readers. Only affects table creation; existing tables (and their data files, which embed field ids) keep their original ids.</td>
+        </tr>
+        <tr>
             <td><h5>fields.default-aggregate-function</h5></td>
             <td style="word-wrap: break-word;">(none)</td>
             <td>String</td>

--- a/paimon-api/src/main/java/org/apache/paimon/CoreOptions.java
+++ b/paimon-api/src/main/java/org/apache/paimon/CoreOptions.java
@@ -2487,6 +2487,21 @@ public class CoreOptions implements Serializable {
                     .defaultValue(false)
                     .withDescription("Whether enable unique row id for append table.");
 
+    @Immutable
+    public static final ConfigOption<Boolean> FIELD_ID_ONE_BASED =
+            key("field-id.one-based")
+                    .booleanType()
+                    .defaultValue(false)
+                    .withDescription(
+                            "Whether to assign field ids starting from 1 instead of 0 when creating "
+                                    + "a table (ids of all columns, including nested ones, are "
+                                    + "shifted by one). Paimon historically starts field ids at 0, "
+                                    + "but some external Iceberg readers (e.g. Snowflake) reject "
+                                    + "field id 0 in Iceberg metadata. Enable when creating tables "
+                                    + "with Iceberg compatibility for such readers. Only affects "
+                                    + "table creation; existing tables (and their data files, which "
+                                    + "embed field ids) keep their original ids.");
+
     public static final ConfigOption<Boolean> ROW_TRACKING_PARTITION_GROUP_ON_COMMIT =
             key("row-tracking.partition-group-on-commit")
                     .booleanType()
@@ -4350,6 +4365,10 @@ public class CoreOptions implements Serializable {
 
     public boolean rowTrackingEnabled() {
         return options.get(ROW_TRACKING_ENABLED);
+    }
+
+    public boolean fieldIdOneBased() {
+        return options.get(FIELD_ID_ONE_BASED);
     }
 
     public boolean rowTrackingPartitionGroupOnCommit() {

--- a/paimon-api/src/main/java/org/apache/paimon/types/ShiftFieldId.java
+++ b/paimon-api/src/main/java/org/apache/paimon/types/ShiftFieldId.java
@@ -38,6 +38,55 @@ public class ShiftFieldId extends DataTypeDefaultVisitor<DataType> {
         return input.accept(new ShiftFieldId(offset));
     }
 
+    /** Whether any field of the type, nested ones included, carries the given field id. */
+    public static boolean containsFieldId(DataType input, int fieldId) {
+        return input.accept(new ContainsFieldId(fieldId));
+    }
+
+    private static class ContainsFieldId extends DataTypeDefaultVisitor<Boolean> {
+
+        private final int fieldId;
+
+        private ContainsFieldId(int fieldId) {
+            this.fieldId = fieldId;
+        }
+
+        @Override
+        public Boolean visit(ArrayType arrayType) {
+            return arrayType.getElementType().accept(this);
+        }
+
+        @Override
+        public Boolean visit(VectorType vectorType) {
+            return vectorType.getElementType().accept(this);
+        }
+
+        @Override
+        public Boolean visit(MultisetType multisetType) {
+            return multisetType.getElementType().accept(this);
+        }
+
+        @Override
+        public Boolean visit(MapType mapType) {
+            return mapType.getKeyType().accept(this) || mapType.getValueType().accept(this);
+        }
+
+        @Override
+        public Boolean visit(RowType rowType) {
+            for (DataField field : rowType.getFields()) {
+                if (field.id() == fieldId || field.type().accept(this)) {
+                    return true;
+                }
+            }
+            return false;
+        }
+
+        @Override
+        protected Boolean defaultMethod(DataType dataType) {
+            return false;
+        }
+    }
+
     @Override
     public DataType visit(ArrayType arrayType) {
         return new ArrayType(arrayType.isNullable(), arrayType.getElementType().accept(this));

--- a/paimon-api/src/main/java/org/apache/paimon/types/ShiftFieldId.java
+++ b/paimon-api/src/main/java/org/apache/paimon/types/ShiftFieldId.java
@@ -1,0 +1,88 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.types;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * Shift every field id in a type by a fixed offset. Unlike {@link ReassignFieldId} this preserves
+ * the relative order and gaps of the existing ids, so the result is exactly the original id space
+ * translated by {@code offset}.
+ */
+public class ShiftFieldId extends DataTypeDefaultVisitor<DataType> {
+
+    private final int offset;
+
+    public ShiftFieldId(int offset) {
+        this.offset = offset;
+    }
+
+    public static DataType shift(DataType input, int offset) {
+        return input.accept(new ShiftFieldId(offset));
+    }
+
+    @Override
+    public DataType visit(ArrayType arrayType) {
+        return new ArrayType(arrayType.isNullable(), arrayType.getElementType().accept(this));
+    }
+
+    @Override
+    public DataType visit(VectorType vectorType) {
+        return new VectorType(
+                vectorType.isNullable(),
+                vectorType.getLength(),
+                vectorType.getElementType().accept(this));
+    }
+
+    @Override
+    public DataType visit(MultisetType multisetType) {
+        return new MultisetType(
+                multisetType.isNullable(), multisetType.getElementType().accept(this));
+    }
+
+    @Override
+    public DataType visit(MapType mapType) {
+        return new MapType(
+                mapType.isNullable(),
+                mapType.getKeyType().accept(this),
+                mapType.getValueType().accept(this));
+    }
+
+    @Override
+    public DataType visit(RowType rowType) {
+        List<DataField> fields =
+                rowType.getFields().stream()
+                        .map(
+                                f ->
+                                        new DataField(
+                                                f.id() + offset,
+                                                f.name(),
+                                                f.type().accept(this),
+                                                f.description(),
+                                                f.defaultValue()))
+                        .collect(Collectors.toList());
+        return new RowType(rowType.isNullable(), fields);
+    }
+
+    @Override
+    protected DataType defaultMethod(DataType dataType) {
+        return dataType;
+    }
+}

--- a/paimon-core/src/main/java/org/apache/paimon/schema/SchemaManager.java
+++ b/paimon-core/src/main/java/org/apache/paimon/schema/SchemaManager.java
@@ -350,6 +350,16 @@ public class SchemaManager implements Serializable {
                 if (!unchanged && CoreOptions.TYPE.key().equals(setOption.key())) {
                     throw new UnsupportedOperationException("Change 'type' is not supported yet.");
                 }
+                // reject even without snapshots: field ids are assigned once at creation,
+                // so changing the value later only makes the option lie about the schema
+                // (restating the effective value, e.g. an explicit default, stays allowed)
+                if (CoreOptions.FIELD_ID_ONE_BASED.key().equals(setOption.key())
+                        && Boolean.parseBoolean(oldValue) != Boolean.parseBoolean(newValue)) {
+                    throw new UnsupportedOperationException(
+                            "Change '"
+                                    + CoreOptions.FIELD_ID_ONE_BASED.key()
+                                    + "' is not supported.");
+                }
                 if (hasSnapshots.get() && !unchanged) {
                     checkAlterTableOption(oldOptions, setOption.key(), oldValue, newValue);
                 }
@@ -360,6 +370,14 @@ public class SchemaManager implements Serializable {
                 RemoveOption removeOption = (RemoveOption) change;
                 if (CoreOptions.TYPE.key().equals(removeOption.key())) {
                     throw new UnsupportedOperationException("Change 'type' is not supported yet.");
+                }
+                if (CoreOptions.FIELD_ID_ONE_BASED.key().equals(removeOption.key())
+                        && Boolean.parseBoolean(oldOptions.get(removeOption.key()))) {
+                    // removing the option while it is true changes the effective value
+                    throw new UnsupportedOperationException(
+                            "Change '"
+                                    + CoreOptions.FIELD_ID_ONE_BASED.key()
+                                    + "' is not supported.");
                 }
                 if (hasSnapshots.get()) {
                     checkResetTableOption(oldOptions, removeOption.key());

--- a/paimon-core/src/main/java/org/apache/paimon/schema/SchemaManager.java
+++ b/paimon-core/src/main/java/org/apache/paimon/schema/SchemaManager.java
@@ -25,6 +25,7 @@ import org.apache.paimon.catalog.Catalog;
 import org.apache.paimon.catalog.Identifier;
 import org.apache.paimon.fs.FileIO;
 import org.apache.paimon.fs.Path;
+import org.apache.paimon.options.Options;
 import org.apache.paimon.schema.ColumnDirectiveUtils.ConvertedColumn;
 import org.apache.paimon.schema.SchemaChange.AddColumn;
 import org.apache.paimon.schema.SchemaChange.DropColumn;
@@ -227,7 +228,27 @@ public class SchemaManager implements Serializable {
         if (!CoreOptions.fromMap(schema.options()).fieldIdOneBased()) {
             return schema;
         }
+        if (!ShiftFieldId.containsFieldId(schema.rowType(), 0)) {
+            // Already conformant: no field carries id 0. A persisted schema passed back into
+            // creation (e.g. the copy_files procedure copies a table's fields together with
+            // this option) must keep its ids, which the copied data files embed.
+            return schema;
+        }
         return schema.copy((RowType) ShiftFieldId.shift(schema.rowType(), 1));
+    }
+
+    /**
+     * The effective value of {@link CoreOptions#FIELD_ID_ONE_BASED} for a raw option string, parsed
+     * strictly: an invalid value is rejected here instead of being persisted as an accidental
+     * {@code false} that the immutability check would then freeze forever.
+     */
+    private static boolean fieldIdOneBasedValue(@Nullable String value) {
+        if (value == null) {
+            return CoreOptions.FIELD_ID_ONE_BASED.defaultValue();
+        }
+        Options options = new Options();
+        options.setString(CoreOptions.FIELD_ID_ONE_BASED.key(), value);
+        return options.get(CoreOptions.FIELD_ID_ONE_BASED);
     }
 
     private void checkSchemaForExternalTable(Schema existsSchema, Schema newSchema) {
@@ -354,7 +375,7 @@ public class SchemaManager implements Serializable {
                 // so changing the value later only makes the option lie about the schema
                 // (restating the effective value, e.g. an explicit default, stays allowed)
                 if (CoreOptions.FIELD_ID_ONE_BASED.key().equals(setOption.key())
-                        && Boolean.parseBoolean(oldValue) != Boolean.parseBoolean(newValue)) {
+                        && fieldIdOneBasedValue(oldValue) != fieldIdOneBasedValue(newValue)) {
                     throw new UnsupportedOperationException(
                             "Change '"
                                     + CoreOptions.FIELD_ID_ONE_BASED.key()
@@ -372,7 +393,7 @@ public class SchemaManager implements Serializable {
                     throw new UnsupportedOperationException("Change 'type' is not supported yet.");
                 }
                 if (CoreOptions.FIELD_ID_ONE_BASED.key().equals(removeOption.key())
-                        && Boolean.parseBoolean(oldOptions.get(removeOption.key()))) {
+                        && fieldIdOneBasedValue(oldOptions.get(removeOption.key()))) {
                     // removing the option while it is true changes the effective value
                     throw new UnsupportedOperationException(
                             "Change '"

--- a/paimon-core/src/main/java/org/apache/paimon/schema/SchemaManager.java
+++ b/paimon-core/src/main/java/org/apache/paimon/schema/SchemaManager.java
@@ -46,6 +46,7 @@ import org.apache.paimon.types.DataTypeCasts;
 import org.apache.paimon.types.MapType;
 import org.apache.paimon.types.ReassignFieldId;
 import org.apache.paimon.types.RowType;
+import org.apache.paimon.types.ShiftFieldId;
 import org.apache.paimon.utils.BranchManager;
 import org.apache.paimon.utils.ChangelogManager;
 import org.apache.paimon.utils.LazyField;
@@ -204,6 +205,7 @@ public class SchemaManager implements Serializable {
             }
 
             schema = applyDirectives(schema);
+            schema = applyFieldIdOneBased(schema);
             TableSchema newSchema = TableSchema.create(0, schema);
 
             // validate table from creating table
@@ -214,6 +216,18 @@ public class SchemaManager implements Serializable {
                 return newSchema;
             }
         }
+    }
+
+    /**
+     * Shift all field ids of a new table by one when {@link CoreOptions#FIELD_ID_ONE_BASED} is set.
+     * Applied only at table creation: data files embed these ids (Parquet footers, Iceberg
+     * metadata), so the id space of an existing table must never be re-based.
+     */
+    private static Schema applyFieldIdOneBased(Schema schema) {
+        if (!CoreOptions.fromMap(schema.options()).fieldIdOneBased()) {
+            return schema;
+        }
+        return schema.copy((RowType) ShiftFieldId.shift(schema.rowType(), 1));
     }
 
     private void checkSchemaForExternalTable(Schema existsSchema, Schema newSchema) {

--- a/paimon-core/src/test/java/org/apache/paimon/schema/FieldIdOneBasedTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/schema/FieldIdOneBasedTest.java
@@ -1,0 +1,121 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.schema;
+
+import org.apache.paimon.CoreOptions;
+import org.apache.paimon.fs.Path;
+import org.apache.paimon.fs.local.LocalFileIO;
+import org.apache.paimon.types.ArrayType;
+import org.apache.paimon.types.DataField;
+import org.apache.paimon.types.DataTypes;
+import org.apache.paimon.types.MapType;
+import org.apache.paimon.types.RowType;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.util.List;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Tests for {@link CoreOptions#FIELD_ID_ONE_BASED} at table creation and evolution. */
+public class FieldIdOneBasedTest {
+
+    @TempDir java.nio.file.Path tempDir;
+
+    private Schema.Builder schemaBuilder() {
+        return Schema.newBuilder()
+                .column("a", DataTypes.INT())
+                .column(
+                        "s",
+                        DataTypes.ROW(
+                                DataTypes.FIELD(0, "x", DataTypes.INT()),
+                                DataTypes.FIELD(0, "y", DataTypes.STRING())))
+                .column("m", DataTypes.MAP(DataTypes.STRING(), DataTypes.ARRAY(DataTypes.INT())));
+    }
+
+    private SchemaManager newSchemaManager(String name) {
+        return new SchemaManager(
+                LocalFileIO.create(),
+                new Path(tempDir.toString() + "/" + name + UUID.randomUUID()));
+    }
+
+    @Test
+    public void testDefaultRemainsZeroBased() throws Exception {
+        TableSchema schema = newSchemaManager("t").createTable(schemaBuilder().build());
+        assertThat(topLevelIds(schema)).containsExactly(0, 1, 4);
+        RowType nested = (RowType) schema.fields().get(1).type();
+        assertThat(nested.getFields().get(0).id()).isEqualTo(2);
+        assertThat(nested.getFields().get(1).id()).isEqualTo(3);
+        assertThat(schema.highestFieldId()).isEqualTo(4);
+    }
+
+    @Test
+    public void testOneBasedShiftsAllIds() throws Exception {
+        TableSchema schema =
+                newSchemaManager("t")
+                        .createTable(
+                                schemaBuilder()
+                                        .option(CoreOptions.FIELD_ID_ONE_BASED.key(), "true")
+                                        .build());
+        assertThat(topLevelIds(schema)).containsExactly(1, 2, 5);
+        RowType nested = (RowType) schema.fields().get(1).type();
+        assertThat(nested.getFields().get(0).id()).isEqualTo(3);
+        assertThat(nested.getFields().get(1).id()).isEqualTo(4);
+        // map/array types carry no ids of their own; ensure the structure survived the shift
+        MapType map = (MapType) schema.fields().get(2).type();
+        assertThat(map.getValueType()).isInstanceOf(ArrayType.class);
+        assertThat(schema.highestFieldId()).isEqualTo(5);
+    }
+
+    @Test
+    public void testEvolutionContinuesFromShiftedIds() throws Exception {
+        SchemaManager manager = newSchemaManager("t");
+        manager.createTable(
+                schemaBuilder().option(CoreOptions.FIELD_ID_ONE_BASED.key(), "true").build());
+        TableSchema evolved = manager.commitChanges(SchemaChange.addColumn("z", DataTypes.INT()));
+        DataField added =
+                evolved.fields().stream()
+                        .filter(f -> f.name().equals("z"))
+                        .findFirst()
+                        .orElseThrow(IllegalStateException::new);
+        assertThat(added.id()).isEqualTo(6);
+        assertThat(evolved.highestFieldId()).isEqualTo(6);
+    }
+
+    @Test
+    public void testOneBasedImmutableAndCreateTimeOnly() throws Exception {
+        // registered as immutable, so ALTER is rejected once the table has snapshots
+        assertThat(CoreOptions.IMMUTABLE_OPTIONS).contains(CoreOptions.FIELD_ID_ONE_BASED.key());
+        // a pre-snapshot option change must not re-base ids: assignment happens at creation only
+        SchemaManager manager = newSchemaManager("t");
+        manager.createTable(schemaBuilder().build());
+        TableSchema altered =
+                manager.commitChanges(
+                        SchemaChange.setOption(CoreOptions.FIELD_ID_ONE_BASED.key(), "true"));
+        assertThat(topLevelIds(altered)).containsExactly(0, 1, 4);
+        assertThat(altered.highestFieldId()).isEqualTo(4);
+    }
+
+    private static List<Integer> topLevelIds(TableSchema schema) {
+        return schema.fields().stream().map(DataField::id).collect(Collectors.toList());
+    }
+}

--- a/paimon-core/src/test/java/org/apache/paimon/schema/FieldIdOneBasedTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/schema/FieldIdOneBasedTest.java
@@ -35,6 +35,7 @@ import java.util.UUID;
 import java.util.stream.Collectors;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /** Tests for {@link CoreOptions#FIELD_ID_ONE_BASED} at table creation and evolution. */
 public class FieldIdOneBasedTest {
@@ -105,14 +106,33 @@ public class FieldIdOneBasedTest {
     public void testOneBasedImmutableAndCreateTimeOnly() throws Exception {
         // registered as immutable, so ALTER is rejected once the table has snapshots
         assertThat(CoreOptions.IMMUTABLE_OPTIONS).contains(CoreOptions.FIELD_ID_ONE_BASED.key());
-        // a pre-snapshot option change must not re-base ids: assignment happens at creation only
+        // ids are assigned once at creation, so changing the value is rejected even before the
+        // first snapshot: the ids would keep their base while the option claims another one
         SchemaManager manager = newSchemaManager("t");
         manager.createTable(schemaBuilder().build());
-        TableSchema altered =
+        assertThatThrownBy(
+                        () ->
+                                manager.commitChanges(
+                                        SchemaChange.setOption(
+                                                CoreOptions.FIELD_ID_ONE_BASED.key(), "true")))
+                .isInstanceOf(UnsupportedOperationException.class)
+                .hasMessageContaining(CoreOptions.FIELD_ID_ONE_BASED.key());
+        // removing the option from a one-based table would change the effective value back
+        SchemaManager oneBased = newSchemaManager("t2");
+        oneBased.createTable(
+                schemaBuilder().option(CoreOptions.FIELD_ID_ONE_BASED.key(), "true").build());
+        assertThatThrownBy(
+                        () ->
+                                oneBased.commitChanges(
+                                        SchemaChange.removeOption(
+                                                CoreOptions.FIELD_ID_ONE_BASED.key())))
+                .isInstanceOf(UnsupportedOperationException.class)
+                .hasMessageContaining(CoreOptions.FIELD_ID_ONE_BASED.key());
+        // re-stating the current value is a no-op, not a change, and stays allowed
+        TableSchema unchanged =
                 manager.commitChanges(
-                        SchemaChange.setOption(CoreOptions.FIELD_ID_ONE_BASED.key(), "true"));
-        assertThat(topLevelIds(altered)).containsExactly(0, 1, 4);
-        assertThat(altered.highestFieldId()).isEqualTo(4);
+                        SchemaChange.setOption(CoreOptions.FIELD_ID_ONE_BASED.key(), "false"));
+        assertThat(topLevelIds(unchanged)).containsExactly(0, 1, 4);
     }
 
     private static List<Integer> topLevelIds(TableSchema schema) {

--- a/paimon-core/src/test/java/org/apache/paimon/schema/FieldIdOneBasedTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/schema/FieldIdOneBasedTest.java
@@ -103,6 +103,52 @@ public class FieldIdOneBasedTest {
     }
 
     @Test
+    public void testCreateFromPersistedOneBasedSchemaPreservesIds() throws Exception {
+        // the copy_files procedure rebuilds a Schema from a persisted TableSchema, options
+        // included; already-shifted ids must survive creation unchanged, since the copied
+        // data files embed them
+        SchemaManager source = newSchemaManager("src");
+        TableSchema sourceSchema =
+                source.createTable(
+                        schemaBuilder()
+                                .option(CoreOptions.FIELD_ID_ONE_BASED.key(), "true")
+                                .build());
+        assertThat(topLevelIds(sourceSchema)).containsExactly(1, 2, 5);
+
+        Schema copied =
+                new Schema(
+                        sourceSchema.fields(),
+                        sourceSchema.partitionKeys(),
+                        sourceSchema.primaryKeys(),
+                        sourceSchema.options(),
+                        sourceSchema.comment());
+        TableSchema copiedSchema = newSchemaManager("dst").createTable(copied);
+        assertThat(topLevelIds(copiedSchema)).isEqualTo(topLevelIds(sourceSchema));
+        RowType sourceNested = (RowType) sourceSchema.fields().get(1).type();
+        RowType copiedNested = (RowType) copiedSchema.fields().get(1).type();
+        assertThat(copiedNested.getFields().stream().map(DataField::id))
+                .containsExactlyElementsOf(
+                        sourceNested.getFields().stream()
+                                .map(DataField::id)
+                                .collect(java.util.stream.Collectors.toList()));
+        assertThat(copiedSchema.highestFieldId()).isEqualTo(sourceSchema.highestFieldId());
+    }
+
+    @Test
+    public void testInvalidOptionValueRejected() throws Exception {
+        SchemaManager manager = newSchemaManager("t");
+        manager.createTable(schemaBuilder().build());
+        // a lax parse would persist this as an accidental 'false' that the immutability
+        // check then freezes forever
+        assertThatThrownBy(
+                        () ->
+                                manager.commitChanges(
+                                        SchemaChange.setOption(
+                                                CoreOptions.FIELD_ID_ONE_BASED.key(), "yes")))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
     public void testOneBasedImmutableAndCreateTimeOnly() throws Exception {
         // registered as immutable, so ALTER is rejected once the table has snapshots
         assertThat(CoreOptions.IMMUTABLE_OPTIONS).contains(CoreOptions.FIELD_ID_ONE_BASED.key());

--- a/paimon-iceberg/src/test/java/org/apache/paimon/core/IcebergFieldIdOneBasedCompatibilityTest.java
+++ b/paimon-iceberg/src/test/java/org/apache/paimon/core/IcebergFieldIdOneBasedCompatibilityTest.java
@@ -1,0 +1,377 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.core;
+
+import org.apache.paimon.CoreOptions;
+import org.apache.paimon.catalog.FileSystemCatalog;
+import org.apache.paimon.catalog.Identifier;
+import org.apache.paimon.data.BinaryRow;
+import org.apache.paimon.data.BinaryRowWriter;
+import org.apache.paimon.data.BinaryString;
+import org.apache.paimon.data.GenericRow;
+import org.apache.paimon.data.InternalRow;
+import org.apache.paimon.disk.IOManagerImpl;
+import org.apache.paimon.fs.Path;
+import org.apache.paimon.fs.local.LocalFileIO;
+import org.apache.paimon.iceberg.IcebergOptions;
+import org.apache.paimon.iceberg.IcebergPathFactory;
+import org.apache.paimon.iceberg.manifest.IcebergManifestFileMeta;
+import org.apache.paimon.iceberg.manifest.IcebergManifestList;
+import org.apache.paimon.iceberg.metadata.IcebergDataField;
+import org.apache.paimon.iceberg.metadata.IcebergMetadata;
+import org.apache.paimon.iceberg.metadata.IcebergPartitionField;
+import org.apache.paimon.iceberg.metadata.IcebergSchema;
+import org.apache.paimon.iceberg.metadata.IcebergStructType;
+import org.apache.paimon.options.MemorySize;
+import org.apache.paimon.options.Options;
+import org.apache.paimon.reader.RecordReader;
+import org.apache.paimon.schema.Schema;
+import org.apache.paimon.table.FileStoreTable;
+import org.apache.paimon.table.sink.TableCommitImpl;
+import org.apache.paimon.table.sink.TableWriteImpl;
+import org.apache.paimon.table.source.ReadBuilder;
+import org.apache.paimon.table.source.Split;
+import org.apache.paimon.types.DataField;
+import org.apache.paimon.types.DataTypes;
+import org.apache.paimon.types.RowKind;
+import org.apache.paimon.types.RowType;
+
+import org.apache.paimon.shade.org.apache.parquet.hadoop.ParquetFileReader;
+import org.apache.paimon.shade.org.apache.parquet.schema.GroupType;
+import org.apache.paimon.shade.org.apache.parquet.schema.MessageType;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.iceberg.Table;
+import org.apache.iceberg.catalog.TableIdentifier;
+import org.apache.iceberg.data.IcebergGenerics;
+import org.apache.iceberg.data.Record;
+import org.apache.iceberg.hadoop.HadoopCatalog;
+import org.apache.iceberg.io.CloseableIterable;
+import org.apache.iceberg.types.Types;
+import org.apache.iceberg.util.StructLikeSet;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.file.Files;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests for {@link CoreOptions#FIELD_ID_ONE_BASED} with Iceberg compatibility: a table created with
+ * 1-based field ids must emit strictly positive ids in Iceberg metadata that exactly match the ids
+ * embedded in the Parquet data files (readers like Snowflake reject field id 0 and resolve columns
+ * by the physical ids).
+ */
+public class IcebergFieldIdOneBasedCompatibilityTest {
+
+    @TempDir java.nio.file.Path tempDir;
+
+    private RowType rowType() {
+        return new RowType(
+                Arrays.asList(
+                        new DataField(0, "pt", DataTypes.INT().notNull()),
+                        new DataField(1, "k", DataTypes.INT().notNull()),
+                        new DataField(2, "v", DataTypes.STRING()),
+                        new DataField(
+                                3,
+                                "nested",
+                                new RowType(
+                                        Arrays.asList(
+                                                new DataField(4, "a", DataTypes.INT()),
+                                                new DataField(5, "b", DataTypes.STRING()))))));
+    }
+
+    @Test
+    public void testStrictModePrimaryKeyDvTable() throws Exception {
+        Map<String, String> customOptions = new HashMap<>();
+        customOptions.put(CoreOptions.FIELD_ID_ONE_BASED.key(), "true");
+        customOptions.put(CoreOptions.DELETION_VECTORS_ENABLED.key(), "true");
+        customOptions.put(CoreOptions.DELETION_VECTOR_BITMAP64.key(), "true");
+        customOptions.put(IcebergOptions.FORMAT_VERSION.key(), "3");
+
+        FileStoreTable table = createPaimonTable(customOptions);
+
+        // the Paimon schema itself is 1-based, top-level and nested alike
+        List<DataField> fields = table.schema().fields();
+        assertThat(fields.stream().map(DataField::id)).containsExactly(1, 2, 3, 4);
+        RowType nested = (RowType) fields.get(3).type();
+        assertThat(nested.getFields().stream().map(DataField::id)).containsExactly(5, 6);
+        assertThat(table.schema().highestFieldId()).isEqualTo(6);
+
+        String commitUser = UUID.randomUUID().toString();
+        TableWriteImpl<?> write =
+                table.newWrite(commitUser)
+                        .withIOManager(new IOManagerImpl(tempDir.toString() + "/tmp"));
+        TableCommitImpl commit = table.newCommit(commitUser);
+
+        write.write(row(RowKind.INSERT, 1, 1, "a", 10, "x"));
+        write.write(row(RowKind.INSERT, 1, 2, "b", 20, "y"));
+        commit.commit(1, write.prepareCommit(false, 1));
+
+        write.write(row(RowKind.DELETE, 1, 2, "b", 20, "y"));
+        commit.commit(2, write.prepareCommit(false, 2));
+
+        // produce a deletion vector
+        write.compact(partition(1), 0, false);
+        commit.commit(3, write.prepareCommit(true, 3));
+        write.close();
+        commit.close();
+
+        IcebergMetadata metadata = readLatestIcebergMetadata(table);
+
+        // 1) metadata field ids are strictly positive and match the Paimon schema
+        assertThat(metadata.formatVersion()).isEqualTo(3);
+        for (IcebergSchema schema : metadata.schemas()) {
+            assertThat(collectAllFieldIds(schema.fields())).allMatch(id -> id >= 1);
+        }
+        IcebergSchema currentSchema = metadata.schemas().get(metadata.currentSchemaId());
+        assertThat(currentSchema.fields().stream().map(IcebergDataField::id))
+                .containsExactly(1, 2, 3, 4);
+        IcebergStructType nestedType = (IcebergStructType) currentSchema.fields().get(3).type();
+        assertThat(nestedType.fields().stream().map(IcebergDataField::id)).containsExactly(5, 6);
+        assertThat(metadata.lastColumnId()).isEqualTo(4);
+
+        // 2) partition source ids reference the shifted ids
+        assertThat(metadata.partitionSpecs()).hasSize(1);
+        List<IcebergPartitionField> partitionFields = metadata.partitionSpecs().get(0).fields();
+        assertThat(partitionFields).hasSize(1);
+        assertThat(partitionFields.get(0).sourceId()).isEqualTo(1);
+        assertThat(partitionFields.get(0).fieldId())
+                .isGreaterThanOrEqualTo(IcebergPartitionField.FIRST_FIELD_ID);
+
+        // 3) v3 data manifest-list entries carry a non-null first_row_id
+        IcebergPathFactory paths = new IcebergPathFactory(new Path(table.location(), "metadata"));
+        IcebergManifestList manifestList = IcebergManifestList.create(table, paths);
+        List<IcebergManifestFileMeta> metas =
+                manifestList.read(new Path(metadata.currentSnapshot().manifestList()).getName());
+        assertThat(metas).isNotEmpty();
+        assertThat(metas.stream().filter(m -> m.content() == IcebergManifestFileMeta.Content.DATA))
+                .allMatch(m -> m.firstRowId() != null);
+
+        // 4) Parquet footers embed exactly the metadata ids
+        List<java.nio.file.Path> parquetFiles = dataParquetFiles(table);
+        assertThat(parquetFiles).isNotEmpty();
+        for (java.nio.file.Path file : parquetFiles) {
+            MessageType parquetSchema = readParquetSchema(file);
+            assertFieldId(parquetSchema, "pt", 1);
+            assertFieldId(parquetSchema, "k", 2);
+            assertFieldId(parquetSchema, "v", 3);
+            assertFieldId(parquetSchema, "nested", 4);
+            GroupType nestedGroup = parquetSchema.getType("nested").asGroupType();
+            assertFieldId(nestedGroup, "a", 5);
+            assertFieldId(nestedGroup, "b", 6);
+        }
+
+        // 5) Apache Iceberg reads the table (schema ids and data, with the DV applied)
+        HadoopCatalog icebergCatalog = new HadoopCatalog(new Configuration(), tempDir.toString());
+        Table icebergTable = icebergCatalog.loadTable(TableIdentifier.of("mydb.db", "t"));
+        assertThat(icebergTable.schema().findField("pt").fieldId()).isEqualTo(1);
+        assertThat(icebergTable.schema().findField("k").fieldId()).isEqualTo(2);
+        assertThat(icebergTable.schema().findField("v").fieldId()).isEqualTo(3);
+        assertThat(icebergTable.schema().findField("nested").fieldId()).isEqualTo(4);
+        assertThat(icebergTable.schema().findField("nested.a").fieldId()).isEqualTo(5);
+        assertThat(icebergTable.schema().findField("nested.b").fieldId()).isEqualTo(6);
+
+        Types.StructType structType = icebergTable.schema().asStruct();
+        StructLikeSet actual = StructLikeSet.create(structType);
+        try (CloseableIterable<Record> reader = IcebergGenerics.read(icebergTable).build()) {
+            reader.forEach(actual::add);
+        }
+        org.apache.iceberg.data.GenericRecord expected =
+                org.apache.iceberg.data.GenericRecord.create(structType);
+        expected.set(0, 1);
+        expected.set(1, 1);
+        expected.set(2, "a");
+        org.apache.iceberg.data.GenericRecord expectedNested =
+                org.apache.iceberg.data.GenericRecord.create(
+                        structType.fieldType("nested").asStructType());
+        expectedNested.set(0, 10);
+        expectedNested.set(1, "x");
+        expected.set(3, expectedNested);
+        StructLikeSet expectedSet = StructLikeSet.create(structType);
+        expectedSet.add(expected);
+        assertThat(actual).isEqualTo(expectedSet);
+
+        // 6) Paimon itself reads the strict-mode files
+        List<InternalRow> rows = readPaimonRows(table);
+        assertThat(rows).hasSize(1);
+        InternalRow row = rows.get(0);
+        assertThat(row.getInt(0)).isEqualTo(1);
+        assertThat(row.getInt(1)).isEqualTo(1);
+        assertThat(row.getString(2).toString()).isEqualTo("a");
+        assertThat(row.getRow(3, 2).getInt(0)).isEqualTo(10);
+        assertThat(row.getRow(3, 2).getString(1).toString()).isEqualTo("x");
+    }
+
+    @Test
+    public void testDefaultRemainsZeroBased() throws Exception {
+        Map<String, String> customOptions = new HashMap<>();
+        customOptions.put(IcebergOptions.FORMAT_VERSION.key(), "3");
+        FileStoreTable table = createPaimonTable(customOptions);
+
+        assertThat(table.schema().fields().stream().map(DataField::id)).containsExactly(0, 1, 2, 3);
+
+        String commitUser = UUID.randomUUID().toString();
+        TableWriteImpl<?> write =
+                table.newWrite(commitUser)
+                        .withIOManager(new IOManagerImpl(tempDir.toString() + "/tmp"));
+        TableCommitImpl commit = table.newCommit(commitUser);
+        write.write(row(RowKind.INSERT, 1, 1, "a", 10, "x"));
+        commit.commit(1, write.prepareCommit(false, 1));
+        write.close();
+        commit.close();
+
+        IcebergMetadata metadata = readLatestIcebergMetadata(table);
+        IcebergSchema currentSchema = metadata.schemas().get(metadata.currentSchemaId());
+        assertThat(currentSchema.fields().stream().map(IcebergDataField::id))
+                .containsExactly(0, 1, 2, 3);
+    }
+
+    private FileStoreTable createPaimonTable(Map<String, String> customOptions) throws Exception {
+        LocalFileIO fileIO = LocalFileIO.create();
+        Path path = new Path(tempDir.toString());
+
+        Options options = new Options(customOptions);
+        options.set(CoreOptions.BUCKET, 1);
+        options.set(
+                IcebergOptions.METADATA_ICEBERG_STORAGE, IcebergOptions.StorageType.TABLE_LOCATION);
+        options.set(CoreOptions.FILE_FORMAT, "parquet");
+        options.set(CoreOptions.TARGET_FILE_SIZE, MemorySize.ofKibiBytes(32));
+
+        Schema schema =
+                new Schema(
+                        rowType().getFields(),
+                        Collections.singletonList("pt"),
+                        Arrays.asList("pt", "k"),
+                        options.toMap(),
+                        "");
+
+        try (FileSystemCatalog paimonCatalog = new FileSystemCatalog(fileIO, path)) {
+            paimonCatalog.createDatabase("mydb", false);
+            Identifier paimonIdentifier = Identifier.create("mydb", "t");
+            paimonCatalog.createTable(paimonIdentifier, schema, false);
+            return (FileStoreTable) paimonCatalog.getTable(paimonIdentifier);
+        }
+    }
+
+    private static GenericRow row(RowKind kind, int pt, int k, String v, int a, String b) {
+        return GenericRow.ofKind(
+                kind,
+                pt,
+                k,
+                BinaryString.fromString(v),
+                GenericRow.of(a, BinaryString.fromString(b)));
+    }
+
+    private static BinaryRow partition(int pt) {
+        BinaryRow partition = new BinaryRow(1);
+        BinaryRowWriter writer = new BinaryRowWriter(partition);
+        writer.writeInt(0, pt);
+        writer.complete();
+        return partition;
+    }
+
+    private IcebergMetadata readLatestIcebergMetadata(FileStoreTable table) throws IOException {
+        java.nio.file.Path metadataDir =
+                java.nio.file.Paths.get(new Path(table.location(), "metadata").toUri().getPath());
+        java.nio.file.Path latest;
+        try (Stream<java.nio.file.Path> files = Files.list(metadataDir)) {
+            latest =
+                    files.filter(f -> f.getFileName().toString().endsWith(".metadata.json"))
+                            .max(
+                                    java.util.Comparator.comparingLong(
+                                            f ->
+                                                    Long.parseLong(
+                                                            f.getFileName()
+                                                                    .toString()
+                                                                    .replaceAll("[^0-9]", ""))))
+                            .orElseThrow(() -> new IllegalStateException("no metadata.json found"));
+        }
+        return IcebergMetadata.fromPath(LocalFileIO.create(), new Path(latest.toUri()));
+    }
+
+    private List<java.nio.file.Path> dataParquetFiles(FileStoreTable table) throws IOException {
+        java.nio.file.Path tableDir = java.nio.file.Paths.get(table.location().toUri().getPath());
+        try (Stream<java.nio.file.Path> files = Files.walk(tableDir)) {
+            return files.filter(f -> f.getFileName().toString().endsWith(".parquet"))
+                    .filter(f -> !f.toString().contains("/metadata/"))
+                    .collect(Collectors.toList());
+        }
+    }
+
+    private MessageType readParquetSchema(java.nio.file.Path file) {
+        try (ParquetFileReader reader =
+                org.apache.paimon.format.parquet.ParquetUtil.getParquetReader(
+                        LocalFileIO.create(),
+                        new Path(file.toUri()),
+                        Files.size(file),
+                        new Options())) {
+            return reader.getFooter().getFileMetaData().getSchema();
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+
+    private static void assertFieldId(GroupType parent, String name, int expectedId) {
+        org.apache.paimon.shade.org.apache.parquet.schema.Type field = parent.getType(name);
+        assertThat(field.getId()).as("field id of '%s'", name).isNotNull();
+        assertThat(field.getId().intValue()).as("field id of '%s'", name).isEqualTo(expectedId);
+    }
+
+    private static List<Integer> collectAllFieldIds(List<IcebergDataField> fields) {
+        List<Integer> ids = new ArrayList<>();
+        for (IcebergDataField field : fields) {
+            ids.add(field.id());
+            if (field.type() instanceof IcebergStructType) {
+                ids.addAll(collectAllFieldIds(((IcebergStructType) field.type()).fields()));
+            }
+        }
+        return ids;
+    }
+
+    private static List<InternalRow> readPaimonRows(FileStoreTable table) throws Exception {
+        ReadBuilder readBuilder = table.newReadBuilder();
+        List<Split> splits = readBuilder.newScan().plan().splits();
+        List<InternalRow> rows = new ArrayList<>();
+        try (RecordReader<InternalRow> reader = readBuilder.newRead().createReader(splits)) {
+            reader.forEachRemaining(
+                    r ->
+                            rows.add(
+                                    GenericRow.of(
+                                            r.getInt(0),
+                                            r.getInt(1),
+                                            r.getString(2).copy(),
+                                            GenericRow.of(
+                                                    r.getRow(3, 2).getInt(0),
+                                                    r.getRow(3, 2).getString(1).copy()))));
+        }
+        return rows;
+    }
+}


### PR DESCRIPTION
### Purpose

Paimon starts field ids at 0. The Iceberg ecosystem starts them at 1. Because of this, Iceberg metadata for a Paimon table contains a field with id 0. Some external Iceberg readers reject these tables. For example, Snowflake refuses them. This also requires workarounds elsewhere. When a partition column has field id 0, the REST committer creates a dummy schema or falls back to partition evolution.

This PR adds an opt-in table option, `field-id.one-based`. It shifts every field id by one when the table is created. This includes top-level and nested fields. The table's id space then matches what Iceberg-native readers expect from the start.

```
CREATE TABLE t (...) WITH (
    'field-id.one-based' = 'true',
    'metadata.iceberg.storage' = 'rest-catalog',
    ...
);
```

Design points:

* **Creation-time only, immutable.** Field ids are stored in data files (Parquet footers) and Iceberg metadata. Changing the base of an existing table would break column resolution. The option is `@Immutable`. It is applied once in `SchemaManager.createTable`. Existing tables keep their ids.
* **A shift, not a reassignment.** The new `ShiftFieldId` visitor moves the whole id space by a fixed offset. It keeps the relative order and any gaps. This differs from `ReassignFieldId`, which renumbers ids without gaps. Schema evolution then continues from the shifted highest field id.
* **Default unchanged.** If the option is not set, ids remain zero-based. The result is byte-for-byte identical to today.

### Tests

* `FieldIdOneBasedTest` (paimon-core): checks that the default stays zero-based, nested ids are shifted, schema evolution continues from the shifted ids, and the option is create-time-only and immutable.
* `IcebergFieldIdOneBasedCompatibilityTest` (paimon-iceberg): runs end-to-end on a primary-key DV table with Iceberg format version 3. It checks that the Paimon schema, Iceberg metadata, and Parquet footers all use the same strictly positive ids. It verifies them with the Iceberg reader. It also includes a control test showing that the default remains zero-based.

### API and Format

New optional table option `field-id.one-based`. Its default is `false`, and it is immutable. Existing tables and the default id assignment do not change.

### Documentation

The option is documented in its description, which is included in the generated configuration docs.

---

*AI notice: The code is generated using Fable 5 (with reviews from Codex) but has been verified to run on a real cluster with Flink, Paimon, Iceberg, StarRocks and Snowflake.*
