### PR TITLE
[core][iceberg] Include table name in commit/Iceberg-commit exception

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/iceberg/IcebergCommitCallback.java
+++ b/paimon-core/src/main/java/org/apache/paimon/iceberg/IcebergCommitCallback.java
@@ -293,6 +293,8 @@ public class IcebergCommitCallback implements CommitCallback, TagCallback {
                                                         + commitUser
                                                         + " and identifier "
                                                         + committable.identifier()
+                                                        + " for table "
+                                                        + table.name()
                                                         + ". This is unexpected."));
         long snapshotId = snapshot.id();
         createMetadata(

--- a/paimon-core/src/main/java/org/apache/paimon/operation/FileStoreCommitImpl.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/FileStoreCommitImpl.java
@@ -866,8 +866,8 @@ public class FileStoreCommitImpl implements FileStoreCommit {
                     || retryCount >= options.commitMaxRetries()) {
                 String message =
                         String.format(
-                                "Commit failed after %s millis with %s retries, there maybe exist commit conflicts between multiple jobs.",
-                                options.commitTimeout(), retryCount);
+                                "Commit failed for table %s after %s millis with %s retries, there maybe exist commit conflicts between multiple jobs.",
+                                tableName, options.commitTimeout(), retryCount);
                 throw new RuntimeException(message, retryResult.exception);
             }
 
@@ -1249,9 +1249,9 @@ public class FileStoreCommitImpl implements FileStoreCommit {
                     baseManifestList, mergeBeforeManifests, mergeAfterManifests);
             throw new RuntimeException(
                     String.format(
-                            "Exception occurs when preparing snapshot #%d by user %s "
+                            "Exception occurs when preparing snapshot #%d for table %s by user %s "
                                     + "with hash %s and kind %s. Clean up.",
-                            newSnapshotId, commitUser, identifier, commitKind.name()),
+                            newSnapshotId, tableName, commitUser, identifier, commitKind.name()),
                     e);
         }
 
@@ -1265,17 +1265,23 @@ public class FileStoreCommitImpl implements FileStoreCommit {
             success = commitSnapshotImpl(latestSnapshot, newSnapshot, deltaStatistics);
         } catch (Exception e) {
             // commit exception, not sure about the situation and should not clean up the files
-            LOG.warn("Retry commit for exception.", e);
+            LOG.warn(
+                    "Retry commit for exception when committing snapshot #{} for table {} by user {}.",
+                    newSnapshotId,
+                    tableName,
+                    commitUser,
+                    e);
             return RetryCommitResult.forCommitFail(latestSnapshot, baseDataFiles, e, null);
         }
 
         if (!success) {
             long commitTime = (System.currentTimeMillis() - startMillis) / 1000;
             LOG.warn(
-                    "Atomic commit failed for snapshot #{} by user {} "
+                    "Atomic commit failed for snapshot #{} for table {} by user {} "
                             + "with identifier {} and kind {} after {} seconds. "
                             + "Skip clean up and try again.",
                     newSnapshotId,
+                    tableName,
                     commitUser,
                     identifier,
                     commitKind.name(),
@@ -1569,8 +1575,8 @@ public class FileStoreCommitImpl implements FileStoreCommit {
                     || retryCount >= options.commitMaxRetries()) {
                 throw new RuntimeException(
                         String.format(
-                                "Commit failed after %s millis with %s retries, there maybe exist commit conflicts between multiple jobs.",
-                                options.commitTimeout(), retryCount));
+                                "Commit failed for table %s after %s millis with %s retries, there maybe exist commit conflicts between multiple jobs.",
+                                tableName, options.commitTimeout(), retryCount));
             }
 
             retryWaiter.retryWait(retryCount);
@@ -1656,10 +1662,11 @@ public class FileStoreCommitImpl implements FileStoreCommit {
             // we cannot clean up because we can't determine the success
             throw new RuntimeException(
                     String.format(
-                            "Exception occurs when committing snapshot #%d by user %s "
+                            "Exception occurs when committing snapshot #%d for table %s by user %s "
                                     + "with identifier %s and kind %s. "
                                     + "Cannot clean up because we can't determine the success.",
                             newSnapshot.id(),
+                            tableName,
                             newSnapshot.commitUser(),
                             newSnapshot.commitIdentifier(),
                             newSnapshot.commitKind().name()),

--- a/paimon-hive/paimon-hive-catalog/src/main/java/org/apache/paimon/iceberg/IcebergHiveMetadataCommitter.java
+++ b/paimon-hive/paimon-hive-catalog/src/main/java/org/apache/paimon/iceberg/IcebergHiveMetadataCommitter.java
@@ -128,7 +128,15 @@ public class IcebergHiveMetadataCommitter implements IcebergMetadataCommitter {
         try {
             commitMetadataImpl(newMetadataPath, baseMetadataPath);
         } catch (Exception e) {
-            throw new RuntimeException(e);
+            throw new RuntimeException(
+                    "Fail to commit iceberg metadata to hive metastore for table: "
+                            + icebergDatabases
+                            + "."
+                            + icebergTableName
+                            + " (paimon table: "
+                            + table.name()
+                            + ")",
+                    e);
         }
     }
 

--- a/paimon-iceberg/src/main/java/org/apache/paimon/iceberg/IcebergRestMetadataCommitter.java
+++ b/paimon-iceberg/src/main/java/org/apache/paimon/iceberg/IcebergRestMetadataCommitter.java
@@ -110,7 +110,9 @@ public class IcebergRestMetadataCommitter implements IcebergMetadataCommitter {
 
             this.restCatalog = initRestCatalog(restConfigs, hadoopConf);
         } catch (Exception e) {
-            throw new RuntimeException("Fail to initialize iceberg rest catalog.", e);
+            throw new RuntimeException(
+                    "Fail to initialize iceberg rest catalog for table: " + icebergTableIdentifier,
+                    e);
         }
     }
 
@@ -130,7 +132,8 @@ public class IcebergRestMetadataCommitter implements IcebergMetadataCommitter {
         try {
             commitMetadataImpl(newIcebergMetadata, baseIcebergMetadata);
         } catch (Exception e) {
-            throw new RuntimeException(e);
+            throw new RuntimeException(
+                    "Fail to commit iceberg metadata for table: " + icebergTableIdentifier, e);
         }
     }
 
@@ -223,7 +226,9 @@ public class IcebergRestMetadataCommitter implements IcebergMetadataCommitter {
                     .operations()
                     .commit(((BaseTable) icebergTable).operations().current(), updatedForCommit);
         } catch (Exception e) {
-            throw new RuntimeException("Fail to commit metadata to rest catalog.", e);
+            throw new RuntimeException(
+                    "Fail to commit metadata to rest catalog for table: " + icebergTableIdentifier,
+                    e);
         }
     }
 
