### PR TITLE
[spark] Reject SET LOCATION for format tables

### DIFF
--- a/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/catalyst/analysis/PaimonAnalysis.scala
+++ b/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/catalyst/analysis/PaimonAnalysis.scala
@@ -84,6 +84,12 @@ class PaimonAnalysis(session: SparkSession) extends Rule[LogicalPlan] {
         throw new UnsupportedOperationException(
           "ALTER TABLE ... SET LOCATION is not supported for Paimon tables.")
 
+      // Only the table-level form. Spark's own analyzer already rejects the partition form with a
+      // structured AnalysisException, and replacing it here would be a worse error.
+      case SetTableLocation(ResolvedTable(_, _, _: PaimonFormatTable, _), None, _) =>
+        throw new UnsupportedOperationException(
+          "ALTER TABLE ... SET LOCATION is not supported for Paimon tables.")
+
       case r: ReplaceColumns if r.resolved && isPaimonTable(r.table) =>
         // Spark rewrites REPLACE COLUMNS into a batch that drops every existing column and re-adds
         // the new set. Re-adding columns assigns brand-new field ids while existing data files keep

--- a/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/sql/CatalogManagedPartitionDdlParityTest.scala
+++ b/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/sql/CatalogManagedPartitionDdlParityTest.scala
@@ -19,10 +19,11 @@
 package org.apache.paimon.spark.sql
 
 import org.apache.paimon.catalog.Identifier
+import org.apache.paimon.fs.Path
 import org.apache.paimon.spark.PaimonSparkTestWithRestCatalogBase
 import org.apache.paimon.table.FormatTable
 
-import org.apache.spark.sql.Row
+import org.apache.spark.sql.{AnalysisException, Row}
 
 import scala.collection.JavaConverters._
 
@@ -151,6 +152,58 @@ class CatalogManagedPartitionDdlParityTest extends PaimonSparkTestWithRestCatalo
       // and drift reads as empty instead of taking the query down.
       checkAnswer(sql(s"SELECT id FROM ${qualified(tableName)} ORDER BY id"), Seq(Row(2)))
       assert(registered(tableName) == Set("20260101/00", "20260102/00"))
+    }
+  }
+
+  test("SET LOCATION is rejected without changing a catalog-managed Format Table") {
+    val tableName = "ddl_set_location"
+    withTable(tableName) {
+      createTable(tableName)
+      val table = formatTable(tableName)
+      val originalLocation = table.location().toString
+      sql(s"ALTER TABLE ${qualified(tableName)} ADD PARTITION (dt = '20260101', hour = '00')")
+      table
+        .fileIO()
+        .writeFile(new Path(table.location(), "dt=20260101/hour=00/part-00001.csv"), "1,a\n", false)
+
+      val error = intercept[UnsupportedOperationException] {
+        sql(s"ALTER TABLE ${qualified(tableName)} SET LOCATION '${originalLocation}_relocated'")
+      }
+
+      assert(error.getMessage == "ALTER TABLE ... SET LOCATION is not supported for Paimon tables.")
+      assert(formatTable(tableName).location().toString == originalLocation)
+      assert(registered(tableName) == Set("20260101/00"))
+      checkAnswer(
+        sql(s"SELECT id, payload, dt, hour FROM ${qualified(tableName)}"),
+        Seq(Row(1, "a", "20260101", "00")))
+    }
+  }
+
+  test("partition SET LOCATION keeps Spark's structured rejection and table state") {
+    val tableName = "ddl_partition_set_location"
+    withTable(tableName) {
+      createTable(tableName)
+      val table = formatTable(tableName)
+      val originalLocation = table.location().toString
+      sql(s"ALTER TABLE ${qualified(tableName)} ADD PARTITION (dt = '20260101', hour = '00')")
+      table
+        .fileIO()
+        .writeFile(new Path(table.location(), "dt=20260101/hour=00/part-00001.csv"), "1,a\n", false)
+
+      val error = intercept[AnalysisException] {
+        sql(
+          s"ALTER TABLE ${qualified(tableName)} PARTITION " +
+            s"(dt = '20260101', hour = '00') SET LOCATION '${originalLocation}_relocated'")
+      }
+
+      // Spark 4 renamed getErrorClass to getCondition and is still moving these legacy ids to
+      // named conditions, so match the message instead of the id.
+      assert(error.getMessage.contains("does not support partition"))
+      assert(formatTable(tableName).location().toString == originalLocation)
+      assert(registered(tableName) == Set("20260101/00"))
+      checkAnswer(
+        sql(s"SELECT id, payload, dt, hour FROM ${qualified(tableName)}"),
+        Seq(Row(1, "a", "20260101", "00")))
     }
   }
 


### PR DESCRIPTION
### Purpose

`PaimonAnalysis` rejects `ALTER TABLE ... SET LOCATION` for Paimon tables, but the pattern only matched `SparkTable`. A format table resolves to `PaimonFormatTable`, so the rule fell through and Spark applied the location change to the catalog entry. A catalog-managed format table registers its partitions relative to the location, so after that the catalog lists partitions that no longer describe the data it points at.

This adds the `PaimonFormatTable` case with the same error. The partition-level form is left alone: Spark's own analyzer already rejects it with a structured `AnalysisException`.

### Tests

`CatalogManagedPartitionDdlParityTest`: 9 tests passed.