### PR TITLE
[spark] Fix MERGE INTO delete clause corrupting partial-update tables

### DIFF
--- a/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/catalyst/analysis/PaimonMergeInto.scala
+++ b/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/catalyst/analysis/PaimonMergeInto.scala
@@ -21,6 +21,8 @@ package org.apache.paimon.spark.catalyst.analysis
 import org.apache.paimon.spark.SparkTable
 import org.apache.paimon.spark.catalyst.analysis.expressions.ExpressionHelper
 import org.apache.paimon.spark.commands.{MergeIntoPaimonDataEvolutionTable, MergeIntoPaimonTable}
+import org.apache.paimon.table.PrimaryKeyTableUtils.validatePKUpsertDeletable
+import org.apache.paimon.table.Table
 
 import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.catalyst.expressions.{Attribute, AttributeSet, Expression, SubqueryExpression}
@@ -51,6 +53,7 @@ case class PaimonMergeInto(spark: SparkSession)
           var v2Table = relation.table.asInstanceOf[SparkTable]
 
           checkPaimonTable(v2Table.getTable)
+          checkDeleteActionValidity(v2Table.getTable, merge)
           checkCondition(merge.mergeCondition)
           (merge.matchedActions ++ merge.notMatchedActions)
             .flatMap(_.condition)
@@ -120,6 +123,35 @@ case class PaimonMergeInto(spark: SparkSession)
     }
     if (SubqueryExpression.hasSubquery(condition)) {
       throw new RuntimeException(s"Condition $condition with subquery can't be supported.")
+    }
+  }
+
+  /**
+   * A `WHEN MATCHED ... THEN DELETE` or `WHEN NOT MATCHED BY SOURCE ... THEN DELETE` clause emits
+   * real [[org.apache.paimon.types.RowKind.DELETE]] records into the LSM tree (see
+   * `MergeIntoPaimonTable.constructChangedRows`), so the target's merge engine has to be able to
+   * consume them.
+   *
+   * Without this check a merge engine that rejects delete records -- `partial-update` without
+   * `partial-update.remove-record-on-delete` -- accepts the write and commits a snapshot that later
+   * makes the table unreadable: the failure only surfaces much later, in
+   * `PartialUpdateMergeFunction#add`, at *read* time.
+   *
+   * This mirrors the validation Flink runs for SQL `DELETE`
+   * (`SupportsRowLevelOperationFlinkTableSink#applyRowLevelDelete`) and the one
+   * `DeleteFromPaimonTableCommand` already runs, so all three paths reject the same tables with the
+   * same message.
+   */
+  private def checkDeleteActionValidity(table: Table, merge: MergeIntoTable): Unit = {
+    // Tables without primary keys rewrite the touched files (or maintain deletion vectors) instead
+    // of emitting delete records, so no merge engine is involved.
+    if (table.primaryKeys().isEmpty) {
+      return
+    }
+    val deletesRows = (merge.matchedActions ++ resolveNotMatchedBySourceActions(merge))
+      .exists(_.isInstanceOf[DeleteAction])
+    if (deletesRows) {
+      validatePKUpsertDeletable(table)
     }
   }
 

