### PR TITLE
[python][ray] Avoid MERGE shuffle starvation on small clusters

### DIFF
--- a/paimon-python/pypaimon/ray/data_evolution_merge_into.py
+++ b/paimon-python/pypaimon/ray/data_evolution_merge_into.py
@@ -97,6 +97,9 @@ def merge_into(
         list(when_matched), list(when_not_matched), on,
         read_columns,
     )
+    materialize_matched_before_routing = (
+        _has_upstream_join_or_shuffle(source_ds)
+    )
     base_snapshot = table.snapshot_manager().get_latest_snapshot()
     target_empty = _is_target_empty(base_snapshot)
     estimated_size_bytes = None
@@ -153,6 +156,7 @@ def merge_into(
         ray_remote_args, concurrency,
         update_num_partitions=update_num_partitions,
         delete_num_partitions=delete_num_partitions,
+        materialize_matched_before_routing=materialize_matched_before_routing,
     )
 
 
@@ -483,6 +487,7 @@ def _execute_and_commit(
     ray_remote_args, concurrency,
     update_num_partitions=None,
     delete_num_partitions=None,
+    materialize_matched_before_routing=False,
 ):
     collect_action_row_ids = update_ds is not None and delete_ds is not None
     commit_messages: list = []
@@ -529,6 +534,9 @@ def _execute_and_commit(
                             if base_snapshot is not None else None
                         ),
                         collect_row_ids=collect_action_row_ids,
+                        materialize_before_routing=(
+                            materialize_matched_before_routing
+                        ),
                     )
                 )
             commit_messages.extend(update_msgs)
@@ -543,6 +551,9 @@ def _execute_and_commit(
                     if base_snapshot is not None else None
                 ),
                 collect_row_ids=collect_action_row_ids,
+                materialize_before_routing=(
+                    materialize_matched_before_routing
+                ),
             )
             commit_messages.extend(delete_msgs)
 
@@ -821,6 +832,35 @@ def _normalize_source(
         "source must be a ray.data.Dataset, a Paimon table identifier string, "
         f"a pyarrow.Table, or a pandas.DataFrame; got {type(source).__name__}."
     )
+
+
+def _has_upstream_join_or_shuffle(dataset) -> bool:
+    """Best-effort check for a lazy source join or shuffle."""
+    try:
+        logical_plan = getattr(dataset, "_logical_plan", None)
+        operator = getattr(logical_plan, "dag", None)
+        pending = [operator] if operator is not None else []
+        visited = set()
+        while pending:
+            operator = pending.pop()
+            if id(operator) in visited:
+                continue
+            visited.add(id(operator))
+            operator_name = type(operator).__name__
+            if operator_name in {
+                "Aggregate", "Join", "RandomShuffle", "Sort",
+            }:
+                return True
+            if operator_name == "Repartition":
+                shuffle = getattr(
+                    operator, "shuffle", getattr(operator, "_shuffle", False)
+                )
+                if shuffle:
+                    return True
+            pending.extend(getattr(operator, "input_dependencies", ()))
+    except Exception:
+        pass
+    return False
 
 
 def _source_schema_or_raise(source_ds):

--- a/paimon-python/pypaimon/ray/data_evolution_merge_join.py
+++ b/paimon-python/pypaimon/ray/data_evolution_merge_join.py
@@ -695,6 +695,7 @@ def distributed_update_apply(
     estimated_size_bytes: Optional[int] = None,
     estimated_num_rows: Optional[int] = None,
     data_context=None,
+    materialize_before_routing: bool = False,
 ) -> Tuple[list, int, list]:
     import numpy as np
     import pickle
@@ -740,6 +741,9 @@ def distributed_update_apply(
         len(sorted_first_row_ids),
         data_context=data_context,
     )
+    if materialize_before_routing:
+        # Keep the matched join and file-routing shuffle in separate Ray jobs.
+        update_ds = update_ds.materialize()
 
     # Pin commit-time conflict check to the snapshot the join was built on,
     # so concurrent commits between read and planner are detected.
@@ -1035,6 +1039,7 @@ def distributed_delete_apply(
     ray_remote_args: Optional[Dict[str, Any]] = None,
     base_snapshot_id: Optional[int] = None,
     collect_row_ids: bool = False,
+    materialize_before_routing: bool = False,
 ) -> Tuple[list, int, list]:
     import base64
     import numpy as np
