### PR TITLE
[core] Reject resetting ignore-delete and ignore-update-before from true

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/schema/SchemaManager.java
+++ b/paimon-core/src/main/java/org/apache/paimon/schema/SchemaManager.java
@@ -1486,6 +1486,16 @@ public class SchemaManager implements Serializable {
                     DELETION_VECTORS_ENABLED.defaultValue().toString());
         }
 
+        if (IGNORE_DELETE.key().equals(key)) {
+            checkAlterTableOption(
+                    options, key, options.get(key), IGNORE_DELETE.defaultValue().toString());
+        }
+
+        if (IGNORE_UPDATE_BEFORE.key().equals(key)) {
+            checkAlterTableOption(
+                    options, key, options.get(key), IGNORE_UPDATE_BEFORE.defaultValue().toString());
+        }
+
         if (options.containsKey(PK_CLUSTERING_OVERRIDE.key())
                 && CLUSTERING_COLUMNS.key().equals(key)) {
             throw new UnsupportedOperationException(

--- a/paimon-core/src/test/java/org/apache/paimon/schema/SchemaManagerTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/schema/SchemaManagerTest.java
@@ -27,6 +27,7 @@ import org.apache.paimon.fs.FileIOFinder;
 import org.apache.paimon.fs.Path;
 import org.apache.paimon.fs.local.LocalFileIO;
 import org.apache.paimon.iceberg.IcebergOptions;
+import org.apache.paimon.options.ConfigOption;
 import org.apache.paimon.reader.RecordReaderIterator;
 import org.apache.paimon.table.FileStoreTable;
 import org.apache.paimon.table.FileStoreTableFactory;
@@ -77,6 +78,8 @@ import java.util.stream.Stream;
 
 import static org.apache.paimon.CoreOptions.DELETION_VECTORS_ENABLED;
 import static org.apache.paimon.CoreOptions.DELETION_VECTORS_MODIFIABLE;
+import static org.apache.paimon.CoreOptions.IGNORE_DELETE;
+import static org.apache.paimon.CoreOptions.IGNORE_UPDATE_BEFORE;
 import static org.apache.paimon.utils.FailingFileIO.retryArtificialException;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
@@ -1557,5 +1560,27 @@ public class SchemaManagerTest {
                                 FileStoreTableFactory.create(LocalFileIO.create(), path, after)
                                         .newWrite("u"))
                 .doesNotThrowAnyException();
+    }
+
+    @Test
+    public void testResetCannotWeakenAnOptionThatSetCannotWeaken() {
+        // Resetting an option puts it back to its default. For these three the default is the
+        // weaker value, so a reset is the same change that setting it explicitly already rejects.
+        for (ConfigOption<Boolean> option :
+                Arrays.asList(DELETION_VECTORS_ENABLED, IGNORE_DELETE, IGNORE_UPDATE_BEFORE)) {
+            Map<String, String> enabled = new HashMap<>();
+            enabled.put(option.key(), "true");
+            assertThatThrownBy(
+                            () -> SchemaManager.checkResetTableOption(enabled, option.key()),
+                            option.key())
+                    .isInstanceOf(UnsupportedOperationException.class);
+
+            // resetting an option that is already at its default changes nothing
+            Map<String, String> disabled = new HashMap<>();
+            disabled.put(option.key(), "false");
+            assertThatCode(() -> SchemaManager.checkResetTableOption(disabled, option.key()))
+                    .as("%s", option.key())
+                    .doesNotThrowAnyException();
+        }
     }
 }


### PR DESCRIPTION
### Purpose

`ALTER TABLE ... SET ('ignore-delete' = 'false')` is rejected on a table where it is on:

```
Cannot change ignore-delete from true to false.
```

`ALTER TABLE ... RESET ('ignore-delete')` reaches the same state — the option goes back to its default, which is `false` — and is accepted.

`checkResetTableOption` already mirrors the alter-side guards for immutable options, `bucket`, `deletion-vectors.enabled` and `clustering.columns`. `deletion-vectors.enabled` is handled by routing the reset through `checkAlterTableOption` with the default as the new value:

```java
if (DELETION_VECTORS_ENABLED.key().equals(key)) {
    checkAlterTableOption(
            options, key, options.get(key), DELETION_VECTORS_ENABLED.defaultValue().toString());
}
```

`ignore-delete` and `ignore-update-before` carry the same "cannot weaken" rule in `checkAlterTableOption` but were not carried over. This mirrors them the same way.

### Tests

`SchemaManagerTest#testResetCannotWeakenAnOptionThatSetCannotWeaken` walks all three options that share the rule. For each: resetting from `true` must be rejected, and resetting an option already at its default must not be.

Putting `deletion-vectors.enabled` in the same loop is deliberate — it already passes on `master`, so it shows the loop is a fair test and it is only the two new arms that were missing. Reverting the change, the failure names which one:

```
java.lang.AssertionError:
[ignore-delete]
Expecting code to raise a throwable.
```

`mvn test -pl paimon-core -Dtest='org.apache.paimon.schema.**'` — 488 tests, all passing.