--- a/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/sql/MergeIntoTableTestBase.scala
+++ b/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/sql/MergeIntoTableTestBase.scala
@@ -1573,11 +1573,13 @@ trait MergeIntoPrimaryKeyTableTest extends PaimonSparkTestBase with PaimonPrimar
    * later at read time in `PartialUpdateMergeFunction#add`.
    */
   test("Paimon MergeInto: reject DELETE clause when the merge engine can not accept deletes") {
-    Seq(
-      "WHEN MATCHED THEN DELETE",
-      "WHEN MATCHED AND target.b > 0 THEN DELETE",
-      "WHEN NOT MATCHED BY SOURCE THEN DELETE"
-    ).foreach {
+    val deleteClauses =
+      Seq("WHEN MATCHED THEN DELETE", "WHEN MATCHED AND target.b > 0 THEN DELETE") ++
+        // `WHEN NOT MATCHED BY SOURCE` was only added to Spark's parser in 3.4; on 3.2/3.3 the
+        // statement fails to parse before it ever reaches the analysis rule under test.
+        (if (gteqSpark3_4) Seq("WHEN NOT MATCHED BY SOURCE THEN DELETE") else Nil)
+
+    deleteClauses.foreach {
       deleteClause =>
         withTable("source", "target") {
           Seq((1, 100, "c11")).toDF("a", "b", "c").createOrReplaceTempView("source")

--- a/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/sql/MergeIntoTableTestBase.scala
+++ b/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/sql/MergeIntoTableTestBase.scala
@@ -1565,6 +1565,93 @@ trait MergeIntoPrimaryKeyTableTest extends PaimonSparkTestBase with PaimonPrimar
         Row(1, 10, "c111") :: Row(2, 20, "c2") :: Row(103, 30, "c333") :: Nil)
     }
   }
+
+  /**
+   * A DELETE clause emits real `RowKind.DELETE` records, so the target's merge engine must be able
+   * to consume them. `partial-update` without `partial-update.remove-record-on-delete` cannot:
+   * before the check in `PaimonMergeInto`, the merge committed happily and the table only blew up
+   * later at read time in `PartialUpdateMergeFunction#add`.
+   */
+  test("Paimon MergeInto: reject DELETE clause when the merge engine can not accept deletes") {
+    Seq(
+      "WHEN MATCHED THEN DELETE",
+      "WHEN MATCHED AND target.b > 0 THEN DELETE",
+      "WHEN NOT MATCHED BY SOURCE THEN DELETE"
+    ).foreach {
+      deleteClause =>
+        withTable("source", "target") {
+          Seq((1, 100, "c11")).toDF("a", "b", "c").createOrReplaceTempView("source")
+          createTable(
+            "target",
+            "a INT, b INT, c STRING",
+            Seq("a"),
+            extraProps = Map("merge-engine" -> "partial-update"))
+          spark.sql("INSERT INTO target values (1, 10, 'c1'), (2, 20, 'c2')")
+
+          val error = intercept[UnsupportedOperationException] {
+            spark.sql(s"""
+                         |MERGE INTO target
+                         |USING source
+                         |ON target.a = source.a
+                         |$deleteClause
+                         |""".stripMargin)
+          }.getMessage
+          assert(error.contains("partial-update.remove-record-on-delete"), error)
+
+          // The statement was rejected before anything was committed.
+          checkAnswer(
+            spark.sql("SELECT * FROM target ORDER BY a"),
+            Row(1, 10, "c1") :: Row(2, 20, "c2") :: Nil)
+        }
+    }
+  }
+
+  test("Paimon MergeInto: allow DELETE clause once the merge engine can accept deletes") {
+    withTable("source", "target") {
+      Seq((1, 100, "c11")).toDF("a", "b", "c").createOrReplaceTempView("source")
+      createTable(
+        "target",
+        "a INT, b INT, c STRING",
+        Seq("a"),
+        extraProps = Map(
+          "merge-engine" -> "partial-update",
+          "partial-update.remove-record-on-delete" -> "true"))
+      spark.sql("INSERT INTO target values (1, 10, 'c1'), (2, 20, 'c2')")
+
+      spark.sql(s"""
+                   |MERGE INTO target
+                   |USING source
+                   |ON target.a = source.a
+                   |WHEN MATCHED THEN DELETE
+                   |""".stripMargin)
+
+      checkAnswer(spark.sql("SELECT * FROM target ORDER BY a"), Row(2, 20, "c2") :: Nil)
+    }
+  }
+
+  test("Paimon MergeInto: a delete-free merge on partial-update is unaffected") {
+    withTable("source", "target") {
+      Seq((1, 100, "c11"), (3, 300, "c33")).toDF("a", "b", "c").createOrReplaceTempView("source")
+      createTable(
+        "target",
+        "a INT, b INT, c STRING",
+        Seq("a"),
+        extraProps = Map("merge-engine" -> "partial-update"))
+      spark.sql("INSERT INTO target values (1, 10, 'c1'), (2, 20, 'c2')")
+
+      spark.sql(s"""
+                   |MERGE INTO target
+                   |USING source
+                   |ON target.a = source.a
+                   |WHEN MATCHED THEN UPDATE SET b = source.b
+                   |WHEN NOT MATCHED THEN INSERT *
+                   |""".stripMargin)
+
+      checkAnswer(
+        spark.sql("SELECT * FROM target ORDER BY a"),
+        Row(1, 100, "c1") :: Row(2, 20, "c2") :: Row(3, 300, "c33") :: Nil)
+    }
+  }
 }
 
 trait MergeIntoAppendTableTest extends PaimonSparkTestBase with PaimonAppendTable {


### PR DESCRIPTION
### Purpose

`MERGE INTO` with a `DELETE` clause silently corrupts a `partial-update` primary key table: the
statement succeeds and commits a snapshot, but the table becomes unreadable afterwards.

```sql
CREATE TABLE t (id INT, a INT, b INT) TBLPROPERTIES (
  'primary-key' = 'id', 'bucket' = '1', 'merge-engine' = 'partial-update');
INSERT INTO t VALUES (1, 10, 100), (2, 20, 200);

MERGE INTO t USING s ON t.id = s.id WHEN MATCHED THEN DELETE;  -- succeeds, commits a snapshot
SELECT * FROM t;                                               -- throws
```

```
java.lang.IllegalArgumentException: By default, Partial update can not accept delete records,
you can choose one of the following solutions:
1. Configure 'ignore-delete' to ignore delete records.
2. Configure 'partial-update.remove-record-on-delete' to remove the whole row ...
  at org.apache.paimon.mergetree.compact.PartialUpdateMergeFunction.add(PartialUpdateMergeFunction.java:191)
```

The write side never notices; the failure only surfaces at read time, and only for queries that
actually have to merge the affected key — so the table looks partly healthy, which makes this hard
to diagnose.

**Root cause.** `PrimaryKeyTableUtils#validatePKUpsertDeletable` already encodes which merge engines
can consume delete records. It is called by Flink's SQL `DELETE`
(`SupportsRowLevelOperationFlinkTableSink#applyRowLevelDelete` / `#applyDeleteFilters`) and by
Spark's `DeleteFromPaimonTableCommand`, but **not** by Spark's `MERGE INTO`, which emits
`RowKind.DELETE` records unconditionally. `RowLevelOp.MergeInto` only checks that the merge engine
is `deduplicate` or `partial-update`, and `partial-update` is exactly the one that cannot accept
delete records by default.

**Fix.** Run the same validation in `PaimonMergeInto` when the statement has a `DELETE` clause and
the target is a primary key table, so all three paths reject the same tables with the same message.

The check lives in the analysis rule rather than in the command because both V2 row-level paths
(`SparkTable#supportsV2CopyOnWriteOps` / `#supportsV2DeltaOps`) require `primaryKeys().isEmpty` —
primary key tables therefore always go through `PaimonMergeInto` on every supported Spark version,
making it the single choke point. Failing during analysis also means nothing has been written yet.

**Behavior change.** Such statements now fail with the existing, actionable message instead of
committing a corrupt snapshot:

> Merge engine partial-update doesn't support batch delete by default. To support batch delete,
> please set partial-update.remove-record-on-delete to true when there is no sequence.field or set
> partial-update.remove-record-on-sequence-group.

Scope is narrow — only *primary key table* + *statement contains a DELETE clause* + *merge engine
cannot accept delete records*:

- `aggregate` / `first-row` are already rejected earlier by `RowLevelOp.MergeInto`.
- `deduplicate` passes the validation.
- `partial-update` passes once `partial-update.remove-record-on-delete` or
  `partial-update.remove-record-on-sequence-group` is set.
- Merges without a `DELETE` clause, and append-only tables, are unaffected.

This also stops the related silent no-op: with `ignore-delete = true`, a `MERGE ... THEN DELETE`
used to report success while keeping the row, because `PartialUpdateMergeFunction#add` discards the
delete record at read time. It is now rejected instead.

### Tests

New in `MergeIntoPrimaryKeyTableTest` (`MergeIntoTableTestBase.scala`):

- `reject DELETE clause when the merge engine can not accept deletes` — covers
  `WHEN MATCHED THEN DELETE`, `WHEN MATCHED AND <cond> THEN DELETE` and
  `WHEN NOT MATCHED BY SOURCE THEN DELETE`, and asserts the target is left untouched.
- `allow DELETE clause once the merge engine can accept deletes` — `partial-update` with
  `partial-update.remove-record-on-delete = true` still deletes.
- `a delete-free merge on partial-update is unaffected`.

Existing suites, all green with no changes:

- `MergeInto{PrimaryKeyBucketed,PrimaryKeyNonBucket}TableTest` and their `V2` variants —
  `Tests: succeeded 244, failed 0`
- `MergeIntoAppend{Bucketed,NonBucketed}TableTest` + `V2` variants, `DeleteFromTableTest` /
  `V2DeleteFromTableTest`, `UpdateTableTest` / `V2UpdateTableTest` —
  `Tests: succeeded 352, failed 0`
