### PR TITLE
[spark] Fix nested struct values wrong order for insert columns

### DIFF
--- a/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/catalyst/analysis/PaimonAnalysis.scala
+++ b/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/catalyst/analysis/PaimonAnalysis.scala
@@ -110,20 +110,21 @@ class PaimonAnalysis(session: SparkSession) extends Rule[LogicalPlan] {
       table: DataSourceV2Relation,
       options: Options,
       mergeSchemaEnabled: Boolean): LogicalPlan = {
+    val columnListWrite = containsColumnListWrite(v2WriteCommand.query)
+    val effectiveByName = v2WriteCommand.isByName || columnListWrite
     val queryWithoutMarker = stripHiveDynamicPartitionMarker(v2WriteCommand.query)
     val query =
-      if (
-        v2WriteCommand.isByName &&
-        containsColumnListWrite(v2WriteCommand.query)
-      ) {
-        PaimonOutputResolver.renameNestedFieldsByPosition(queryWithoutMarker, table.output)
+      if (columnListWrite) {
+        PaimonOutputResolver.renameNestedFieldsByPosition(
+          queryWithoutMarker,
+          table.output,
+          v2WriteCommand.isByName)
       } else {
         queryWithoutMarker
       }
     val hiveStyleDynamicPartitionEnabled = OptionUtils.hiveStyleDynamicPartitionEnabled()
     hiveDynamicPartitionColumns(v2WriteCommand.query) match {
-      case Some(dynamicPartitionColumns)
-          if hiveStyleDynamicPartitionEnabled && !v2WriteCommand.isByName =>
+      case Some(dynamicPartitionColumns) if hiveStyleDynamicPartitionEnabled && !effectiveByName =>
         resolveDynamicPartitionWrite(
           query,
           table,
@@ -132,7 +133,8 @@ class PaimonAnalysis(session: SparkSession) extends Rule[LogicalPlan] {
           mergeSchemaEnabled)
       case _ =>
         v2WriteCommand match {
-          case o: OverwritePartitionsDynamic if hiveStyleDynamicPartitionEnabled && !o.isByName =>
+          case _: OverwritePartitionsDynamic
+              if hiveStyleDynamicPartitionEnabled && !effectiveByName =>
             resolveDynamicPartitionWrite(
               query,
               table,
@@ -140,14 +142,8 @@ class PaimonAnalysis(session: SparkSession) extends Rule[LogicalPlan] {
               options,
               mergeSchemaEnabled)
           case _ =>
-            val expected =
-              expectedAttrsForWrite(query, table, options, v2WriteCommand.isByName)
-            resolveWriteOutput(
-              query,
-              table.name,
-              expected,
-              v2WriteCommand.isByName,
-              mergeSchemaEnabled)
+            val expected = expectedAttrsForWrite(query, table, options, effectiveByName)
+            resolveWriteOutput(query, table.name, expected, effectiveByName, mergeSchemaEnabled)
         }
     }
   }

--- a/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/catalyst/analysis/PaimonAnalysis.scala
+++ b/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/catalyst/analysis/PaimonAnalysis.scala
@@ -110,7 +110,16 @@ class PaimonAnalysis(session: SparkSession) extends Rule[LogicalPlan] {
       table: DataSourceV2Relation,
       options: Options,
       mergeSchemaEnabled: Boolean): LogicalPlan = {
-    val query = stripHiveDynamicPartitionMarker(v2WriteCommand.query)
+    val queryWithoutMarker = stripHiveDynamicPartitionMarker(v2WriteCommand.query)
+    val query =
+      if (
+        v2WriteCommand.isByName &&
+        containsColumnListWrite(v2WriteCommand.query)
+      ) {
+        PaimonOutputResolver.renameNestedFieldsByPosition(queryWithoutMarker, table.output)
+      } else {
+        queryWithoutMarker
+      }
     val hiveStyleDynamicPartitionEnabled = OptionUtils.hiveStyleDynamicPartitionEnabled()
     hiveDynamicPartitionColumns(v2WriteCommand.query) match {
       case Some(dynamicPartitionColumns)
@@ -152,6 +161,14 @@ class PaimonAnalysis(session: SparkSession) extends Rule[LogicalPlan] {
 
   private def stripHiveDynamicPartitionMarker(query: LogicalPlan): LogicalPlan = {
     query.transformDown { case PaimonHiveDynamicPartitionQuery(_, child) => child }
+  }
+
+  private def containsColumnListWrite(query: LogicalPlan): Boolean = {
+    query
+      .collectFirst {
+        case node if node.getTagValue(COLUMN_LIST_WRITE).isDefined => true
+      }
+      .contains(true)
   }
 
   private def resolveDynamicPartitionWrite(
@@ -273,6 +290,7 @@ class PaimonAnalysis(session: SparkSession) extends Rule[LogicalPlan] {
 
 object PaimonAnalysis {
   val PAIMON_WRITE_RESOLVED: TreeNodeTag[Unit] = TreeNodeTag[Unit]("paimon.write.resolved")
+  val COLUMN_LIST_WRITE: TreeNodeTag[Unit] = TreeNodeTag[Unit]("paimon.write.columnList")
 }
 
 case class PaimonPostHocResolutionRules(session: SparkSession) extends Rule[LogicalPlan] {

--- a/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/catalyst/analysis/PaimonOutputResolver.scala
+++ b/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/catalyst/analysis/PaimonOutputResolver.scala
@@ -58,6 +58,29 @@ object PaimonOutputResolver extends SQLConfHelper {
 
   import MissingFieldBehavior._
 
+  def renameNestedFieldsByPosition(query: LogicalPlan, expected: Seq[Attribute]): LogicalPlan = {
+    val renamed = query.output.map {
+      input =>
+        expected.find(target => conf.resolver(input.name, target.name)) match {
+          case Some(target) =>
+            val targetType =
+              CharVarcharUtils.getRawType(target.metadata).getOrElse(target.dataType)
+            val renamedType = renameFieldsInType(input.dataType, targetType)
+            if (renamedType == input.dataType) {
+              input
+            } else {
+              applyColumnMetadata(addCast(input, renamedType), input)
+            }
+          case None => input
+        }
+    }
+    if (renamed == query.output) {
+      query
+    } else {
+      Project(renamed, query)
+    }
+  }
+
   def resolveOutputColumns(
       tableName: String,
       expected: Seq[Attribute],
@@ -476,6 +499,36 @@ object PaimonOutputResolver extends SQLConfHelper {
 
   private def restoreActualType(attr: Attribute): Attribute = {
     attr.withDataType(CharVarcharUtils.getRawType(attr.metadata).getOrElse(attr.dataType))
+  }
+
+  private def renameFieldsInStruct(input: StructType, expected: StructType): StructType = {
+    if (input.length == expected.length) {
+      StructType(input.zip(expected).map {
+        case (inputField, expectedField) =>
+          inputField.copy(
+            name = expectedField.name,
+            dataType = renameFieldsInType(inputField.dataType, expectedField.dataType))
+      })
+    } else {
+      input
+    }
+  }
+
+  private def renameFieldsInType(input: DataType, expected: DataType): DataType = {
+    (input, expected) match {
+      case (inputStruct: StructType, expectedStruct: StructType) =>
+        renameFieldsInStruct(inputStruct, expectedStruct)
+      case (ArrayType(inputElement, containsNull), ArrayType(expectedElement, _)) =>
+        ArrayType(renameFieldsInType(inputElement, expectedElement), containsNull)
+      case (
+            MapType(inputKey, inputValue, valueContainsNull),
+            MapType(expectedKey, expectedValue, _)) =>
+        MapType(
+          renameFieldsInType(inputKey, expectedKey),
+          renameFieldsInType(inputValue, expectedValue),
+          valueContainsNull)
+      case _ => input
+    }
   }
 
   // Inlined `CharVarcharUtils.CHAR_VARCHAR_TYPE_STRING_METADATA_KEY` — the constant is

--- a/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/catalyst/analysis/PaimonOutputResolver.scala
+++ b/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/catalyst/analysis/PaimonOutputResolver.scala
@@ -58,19 +58,25 @@ object PaimonOutputResolver extends SQLConfHelper {
 
   import MissingFieldBehavior._
 
-  def renameNestedFieldsByPosition(query: LogicalPlan, expected: Seq[Attribute]): LogicalPlan = {
-    val renamed = query.output.map {
-      input =>
-        expected.find(target => conf.resolver(input.name, target.name)) match {
+  def renameNestedFieldsByPosition(
+      query: LogicalPlan,
+      expected: Seq[Attribute],
+      queryOutputByName: Boolean): LogicalPlan = {
+    val renamed = query.output.zipWithIndex.map {
+      case (input, index) =>
+        val target = if (queryOutputByName) {
+          expected.find(target => conf.resolver(input.name, target.name))
+        } else {
+          expected.lift(index)
+        }
+        target match {
           case Some(target) =>
             val targetType =
               CharVarcharUtils.getRawType(target.metadata).getOrElse(target.dataType)
             val renamedType = renameFieldsInType(input.dataType, targetType)
-            if (renamedType == input.dataType) {
-              input
-            } else {
-              applyColumnMetadata(addCast(input, renamedType), input)
-            }
+            val renamedExpr =
+              if (renamedType == input.dataType) input else addCast(input, renamedType)
+            applyColumnMetadata(renamedExpr, target)
           case None => input
         }
     }

--- a/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/catalyst/analysis/PaimonOutputResolver.scala
+++ b/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/catalyst/analysis/PaimonOutputResolver.scala
@@ -502,16 +502,14 @@ object PaimonOutputResolver extends SQLConfHelper {
   }
 
   private def renameFieldsInStruct(input: StructType, expected: StructType): StructType = {
-    if (input.length == expected.length) {
-      StructType(input.zip(expected).map {
-        case (inputField, expectedField) =>
-          inputField.copy(
-            name = expectedField.name,
-            dataType = renameFieldsInType(inputField.dataType, expectedField.dataType))
-      })
-    } else {
-      input
-    }
+    StructType(input.zipWithIndex.map {
+      case (inputField, index) if index < expected.length =>
+        val expectedField = expected(index)
+        inputField.copy(
+          name = expectedField.name,
+          dataType = renameFieldsInType(inputField.dataType, expectedField.dataType))
+      case (inputField, _) => inputField
+    })
   }
 
   private def renameFieldsInType(input: DataType, expected: DataType): DataType = {

--- a/paimon-spark/paimon-spark-common/src/main/scala/org/apache/spark/sql/catalyst/parser/extensions/AbstractPaimonSparkSqlExtensionsParser.scala
+++ b/paimon-spark/paimon-spark-common/src/main/scala/org/apache/spark/sql/catalyst/parser/extensions/AbstractPaimonSparkSqlExtensionsParser.scala
@@ -19,6 +19,7 @@
 package org.apache.spark.sql.catalyst.parser.extensions
 
 import org.apache.paimon.spark.SparkProcedures
+import org.apache.paimon.spark.catalyst.analysis.PaimonAnalysis.COLUMN_LIST_WRITE
 import org.apache.paimon.spark.catalyst.plans.logical.PaimonHiveDynamicPartitionQuery
 
 import org.antlr.v4.runtime._
@@ -112,6 +113,7 @@ abstract class AbstractPaimonSparkSqlExtensionsParser(val delegate: ParserInterf
 
   private def parserRules(sparkSession: SparkSession): Seq[Rule[LogicalPlan]] = {
     Seq(
+      MarkInsertColumnList,
       MarkHiveDynamicPartitionWrite,
       RewritePaimonViewCommands(sparkSession),
       RewritePaimonFunctionCommands(sparkSession),
@@ -370,6 +372,21 @@ class UpperCaseCharStream(wrapped: CodePointCharStream) extends CharStream {
   // scalastyle:on
 }
 
+object MarkInsertColumnList extends Rule[LogicalPlan] {
+
+  override def apply(plan: LogicalPlan): LogicalPlan = {
+    AnalysisHelper.allowInvokingTransformsInAnalyzer {
+      plan.transformDown {
+        case insert: InsertIntoStatement
+            if insert.userSpecifiedCols.nonEmpty &&
+              !MarkHiveDynamicPartitionWrite.isByName(insert) =>
+          insert.query.setTagValue(COLUMN_LIST_WRITE, ())
+          insert
+      }
+    }
+  }
+}
+
 object MarkHiveDynamicPartitionWrite extends Rule[LogicalPlan] {
 
   override def apply(plan: LogicalPlan): LogicalPlan = {
@@ -391,7 +408,7 @@ object MarkHiveDynamicPartitionWrite extends Rule[LogicalPlan] {
     insert.withNewChildren(Seq(query)).asInstanceOf[InsertIntoStatement]
   }
 
-  private def isByName(insert: InsertIntoStatement): Boolean = {
+  private[extensions] def isByName(insert: InsertIntoStatement): Boolean = {
     try {
       insert.getClass.getMethod("byName").invoke(insert).asInstanceOf[Boolean]
     } catch {

--- a/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/sql/InsertOverwriteTableTestBase.scala
+++ b/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/sql/InsertOverwriteTableTestBase.scala
@@ -919,6 +919,19 @@ abstract class InsertOverwriteTableTestBase extends PaimonSparkTestBase {
     }
   }
 
+  test("Paimon Insert: column list resolves unequal nested structs positionally") {
+    withSparkSQLConf("spark.paimon.write.merge-schema" -> "true") {
+      withTable("t") {
+        sql("CREATE TABLE t (arr ARRAY<STRUCT<x: INT, y: INT, z: INT>>)")
+        sql("""
+              |INSERT INTO t (arr)
+              |SELECT array(named_struct('y', 20, 'x', 10))
+              |""".stripMargin)
+        checkAnswer(sql("SELECT * FROM t"), Row(Seq(Row(20, 10, null))))
+      }
+    }
+  }
+
   test("Paimon Insert: by name resolves nested structs by name") {
     if (gteqSpark3_5) {
       withTable("t") {

--- a/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/sql/InsertOverwriteTableTestBase.scala
+++ b/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/sql/InsertOverwriteTableTestBase.scala
@@ -884,4 +884,51 @@ abstract class InsertOverwriteTableTestBase extends PaimonSparkTestBase {
         .saveAsTable("badTable")
     }.getMessage.contains("Not a supported type: void"))
   }
+
+  test("Paimon Insert: column list resolves nested structs positionally") {
+    withTable("t") {
+      sql("""
+            |CREATE TABLE t (
+            |  s STRUCT<x: INT, y: INT>,
+            |  arr ARRAY<STRUCT<x: INT, y: INT>>,
+            |  map_value MAP<STRING, STRUCT<x: INT, y: INT>>,
+            |  map_key MAP<STRUCT<x: INT, y: INT>, STRING>,
+            |  deep ARRAY<STRUCT<nested: ARRAY<STRUCT<x: INT, y: INT>>>>
+            |)
+            |""".stripMargin)
+
+      sql("""
+            |INSERT INTO t (s, arr, map_value, map_key, deep)
+            |SELECT
+            |  named_struct('y', 20, 'x', 10),
+            |  array(named_struct('y', 20, 'x', 10)),
+            |  map('k', named_struct('y', 20, 'x', 10)),
+            |  map(named_struct('y', 20, 'x', 10), 'v'),
+            |  array(named_struct(
+            |    'nested', array(named_struct('y', 20, 'x', 10))))
+            |""".stripMargin)
+
+      checkAnswer(
+        sql("SELECT * FROM t"),
+        Row(
+          Row(20, 10),
+          Seq(Row(20, 10)),
+          Map("k" -> Row(20, 10)),
+          Map(Row(20, 10) -> "v"),
+          Seq(Row(Seq(Row(20, 10))))))
+    }
+  }
+
+  test("Paimon Insert: by name resolves nested structs by name") {
+    if (gteqSpark3_5) {
+      withTable("t") {
+        sql("CREATE TABLE t (arr ARRAY<STRUCT<x: INT, y: INT>>)")
+        sql("""
+              |INSERT INTO t BY NAME
+              |SELECT array(named_struct('y', 20, 'x', 10)) AS arr
+              |""".stripMargin)
+        checkAnswer(sql("SELECT * FROM t"), Row(Seq(Row(10, 20))))
+      }
+    }
+  }
 }


### PR DESCRIPTION
### Purpose
 - Insert column lists should order both columns and nested struct fields by position.
 - Paimon maps nested struct fields by name, causing values to be reordered when the source and target field orders differ.
 - This causes the query results to differ, ensure we can fix by preserving the mapping recursively for structs inside arrays and maps.

### Tests
 - UT