@@ -1057,6 +1062,10 @@ def distributed_delete_apply(
     anchor_info = planner._snapshot_anchor_ranges()
     if not anchor_info.anchors:
         return [], 0, []
+
+    if materialize_before_routing:
+        # Keep the matched join and file-routing shuffle in separate Ray jobs.
+        delete_ds = delete_ds.materialize()
 
     precomputed_info_ref = ray.put(anchor_info)
 

--- a/paimon-python/pypaimon/tests/ray_data_evolution_merge_into_test.py
+++ b/paimon-python/pypaimon/tests/ray_data_evolution_merge_into_test.py
@@ -499,14 +499,19 @@ class RayDataEvolutionMergeIntoTest(unittest.TestCase):
             schema=self.pa_schema,
         )
 
-        merge_into(
-            target=target,
-            source=source,
-            catalog_options=self.catalog_options,
-            on=['id'],
-            when_matched=[WhenMatched.update('*')],
-            num_partitions=_TEST_NUM_PARTITIONS,
-        )
+        with patch.object(
+                ray.data.Dataset,
+                'materialize',
+                side_effect=AssertionError('plain source must stay streaming'),
+        ):
+            merge_into(
+                target=target,
+                source=source,
+                catalog_options=self.catalog_options,
+                on=['id'],
+                when_matched=[WhenMatched.update('*')],
+                num_partitions=_TEST_NUM_PARTITIONS,
+            )
 
         out = self._read_sorted(target)
         self.assertEqual(out['id'], [1, 2, 3])
@@ -529,21 +534,26 @@ class RayDataEvolutionMergeIntoTest(unittest.TestCase):
             ),
         )
 
