### PR TITLE
[hive] Avoid binding to HiveConf.ConfVars constants renamed in Hive 4

### DIFF
--- a/paimon-hive/paimon-hive-catalog/src/main/java/org/apache/paimon/hive/HiveCatalog.java
+++ b/paimon-hive/paimon-hive-catalog/src/main/java/org/apache/paimon/hive/HiveCatalog.java
@@ -101,7 +101,6 @@ import java.util.concurrent.Callable;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
-import static org.apache.hadoop.hive.conf.HiveConf.ConfVars.METASTOREWAREHOUSE;
 import static org.apache.hadoop.hive.serde.serdeConstants.FIELD_DELIM;
 import static org.apache.paimon.CoreOptions.DATA_FILE_PATH_DIRECTORY;
 import static org.apache.paimon.CoreOptions.FILE_FORMAT;
@@ -189,7 +188,7 @@ public class HiveCatalog extends AbstractCatalog {
             locationHelper = new TBPropertiesLocationHelper();
         } else {
             // set the warehouse location to the hiveConf
-            hiveConf.set(HiveConf.ConfVars.METASTOREWAREHOUSE.varname, warehouse);
+            hiveConf.set("hive.metastore.warehouse.dir", warehouse);
             locationHelper = new StorageLocationHelper();
         }
     }
