### PR TITLE
[flink] Fix lookup output projection with internal key fields

### DIFF
--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/lookup/FileStoreLookupFunction.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/lookup/FileStoreLookupFunction.java
@@ -27,6 +27,7 @@ import org.apache.paimon.flink.FlinkConnectorOptions.LookupCacheMode;
 import org.apache.paimon.flink.FlinkRowData;
 import org.apache.paimon.flink.FlinkRowDataWithBlob;
 import org.apache.paimon.flink.FlinkRowWrapper;
+import org.apache.paimon.flink.ProjectedRowData;
 import org.apache.paimon.flink.lookup.partitioner.ShuffleStrategy;
 import org.apache.paimon.flink.metrics.FlinkMetricRegistry;
 import org.apache.paimon.flink.utils.RuntimeContextUtils;
@@ -94,6 +95,9 @@ public class FileStoreLookupFunction implements Serializable, Closeable {
     private final FileStoreTable table;
     @Nullable private final PartitionLoader partitionLoader;
     private final List<String> projectFields;
+    /** Projects rows with internal lookup fields back to the fields requested by Flink. */
+    @Nullable private final int[] outputProjection;
+
     private final List<String> joinKeys;
     @Nullable private final Predicate predicate;
     @Nullable private final RefreshBlacklist refreshBlacklist;
@@ -143,10 +147,11 @@ public class FileStoreLookupFunction implements Serializable, Closeable {
                         .mapToObj(i -> rowType.getFieldNames().get(projection[i]))
                         .collect(Collectors.toList());
 
-        this.projectFields =
+        List<String> outputFields =
                 Arrays.stream(projection)
                         .mapToObj(i -> rowType.getFieldNames().get(i))
                         .collect(Collectors.toList());
+        this.projectFields = new ArrayList<>(outputFields);
 
         // add primary keys
         for (String field : table.primaryKeys()) {
@@ -158,6 +163,10 @@ public class FileStoreLookupFunction implements Serializable, Closeable {
         if (partitionLoader != null) {
             partitionLoader.addPartitionKeysTo(joinKeys, projectFields);
         }
+        this.outputProjection =
+                outputFields.equals(projectFields)
+                        ? null
+                        : outputFields.stream().mapToInt(projectFields::indexOf).toArray();
         RowType projectedType = rowType.project(projectFields);
         this.projectFieldsGetters =
                 IntStream.range(0, projectedType.getFieldCount())
@@ -359,10 +368,14 @@ public class FileStoreLookupFunction implements Serializable, Closeable {
         List<RowData> rows = new ArrayList<>();
         List<InternalRow> lookupResults = lookupTable.get(key);
         for (InternalRow matchedRow : lookupResults) {
-            rows.add(
+            RowData rowData =
                     blobFields.isEmpty()
                             ? new FlinkRowData(matchedRow)
-                            : new FlinkRowDataWithBlob(matchedRow, blobFields, blobAsDescriptor));
+                            : new FlinkRowDataWithBlob(matchedRow, blobFields, blobAsDescriptor);
+            rows.add(
+                    outputProjection == null
+                            ? rowData
+                            : ProjectedRowData.from(outputProjection).replaceRow(rowData));
         }
 
         if (LOG.isDebugEnabled()) {

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/LookupJoinITCase.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/LookupJoinITCase.java
@@ -302,6 +302,36 @@ public class LookupJoinITCase extends CatalogITCaseBase {
         iterator.close();
     }
 
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
+    public void testAsyncLookupWithDynamicPartitionProjection(boolean primaryKey) throws Exception {
+        sql(
+                "CREATE TABLE ASYNC_DIM (i INT, j INT, dt STRING%s) "
+                        + "PARTITIONED BY (`dt`) WITH ("
+                        + "'lookup.cache' = 'memory', "
+                        + "'continuous.discovery-interval' = '1 ms')",
+                primaryKey ? ", PRIMARY KEY (dt, i, j) NOT ENFORCED" : "");
+        sql(
+                "INSERT INTO ASYNC_DIM VALUES "
+                        + "(1, 11, '2026-08-25'), "
+                        + "(1, 12, '2026-08-25'), "
+                        + "(2, 21, '2026-08-25')");
+
+        String query =
+                "SELECT T.i, D.j FROM T LEFT JOIN ASYNC_DIM "
+                        + "/*+ OPTIONS("
+                        + "'scan.partitions' = 'max_pt()', "
+                        + "'lookup.dynamic-partition.refresh-interval' = '1 ms', "
+                        + "'lookup.async' = 'true') */ "
+                        + "FOR SYSTEM_TIME AS OF T.proctime AS D ON T.i = D.i";
+        BlockingIterator<Row, Row> iterator = BlockingIterator.of(sEnv.executeSql(query).collect());
+
+        sql("INSERT INTO T VALUES (1), (2)");
+        assertThat(iterator.collect(3))
+                .containsExactlyInAnyOrder(Row.of(1, 11), Row.of(1, 12), Row.of(2, 21));
+        iterator.close();
+    }
+
     @Test
     public void testLookupMaxPtDynamicBucketTable() throws Exception {
         sql(

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/lookup/FileStoreLookupFunctionTest.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/lookup/FileStoreLookupFunctionTest.java
@@ -404,7 +404,7 @@ public class FileStoreLookupFunctionTest {
     }
 
     @Test
-    public void testDebugLogRowsWithAppendedPrimaryKey() throws Exception {
+    public void testLookupProjectionWithAppendedPrimaryKey() throws Exception {
         table = createStringFileStoreTable();
         lookupFunction =
                 new FileStoreLookupFunction(table, new int[] {2, 1}, new int[] {1}, null, null);
@@ -419,8 +419,15 @@ public class FileStoreLookupFunctionTest {
 
         Appender appender = addLookupFunctionAppender(Level.INFO);
         try {
-            lookupFunction.lookup(
-                    new FlinkRowData(GenericRow.of(BinaryString.fromString("key-1"))));
+            List<RowData> rows =
+                    new ArrayList<>(
+                            lookupFunction.lookup(
+                                    new FlinkRowData(
+                                            GenericRow.of(BinaryString.fromString("key-1")))));
+            assertThat(rows).hasSize(1);
+            assertThat(rows.get(0).getArity()).isEqualTo(2);
+            assertThat(rows.get(0).getString(0).toString()).isEqualTo("value-1");
+            assertThat(rows.get(0).getString(1).toString()).isEqualTo("key-1");
             assertThat(((CollectingAppender) appender).messages)
                     .noneMatch(message -> message.contains("matched rows in lookup table"));
         } finally {


### PR DESCRIPTION
### Purpose

Flink may push a projection into a Paimon lookup source. Paimon appends primary-key and partition fields to that projection for internal lookup and dynamic-partition handling, but currently returns those internal fields to Flink as well. In async lookup joins, Flink then copies a row whose arity is larger than the planned serializer arity.

This closes #6878.

### Approach

- Keep the augmented projection for the internal lookup table.
- Record the fields originally requested by Flink.
- Project matched rows back to the requested fields before returning them from `FileStoreLookupFunction`.
- Avoid the extra wrapper when the internal and output projections are identical.

### Tests

- Added a direct lookup test for an internally appended primary-key field.
- Added an async lookup join test for dynamic partition projection, covering both primary-key and append-only tables.
- Verified the new tests with Flink 1.20 and Flink 2.2.
- Verified existing max-partition, async-retry, BLOB lookup, and all `FileStoreLookupFunctionTest` cases with Flink 2.2.
