### PR TITLE
[core] Short-circuit always-false format table scans

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/partition/PartitionPredicate.java
+++ b/paimon-core/src/main/java/org/apache/paimon/partition/PartitionPredicate.java
@@ -127,6 +127,10 @@ public interface PartitionPredicate extends Serializable {
 
     PartitionPredicate ALWAYS_FALSE =
             new PartitionPredicate() {
+                private Object readResolve() {
+                    return ALWAYS_FALSE;
+                }
+
                 @Override
                 public boolean test(BinaryRow part) {
                     return false;

--- a/paimon-core/src/main/java/org/apache/paimon/table/format/FormatTableScan.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/format/FormatTableScan.java
@@ -53,6 +53,7 @@ import javax.annotation.Nullable;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -101,6 +102,9 @@ public class FormatTableScan implements InnerTableScan {
 
     @Override
     public List<PartitionEntry> listPartitionEntries() {
+        if (partitionFilter == PartitionPredicate.ALWAYS_FALSE) {
+            return Collections.emptyList();
+        }
         return splitEnumerator.listPartitionEntries(partitionFilter);
     }
 
@@ -232,6 +236,11 @@ public class FormatTableScan implements InnerTableScan {
 
         private synchronized SplitEnumerator.ScanPlan scanPlan() {
             if (scanPlan != null) {
+                return scanPlan;
+            }
+            if (partitionFilter == PartitionPredicate.ALWAYS_FALSE) {
+                scanPlan =
+                        new SplitEnumerator.ScanPlan(Collections.emptyList(), OptionalLong.of(0L));
                 return scanPlan;
             }
             try {

--- a/paimon-core/src/test/java/org/apache/paimon/table/format/FormatTableAlwaysFalseScanTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/table/format/FormatTableAlwaysFalseScanTest.java
@@ -1,0 +1,144 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.table.format;
+
+import org.apache.paimon.catalog.Identifier;
+import org.apache.paimon.fs.FileIO;
+import org.apache.paimon.partition.PartitionPredicate;
+import org.apache.paimon.table.FormatTable;
+import org.apache.paimon.types.DataTypes;
+import org.apache.paimon.types.RowType;
+import org.apache.paimon.utils.InstantiationUtil;
+
+import org.junit.jupiter.api.Test;
+
+import javax.annotation.Nullable;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.OptionalLong;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.mockito.Mockito.mock;
+
+/** Tests for empty Format Table scans selected by an explicit false partition predicate. */
+class FormatTableAlwaysFalseScanTest {
+
+    @Test
+    void testAlwaysFalseSkipsAllScanBackends() {
+        assertAll(
+                () -> assertEmptyWithoutBackendAccess(createTable("unpartitioned", false, null)),
+                () ->
+                        assertEmptyWithoutBackendAccess(
+                                createTable("filesystem_partitioned", true, null)),
+                () ->
+                        assertEmptyWithoutBackendAccess(
+                                createTable(
+                                        "catalog_managed",
+                                        true,
+                                        failOnAccess(
+                                                FormatTablePartitionManager.class, "catalog"))));
+    }
+
+    @Test
+    void testSerializedAlwaysFalseSkipsUnpartitionedBackend() throws Exception {
+        PartitionPredicate restoredAlwaysFalse =
+                InstantiationUtil.deserializeObject(
+                        InstantiationUtil.serializeObject(PartitionPredicate.ALWAYS_FALSE),
+                        getClass().getClassLoader());
+        FormatTableScan scan =
+                (FormatTableScan)
+                        createTable("serialized", false, null)
+                                .newReadBuilder()
+                                .withPartitionFilter(restoredAlwaysFalse)
+                                .newScan();
+
+        assertEmptyWithoutBackendAccess(scan);
+    }
+
+    @Test
+    void testEquivalentNonSingletonPredicateKeepsNormalScanPath() {
+        FormatTable table = createTable("non_singleton", false, null);
+        PartitionPredicate equivalentPredicate =
+                PartitionPredicate.and(
+                        Arrays.asList(
+                                PartitionPredicate.ALWAYS_FALSE, PartitionPredicate.ALWAYS_TRUE));
+        assertThat(equivalentPredicate).isNotSameAs(PartitionPredicate.ALWAYS_FALSE);
+        FormatTableScan scan = new FormatTableScan(table, equivalentPredicate, null);
+
+        assertAll(
+                () ->
+                        assertThatThrownBy(() -> scan.plan().splits())
+                                .isInstanceOf(AssertionError.class)
+                                .hasMessageContaining("FileIO accessed"),
+                () ->
+                        assertThatThrownBy(scan::listPartitionEntries)
+                                .isInstanceOf(AssertionError.class)
+                                .hasMessageContaining("FileIO accessed"));
+    }
+
+    private void assertEmptyWithoutBackendAccess(FormatTable table) {
+        assertEmptyWithoutBackendAccess(
+                new FormatTableScan(table, PartitionPredicate.ALWAYS_FALSE, null));
+    }
+
+    private void assertEmptyWithoutBackendAccess(FormatTableScan scan) {
+        FormatTableScan.Plan plan = scan.plan();
+
+        assertAll(
+                () -> assertThat(plan.splits()).isEmpty(),
+                () -> assertThat(plan.rowCount()).isEqualTo(OptionalLong.of(0L)),
+                () -> assertThat(scan.listPartitionEntries()).isEmpty());
+    }
+
+    private FormatTable createTable(
+            String name,
+            boolean partitioned,
+            @Nullable FormatTablePartitionManager partitionManager) {
+        RowType rowType =
+                RowType.builder()
+                        .field("partition", DataTypes.INT())
+                        .field("value", DataTypes.INT())
+                        .build();
+        List<String> partitionKeys =
+                partitioned ? Collections.singletonList("partition") : Collections.emptyList();
+        return FormatTable.builder()
+                .fileIO(failOnAccess(FileIO.class, "FileIO"))
+                .identifier(Identifier.create("test_db", name))
+                .rowType(rowType)
+                .partitionKeys(partitionKeys)
+                .location("file:/path/which/must/not/be/accessed")
+                .format(FormatTable.Format.CSV)
+                .options(Collections.emptyMap())
+                .partitionManager(partitionManager)
+                .build();
+    }
+
+    private static <T> T failOnAccess(Class<T> backendClass, String backendName) {
+        return mock(
+                backendClass,
+                invocation -> {
+                    throw new AssertionError(
+                            backendName + " accessed through " + invocation.getMethod().getName());
+                });
+    }
+}


### PR DESCRIPTION
### Purpose

`PartitionPredicate.ALWAYS_FALSE` says "no partition can match", but `FormatTableScan` still handed it to the split enumerator, which then listed the table's partition directories and filtered every entry out. On a catalog-managed format table that listing is a remote FS call per partition level, so a query whose filter is provably unsatisfiable still paid the full listing cost before returning nothing.

Two places now short-circuit on `ALWAYS_FALSE`:

- `listPartitionEntries()` returns an empty list;
- the scan-plan path returns `new ScanPlan(emptyList(), OptionalLong.of(0L))`, i.e. no splits and a row count of exactly 0 rather than "unknown".

Both checks are reference comparisons against the singleton, which is why the anonymous `ALWAYS_FALSE` instance also gains `readResolve()`. `PartitionPredicate` is `Serializable` and is shipped to Flink/Spark tasks; without `readResolve` the deserialized copy is a distinct object and the reference check on the task side would silently miss, leaving the short-circuit working only on the client. `readResolve` makes the singleton survive a round trip so the optimization holds wherever the predicate lands.

### Tests

`FormatTableAlwaysFalseScanTest` (new, 3 cases): `listPartitionEntries` returns empty without touching the enumerator, the scan plan reports zero splits and `rowCount == 0`, and `ALWAYS_FALSE` deserializes back to the same instance so the reference check still fires.

```
mvn -pl paimon-core -am -DfailIfNoTests=false -DwildcardSuites=none \
  -Dtest=FormatTableAlwaysFalseScanTest,PartitionPredicateTest test
```

Tests run: 11, Failures: 0, Errors: 0, Skipped: 0 (3 new + the existing 8 in `PartitionPredicateTest`). `spotless:check` + `checkstyle:check` pass.
