### PR TITLE
[flink] Do not shuffle to a negative channel when the partition hash is Integer.MIN_VALUE

### DIFF
--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/partition/StatisticsOrRecordChannelComputer.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/partition/StatisticsOrRecordChannelComputer.java
@@ -186,7 +186,7 @@ public class StatisticsOrRecordChannelComputer implements ChannelComputer<Statis
             if (assignment == null) {
                 int defaultSubtaskCount =
                         Math.min(numChannels, DEFAULT_SUBTASK_COUNT_FOR_UNKNOWN_PARTITION);
-                int startChannel = Math.abs(partitionKey.hashCode()) % numChannels;
+                int startChannel = ChannelComputer.startChannel(partitionKey, numChannels);
                 List<Integer> subtasks = new ArrayList<>(defaultSubtaskCount);
                 List<Long> weights = new ArrayList<>(defaultSubtaskCount);
                 for (int i = 0; i < defaultSubtaskCount; i++) {

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/sink/partition/StatisticsOrRecordChannelComputerTest.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/sink/partition/StatisticsOrRecordChannelComputerTest.java
@@ -226,6 +226,29 @@ class StatisticsOrRecordChannelComputerTest {
         assertThat(assignment).containsKey(p2);
     }
 
+    @Test
+    void testUnknownPartitionWhoseKeyHashesToMinValue() {
+        // Math.abs leaves Integer.MIN_VALUE negative. Pin the fixture: if the row hash ever
+        // changes this stops testing anything, and this assertion says so instead of passing.
+        InternalRow row =
+                GenericRow.of(
+                        0, BinaryString.fromString("p3588823253"), BinaryString.fromString("d"));
+        assertThat(getPartitionKey(row).hashCode()).isEqualTo(Integer.MIN_VALUE);
+
+        // Integer.MIN_VALUE % n is only zero when n divides 2^31, so a parallelism that is not a
+        // power of two is what turns the negative hash into a negative channel.
+        for (int downstreamParallelism = 1; downstreamParallelism <= 16; downstreamParallelism++) {
+            StatisticsOrRecordChannelComputer channelComputer =
+                    new StatisticsOrRecordChannelComputer(schema);
+            channelComputer.setup(downstreamParallelism);
+            for (int i = 0; i < 50; i++) {
+                assertThat(channelComputer.channel(StatisticsOrRecord.fromRecord(row)))
+                        .as("parallelism %d", downstreamParallelism)
+                        .isBetween(0, downstreamParallelism - 1);
+            }
+        }
+    }
+
     private BinaryRow getPartitionKey(InternalRow row) {
         RowPartitionKeyExtractor extractor = new RowPartitionKeyExtractor(schema);
         return extractor.partition(row).copy();


### PR DESCRIPTION
### Purpose

`PARTITION_DYNAMIC` picks a fallback start channel for a partition it has no statistics for:

```java
int startChannel = Math.abs(partitionKey.hashCode()) % numChannels;
```

`Math.abs(Integer.MIN_VALUE)` is `Integer.MIN_VALUE`, so this can be negative, and every channel built from it inherits the sign:

```java
subtasks.add((startChannel + i) % numChannels);
```

`ChannelComputer.startChannel` already guards this — it was fixed in #5623 with a comment spelling out this exact case — and `StatisticsOrRecordChannelComputer` implements `ChannelComputer`, so this just calls the shared helper instead of repeating the formula without the guard.

Worth noting the failure is parallelism-dependent, which is presumably why it has not been hit yet: `Integer.MIN_VALUE % n` is zero whenever `n` divides 2^31, so at parallelism 2, 4, 8 or 16 the bad hash happens to come out at channel 0. At parallelism 3 the same partition returns channel `-1`.

### Tests

`testUnknownPartitionWhoseKeyHashesToMinValue` in `StatisticsOrRecordChannelComputerTest`. Partition value `p3588823253` is a real value whose partition key hashes to `Integer.MIN_VALUE`; the test asserts that up front, so if the row hash ever changes the test fails rather than quietly stopping to exercise the path. It then checks the returned channel is in range for parallelism 1 through 16.

Without the change the test fails at parallelism 3:

```
[parallelism 3]
Expecting actual:
  -1
to be between:
  [0, 2]
```

Parallelism 8, which the existing tests use, passes either way.

`mvn test -pl paimon-flink/paimon-flink-common -Dtest='org.apache.paimon.flink.sink.partition.**'` — 19 tests, and `-Dtest='*ChannelComputer*'` — 12 tests, all passing.
