### PR TITLE
[spark] Cover the zero a truncation reports surviving a later ANALYZE

### DIFF
--- a/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/sql/CatalogManagedPartitionAnalyzeTest.scala
+++ b/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/sql/CatalogManagedPartitionAnalyzeTest.scala
@@ -42,6 +42,33 @@ import scala.collection.JavaConverters._
  */
 class CatalogManagedPartitionAnalyzeTest extends PaimonSparkTestWithRestCatalogBase {
 
+  test("ANALYZE after a TRUNCATE keeps the exact zero the truncation reported") {
+    val tableName = "analyze_after_truncate"
+    withTable(tableName) {
+      createTable(tableName)
+      writeCsvPartition(tableName, "20260101", "00", 1)
+      repair(tableName)
+      sql(s"ANALYZE TABLE ${qualified(tableName)} COMPUTE STATISTICS NOSCAN").collect()
+      assert(statisticsOf(tableName, "20260101", "00").fileCount() == 1L)
+
+      sql(s"TRUNCATE TABLE ${qualified(tableName)} PARTITION (dt = '20260101', hour = '00')")
+      val truncated = statisticsOf(tableName, "20260101", "00")
+      assert(truncated.fileCount() == 0L, truncated.toString)
+      assert(truncated.recordCount() == 0L, truncated.toString)
+
+      // Measuring an empty partition must not turn "nothing is here" back into "nobody measured".
+      sql(s"ANALYZE TABLE ${qualified(tableName)} COMPUTE STATISTICS NOSCAN").collect()
+      val listed = statisticsOf(tableName, "20260101", "00")
+      assert(listed.fileCount() == 0L, listed.toString)
+      assert(listed.recordCount() == 0L, listed.toString)
+
+      sql(s"ANALYZE TABLE ${qualified(tableName)} COMPUTE STATISTICS").collect()
+      val scanned = statisticsOf(tableName, "20260101", "00")
+      assert(scanned.fileCount() == 0L, scanned.toString)
+      assert(scanned.recordCount() == 0L, scanned.toString)
+    }
+  }
+
   test("ANALYZE with a full partition spec measures only that partition") {
     val tableName = "analyze_full_spec"
     withTable(tableName) {


### PR DESCRIPTION
### Purpose

A truncation reports an exact zero for every partition it emptied. `ANALYZE` measures a partition
and writes down what it found. Nothing pinned what the second does to the first.

The failure would be silent in the direction that matters. Statistics carry `UNKNOWN` as a negative
value, so a zero degraded back to unknown does not read as "this partition is empty" but as "nobody
measured it", and a consumer that guards on the value being known skips the partition instead of
planning for an empty one. An exact zero is a measurement; it should not be reachable to lose it by
measuring again.

### Tests

`CatalogManagedPartitionAnalyzeTest`: measure a partition, truncate it, then run `COMPUTE STATISTICS
NOSCAN` and a full `COMPUTE STATISTICS` over it, asserting the row count and file count are still
zero rather than unknown.

The case needs `TRUNCATE TABLE` (#9330) and `ANALYZE TABLE` (#9298) in the same tree, which is why
it could not ride along with either of them. Both are in `master` now.

### API and Format

No production change; test only.