@@ -415,7 +420,8 @@ public class IcebergRestMetadataCommitter implements IcebergMetadataCommitter {
             dropTable();
             return createTable(newMetadata);
         } catch (Exception e) {
-            throw new RuntimeException("Fail to recreate iceberg table.", e);
+            throw new RuntimeException(
+                    "Fail to recreate iceberg table: " + icebergTableIdentifier, e);
         }
     }
 


### PR DESCRIPTION
### Purpose

When we run Paimon CDC Sink (aka Dynamic Paimon Sink) on the failures it would be handy to see the table name, thus we can see how to tune the given table.

Example of the stacktrace which is not practical:
```
java.lang.RuntimeException: There is no snapshot for commit user 44e8bd48-3cf4-4f51-98d8-70b56ae6a680 and identifier 71. This is unexpected.
	at org.apache.paimon.iceberg.IcebergCommitCallback.lambda$retry$1(IcebergCommitCallback.java:246)
	at java.base/java.util.Optional.orElseThrow(Optional.java:403)
	at org.apache.paimon.iceberg.IcebergCommitCallback.retry(IcebergCommitCallback.java:240)
	at org.apache.paimon.operation.FileStoreCommitImpl.lambda$filterCommitted$1(FileStoreCommitImpl.java:277)
	at java.base/java.util.ArrayList.forEach(ArrayList.java:1511)
	at org.apache.paimon.operation.FileStoreCommitImpl.filterCommitted(FileStoreCommitImpl.java:277)
	at org.apache.paimon.table.sink.TableCommitImpl.filterAndCommitMultiple(TableCommitImpl.java:284)
	at org.apache.paimon.flink.sink.StoreCommitter.filterAndCommit(StoreCommitter.java:111)
	at org.apache.paimon.flink.sink.StoreMultiCommitter.filterAndCommit(StoreMultiCommitter.java:182)
	at org.apache.paimon.flink.sink.RestoreCommittableStateManager.recover(RestoreCommittableStateManager.java:81)
	at org.apache.paimon.flink.sink.RestoreAndFailCommittableStateManager.recover(RestoreAndFailCommittableStateManager.java:86)
	at org.apache.paimon.flink.sink.RestoreCommittableStateManager.initializeState(RestoreCommittableStateManager.java:76)
	at org.apache.paimon.flink.sink.CommitterOperator.initializeState(CommitterOperator.java:147)
	at org.apache.flink.streaming.api.operators.StreamOperatorStateHandler.initializeOperatorState(StreamOperatorStateHandler.java:142)
	at org.apache.flink.streaming.api.operators.AbstractStreamOperator.initializeState(AbstractStreamOperator.java:304)
	at org.apache.flink.streaming.runtime.tasks.RegularOperatorChain.initializeStateAndOpenOperators(RegularOperatorChain.java:106)
	at org.apache.flink.streaming.runtime.tasks.StreamTask.restoreStateAndGates(StreamTask.java:858)
	at org.apache.flink.streaming.runtime.tasks.StreamTask.lambda$restoreInternal$5(StreamTask.java:812)
	at org.apache.flink.streaming.runtime.tasks.StreamTaskActionExecutor$1.call(StreamTaskActionExecutor.java:55)
	at org.apache.flink.streaming.runtime.tasks.StreamTask.restoreInternal(StreamTask.java:812)
	at org.apache.flink.streaming.runtime.tasks.StreamTask.restore(StreamTask.java:771)
	at org.apache.flink.runtime.taskmanager.Task.runWithSystemExitMonitoring(Task.java:963)
	at org.apache.flink.runtime.taskmanager.Task.restoreAndInvoke(Task.java:932)
	at org.apache.flink.runtime.taskmanager.Task.doRun(Task.java:756)
	at org.apache.flink.runtime.taskmanager.Task.run(Task.java:568)
```
Ideally you would like to track the metadata and troubleshoot the root cause of missing snapshot, but since there is no table name reporter - it is harder to act.

### Tests

- mvn -Ppaimon-iceberg -pl paimon-core,paimon-iceberg,paimon-hive/paimon-hive-catalog -am compile passes
- mvn -Ppaimon-iceberg -pl paimon-core,paimon-iceberg,paimon-hive/paimon-hive-catalog spotless:check passes

