### PR TITLE
[format] Fix Parquet delta length reads across vector batches

### DIFF
--- a/paimon-format/src/main/java/org/apache/paimon/format/parquet/reader/VectorizedDeltaLengthByteArrayReader.java
+++ b/paimon-format/src/main/java/org/apache/paimon/format/parquet/reader/VectorizedDeltaLengthByteArrayReader.java
@@ -58,7 +58,7 @@ public class VectorizedDeltaLengthByteArrayReader extends VectorizedReaderBase
         ByteBufferOutputWriter outputWriter = ByteBufferOutputWriter::writeArrayByteBuffer;
         int length;
         for (int i = 0; i < total; i++) {
-            length = lengthsVector.getInt(rowId + i);
+            length = lengthsVector.getInt(currentRow + i);
             try {
                 buffer = in.slice(length);
             } catch (EOFException e) {

--- a/paimon-format/src/test/java/org/apache/paimon/format/parquet/reader/DeltaLengthByteArrayEncodingTest.java
+++ b/paimon-format/src/test/java/org/apache/paimon/format/parquet/reader/DeltaLengthByteArrayEncodingTest.java
@@ -58,6 +58,22 @@ public class DeltaLengthByteArrayEncodingTest {
     }
 
     @Test
+    public void testReadOnePageAcrossVectorBatches() throws Exception {
+        String[] values = {"a", "bbbb", "ccccc"};
+        writeData(writer, values);
+        reader.initFromPage(values.length, writer.getBytes().toInputStream());
+        HeapBytesVector vector = new HeapBytesVector(values.length);
+
+        reader.readBinary(1, vector, 0);
+        assertArrayEquals(values[0].getBytes(), vector.getBytes(0).getBytes());
+
+        vector.reset();
+        reader.readBinary(2, vector, 0);
+        assertArrayEquals(values[1].getBytes(), vector.getBytes(0).getBytes());
+        assertArrayEquals(values[2].getBytes(), vector.getBytes(1).getBytes());
+    }
+
+    @Test
     public void testRandomStrings() throws Exception {
         String[] values = Utils.getRandomStringSamples(1000, 32);
         writeData(writer, values);


### PR DESCRIPTION
### Purpose
 - Parquet delta encoding stores variable string length based on position on encoded page.
 - For 1 page -> many vector batches, this incorrectly uses the output position had been reset and causes later strings to be truncated.
 - Ensure we can correctly track the variable length string
 - This is a bug fix ported from Spark

### Tests
 - UT