@@ -1964,7 +1963,7 @@ public class HiveCatalog extends AbstractCatalog {
             try (InputStream inputStream = hiveSite.getFileSystem(hadoopConf).open(hiveSite)) {
                 hiveConf.addResource(inputStream, hiveSite.toString());
                 // trigger a read from the conf to avoid input stream is closed
-                hiveConf.getVar(HiveConf.ConfVars.METASTOREURIS);
+                hiveConf.getVar(HiveConf.getConfVars("hive.metastore.uris"));
             } catch (IOException e) {
                 throw new RuntimeException(
                         "Failed to load hive-site.xml from specified path:" + hiveSite, e);
@@ -1990,8 +1989,7 @@ public class HiveCatalog extends AbstractCatalog {
         Options options = context.options();
         String warehouseStr = options.get(CatalogOptions.WAREHOUSE);
         if (warehouseStr == null) {
-            warehouseStr =
-                    hiveConf.get(METASTOREWAREHOUSE.varname, METASTOREWAREHOUSE.defaultStrVal);
+            warehouseStr = hiveConf.getVar(HiveConf.getConfVars("hive.metastore.warehouse.dir"));
         }
         Path warehouse = new Path(warehouseStr);
         Path uri =
@@ -2024,10 +2022,10 @@ public class HiveCatalog extends AbstractCatalog {
         // always using user-set parameters overwrite hive-site.xml parameters
         context.options().toMap().forEach(hiveConf::set);
         if (uri != null) {
-            hiveConf.set(HiveConf.ConfVars.METASTOREURIS.varname, uri);
+            hiveConf.set("hive.metastore.uris", uri);
         }
 
-        if (hiveConf.get(HiveConf.ConfVars.METASTOREURIS.varname) == null) {
+        if (hiveConf.get("hive.metastore.uris") == null) {
             LOG.error(
                     "Can't find hive metastore uri to connect: "
                             + " either set "

--- a/paimon-hive/paimon-hive-catalog/src/main/java/org/apache/paimon/hive/RetryingMetaStoreClientFactory.java
+++ b/paimon-hive/paimon-hive-catalog/src/main/java/org/apache/paimon/hive/RetryingMetaStoreClientFactory.java
@@ -158,7 +158,7 @@ public class RetryingMetaStoreClientFactory {
                 Method getProxy = RetryingMetaStoreClient.class.getMethod("getProxy", classes);
                 HiveMetastoreProxySupplier supplier = entry.getValue();
                 IMetaStoreClient client = supplier.get(getProxy, hiveConf, clientClassName);
-                return isNullOrWhitespaceOnly(hiveConf.get(HiveConf.ConfVars.METASTOREURIS.varname))
+                return isNullOrWhitespaceOnly(hiveConf.get("hive.metastore.uris"))
                         ? client
                         : HiveMetaStoreClient.newSynchronizedClient(client);
             } catch (Exception e) {

--- a/paimon-hive/paimon-hive-catalog/src/main/java/org/apache/paimon/hive/pool/CachedClientPool.java
+++ b/paimon-hive/paimon-hive-catalog/src/main/java/org/apache/paimon/hive/pool/CachedClientPool.java
@@ -33,7 +33,6 @@ import org.apache.paimon.shade.guava30.com.google.common.collect.Sets;
 import org.apache.paimon.shade.guava30.com.google.common.util.concurrent.ThreadFactoryBuilder;
 
 import org.apache.hadoop.conf.Configuration;
-import org.apache.hadoop.hive.conf.HiveConf;
 import org.apache.hadoop.hive.metastore.IMetaStoreClient;
 import org.apache.hadoop.security.UserGroupInformation;
 import org.apache.thrift.TException;
@@ -146,7 +145,7 @@ public class CachedClientPool implements ClientPool<IMetaStoreClient, TException
         // generate key elements in a certain order, so that the Key instances are comparable
         List<Object> elements = Lists.newArrayList();
         elements.add(clientClassName);
-        elements.add(conf.get(HiveConf.ConfVars.METASTOREURIS.varname, ""));
+        elements.add(conf.get("hive.metastore.uris", ""));
         elements.add(HiveCatalogOptions.IDENTIFIER);
         if (cacheKeys == null || cacheKeys.isEmpty()) {
             return Key.of(elements);

--- a/paimon-hive/paimon-hive-catalog/src/main/java/org/apache/paimon/iceberg/IcebergHiveMetadataCommitter.java
+++ b/paimon-hive/paimon-hive-catalog/src/main/java/org/apache/paimon/iceberg/IcebergHiveMetadataCommitter.java
@@ -92,10 +92,10 @@ public class IcebergHiveMetadataCommitter implements IcebergMetadataCommitter {
 
         table.options().forEach(hiveConf::set);
         if (uri != null) {
-            hiveConf.set(HiveConf.ConfVars.METASTOREURIS.varname, uri);
+            hiveConf.set("hive.metastore.uris", uri);
         }
 
-        if (hiveConf.get(HiveConf.ConfVars.METASTOREURIS.varname) == null) {
+        if (hiveConf.get("hive.metastore.uris") == null) {
             LOG.error(
                     "Can't find hive metastore uri to connect: "
                             + "either set {} for paimon table or set hive.metastore.uris "

--- a/paimon-hive/paimon-hive-connector-common/src/main/java/org/apache/paimon/hive/PaimonMetaHook.java
+++ b/paimon-hive/paimon-hive-connector-common/src/main/java/org/apache/paimon/hive/PaimonMetaHook.java
@@ -33,7 +33,6 @@ import org.apache.paimon.schema.SchemaManager;
 import org.apache.paimon.schema.TableSchema;
 
 import org.apache.hadoop.conf.Configuration;
-import org.apache.hadoop.hive.conf.HiveConf;
 import org.apache.hadoop.hive.metastore.HiveMetaHook;
 import org.apache.hadoop.hive.metastore.api.FieldSchema;
 import org.apache.hadoop.hive.metastore.api.MetaException;
@@ -83,7 +82,7 @@ public class PaimonMetaHook implements HiveMetaHook {
         String location = LocationKeyExtractor.getPaimonLocation(conf, table);
         Identifier identifier = Identifier.create(table.getDbName(), table.getTableName());
         if (location == null) {
-            String warehouse = conf.get(HiveConf.ConfVars.METASTOREWAREHOUSE.varname);
+            String warehouse = conf.get("hive.metastore.warehouse.dir");
             org.apache.hadoop.fs.Path hadoopPath =
                     getDnsPath(new org.apache.hadoop.fs.Path(warehouse), conf);
             warehouse = hadoopPath.toString();

--- a/paimon-hive/paimon-hive-connector-common/src/main/java/org/apache/paimon/hive/utils/HiveSplitGenerator.java
+++ b/paimon-hive/paimon-hive-connector-common/src/main/java/org/apache/paimon/hive/utils/HiveSplitGenerator.java
@@ -231,8 +231,14 @@ public class HiveSplitGenerator {
 
     private static Long computeSplitSize(
             JobConf jobConf, List<DataSplit> splits, int numSplits, long openCostInBytes) {
-        long maxSize = HiveConf.getLongVar(jobConf, HiveConf.ConfVars.MAPREDMAXSPLITSIZE);
-        long minSize = HiveConf.getLongVar(jobConf, HiveConf.ConfVars.MAPREDMINSPLITSIZE);
+        long maxSize =
+                HiveConf.getLongVar(
+                        jobConf,
+                        HiveConf.getConfVars("mapreduce.input.fileinputformat.split.maxsize"));
+        long minSize =
+                HiveConf.getLongVar(
+                        jobConf,
+                        HiveConf.getConfVars("mapreduce.input.fileinputformat.split.minsize"));
         long avgSize;
         long splitSize;
         if (numSplits > 0) {

--- a/paimon-hive/paimon-hive-connector-common/src/test/java/org/apache/paimon/hive/HiveSplitGeneratorTest.java
+++ b/paimon-hive/paimon-hive-connector-common/src/test/java/org/apache/paimon/hive/HiveSplitGeneratorTest.java
@@ -44,7 +44,6 @@ import org.apache.paimon.types.IntType;
 import org.apache.paimon.types.VarCharType;
 import org.apache.paimon.utils.TraceableFileIO;
 
-import org.apache.hadoop.hive.conf.HiveConf;
 import org.apache.hadoop.mapred.InputSplit;
 import org.apache.hadoop.mapred.JobConf;
 import org.apache.hadoop.mapreduce.lib.input.FileInputFormat;
@@ -118,8 +117,8 @@ public class HiveSplitGeneratorTest {
     @Test
     public void testPackSplitsForNonBucketTable() throws Exception {
         JobConf jobConf = new JobConf();
-        jobConf.set(HiveConf.ConfVars.MAPREDMAXSPLITSIZE.varname, "268435456"); // 256MB
-        jobConf.set(HiveConf.ConfVars.MAPREDMINSPLITSIZE.varname, "268435456"); // 256MB
+        jobConf.set("mapreduce.input.fileinputformat.split.maxsize", "268435456"); // 256MB
+        jobConf.set("mapreduce.input.fileinputformat.split.minsize", "268435456"); // 256MB
 
         FileStoreTable table = createFileStoreTable(TABLE_SCHEMA);
 
@@ -140,8 +139,8 @@ public class HiveSplitGeneratorTest {
     @Test
     public void testPackSplitsForBucketTable() throws Exception {
         JobConf jobConf = new JobConf();
-        jobConf.set(HiveConf.ConfVars.MAPREDMAXSPLITSIZE.varname, "268435456");
-        jobConf.set(HiveConf.ConfVars.MAPREDMINSPLITSIZE.varname, "268435456");
+        jobConf.set("mapreduce.input.fileinputformat.split.maxsize", "268435456");
+        jobConf.set("mapreduce.input.fileinputformat.split.minsize", "268435456");
 
         FileStoreTable table = createFileStoreTable(TABLE_SCHEMA);
 


### PR DESCRIPTION
## Purpose

Fix hive 4 client error:

```
java.lang.NoSuchFieldError: Class org.apache.hadoop.hive.conf.HiveConf$ConfVars
    does not have member field 'org.apache.hadoop.hive.conf.HiveConf$ConfVars METASTOREURIS'
    at org.apache.paimon.hive.HiveCatalog.createHiveConf(HiveCatalog.java:1997)
    at org.apache.paimon.hive.HiveCatalog.createHiveCatalog(HiveCatalog.java:1959)
    at org.apache.paimon.hive.HiveCatalogFactory.create(HiveCatalogFactory.java:37)
```

Hive 4 renamed a number of HiveConf.ConfVars enum constants in HIVE-27925, 
for example `METASTOREURIS → METASTORE_URIS`
and `METASTOREWAREHOUSE → METASTORE_WAREHOUSE`.

The build target is unchanged (`hive.version` 2.3.10, Java 8). No new module, no new dependency,
no JDK bump. Hive 2.1 / 2.2 / 2.3 / 3.1 keep working exactly as before.

### Prior art in Apache Spark

Spark hit the very same incompatibility and fixed it the same way. Its Hive 4 work landed in this
order, which is also the order proposed here:

 [SPARK-47679](https://issues.apache.org/jira/browse/SPARK-47679) — [apache/spark#45804](https://github.com/apache/spark/pull/45804) 
 *"Use `HiveConf.getConfVars` or Hive conf names directly"* — removes the `ConfVars` symbol binding. **This PR is the direct analogue.** 


### Related issues

Partially addresses:

* apache/paimon#3236 — Support Hive 4.0.0
* apache/paimon#6236 — paimon-hive support Hive4.x
* apache/paimon#9166 — Support hive 4.x


## Tests

* Existing `paimon-hive-catalog` and `paimon-hive-connector-common` tests.

* **End-to-end against a real Hive 4 metastore.** Using the released
  `paimon-spark-4.1_2.13-2.0.0` bundle with a Hive 4.0.1 client on the classpath