### PR TITLE
[Spark] Introduce codegen support for whole stage merge query

### DIFF
--- a/paimon-spark/paimon-spark-3.2/src/main/scala/org/apache/spark/sql/execution/datasources/v2/MergeRowsExec.scala
+++ b/paimon-spark/paimon-spark-3.2/src/main/scala/org/apache/spark/sql/execution/datasources/v2/MergeRowsExec.scala
@@ -86,7 +86,8 @@ case class MergeRowsExec(
   override def supportCodegen: Boolean = {
     OptionUtils.mergeCodegenEnabled() &&
     conf.wholeStageEnabled &&
-    CodeGenerator.isValidParamLength(CodeGenerator.calculateParamLength(child.output))
+    CodeGenerator.isValidParamLength(
+      CodeGenerator.calculateParamLength(child.output.filter(usedInputs.contains)))
   }
 
   override protected def doProduce(ctx: CodegenContext): String = {
@@ -267,23 +268,26 @@ case class MergeRowsExec(
       variables: Seq[ExprCode]): (Seq[String], Seq[String], Seq[ExprCode]) = {
     val arguments = mutable.ArrayBuffer[String]()
     val parameters = mutable.ArrayBuffer[String]()
-    val paramVars = mutable.ArrayBuffer[ExprCode]()
+    val paramVars = mutable.ArrayBuffer(variables: _*)
 
     variables.zipWithIndex.foreach {
       case (evaluatedVariable, index) =>
-        val paramName = ctx.freshName(s"expr_$index")
-        val paramType = CodeGenerator.javaType(attributes(index).dataType)
-        arguments += evaluatedVariable.value.toString
-        parameters += s"$paramType $paramName"
-        val paramIsNull = if (!attributes(index).nullable) {
-          FalseLiteral
-        } else {
-          val isNull = ctx.freshName(s"exprIsNull_$index")
-          arguments += evaluatedVariable.isNull.toString
-          parameters += s"boolean $isNull"
-          JavaCode.isNullVariable(isNull)
+        if (usedInputs.contains(attributes(index))) {
+          val paramName = ctx.freshName(s"expr_$index")
+          val paramType = CodeGenerator.javaType(attributes(index).dataType)
+          arguments += evaluatedVariable.value.toString
+          parameters += s"$paramType $paramName"
+          val paramIsNull = if (!attributes(index).nullable) {
+            FalseLiteral
+          } else {
+            val isNull = ctx.freshName(s"exprIsNull_$index")
+            arguments += evaluatedVariable.isNull.toString
+            parameters += s"boolean $isNull"
+            JavaCode.isNullVariable(isNull)
+          }
+          paramVars(index) =
+            ExprCode(paramIsNull, JavaCode.variable(paramName, attributes(index).dataType))
         }
-        paramVars += ExprCode(paramIsNull, JavaCode.variable(paramName, attributes(index).dataType))
     }
 
     (arguments.toSeq, parameters.toSeq, paramVars.toSeq)

--- a/paimon-spark/paimon-spark-3.2/src/main/scala/org/apache/spark/sql/execution/datasources/v2/MergeRowsExec.scala
+++ b/paimon-spark/paimon-spark-3.2/src/main/scala/org/apache/spark/sql/execution/datasources/v2/MergeRowsExec.scala
@@ -18,14 +18,20 @@
 
 package org.apache.spark.sql.execution.datasources.v2
 
+import org.apache.paimon.spark.util.OptionUtils
+
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.catalyst.InternalRow
-import org.apache.spark.sql.catalyst.expressions.{Attribute, AttributeSet, BasePredicate, Expression, Projection, UnsafeProjection}
-import org.apache.spark.sql.catalyst.expressions.codegen.GeneratePredicate
+import org.apache.spark.sql.catalyst.expressions.{Attribute, AttributeSet, BasePredicate, BindReferences, Expression, Projection, UnsafeProjection}
+import org.apache.spark.sql.catalyst.expressions.codegen.{CodegenContext, CodeGenerator, ExprCode, FalseLiteral, GeneratePredicate, JavaCode}
+import org.apache.spark.sql.catalyst.expressions.codegen.Block.BlockHelper
 import org.apache.spark.sql.catalyst.plans.logical.MergeRows._
 import org.apache.spark.sql.catalyst.util.truncatedString
-import org.apache.spark.sql.execution.{SparkPlan, UnaryExecNode}
+import org.apache.spark.sql.execution.{CodegenSupport, SparkPlan, UnaryExecNode}
+import org.apache.spark.sql.types.BooleanType
 import org.roaringbitmap.longlong.Roaring64Bitmap
+
+import scala.collection.mutable
 
 case class MergeRowsExec(
     isSourceRowPresent: Expression,
@@ -36,7 +42,8 @@ case class MergeRowsExec(
     checkCardinality: Boolean,
     output: Seq[Attribute],
     child: SparkPlan)
-  extends UnaryExecNode {
+  extends UnaryExecNode
+  with CodegenSupport {
 
   @transient override lazy val producedAttributes: AttributeSet = {
     AttributeSet(output.filterNot(attr => inputSet.contains(attr)))
@@ -64,6 +71,222 @@ case class MergeRowsExec(
 
   override protected def doExecute(): RDD[InternalRow] = {
     child.execute().mapPartitions(processPartition)
+  }
+
+  override def inputRDDs(): Seq[RDD[InternalRow]] = {
+    child.asInstanceOf[CodegenSupport].inputRDDs()
+  }
+
+  override def needCopyResult: Boolean = {
+    val hasSplitInstruction = (matchedInstructions ++ notMatchedInstructions ++
+      notMatchedBySourceInstructions).exists(_.isInstanceOf[Split])
+    hasSplitInstruction || child.asInstanceOf[CodegenSupport].needCopyResult
+  }
+
+  override def supportCodegen: Boolean = {
+    OptionUtils.mergeCodegenEnabled() &&
+    conf.wholeStageEnabled &&
+    CodeGenerator.isValidParamLength(CodeGenerator.calculateParamLength(child.output))
+  }
+
+  override protected def doProduce(ctx: CodegenContext): String = {
+    child.asInstanceOf[CodegenSupport].produce(ctx, this)
+  }
+
+  override def doConsume(ctx: CodegenContext, input: Seq[ExprCode], row: ExprCode): String = {
+    val funcName = ctx.freshName("mergeProcessRow")
+    val (args, params, paramExprs) = constructConsumeParameters(ctx, child.output, input)
+    val body = generateInstructionExecutionCode(ctx, paramExprs)
+    val addedFuncName = ctx.addNewFunction(
+      funcName,
+      s"""
+         |private void $funcName(${params.mkString(", ")}) throws java.io.IOException {
+         |  $body
+         |}
+       """.stripMargin
+    )
+
+    s"$addedFuncName(${args.mkString(", ")});"
+  }
+
+  private def generateCardinalityValidationCode(
+      ctx: CodegenContext,
+      rowIdOrdinal: Int,
+      input: Seq[ExprCode]): String = {
+    val bitmapClass = classOf[Roaring64Bitmap]
+    val rowIdBitmap = ctx.addMutableState(
+      bitmapClass.getName,
+      "matchedRowIds",
+      variable => s"$variable = new ${bitmapClass.getName}();")
+    val currentRowId = input(rowIdOrdinal)
+
+    code"""
+          |${currentRowId.code}
+          |if ($rowIdBitmap.contains(${currentRowId.value})) {
+          |  throw new RuntimeException("Should not happens");
+          |}
+          |$rowIdBitmap.add(${currentRowId.value});
+     """.stripMargin.toString
+  }
+
+  private def generateInstructionExecutionCode(
+      ctx: CodegenContext,
+      inputExprs: Seq[ExprCode]): String = {
+    val sourcePresentExpr = generatePredicateCode(ctx, isSourceRowPresent, child.output, inputExprs)
+    val targetPresentExpr = generatePredicateCode(ctx, isTargetRowPresent, child.output, inputExprs)
+    val matchedInstructionsCode = generateInstructionsCode(ctx, matchedInstructions, inputExprs)
+    val notMatchedInstructionsCode =
+      generateInstructionsCode(ctx, notMatchedInstructions, inputExprs)
+    val notMatchedBySourceInstructionsCode =
+      generateInstructionsCode(ctx, notMatchedBySourceInstructions, inputExprs)
+    val cardinalityValidationCode = if (checkCardinality) {
+      val rowIdOrdinal = child.output.indexWhere(attr => conf.resolver(attr.name, ROW_ID))
+      assert(rowIdOrdinal != -1, "Cannot find row ID attr")
+      generateCardinalityValidationCode(ctx, rowIdOrdinal, inputExprs)
+    } else {
+      ""
+    }
+
+    s"""
+       |${sourcePresentExpr.code}
+       |${targetPresentExpr.code}
+       |if (${targetPresentExpr.value} && ${sourcePresentExpr.value}) {
+       |  $cardinalityValidationCode
+       |  $matchedInstructionsCode
+       |} else if (${sourcePresentExpr.value}) {
+       |  $notMatchedInstructionsCode
+       |} else if (${targetPresentExpr.value}) {
+       |  $notMatchedBySourceInstructionsCode
+       |}
+     """.stripMargin
+  }
+
+  private def generateInstructionsCode(
+      ctx: CodegenContext,
+      instructions: Seq[Instruction],
+      inputExprs: Seq[ExprCode]): String = {
+    if (instructions.isEmpty) {
+      ""
+    } else {
+      val instructionCodes =
+        instructions.map(instruction => generateSingleInstructionCode(ctx, instruction, inputExprs))
+      s"""
+         |${instructionCodes.mkString("\n")}
+         |return;
+       """.stripMargin
+    }
+  }
+
+  private def generateSingleInstructionCode(
+      ctx: CodegenContext,
+      instruction: Instruction,
+      inputExprs: Seq[ExprCode]): String = {
+    instruction match {
+      case Keep(condition, outputExprs) =>
+        val projectionExpr = generateProjectionCode(ctx, outputExprs, inputExprs)
+        val predicateExpr = generatePredicateCode(ctx, condition, child.output, inputExprs)
+        s"""
+           |${predicateExpr.code}
+           |if (${predicateExpr.value}) {
+           |  ${consume(ctx, projectionExpr)}
+           |  return;
+           |}
+         """.stripMargin
+
+      case Discard(condition) =>
+        val predicateExpr = generatePredicateCode(ctx, condition, child.output, inputExprs)
+        s"""
+           |${predicateExpr.code}
+           |if (${predicateExpr.value}) {
+           |  return;
+           |}
+         """.stripMargin
+
+      case Split(condition, outputExprs, otherOutputExprs) =>
+        val projectionExpr = generateProjectionCode(ctx, outputExprs, inputExprs)
+        val otherProjectionExpr = generateProjectionCode(ctx, otherOutputExprs, inputExprs)
+        val predicateExpr = generatePredicateCode(ctx, condition, child.output, inputExprs)
+        s"""
+           |${predicateExpr.code}
+           |if (${predicateExpr.value}) {
+           |  ${consume(ctx, projectionExpr)}
+           |  ${consume(ctx, otherProjectionExpr)}
+           |  return;
+           |}
+         """.stripMargin
+
+      case other =>
+        throw new RuntimeException("Unsupported instruction type: " + other.getClass.getSimpleName)
+    }
+  }
+
+  private def withCodegenContext[T](ctx: CodegenContext, inputCurrentVars: Seq[ExprCode])(
+      block: => T): T = {
+    val originalCurrentVars = ctx.currentVars
+    val originalInputRow = ctx.INPUT_ROW
+    try {
+      ctx.currentVars = inputCurrentVars
+      block
+    } finally {
+      ctx.currentVars = originalCurrentVars
+      ctx.INPUT_ROW = originalInputRow
+    }
+  }
+
+  private def generatePredicateCode(
+      ctx: CodegenContext,
+      predicate: Expression,
+      inputAttrs: Seq[Attribute],
+      inputCurrentVars: Seq[ExprCode]): ExprCode = {
+    withCodegenContext(ctx, inputCurrentVars) {
+      val boundPredicate = BindReferences.bindReference(predicate, inputAttrs)
+      val evaluatedPredicate = boundPredicate.genCode(ctx)
+      val predicateVar = ctx.freshName("predicateResult")
+      val code = code"""
+                       |${evaluatedPredicate.code}
+                       |boolean $predicateVar = !${evaluatedPredicate.isNull} &&
+                       |  ${evaluatedPredicate.value};
+                     """.stripMargin
+      ExprCode(code, FalseLiteral, JavaCode.variable(predicateVar, BooleanType))
+    }
+  }
+
+  private def generateProjectionCode(
+      ctx: CodegenContext,
+      outputExprs: Seq[Expression],
+      inputCurrentVars: Seq[ExprCode]): Seq[ExprCode] = {
+    withCodegenContext(ctx, inputCurrentVars) {
+      val boundExprs = outputExprs.map(BindReferences.bindReference(_, child.output))
+      boundExprs.map(_.genCode(ctx))
+    }
+  }
+
+  private def constructConsumeParameters(
+      ctx: CodegenContext,
+      attributes: Seq[Attribute],
+      variables: Seq[ExprCode]): (Seq[String], Seq[String], Seq[ExprCode]) = {
+    val arguments = mutable.ArrayBuffer[String]()
+    val parameters = mutable.ArrayBuffer[String]()
+    val paramVars = mutable.ArrayBuffer[ExprCode]()
+
+    variables.zipWithIndex.foreach {
+      case (evaluatedVariable, index) =>
+        val paramName = ctx.freshName(s"expr_$index")
+        val paramType = CodeGenerator.javaType(attributes(index).dataType)
+        arguments += evaluatedVariable.value.toString
+        parameters += s"$paramType $paramName"
+        val paramIsNull = if (!attributes(index).nullable) {
+          FalseLiteral
+        } else {
+          val isNull = ctx.freshName(s"exprIsNull_$index")
+          arguments += evaluatedVariable.isNull.toString
+          parameters += s"boolean $isNull"
+          JavaCode.isNullVariable(isNull)
+        }
+        paramVars += ExprCode(paramIsNull, JavaCode.variable(paramName, attributes(index).dataType))
+    }
+
+    (arguments.toSeq, parameters.toSeq, paramVars.toSeq)
   }
 
   private def processPartition(rowIterator: Iterator[InternalRow]): Iterator[InternalRow] = {

--- a/paimon-spark/paimon-spark-3.2/src/test/scala/org/apache/paimon/spark/sql/MergeRowsCodegenTest.scala
+++ b/paimon-spark/paimon-spark-3.2/src/test/scala/org/apache/paimon/spark/sql/MergeRowsCodegenTest.scala
@@ -18,4 +18,13 @@
 
 package org.apache.paimon.spark.sql
 
-class MergeRowsCodegenTest extends MergeRowsCodegenTestBase
+import org.apache.spark.sql.catalyst.expressions.Expression
+import org.apache.spark.sql.catalyst.plans.logical.MergeRows.{Instruction, Keep}
+
+class MergeRowsCodegenTest extends MergeRowsCodegenTestBase {
+
+  override protected def keepInstruction(
+      condition: Expression,
+      output: Seq[Expression]): Instruction =
+    Keep(condition, output)
+}

--- a/paimon-spark/paimon-spark-3.2/src/test/scala/org/apache/paimon/spark/sql/MergeRowsCodegenTest.scala
+++ b/paimon-spark/paimon-spark-3.2/src/test/scala/org/apache/paimon/spark/sql/MergeRowsCodegenTest.scala
@@ -1,0 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.spark.sql
+
+class MergeRowsCodegenTest extends MergeRowsCodegenTestBase

--- a/paimon-spark/paimon-spark-3.3/src/main/scala/org/apache/spark/sql/execution/datasources/v2/MergeRowsExec.scala
+++ b/paimon-spark/paimon-spark-3.3/src/main/scala/org/apache/spark/sql/execution/datasources/v2/MergeRowsExec.scala
@@ -86,7 +86,8 @@ case class MergeRowsExec(
   override def supportCodegen: Boolean = {
     OptionUtils.mergeCodegenEnabled() &&
     conf.wholeStageEnabled &&
-    CodeGenerator.isValidParamLength(CodeGenerator.calculateParamLength(child.output))
+    CodeGenerator.isValidParamLength(
+      CodeGenerator.calculateParamLength(child.output.filter(usedInputs.contains)))
   }
 
   override protected def doProduce(ctx: CodegenContext): String = {
@@ -267,23 +268,26 @@ case class MergeRowsExec(
       variables: Seq[ExprCode]): (Seq[String], Seq[String], Seq[ExprCode]) = {
     val arguments = mutable.ArrayBuffer[String]()
     val parameters = mutable.ArrayBuffer[String]()
-    val paramVars = mutable.ArrayBuffer[ExprCode]()
+    val paramVars = mutable.ArrayBuffer(variables: _*)
 
     variables.zipWithIndex.foreach {
       case (evaluatedVariable, index) =>
-        val paramName = ctx.freshName(s"expr_$index")
-        val paramType = CodeGenerator.javaType(attributes(index).dataType)
-        arguments += evaluatedVariable.value.toString
-        parameters += s"$paramType $paramName"
-        val paramIsNull = if (!attributes(index).nullable) {
-          FalseLiteral
-        } else {
-          val isNull = ctx.freshName(s"exprIsNull_$index")
-          arguments += evaluatedVariable.isNull.toString
-          parameters += s"boolean $isNull"
-          JavaCode.isNullVariable(isNull)
+        if (usedInputs.contains(attributes(index))) {
+          val paramName = ctx.freshName(s"expr_$index")
+          val paramType = CodeGenerator.javaType(attributes(index).dataType)
+          arguments += evaluatedVariable.value.toString
+          parameters += s"$paramType $paramName"
+          val paramIsNull = if (!attributes(index).nullable) {
+            FalseLiteral
+          } else {
+            val isNull = ctx.freshName(s"exprIsNull_$index")
+            arguments += evaluatedVariable.isNull.toString
+            parameters += s"boolean $isNull"
+            JavaCode.isNullVariable(isNull)
+          }
+          paramVars(index) =
+            ExprCode(paramIsNull, JavaCode.variable(paramName, attributes(index).dataType))
         }
-        paramVars += ExprCode(paramIsNull, JavaCode.variable(paramName, attributes(index).dataType))
     }
 
     (arguments.toSeq, parameters.toSeq, paramVars.toSeq)

--- a/paimon-spark/paimon-spark-3.3/src/main/scala/org/apache/spark/sql/execution/datasources/v2/MergeRowsExec.scala
+++ b/paimon-spark/paimon-spark-3.3/src/main/scala/org/apache/spark/sql/execution/datasources/v2/MergeRowsExec.scala
@@ -18,14 +18,20 @@
 
 package org.apache.spark.sql.execution.datasources.v2
 
+import org.apache.paimon.spark.util.OptionUtils
+
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.catalyst.InternalRow
-import org.apache.spark.sql.catalyst.expressions.{Attribute, AttributeSet, BasePredicate, Expression, Projection, UnsafeProjection}
-import org.apache.spark.sql.catalyst.expressions.codegen.GeneratePredicate
+import org.apache.spark.sql.catalyst.expressions.{Attribute, AttributeSet, BasePredicate, BindReferences, Expression, Projection, UnsafeProjection}
+import org.apache.spark.sql.catalyst.expressions.codegen.{CodegenContext, CodeGenerator, ExprCode, FalseLiteral, GeneratePredicate, JavaCode}
+import org.apache.spark.sql.catalyst.expressions.codegen.Block.BlockHelper
 import org.apache.spark.sql.catalyst.plans.logical.MergeRows._
 import org.apache.spark.sql.catalyst.util.truncatedString
-import org.apache.spark.sql.execution.{SparkPlan, UnaryExecNode}
+import org.apache.spark.sql.execution.{CodegenSupport, SparkPlan, UnaryExecNode}
+import org.apache.spark.sql.types.BooleanType
 import org.roaringbitmap.longlong.Roaring64Bitmap
+
+import scala.collection.mutable
 
 case class MergeRowsExec(
     isSourceRowPresent: Expression,
@@ -36,7 +42,8 @@ case class MergeRowsExec(
     checkCardinality: Boolean,
     output: Seq[Attribute],
     child: SparkPlan)
-  extends UnaryExecNode {
+  extends UnaryExecNode
+  with CodegenSupport {
 
   @transient override lazy val producedAttributes: AttributeSet = {
     AttributeSet(output.filterNot(attr => inputSet.contains(attr)))
@@ -64,6 +71,222 @@ case class MergeRowsExec(
 
   override protected def doExecute(): RDD[InternalRow] = {
     child.execute().mapPartitions(processPartition)
+  }
+
+  override def inputRDDs(): Seq[RDD[InternalRow]] = {
+    child.asInstanceOf[CodegenSupport].inputRDDs()
+  }
+
+  override def needCopyResult: Boolean = {
+    val hasSplitInstruction = (matchedInstructions ++ notMatchedInstructions ++
+      notMatchedBySourceInstructions).exists(_.isInstanceOf[Split])
+    hasSplitInstruction || child.asInstanceOf[CodegenSupport].needCopyResult
+  }
+
+  override def supportCodegen: Boolean = {
+    OptionUtils.mergeCodegenEnabled() &&
+    conf.wholeStageEnabled &&
+    CodeGenerator.isValidParamLength(CodeGenerator.calculateParamLength(child.output))
+  }
+
+  override protected def doProduce(ctx: CodegenContext): String = {
+    child.asInstanceOf[CodegenSupport].produce(ctx, this)
+  }
+
+  override def doConsume(ctx: CodegenContext, input: Seq[ExprCode], row: ExprCode): String = {
+    val funcName = ctx.freshName("mergeProcessRow")
+    val (args, params, paramExprs) = constructConsumeParameters(ctx, child.output, input)
+    val body = generateInstructionExecutionCode(ctx, paramExprs)
+    val addedFuncName = ctx.addNewFunction(
+      funcName,
+      s"""
+         |private void $funcName(${params.mkString(", ")}) throws java.io.IOException {
+         |  $body
+         |}
+       """.stripMargin
+    )
+
+    s"$addedFuncName(${args.mkString(", ")});"
+  }
+
+  private def generateCardinalityValidationCode(
+      ctx: CodegenContext,
+      rowIdOrdinal: Int,
+      input: Seq[ExprCode]): String = {
+    val bitmapClass = classOf[Roaring64Bitmap]
+    val rowIdBitmap = ctx.addMutableState(
+      bitmapClass.getName,
+      "matchedRowIds",
+      variable => s"$variable = new ${bitmapClass.getName}();")
+    val currentRowId = input(rowIdOrdinal)
+
+    code"""
+          |${currentRowId.code}
+          |if ($rowIdBitmap.contains(${currentRowId.value})) {
+          |  throw new RuntimeException("Should not happens");
+          |}
+          |$rowIdBitmap.add(${currentRowId.value});
+     """.stripMargin.toString
+  }
+
+  private def generateInstructionExecutionCode(
+      ctx: CodegenContext,
+      inputExprs: Seq[ExprCode]): String = {
+    val sourcePresentExpr = generatePredicateCode(ctx, isSourceRowPresent, child.output, inputExprs)
+    val targetPresentExpr = generatePredicateCode(ctx, isTargetRowPresent, child.output, inputExprs)
+    val matchedInstructionsCode = generateInstructionsCode(ctx, matchedInstructions, inputExprs)
+    val notMatchedInstructionsCode =
+      generateInstructionsCode(ctx, notMatchedInstructions, inputExprs)
+    val notMatchedBySourceInstructionsCode =
+      generateInstructionsCode(ctx, notMatchedBySourceInstructions, inputExprs)
+    val cardinalityValidationCode = if (checkCardinality) {
+      val rowIdOrdinal = child.output.indexWhere(attr => conf.resolver(attr.name, ROW_ID))
+      assert(rowIdOrdinal != -1, "Cannot find row ID attr")
+      generateCardinalityValidationCode(ctx, rowIdOrdinal, inputExprs)
+    } else {
+      ""
+    }
+
+    s"""
+       |${sourcePresentExpr.code}
+       |${targetPresentExpr.code}
+       |if (${targetPresentExpr.value} && ${sourcePresentExpr.value}) {
+       |  $cardinalityValidationCode
+       |  $matchedInstructionsCode
+       |} else if (${sourcePresentExpr.value}) {
+       |  $notMatchedInstructionsCode
+       |} else if (${targetPresentExpr.value}) {
+       |  $notMatchedBySourceInstructionsCode
+       |}
+     """.stripMargin
+  }
+
+  private def generateInstructionsCode(
+      ctx: CodegenContext,
+      instructions: Seq[Instruction],
+      inputExprs: Seq[ExprCode]): String = {
+    if (instructions.isEmpty) {
+      ""
+    } else {
+      val instructionCodes =
+        instructions.map(instruction => generateSingleInstructionCode(ctx, instruction, inputExprs))
+      s"""
+         |${instructionCodes.mkString("\n")}
+         |return;
+       """.stripMargin
+    }
+  }
+
+  private def generateSingleInstructionCode(
+      ctx: CodegenContext,
+      instruction: Instruction,
+      inputExprs: Seq[ExprCode]): String = {
+    instruction match {
+      case Keep(condition, outputExprs) =>
+        val projectionExpr = generateProjectionCode(ctx, outputExprs, inputExprs)
+        val predicateExpr = generatePredicateCode(ctx, condition, child.output, inputExprs)
+        s"""
+           |${predicateExpr.code}
+           |if (${predicateExpr.value}) {
+           |  ${consume(ctx, projectionExpr)}
+           |  return;
+           |}
+         """.stripMargin
+
+      case Discard(condition) =>
+        val predicateExpr = generatePredicateCode(ctx, condition, child.output, inputExprs)
+        s"""
+           |${predicateExpr.code}
+           |if (${predicateExpr.value}) {
+           |  return;
+           |}
+         """.stripMargin
+
+      case Split(condition, outputExprs, otherOutputExprs) =>
+        val projectionExpr = generateProjectionCode(ctx, outputExprs, inputExprs)
+        val otherProjectionExpr = generateProjectionCode(ctx, otherOutputExprs, inputExprs)
+        val predicateExpr = generatePredicateCode(ctx, condition, child.output, inputExprs)
+        s"""
+           |${predicateExpr.code}
+           |if (${predicateExpr.value}) {
+           |  ${consume(ctx, projectionExpr)}
+           |  ${consume(ctx, otherProjectionExpr)}
+           |  return;
+           |}
+         """.stripMargin
+
+      case other =>
+        throw new RuntimeException("Unsupported instruction type: " + other.getClass.getSimpleName)
+    }
+  }
+
+  private def withCodegenContext[T](ctx: CodegenContext, inputCurrentVars: Seq[ExprCode])(
+      block: => T): T = {
+    val originalCurrentVars = ctx.currentVars
+    val originalInputRow = ctx.INPUT_ROW
+    try {
+      ctx.currentVars = inputCurrentVars
+      block
+    } finally {
+      ctx.currentVars = originalCurrentVars
+      ctx.INPUT_ROW = originalInputRow
+    }
+  }
+
+  private def generatePredicateCode(
+      ctx: CodegenContext,
+      predicate: Expression,
+      inputAttrs: Seq[Attribute],
+      inputCurrentVars: Seq[ExprCode]): ExprCode = {
+    withCodegenContext(ctx, inputCurrentVars) {
+      val boundPredicate = BindReferences.bindReference(predicate, inputAttrs)
+      val evaluatedPredicate = boundPredicate.genCode(ctx)
+      val predicateVar = ctx.freshName("predicateResult")
+      val code = code"""
+                       |${evaluatedPredicate.code}
+                       |boolean $predicateVar = !${evaluatedPredicate.isNull} &&
+                       |  ${evaluatedPredicate.value};
+                     """.stripMargin
+      ExprCode(code, FalseLiteral, JavaCode.variable(predicateVar, BooleanType))
+    }
+  }
+
+  private def generateProjectionCode(
+      ctx: CodegenContext,
+      outputExprs: Seq[Expression],
+      inputCurrentVars: Seq[ExprCode]): Seq[ExprCode] = {
+    withCodegenContext(ctx, inputCurrentVars) {
+      val boundExprs = outputExprs.map(BindReferences.bindReference(_, child.output))
+      boundExprs.map(_.genCode(ctx))
+    }
+  }
+
+  private def constructConsumeParameters(
+      ctx: CodegenContext,
+      attributes: Seq[Attribute],
+      variables: Seq[ExprCode]): (Seq[String], Seq[String], Seq[ExprCode]) = {
+    val arguments = mutable.ArrayBuffer[String]()
+    val parameters = mutable.ArrayBuffer[String]()
+    val paramVars = mutable.ArrayBuffer[ExprCode]()
+
+    variables.zipWithIndex.foreach {
+      case (evaluatedVariable, index) =>
+        val paramName = ctx.freshName(s"expr_$index")
+        val paramType = CodeGenerator.javaType(attributes(index).dataType)
+        arguments += evaluatedVariable.value.toString
+        parameters += s"$paramType $paramName"
+        val paramIsNull = if (!attributes(index).nullable) {
+          FalseLiteral
+        } else {
+          val isNull = ctx.freshName(s"exprIsNull_$index")
+          arguments += evaluatedVariable.isNull.toString
+          parameters += s"boolean $isNull"
+          JavaCode.isNullVariable(isNull)
+        }
+        paramVars += ExprCode(paramIsNull, JavaCode.variable(paramName, attributes(index).dataType))
+    }
+
+    (arguments.toSeq, parameters.toSeq, paramVars.toSeq)
   }
 
   private def processPartition(rowIterator: Iterator[InternalRow]): Iterator[InternalRow] = {

--- a/paimon-spark/paimon-spark-3.3/src/test/scala/org/apache/paimon/spark/sql/MergeRowsCodegenTest.scala
+++ b/paimon-spark/paimon-spark-3.3/src/test/scala/org/apache/paimon/spark/sql/MergeRowsCodegenTest.scala
@@ -18,4 +18,13 @@
 
 package org.apache.paimon.spark.sql
 
-class MergeRowsCodegenTest extends MergeRowsCodegenTestBase
+import org.apache.spark.sql.catalyst.expressions.Expression
+import org.apache.spark.sql.catalyst.plans.logical.MergeRows.{Instruction, Keep}
+
+class MergeRowsCodegenTest extends MergeRowsCodegenTestBase {
+
+  override protected def keepInstruction(
+      condition: Expression,
+      output: Seq[Expression]): Instruction =
+    Keep(condition, output)
+}

--- a/paimon-spark/paimon-spark-3.3/src/test/scala/org/apache/paimon/spark/sql/MergeRowsCodegenTest.scala
+++ b/paimon-spark/paimon-spark-3.3/src/test/scala/org/apache/paimon/spark/sql/MergeRowsCodegenTest.scala
@@ -1,0 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.spark.sql
+
+class MergeRowsCodegenTest extends MergeRowsCodegenTestBase

--- a/paimon-spark/paimon-spark-3.4/src/main/scala/org/apache/spark/sql/execution/datasources/v2/MergeRowsExec.scala
+++ b/paimon-spark/paimon-spark-3.4/src/main/scala/org/apache/spark/sql/execution/datasources/v2/MergeRowsExec.scala
@@ -86,7 +86,8 @@ case class MergeRowsExec(
   override def supportCodegen: Boolean = {
     OptionUtils.mergeCodegenEnabled() &&
     conf.wholeStageEnabled &&
-    CodeGenerator.isValidParamLength(CodeGenerator.calculateParamLength(child.output))
+    CodeGenerator.isValidParamLength(
+      CodeGenerator.calculateParamLength(child.output.filter(usedInputs.contains)))
   }
 
   override protected def doProduce(ctx: CodegenContext): String = {
@@ -267,23 +268,26 @@ case class MergeRowsExec(
       variables: Seq[ExprCode]): (Seq[String], Seq[String], Seq[ExprCode]) = {
     val arguments = mutable.ArrayBuffer[String]()
     val parameters = mutable.ArrayBuffer[String]()
-    val paramVars = mutable.ArrayBuffer[ExprCode]()
+    val paramVars = mutable.ArrayBuffer(variables: _*)
 
     variables.zipWithIndex.foreach {
       case (evaluatedVariable, index) =>
-        val paramName = ctx.freshName(s"expr_$index")
-        val paramType = CodeGenerator.javaType(attributes(index).dataType)
-        arguments += evaluatedVariable.value.toString
-        parameters += s"$paramType $paramName"
-        val paramIsNull = if (!attributes(index).nullable) {
-          FalseLiteral
-        } else {
-          val isNull = ctx.freshName(s"exprIsNull_$index")
-          arguments += evaluatedVariable.isNull.toString
-          parameters += s"boolean $isNull"
-          JavaCode.isNullVariable(isNull)
+        if (usedInputs.contains(attributes(index))) {
+          val paramName = ctx.freshName(s"expr_$index")
+          val paramType = CodeGenerator.javaType(attributes(index).dataType)
+          arguments += evaluatedVariable.value.toString
+          parameters += s"$paramType $paramName"
+          val paramIsNull = if (!attributes(index).nullable) {
+            FalseLiteral
+          } else {
+            val isNull = ctx.freshName(s"exprIsNull_$index")
+            arguments += evaluatedVariable.isNull.toString
+            parameters += s"boolean $isNull"
+            JavaCode.isNullVariable(isNull)
+          }
+          paramVars(index) =
+            ExprCode(paramIsNull, JavaCode.variable(paramName, attributes(index).dataType))
         }
-        paramVars += ExprCode(paramIsNull, JavaCode.variable(paramName, attributes(index).dataType))
     }
 
     (arguments.toSeq, parameters.toSeq, paramVars.toSeq)

--- a/paimon-spark/paimon-spark-3.4/src/main/scala/org/apache/spark/sql/execution/datasources/v2/MergeRowsExec.scala
+++ b/paimon-spark/paimon-spark-3.4/src/main/scala/org/apache/spark/sql/execution/datasources/v2/MergeRowsExec.scala
@@ -18,14 +18,20 @@
 
 package org.apache.spark.sql.execution.datasources.v2
 
+import org.apache.paimon.spark.util.OptionUtils
+
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.catalyst.InternalRow
-import org.apache.spark.sql.catalyst.expressions.{Attribute, AttributeSet, BasePredicate, Expression, Projection, UnsafeProjection}
-import org.apache.spark.sql.catalyst.expressions.codegen.GeneratePredicate
+import org.apache.spark.sql.catalyst.expressions.{Attribute, AttributeSet, BasePredicate, BindReferences, Expression, Projection, UnsafeProjection}
+import org.apache.spark.sql.catalyst.expressions.codegen.{CodegenContext, CodeGenerator, ExprCode, FalseLiteral, GeneratePredicate, JavaCode}
+import org.apache.spark.sql.catalyst.expressions.codegen.Block.BlockHelper
 import org.apache.spark.sql.catalyst.plans.logical.MergeRows._
 import org.apache.spark.sql.catalyst.util.truncatedString
-import org.apache.spark.sql.execution.{SparkPlan, UnaryExecNode}
+import org.apache.spark.sql.execution.{CodegenSupport, SparkPlan, UnaryExecNode}
+import org.apache.spark.sql.types.BooleanType
 import org.roaringbitmap.longlong.Roaring64Bitmap
+
+import scala.collection.mutable
 
 case class MergeRowsExec(
     isSourceRowPresent: Expression,
@@ -36,7 +42,8 @@ case class MergeRowsExec(
     checkCardinality: Boolean,
     output: Seq[Attribute],
     child: SparkPlan)
-  extends UnaryExecNode {
+  extends UnaryExecNode
+  with CodegenSupport {
 
   @transient override lazy val producedAttributes: AttributeSet = {
     AttributeSet(output.filterNot(attr => inputSet.contains(attr)))
@@ -64,6 +71,222 @@ case class MergeRowsExec(
 
   override protected def doExecute(): RDD[InternalRow] = {
     child.execute().mapPartitions(processPartition)
+  }
+
+  override def inputRDDs(): Seq[RDD[InternalRow]] = {
+    child.asInstanceOf[CodegenSupport].inputRDDs()
+  }
+
+  override def needCopyResult: Boolean = {
+    val hasSplitInstruction = (matchedInstructions ++ notMatchedInstructions ++
+      notMatchedBySourceInstructions).exists(_.isInstanceOf[Split])
+    hasSplitInstruction || child.asInstanceOf[CodegenSupport].needCopyResult
+  }
+
+  override def supportCodegen: Boolean = {
+    OptionUtils.mergeCodegenEnabled() &&
+    conf.wholeStageEnabled &&
+    CodeGenerator.isValidParamLength(CodeGenerator.calculateParamLength(child.output))
+  }
+
+  override protected def doProduce(ctx: CodegenContext): String = {
+    child.asInstanceOf[CodegenSupport].produce(ctx, this)
+  }
+
+  override def doConsume(ctx: CodegenContext, input: Seq[ExprCode], row: ExprCode): String = {
+    val funcName = ctx.freshName("mergeProcessRow")
+    val (args, params, paramExprs) = constructConsumeParameters(ctx, child.output, input)
+    val body = generateInstructionExecutionCode(ctx, paramExprs)
+    val addedFuncName = ctx.addNewFunction(
+      funcName,
+      s"""
+         |private void $funcName(${params.mkString(", ")}) throws java.io.IOException {
+         |  $body
+         |}
+       """.stripMargin
+    )
+
+    s"$addedFuncName(${args.mkString(", ")});"
+  }
+
+  private def generateCardinalityValidationCode(
+      ctx: CodegenContext,
+      rowIdOrdinal: Int,
+      input: Seq[ExprCode]): String = {
+    val bitmapClass = classOf[Roaring64Bitmap]
+    val rowIdBitmap = ctx.addMutableState(
+      bitmapClass.getName,
+      "matchedRowIds",
+      variable => s"$variable = new ${bitmapClass.getName}();")
+    val currentRowId = input(rowIdOrdinal)
+
+    code"""
+          |${currentRowId.code}
+          |if ($rowIdBitmap.contains(${currentRowId.value})) {
+          |  throw new RuntimeException("Should not happens");
+          |}
+          |$rowIdBitmap.add(${currentRowId.value});
+     """.stripMargin.toString
+  }
+
+  private def generateInstructionExecutionCode(
+      ctx: CodegenContext,
+      inputExprs: Seq[ExprCode]): String = {
+    val sourcePresentExpr = generatePredicateCode(ctx, isSourceRowPresent, child.output, inputExprs)
+    val targetPresentExpr = generatePredicateCode(ctx, isTargetRowPresent, child.output, inputExprs)
+    val matchedInstructionsCode = generateInstructionsCode(ctx, matchedInstructions, inputExprs)
+    val notMatchedInstructionsCode =
+      generateInstructionsCode(ctx, notMatchedInstructions, inputExprs)
+    val notMatchedBySourceInstructionsCode =
+      generateInstructionsCode(ctx, notMatchedBySourceInstructions, inputExprs)
+    val cardinalityValidationCode = if (checkCardinality) {
+      val rowIdOrdinal = child.output.indexWhere(attr => conf.resolver(attr.name, ROW_ID))
+      assert(rowIdOrdinal != -1, "Cannot find row ID attr")
+      generateCardinalityValidationCode(ctx, rowIdOrdinal, inputExprs)
+    } else {
+      ""
+    }
+
+    s"""
+       |${sourcePresentExpr.code}
+       |${targetPresentExpr.code}
+       |if (${targetPresentExpr.value} && ${sourcePresentExpr.value}) {
+       |  $cardinalityValidationCode
+       |  $matchedInstructionsCode
+       |} else if (${sourcePresentExpr.value}) {
+       |  $notMatchedInstructionsCode
+       |} else if (${targetPresentExpr.value}) {
+       |  $notMatchedBySourceInstructionsCode
+       |}
+     """.stripMargin
+  }
+
+  private def generateInstructionsCode(
+      ctx: CodegenContext,
+      instructions: Seq[Instruction],
+      inputExprs: Seq[ExprCode]): String = {
+    if (instructions.isEmpty) {
+      ""
+    } else {
+      val instructionCodes =
+        instructions.map(instruction => generateSingleInstructionCode(ctx, instruction, inputExprs))
+      s"""
+         |${instructionCodes.mkString("\n")}
+         |return;
+       """.stripMargin
+    }
+  }
+
+  private def generateSingleInstructionCode(
+      ctx: CodegenContext,
+      instruction: Instruction,
+      inputExprs: Seq[ExprCode]): String = {
+    instruction match {
+      case Keep(condition, outputExprs) =>
+        val projectionExpr = generateProjectionCode(ctx, outputExprs, inputExprs)
+        val predicateExpr = generatePredicateCode(ctx, condition, child.output, inputExprs)
+        s"""
+           |${predicateExpr.code}
+           |if (${predicateExpr.value}) {
+           |  ${consume(ctx, projectionExpr)}
+           |  return;
+           |}
+         """.stripMargin
+
+      case Discard(condition) =>
+        val predicateExpr = generatePredicateCode(ctx, condition, child.output, inputExprs)
+        s"""
+           |${predicateExpr.code}
+           |if (${predicateExpr.value}) {
+           |  return;
+           |}
+         """.stripMargin
+
+      case Split(condition, outputExprs, otherOutputExprs) =>
+        val projectionExpr = generateProjectionCode(ctx, outputExprs, inputExprs)
+        val otherProjectionExpr = generateProjectionCode(ctx, otherOutputExprs, inputExprs)
+        val predicateExpr = generatePredicateCode(ctx, condition, child.output, inputExprs)
+        s"""
+           |${predicateExpr.code}
+           |if (${predicateExpr.value}) {
+           |  ${consume(ctx, projectionExpr)}
+           |  ${consume(ctx, otherProjectionExpr)}
+           |  return;
+           |}
+         """.stripMargin
+
+      case other =>
+        throw new RuntimeException("Unsupported instruction type: " + other.getClass.getSimpleName)
+    }
+  }
+
+  private def withCodegenContext[T](ctx: CodegenContext, inputCurrentVars: Seq[ExprCode])(
+      block: => T): T = {
+    val originalCurrentVars = ctx.currentVars
+    val originalInputRow = ctx.INPUT_ROW
+    try {
+      ctx.currentVars = inputCurrentVars
+      block
+    } finally {
+      ctx.currentVars = originalCurrentVars
+      ctx.INPUT_ROW = originalInputRow
+    }
+  }
+
+  private def generatePredicateCode(
+      ctx: CodegenContext,
+      predicate: Expression,
+      inputAttrs: Seq[Attribute],
+      inputCurrentVars: Seq[ExprCode]): ExprCode = {
+    withCodegenContext(ctx, inputCurrentVars) {
+      val boundPredicate = BindReferences.bindReference(predicate, inputAttrs)
+      val evaluatedPredicate = boundPredicate.genCode(ctx)
+      val predicateVar = ctx.freshName("predicateResult")
+      val code = code"""
+                       |${evaluatedPredicate.code}
+                       |boolean $predicateVar = !${evaluatedPredicate.isNull} &&
+                       |  ${evaluatedPredicate.value};
+                     """.stripMargin
+      ExprCode(code, FalseLiteral, JavaCode.variable(predicateVar, BooleanType))
+    }
+  }
+
+  private def generateProjectionCode(
+      ctx: CodegenContext,
+      outputExprs: Seq[Expression],
+      inputCurrentVars: Seq[ExprCode]): Seq[ExprCode] = {
+    withCodegenContext(ctx, inputCurrentVars) {
+      val boundExprs = outputExprs.map(BindReferences.bindReference(_, child.output))
+      boundExprs.map(_.genCode(ctx))
+    }
+  }
+
+  private def constructConsumeParameters(
+      ctx: CodegenContext,
+      attributes: Seq[Attribute],
+      variables: Seq[ExprCode]): (Seq[String], Seq[String], Seq[ExprCode]) = {
+    val arguments = mutable.ArrayBuffer[String]()
+    val parameters = mutable.ArrayBuffer[String]()
+    val paramVars = mutable.ArrayBuffer[ExprCode]()
+
+    variables.zipWithIndex.foreach {
+      case (evaluatedVariable, index) =>
+        val paramName = ctx.freshName(s"expr_$index")
+        val paramType = CodeGenerator.javaType(attributes(index).dataType)
+        arguments += evaluatedVariable.value.toString
+        parameters += s"$paramType $paramName"
+        val paramIsNull = if (!attributes(index).nullable) {
+          FalseLiteral
+        } else {
+          val isNull = ctx.freshName(s"exprIsNull_$index")
+          arguments += evaluatedVariable.isNull.toString
+          parameters += s"boolean $isNull"
+          JavaCode.isNullVariable(isNull)
+        }
+        paramVars += ExprCode(paramIsNull, JavaCode.variable(paramName, attributes(index).dataType))
+    }
+
+    (arguments.toSeq, parameters.toSeq, paramVars.toSeq)
   }
 
   private def processPartition(rowIterator: Iterator[InternalRow]): Iterator[InternalRow] = {

--- a/paimon-spark/paimon-spark-3.4/src/test/scala/org/apache/paimon/spark/sql/MergeRowsCodegenTest.scala
+++ b/paimon-spark/paimon-spark-3.4/src/test/scala/org/apache/paimon/spark/sql/MergeRowsCodegenTest.scala
@@ -18,4 +18,13 @@
 
 package org.apache.paimon.spark.sql
 
-class MergeRowsCodegenTest extends MergeRowsCodegenTestBase
+import org.apache.spark.sql.catalyst.expressions.Expression
+import org.apache.spark.sql.catalyst.plans.logical.MergeRows.{Instruction, Keep}
+
+class MergeRowsCodegenTest extends MergeRowsCodegenTestBase {
+
+  override protected def keepInstruction(
+      condition: Expression,
+      output: Seq[Expression]): Instruction =
+    Keep(condition, output)
+}

--- a/paimon-spark/paimon-spark-3.4/src/test/scala/org/apache/paimon/spark/sql/MergeRowsCodegenTest.scala
+++ b/paimon-spark/paimon-spark-3.4/src/test/scala/org/apache/paimon/spark/sql/MergeRowsCodegenTest.scala
@@ -1,0 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.spark.sql
+
+class MergeRowsCodegenTest extends MergeRowsCodegenTestBase

--- a/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/SparkConnectorOptions.java
+++ b/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/SparkConnectorOptions.java
@@ -92,12 +92,14 @@ public class SparkConnectorOptions {
                                     + "dynamic partition columns. If false, the query output follows "
                                     + "the table schema order.");
 
+    // The custom MergeRowsExec implementation is only provided for Spark 3.2, 3.3 and 3.4.
     public static final ConfigOption<Boolean> MERGE_CODEGEN_ENABLED =
             key("write.merge.codegen.enabled")
                     .booleanType()
                     .defaultValue(false)
                     .withDescription(
-                            "Whether to enable whole-stage code generation for merge row processing.");
+                            "Whether to enable whole-stage code generation for merge row processing. "
+                                    + "Only applicable to Spark 3.2, 3.3 and 3.4.");
 
     public static final ConfigOption<Integer> DATA_EVOLUTION_UPDATE_CONFLICT_RETRY_MAX_ATTEMPTS =
             key("write.data-evolution.update-conflict-retry.max-attempts")

--- a/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/SparkConnectorOptions.java
+++ b/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/SparkConnectorOptions.java
@@ -92,6 +92,13 @@ public class SparkConnectorOptions {
                                     + "dynamic partition columns. If false, the query output follows "
                                     + "the table schema order.");
 
+    public static final ConfigOption<Boolean> MERGE_CODEGEN_ENABLED =
+            key("write.merge.codegen.enabled")
+                    .booleanType()
+                    .defaultValue(false)
+                    .withDescription(
+                            "Whether to enable whole-stage code generation for merge row processing.");
+
     public static final ConfigOption<Integer> DATA_EVOLUTION_UPDATE_CONFLICT_RETRY_MAX_ATTEMPTS =
             key("write.data-evolution.update-conflict-retry.max-attempts")
                     .intType()

--- a/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/util/OptionUtils.scala
+++ b/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/util/OptionUtils.scala
@@ -114,6 +114,10 @@ object OptionUtils extends SQLConfHelper with Logging {
     getOptionString(SparkConnectorOptions.HIVE_STYLE_DYNAMIC_PARTITION_ENABLED).toBoolean
   }
 
+  def mergeCodegenEnabled(): Boolean = {
+    getOptionString(SparkConnectorOptions.MERGE_CODEGEN_ENABLED).toBoolean
+  }
+
   def writeMergeSchemaExplicitCastEnabled(): Boolean = {
     getOptionString(SparkConnectorOptions.EXPLICIT_CAST).toBoolean
   }

--- a/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/sql/MergeRowsCodegenTestBase.scala
+++ b/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/sql/MergeRowsCodegenTestBase.scala
@@ -1,0 +1,92 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.spark.sql
+
+import org.apache.paimon.spark.{PaimonSparkTestBase, SparkConnectorOptions}
+
+import org.apache.spark.sql.{PaimonUtils, Row}
+import org.apache.spark.sql.catalyst.expressions.{AttributeReference, LessThan, Literal}
+import org.apache.spark.sql.catalyst.expressions.Literal.TrueLiteral
+import org.apache.spark.sql.catalyst.plans.logical.MergeRows
+import org.apache.spark.sql.catalyst.plans.logical.MergeRows.{Discard, Keep, Split}
+import org.apache.spark.sql.execution.WholeStageCodegenExec
+import org.apache.spark.sql.execution.datasources.v2.MergeRowsExec
+import org.apache.spark.sql.types.IntegerType
+
+abstract class MergeRowsCodegenTestBase extends PaimonSparkTestBase {
+
+  import testImplicits._
+
+  test("merge row codegen requires Spark and Paimon flags") {
+    assert(!SparkConnectorOptions.MERGE_CODEGEN_ENABLED.defaultValue())
+
+    val paimonCodegenKey =
+      s"spark.paimon.${SparkConnectorOptions.MERGE_CODEGEN_ENABLED.key()}"
+
+    Seq(
+      (false, true, false),
+      (true, false, false),
+      (true, true, true)
+    ).foreach {
+      case (paimonCodegenEnabled, sparkCodegenEnabled, expectedCodegen) =>
+        withSparkSQLConf(
+          paimonCodegenKey -> paimonCodegenEnabled.toString,
+          "spark.sql.codegen.wholeStage" -> sparkCodegenEnabled.toString) {
+          val input = Seq(
+            (1, 10, true, true, 101L),
+            (2, 20, true, false, 102L),
+            (3, 30, false, true, 103L),
+            (4, 40, false, false, 104L),
+            (5, 50, true, true, 105L)
+          ).toDF("target_id", "source_value", "source_present", "target_present", MergeRows.ROW_ID)
+          val inputPlan = input.queryExecution.analyzed
+          val targetId = inputPlan.output(0)
+          val sourceValue = inputPlan.output(1)
+          val sourcePresent = inputPlan.output(2)
+          val targetPresent = inputPlan.output(3)
+          val output = Seq(
+            AttributeReference("id", IntegerType, nullable = false)(),
+            AttributeReference("value", IntegerType, nullable = false)())
+          val mergeRows = MergeRows(
+            isSourceRowPresent = sourcePresent,
+            isTargetRowPresent = targetPresent,
+            matchedInstructions = Seq(
+              Keep(LessThan(sourceValue, Literal(15)), Seq(targetId, sourceValue)),
+              Discard(TrueLiteral)),
+            notMatchedInstructions = Seq(Keep(TrueLiteral, Seq(sourceValue, sourceValue))),
+            notMatchedBySourceInstructions =
+              Seq(Split(TrueLiteral, Seq(targetId, Literal(-1)), Seq(targetId, Literal(-2)))),
+            checkCardinality = true,
+            output = output,
+            child = inputPlan
+          )
+          val result = PaimonUtils.createDataset(spark, mergeRows)
+          val executedPlan = result.queryExecution.executedPlan
+          val mergeRowsIsCodegen = executedPlan.collectFirst {
+            case stage: WholeStageCodegenExec
+                if stage.collectFirst { case _: MergeRowsExec => true }.isDefined =>
+              true
+          }.isDefined
+
+          assert(mergeRowsIsCodegen == expectedCodegen, executedPlan)
+          checkAnswer(result, Seq(Row(1, 10), Row(20, 20), Row(3, -1), Row(3, -2)))
+        }
+    }
+  }
+}

--- a/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/sql/MergeRowsCodegenTestBase.scala
+++ b/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/sql/MergeRowsCodegenTestBase.scala
@@ -95,14 +95,12 @@ abstract class MergeRowsCodegenTestBase extends PaimonSparkTestBase {
 
           assert(mergeRowsIsCodegen == expectedCodegen, executedPlan)
           checkAnswer(result, Seq(Row(1, 10), Row(20, 20), Row(3, -1), Row(3, -2)))
-      }
+        }
     }
   }
 
   test("Paimon merge query uses codegen") {
-    withSparkSQLConf(
-      paimonCodegenKey -> "true",
-      "spark.sql.codegen.wholeStage" -> "true") {
+    withSparkSQLConf(paimonCodegenKey -> "true", "spark.sql.codegen.wholeStage" -> "true") {
       withTable("target") {
         sql("""
               |CREATE TABLE target (id INT, v INT)
@@ -112,10 +110,7 @@ abstract class MergeRowsCodegenTestBase extends PaimonSparkTestBase {
 
         val mergeCodegenExecuted = new AtomicBoolean(false)
         val listener = new QueryExecutionListener {
-          override def onSuccess(
-              funcName: String,
-              qe: QueryExecution,
-              durationNs: Long): Unit = {
+          override def onSuccess(funcName: String, qe: QueryExecution, durationNs: Long): Unit = {
             if (containsMergeRowsCodegen(qe.executedPlan)) {
               mergeCodegenExecuted.set(true)
             }

--- a/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/sql/MergeRowsCodegenTestBase.scala
+++ b/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/sql/MergeRowsCodegenTestBase.scala
@@ -25,21 +25,25 @@ import org.apache.spark.sql.catalyst.expressions.{AttributeReference, Expression
 import org.apache.spark.sql.catalyst.expressions.Literal.TrueLiteral
 import org.apache.spark.sql.catalyst.plans.logical.MergeRows
 import org.apache.spark.sql.catalyst.plans.logical.MergeRows.{Discard, Instruction, Split}
-import org.apache.spark.sql.execution.WholeStageCodegenExec
+import org.apache.spark.sql.execution.{QueryExecution, SparkPlan, WholeStageCodegenExec}
 import org.apache.spark.sql.execution.datasources.v2.MergeRowsExec
+import org.apache.spark.sql.paimon.Utils
 import org.apache.spark.sql.types.IntegerType
+import org.apache.spark.sql.util.QueryExecutionListener
+
+import java.util.concurrent.atomic.AtomicBoolean
 
 abstract class MergeRowsCodegenTestBase extends PaimonSparkTestBase {
 
   import testImplicits._
 
+  private val paimonCodegenKey =
+    s"spark.paimon.${SparkConnectorOptions.MERGE_CODEGEN_ENABLED.key()}"
+
   protected def keepInstruction(condition: Expression, output: Seq[Expression]): Instruction
 
   test("merge row codegen requires Spark and Paimon flags") {
     assert(!SparkConnectorOptions.MERGE_CODEGEN_ENABLED.defaultValue())
-
-    val paimonCodegenKey =
-      s"spark.paimon.${SparkConnectorOptions.MERGE_CODEGEN_ENABLED.key()}"
 
     Seq(
       (false, true, false),
@@ -51,12 +55,18 @@ abstract class MergeRowsCodegenTestBase extends PaimonSparkTestBase {
           paimonCodegenKey -> paimonCodegenEnabled.toString,
           "spark.sql.codegen.wholeStage" -> sparkCodegenEnabled.toString) {
           val input = Seq(
-            (1, 10, true, true, 101L),
-            (2, 20, true, false, 102L),
-            (3, 30, false, true, 103L),
-            (4, 40, false, false, 104L),
-            (5, 50, true, true, 105L)
-          ).toDF("target_id", "source_value", "source_present", "target_present", MergeRows.ROW_ID)
+            (1, 10, true, true, 101L, "unused-1"),
+            (2, 20, true, false, 102L, "unused-2"),
+            (3, 30, false, true, 103L, "unused-3"),
+            (4, 40, false, false, 104L, "unused-4"),
+            (5, 50, true, true, 105L, "unused-5")
+          ).toDF(
+            "target_id",
+            "source_value",
+            "source_present",
+            "target_present",
+            MergeRows.ROW_ID,
+            "unused")
           val inputPlan = input.queryExecution.analyzed
           val targetId = inputPlan.output(0)
           val sourceValue = inputPlan.output(1)
@@ -81,15 +91,68 @@ abstract class MergeRowsCodegenTestBase extends PaimonSparkTestBase {
           )
           val result = PaimonUtils.createDataset(spark, mergeRows)
           val executedPlan = result.queryExecution.executedPlan
-          val mergeRowsIsCodegen = executedPlan.collectFirst {
-            case stage: WholeStageCodegenExec
-                if stage.collectFirst { case _: MergeRowsExec => true }.isDefined =>
-              true
-          }.isDefined
+          val mergeRowsIsCodegen = containsMergeRowsCodegen(executedPlan)
 
           assert(mergeRowsIsCodegen == expectedCodegen, executedPlan)
           checkAnswer(result, Seq(Row(1, 10), Row(20, 20), Row(3, -1), Row(3, -2)))
-        }
+      }
     }
+  }
+
+  test("Paimon merge query uses codegen") {
+    withSparkSQLConf(
+      paimonCodegenKey -> "true",
+      "spark.sql.codegen.wholeStage" -> "true") {
+      withTable("target") {
+        sql("""
+              |CREATE TABLE target (id INT, v INT)
+              |TBLPROPERTIES ('primary-key' = 'id', 'bucket' = '1')
+              |""".stripMargin)
+        sql("INSERT INTO target VALUES (1, 1), (2, 2)")
+
+        val mergeCodegenExecuted = new AtomicBoolean(false)
+        val listener = new QueryExecutionListener {
+          override def onSuccess(
+              funcName: String,
+              qe: QueryExecution,
+              durationNs: Long): Unit = {
+            if (containsMergeRowsCodegen(qe.executedPlan)) {
+              mergeCodegenExecuted.set(true)
+            }
+          }
+
+          override def onFailure(
+              funcName: String,
+              qe: QueryExecution,
+              exception: Exception): Unit = {}
+        }
+
+        spark.listenerManager.register(listener)
+        try {
+          sql("""
+                |MERGE INTO target
+                |USING (SELECT * FROM VALUES (1, 10), (2, 20), (3, 30) AS source(id, v)) source
+                |ON target.id = source.id
+                |WHEN MATCHED AND source.id = 1 THEN UPDATE SET target.v = source.v
+                |WHEN MATCHED AND source.id = 2 THEN DELETE
+                |WHEN NOT MATCHED THEN INSERT (id, v) VALUES (source.id, source.v)
+                |""".stripMargin)
+          Utils.waitUntilEventEmpty(spark)
+        } finally {
+          spark.listenerManager.unregister(listener)
+        }
+
+        assert(mergeCodegenExecuted.get(), "Expected Paimon MERGE INTO to use whole-stage codegen.")
+        checkAnswer(sql("SELECT id, v FROM target ORDER BY id"), Seq(Row(1, 10), Row(3, 30)))
+      }
+    }
+  }
+
+  private def containsMergeRowsCodegen(plan: SparkPlan): Boolean = {
+    plan.collectFirst {
+      case stage: WholeStageCodegenExec
+          if stage.collectFirst { case _: MergeRowsExec => true }.isDefined =>
+        true
+    }.isDefined
   }
 }

--- a/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/sql/MergeRowsCodegenTestBase.scala
+++ b/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/sql/MergeRowsCodegenTestBase.scala
@@ -21,10 +21,10 @@ package org.apache.paimon.spark.sql
 import org.apache.paimon.spark.{PaimonSparkTestBase, SparkConnectorOptions}
 
 import org.apache.spark.sql.{PaimonUtils, Row}
-import org.apache.spark.sql.catalyst.expressions.{AttributeReference, LessThan, Literal}
+import org.apache.spark.sql.catalyst.expressions.{AttributeReference, Expression, LessThan, Literal}
 import org.apache.spark.sql.catalyst.expressions.Literal.TrueLiteral
 import org.apache.spark.sql.catalyst.plans.logical.MergeRows
-import org.apache.spark.sql.catalyst.plans.logical.MergeRows.{Discard, Keep, Split}
+import org.apache.spark.sql.catalyst.plans.logical.MergeRows.{Discard, Instruction, Split}
 import org.apache.spark.sql.execution.WholeStageCodegenExec
 import org.apache.spark.sql.execution.datasources.v2.MergeRowsExec
 import org.apache.spark.sql.types.IntegerType
@@ -32,6 +32,8 @@ import org.apache.spark.sql.types.IntegerType
 abstract class MergeRowsCodegenTestBase extends PaimonSparkTestBase {
 
   import testImplicits._
+
+  protected def keepInstruction(condition: Expression, output: Seq[Expression]): Instruction
 
   test("merge row codegen requires Spark and Paimon flags") {
     assert(!SparkConnectorOptions.MERGE_CODEGEN_ENABLED.defaultValue())
@@ -67,9 +69,10 @@ abstract class MergeRowsCodegenTestBase extends PaimonSparkTestBase {
             isSourceRowPresent = sourcePresent,
             isTargetRowPresent = targetPresent,
             matchedInstructions = Seq(
-              Keep(LessThan(sourceValue, Literal(15)), Seq(targetId, sourceValue)),
+              keepInstruction(LessThan(sourceValue, Literal(15)), Seq(targetId, sourceValue)),
               Discard(TrueLiteral)),
-            notMatchedInstructions = Seq(Keep(TrueLiteral, Seq(sourceValue, sourceValue))),
+            notMatchedInstructions =
+              Seq(keepInstruction(TrueLiteral, Seq(sourceValue, sourceValue))),
             notMatchedBySourceInstructions =
               Seq(Split(TrueLiteral, Seq(targetId, Literal(-1)), Seq(targetId, Literal(-2)))),
             checkCardinality = true,


### PR DESCRIPTION
### Purpose
 - Paimon processes merge queries through JVM and runs a scala iterator for every joined row.
 - Add support for whole stage codegen for matched and unmatched actions. With keep/discard/split functions support.
 - This optimization is config driven and enabled with `spark.paimon.write.merge.codegen.enabled`. Spark's upstream operator reports 1.7x to 32.3x improvements with wholestage on. 

### Tests
 - UT