### PR TITLE
[core] Compare IcebergRef by value

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/iceberg/metadata/IcebergRef.java
+++ b/paimon-core/src/main/java/org/apache/paimon/iceberg/metadata/IcebergRef.java
@@ -83,8 +83,8 @@ public class IcebergRef {
         }
         IcebergRef that = (IcebergRef) o;
         return snapshotId == that.snapshotId
-                && type.equals(that.type)
-                && maxRefAgeMs == that.maxRefAgeMs;
+                && Objects.equals(type, that.type)
+                && Objects.equals(maxRefAgeMs, that.maxRefAgeMs);
     }
 
     @Override

--- a/paimon-core/src/test/java/org/apache/paimon/iceberg/metadata/IcebergRefTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/iceberg/metadata/IcebergRefTest.java
@@ -1,0 +1,69 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.iceberg.metadata;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Tests for {@link IcebergRef}. */
+public class IcebergRefTest {
+
+    @Test
+    public void testEqualsIsByValue() {
+        IcebergRef one = new IcebergRef(1L);
+        IcebergRef same = new IcebergRef(1L);
+        IcebergRef other = new IcebergRef(2L);
+
+        assertThat(one).isEqualTo(same);
+        assertThat(one).isNotEqualTo(other);
+    }
+
+    @Test
+    public void testEqualObjectsShareAHashCode() {
+        // hashCode already used value semantics, so the two disagreed: refs that hash
+        // alike compared unequal.
+        IcebergRef one = new IcebergRef(1L);
+        IcebergRef same = new IcebergRef(1L);
+
+        assertThat(one.hashCode()).isEqualTo(same.hashCode());
+
+        Set<IcebergRef> set = new HashSet<>();
+        set.add(one);
+        set.add(same);
+        assertThat(set).hasSize(1);
+    }
+
+    @Test
+    public void testMetadataComparesItsRefsByValue() {
+        // IcebergMetadata#equals compares refs with Objects.equals over the map, so a
+        // broken element equals propagates all the way up.
+        Map<String, IcebergRef> left = new HashMap<>();
+        left.put("tag", new IcebergRef(1L));
+        Map<String, IcebergRef> right = new HashMap<>();
+        right.put("tag", new IcebergRef(1L));
+
+        assertThat(left).isEqualTo(right);
+    }
+}


### PR DESCRIPTION
### Purpose

`IcebergRef.equals` compares `maxRefAgeMs` with `==`, and that field is a boxed
`Long`:

```java
// IcebergRef.java:50
@Nullable private final Long maxRefAgeMs;

// :85-87
return snapshotId == that.snapshotId
        && type.equals(that.type)
        && maxRefAgeMs == that.maxRefAgeMs;
```

So the comparison is on references, not values. It would still work if the two
boxes happened to be the same object, but the constructor guarantees they are
not:

```java
// :53-60
public IcebergRef(@JsonProperty(FIELD_SNAPSHOT_ID) long snapshotId) {
    this.snapshotId = snapshotId;
    this.type = "tag";
    this.maxRefAgeMs = Long.MAX_VALUE;
}
```

`Long.MAX_VALUE` is far outside the `Long` cache, so every `new IcebergRef(..)`
autoboxes a fresh object and

```java
new IcebergRef(1L).equals(new IcebergRef(1L))   // false
```

`hashCode` was already written the other way:

```java
// :91-93
return Objects.hash(snapshotId, type, maxRefAgeMs);
```

which is value-based. The two therefore disagree: refs that hash to the same
bucket compare unequal, so a `HashSet<IcebergRef>` keeps both copies rather than
deduplicating.

It does not stop there. `IcebergMetadata.equals` compares its refs map:

```java
// IcebergMetadata.java:371
&& Objects.equals(refs, that.refs);
```

`Map.equals` compares values with `equals`, so two `IcebergMetadata` carrying
identical tags are reported as different.

### What changes

```java
return snapshotId == that.snapshotId
        && Objects.equals(type, that.type)
        && Objects.equals(maxRefAgeMs, that.maxRefAgeMs);
```

`Objects` is already imported. `type` is switched over at the same time — it is
non-null in practice, but there is no reason for one field in the expression to
be able to throw while the others cannot.

### Test

`IcebergRefTest`, three cases, one per layer the defect reaches:

* `testEqualsIsByValue` — two refs built with the same snapshot id are equal, and
  refs with different ids are not
* `testEqualObjectsShareAHashCode` — the hashCodes match, and a `HashSet` holding
  both ends up with one element
* `testMetadataComparesItsRefsByValue` — two `Map<String, IcebergRef>` with the
  same content compare equal, which is the shape `IcebergMetadata.equals` relies
  on

Reverting only the `equals` body, on a forced clean rebuild of `paimon-core`,
fails all three — at three different levels rather than all on the same
assertion.

Wider run: `*Iceberg*` across `paimon-core` — 167 tests, 0 failures.

### API and Format

No change to any option, on-disk format or public signature.
