### PR TITLE
[spark] Fix min and max query failure on metadata columns

### DIFF
--- a/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/aggregate/AggregatePushDownUtils.scala
+++ b/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/aggregate/AggregatePushDownUtils.scala
@@ -113,6 +113,9 @@ object AggregatePushDownUtils {
     }
 
     val columnName = extractColumn.get
+    if (rowType.notContainsField(columnName)) {
+      return None
+    }
     val dataType = rowType.getField(columnName).`type`()
     if (minmaxAvailable(dataType)) {
       Option(columnName)

--- a/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/sql/PushDownAggregatesTest.scala
+++ b/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/sql/PushDownAggregatesTest.scala
@@ -51,6 +51,22 @@ class PushDownAggregatesTest extends PaimonSparkTestBase with AdaptiveSparkPlanH
     }
   }
 
+  test("Push down aggregate - metadata column") {
+    withTable("T") {
+      spark.sql(
+        """
+          |CREATE TABLE T (c1 INT, c2 STRING) TBLPROPERTIES ('bucket-key'='c1', 'bucket'='3')
+          |""".stripMargin)
+      spark.sql(
+        "INSERT INTO T VALUES (1, 'x1'), (2, 'x2'), (3, 'x3'), (4, 'x4'), (5, 'x5'), (6, 'x6')")
+
+      runAndCheckAggregate(
+        "SELECT MIN(__paimon_bucket), MAX(__paimon_bucket) FROM T",
+        Row(0, 2) :: Nil,
+        2)
+    }
+  }
+
   test("Push down aggregate - append table without partitions") {
     withTable("T") {
       spark.sql("CREATE TABLE T (c1 INT, c2 STRING, c3 DOUBLE, c4 DATE)")


### PR DESCRIPTION
### Purpose
 - Min and max queries directly aggregating Paimon metadata columns fail.
 - This is because agg pushdown is checking the physical schema for metadata columns. However, metadata columns are not in the physical schema, instead derived from split metadata as virtual columns.
 - Skip pushdown for such columns and let Spark aggregate to avoid the failure.
 
### Tests
 - UT