### PR TITLE
[common] Fix wildcard matching for line terminators

### DIFF
--- a/paimon-common/src/main/java/org/apache/paimon/predicate/Like.java
+++ b/paimon-common/src/main/java/org/apache/paimon/predicate/Like.java
@@ -116,7 +116,7 @@ public class Like extends LeafBinaryFunction {
                 javaPattern.append(nextChar);
                 ++i;
             } else if (c == '_') {
-                javaPattern.append('.');
+                javaPattern.append("(?s:.)");
             } else if (c == '%') {
                 javaPattern.append("(?s:.*)");
             } else {

--- a/paimon-common/src/test/java/org/apache/paimon/predicate/PredicateTest.java
+++ b/paimon-common/src/test/java/org/apache/paimon/predicate/PredicateTest.java
@@ -604,6 +604,24 @@ public class PredicateTest {
         assertThat(getLikeFunc("a_c")).isEqualTo(Like.INSTANCE);
     }
 
+    @Test
+    public void testLikeSingleCharacterWildcardMatchesLineTerminators() {
+        String[] lineTerminators = {"\n", "\r", "\u0085", "\u2028", "\u2029"};
+        for (String lineTerminator : lineTerminators) {
+            assertThat(
+                            Like.INSTANCE.test(
+                                    DataTypes.STRING(),
+                                    fromString("a" + lineTerminator + "b"),
+                                    fromString("a_b")))
+                    .isTrue();
+        }
+
+        assertThat(Like.INSTANCE.test(DataTypes.STRING(), fromString("a\r\nb"), fromString("a_b")))
+                .isFalse();
+        assertThat(Like.INSTANCE.test(DataTypes.STRING(), fromString("a\r\nb"), fromString("a__b")))
+                .isTrue();
+    }
+
     private boolean executeLike(String s, String pattern) {
         ThreadLocalRandom rnd = ThreadLocalRandom.current();
         if (rnd.nextBoolean()) {


### PR DESCRIPTION
### Purpose
 - The `_` (single char) wildcard should match exactly 1 character, including line terminator.
 - However line terminators is excluded by the regex, causing matching rows to be incorrectly filtered out.
 - Ensure the single char wildcard can match line terminator while and preserve crlf as two separate characters.

### Tests
 - UT