-        metrics = merge_into(
-            target=target,
-            source=pa.Table.from_pydict(
-                {
-                    'id': pa.array([2, 3], type=pa.int32()),
-                    'name': ['ignored', 'ignored'],
-                    'age': pa.array([99, 99], type=pa.int32()),
-                },
-                schema=self.pa_schema,
-            ),
-            catalog_options=self.catalog_options,
-            on=['id'],
-            when_matched=[WhenMatched.delete()],
-            num_partitions=_TEST_NUM_PARTITIONS,
-        )
+        with patch.object(
+                ray.data.Dataset,
+                'materialize',
+                side_effect=AssertionError('plain source must stay streaming'),
+        ):
+            metrics = merge_into(
+                target=target,
+                source=pa.Table.from_pydict(
+                    {
+                        'id': pa.array([2, 3], type=pa.int32()),
+                        'name': ['ignored', 'ignored'],
+                        'age': pa.array([99, 99], type=pa.int32()),
+                    },
+                    schema=self.pa_schema,
+                ),
+                catalog_options=self.catalog_options,
+                on=['id'],
+                when_matched=[WhenMatched.delete()],
+                num_partitions=_TEST_NUM_PARTITIONS,
+            )
 
         self.assertEqual(metrics, {
             'num_matched': 2, 'num_inserted': 0, 'num_unchanged': 0,
@@ -552,6 +562,57 @@ class RayDataEvolutionMergeIntoTest(unittest.TestCase):
         self.assertEqual(out['id'], [1])
         self.assertEqual(out['name'], ['a'])
         self.assertEqual(out['age'], [10])
+
+    def test_joined_source_delete_materializes_before_routing(self):
+        options = dict(self.de_options)
+        options['deletion-vectors.enabled'] = 'true'
+        target = self._create_table(options=options)
+        self._write(target, self._source(ids=(1, 2, 3)))
+
+        source = ray.data.from_arrow(pa.table({
+            'id': pa.array([2, 3], type=pa.int32()),
+        })).join(
+            ray.data.from_arrow(pa.table({
+                'id': pa.array([2, 3], type=pa.int32()),
+                'selected': [True, True],
+            })),
+            join_type='inner',
+            num_partitions=_TEST_NUM_PARTITIONS,
+            on=['id'],
+        )
+        real_materialize = ray.data.Dataset.materialize
+        materialized = []
+
+        def track_materialize(dataset):
+            materialized.append(dataset)
+            return real_materialize(dataset)
+
+        with patch.object(
+                ray.data.Dataset, 'materialize', new=track_materialize,
+        ):
+            metrics = merge_into(
+                target=target,
+                source=source,
+                catalog_options=self.catalog_options,
+                on=['id'],
+                when_matched=[WhenMatched.delete()],
+                num_partitions=_TEST_NUM_PARTITIONS,
+            )
+
+        self.assertEqual(metrics['num_matched'], 2)
+        self.assertEqual(self._read_sorted(target)['id'], [1])
+        self.assertEqual(len(materialized), 1)
+
+    def test_source_shuffle_detection(self):
+        from pypaimon.ray import data_evolution_merge_into as merge_module
+
+        source = ray.data.from_arrow(pa.table({'id': [1, 2]}))
+        detect = merge_module._has_upstream_join_or_shuffle
+
+        self.assertFalse(detect(source))
+        self.assertFalse(detect(source.repartition(2, shuffle=False)))
+        self.assertTrue(detect(source.repartition(2, shuffle=True)))
+        self.assertTrue(detect(source.random_shuffle()))
 
     def test_not_matched_insert_appends_unmatched(self):
         target = self._create_table()
@@ -1051,16 +1112,26 @@ class RayDataEvolutionMergeIntoTest(unittest.TestCase):
 
         updates = matched.map_batches(
             resolve_and_compute, batch_format='pyarrow')
-        metrics = merge_into(
-            target=name,
-            source=updates,
-            catalog_options=self.catalog_options,
-            on=['id'],
-            when_matched=[
-                WhenMatched.update({'feature': source_col('new_feature')})
-            ],
-            num_partitions=num_partitions,
-        )
+        real_materialize = ray.data.Dataset.materialize
+        materialized = []
+
+        def track_materialize(dataset):
+            materialized.append(dataset)
+            return real_materialize(dataset)
+
+        with patch.object(
+                ray.data.Dataset, 'materialize', new=track_materialize,
+        ):
+            metrics = merge_into(
+                target=name,
+                source=updates,
+                catalog_options=self.catalog_options,
+                on=['id'],
+                when_matched=[
+                    WhenMatched.update({'feature': source_col('new_feature')})
+                ],
+                num_partitions=num_partitions,
+            )
 
         table = self.catalog.get_table(name)
         rb = table.new_read_builder()
@@ -1070,6 +1141,7 @@ class RayDataEvolutionMergeIntoTest(unittest.TestCase):
         self.assertEqual(out['feature'], [200, 20, 400])
         self.assertEqual(out['payload'], [b'aa', b'bbb', b'cccc'])
         self.assertEqual(metrics['num_matched'], 2)
+        self.assertEqual(len(materialized), 1)
 
     def test_combined_writes_single_snapshot(self):
         target = self._create_table()
@@ -2306,13 +2378,18 @@ class RayDataEvolutionMergeIntoTest(unittest.TestCase):
             ),
         )
 
-        result = merge_into(
-            target=target,
-            source=target,
-            catalog_options=self.catalog_options,
-            on=['_ROW_ID'],
-            when_matched=[WhenMatched.update({'age': lit(99)})],
-        )
+        with patch.object(
+                ray.data.Dataset,
+                'materialize',
+                side_effect=AssertionError('self-merge must stay streaming'),
+        ):
+            result = merge_into(
+                target=target,
+                source=target,
+                catalog_options=self.catalog_options,
+                on=['_ROW_ID'],
+                when_matched=[WhenMatched.update({'age': lit(99)})],
+            )
 
         self.assertEqual(result['num_matched'], 3)
         out = self._read_sorted(target)


### PR DESCRIPTION
## What changed

- Materialize narrow matched update/delete rows before the file-routing shuffle in generic Ray MERGE.
- Keep self-merge streaming and leave other row-id writers unchanged.

## Why

When a lazy source already contains a join or shuffle, Ray can schedule the source join, MERGE target join, and file-routing shuffle in one streaming plan. On a 2-CPU cluster, shuffle aggregators can reserve the available resources and indefinitely starve the final routing stage.

The new boundary separates the matched join from file routing without materializing the full source.

## Tests

- Joined BLOB transform and matched update on 2 CPUs
- Joined source and matched delete on 2 CPUs
- Self-merge no-materialization regression
- 127 Ray MERGE tests
- 52 update/conflict/core commit tests
- 24 table MERGE API tests
- flake8, py_compile, and git diff check