### PR TITLE
[flink] Avoid slot deadlock when sorting normalized index keys

### DIFF
--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/globalindex/SortedIndexTopoBuilder.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/globalindex/SortedIndexTopoBuilder.java
@@ -66,10 +66,14 @@ import org.apache.paimon.types.DataTypes;
 import org.apache.paimon.types.RowType;
 import org.apache.paimon.utils.Range;
 
+import org.apache.flink.api.common.functions.Partitioner;
 import org.apache.flink.api.java.functions.KeySelector;
 import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.streaming.api.operators.OneInputStreamOperatorFactory;
+import org.apache.flink.streaming.api.transformations.PartitionTransformation;
+import org.apache.flink.streaming.api.transformations.StreamExchangeMode;
+import org.apache.flink.streaming.runtime.partitioner.CustomPartitionerWrapper;
 import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
 import org.apache.flink.table.data.RowData;
 
@@ -96,6 +100,8 @@ public class SortedIndexTopoBuilder {
 
     private static final String BUILD_TASK_ID_FIELD = "_SORTED_INDEX_BUILD_TASK_ID";
     private static final int BUILD_TASK_ID_FIELD_ID = -1;
+    static final Partitioner<Integer> BUILD_TASK_PARTITIONER =
+            (taskId, numPartitions) -> Math.floorMod(taskId, numPartitions);
     private static final HashSet<String> SUPPORTED_INDEX_TYPES =
             new HashSet<>(Arrays.asList("btree", "bitmap", "multivalue"));
 
@@ -384,7 +390,12 @@ public class SortedIndexTopoBuilder {
             RowType readType,
             int parallelism) {
         if (!identity) {
-            return input.keyBy((KeySelector<InternalRow, Integer>) row -> row.getInt(taskIdPos))
+            // Only co-location by build task is required here. Using keyBy in batch mode makes
+            // Flink insert another managed-memory sorter before Paimon's heap-and-spill sorter.
+            // Materialize the repartition result so batch scheduling can reuse slots between the
+            // reader and sorter stages. A pipelined exchange can deadlock when maxSlot is smaller
+            // than their combined parallelism.
+            return partitionByBuildTask(input, taskIdPos)
                     .transform(
                             "Sort Normalized Index Keys",
                             InternalTypeInfo.fromRowType(readType),
@@ -422,6 +433,17 @@ public class SortedIndexTopoBuilder {
                 .sort()
                 .map(FlinkRowWrapper::new, InternalTypeInfo.fromRowType(readType))
                 .setParallelism(parallelism);
+    }
+
+    static DataStream<InternalRow> partitionByBuildTask(
+            DataStream<InternalRow> input, int taskIdPos) {
+        KeySelector<InternalRow, Integer> keySelector = row -> row.getInt(taskIdPos);
+        return new DataStream<>(
+                input.getExecutionEnvironment(),
+                new PartitionTransformation<>(
+                        input.getTransformation(),
+                        new CustomPartitionerWrapper<>(BUILD_TASK_PARTITIONER, keySelector),
+                        StreamExchangeMode.BATCH));
     }
 
     static int calculateParallelism(

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/globalindex/SortedIndexTopoBuilderTest.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/globalindex/SortedIndexTopoBuilderTest.java
@@ -18,7 +18,11 @@
 
 package org.apache.paimon.flink.globalindex;
 
+import org.apache.paimon.data.BinaryRow;
+import org.apache.paimon.data.BinaryRowWriter;
+import org.apache.paimon.data.InternalRow;
 import org.apache.paimon.flink.globalindex.SortedIndexTopoBuilder.SortedBuildTask;
+import org.apache.paimon.flink.utils.InternalTypeInfo;
 import org.apache.paimon.globalindex.GlobalIndexSingleColumnWriter;
 import org.apache.paimon.globalindex.sorted.SortedGlobalIndexScanner;
 import org.apache.paimon.globalindex.sorted.SortedGlobalIndexWriter;
@@ -27,9 +31,13 @@ import org.apache.paimon.options.Options;
 import org.apache.paimon.table.FileStoreTable;
 import org.apache.paimon.table.SpecialFields;
 import org.apache.paimon.types.DataTypes;
+import org.apache.paimon.types.RowType;
 import org.apache.paimon.utils.Range;
 
+import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.streaming.api.transformations.PartitionTransformation;
+import org.apache.flink.streaming.api.transformations.StreamExchangeMode;
 import org.junit.jupiter.api.Test;
 
 import java.io.Closeable;
@@ -179,5 +187,31 @@ public class SortedIndexTopoBuilderTest {
     public void testNormalizedSortColumnsUseRowIdAsTieBreaker() {
         assertThat(SortedIndexTopoBuilder.createSortColumns("task-id", "index-key"))
                 .containsExactly("task-id", "index-key", SpecialFields.ROW_ID.name());
+    }
+
+    @Test
+    public void testBuildTaskPartitioner() {
+        assertThat(SortedIndexTopoBuilder.BUILD_TASK_PARTITIONER.partition(0, 4)).isEqualTo(0);
+        assertThat(SortedIndexTopoBuilder.BUILD_TASK_PARTITIONER.partition(5, 4)).isEqualTo(1);
+        assertThat(SortedIndexTopoBuilder.BUILD_TASK_PARTITIONER.partition(9, 4)).isEqualTo(1);
+    }
+
+    @Test
+    public void testBuildTaskPartitionUsesBatchExchange() {
+        StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+        BinaryRow row = new BinaryRow(1);
+        BinaryRowWriter writer = new BinaryRowWriter(row);
+        writer.writeInt(0, 0);
+        writer.complete();
+        DataStream<InternalRow> input =
+                env.fromData(
+                        Collections.<InternalRow>singletonList(row),
+                        InternalTypeInfo.fromRowType(RowType.of(DataTypes.INT())));
+
+        DataStream<InternalRow> partitioned = SortedIndexTopoBuilder.partitionByBuildTask(input, 0);
+
+        assertThat(partitioned.getTransformation()).isInstanceOf(PartitionTransformation.class);
+        assertThat(((PartitionTransformation<?>) partitioned.getTransformation()).getExchangeMode())
+                .isEqualTo(StreamExchangeMode.BATCH);
     }
 }


### PR DESCRIPTION
### Purpose

Non-identity sorted indexes, such as multivalue indexes, normalize one source value into multiple index keys. The normalized-key path used `keyBy` before the heap-and-spill sorter. Replacing it with a custom partitioner avoids Flink inserting a redundant managed-memory sorter, but a pipelined exchange can require the reader and sorter stages to acquire slots concurrently. A constrained batch deployment may then make no progress once the upstream network buffers fill.

### Changes

- Partition normalized index keys by build task without `keyBy`.
- Explicitly use `StreamExchangeMode.BATCH`, matching the deadlock-breaking approach used by range shuffle.
- Preserve the existing build-task co-location semantics.
- Add tests for the partition mapping and exchange mode.

BTree and scalar bitmap indexes use the identity/global-sort path and are unaffected.

### Tests

- `SortedIndexTopoBuilderTest`
- `SortedGlobalIndexITCase#testMultiValueIndex`
- A constrained-slot validation with 1,000,006 rows completed with full multivalue-index coverage and content checks.