### PR TITLE
[core] Fix null handling in ArrayContains

### DIFF
--- a/paimon-common/src/main/java/org/apache/paimon/predicate/ArrayContains.java
+++ b/paimon-common/src/main/java/org/apache/paimon/predicate/ArrayContains.java
@@ -47,6 +47,9 @@ public class ArrayContains extends LeafBinaryFunction {
 
     @Override
     public boolean test(DataType type, Object field, Object literal) {
+        if (field == null || literal == null) {
+            return false;
+        }
         DataType elementType = elementType(type);
         InternalArray array = (InternalArray) field;
         InternalArray.ElementGetter getter = InternalArray.createElementGetter(elementType);

--- a/paimon-common/src/test/java/org/apache/paimon/predicate/PredicateBuilderTest.java
+++ b/paimon-common/src/test/java/org/apache/paimon/predicate/PredicateBuilderTest.java
@@ -247,6 +247,14 @@ public class PredicateBuilderTest {
                         builder.arrayContains(0, null)
                                 .test(GenericRow.of(new GenericArray(new Integer[] {1, null}))))
                 .isFalse();
+        DataType arrayType = DataTypes.ARRAY(DataTypes.INT());
+        assertThat(ArrayContains.INSTANCE.test(arrayType, null, 2)).isFalse();
+        assertThat(
+                        ArrayContains.INSTANCE.test(
+                                arrayType,
+                                new GenericArray(new Integer[] {1, null}),
+                                (Object) null))
+                .isFalse();
         assertThat(containsTwo.negate()).isEmpty();
     }
 


### PR DESCRIPTION
### Purpose

`ArrayContains.test(DataType, Object, Object)` did not handle null inputs. A null array caused an exception, and a null literal could reach comparison logic and fail unexpectedly.

Return false for null inputs and add regression coverage for direct scalar evaluation.

### Tests

  - `mvn -pl paimon-common -DskipTests validate`
  - Predicate tests: 156 passed
