### PR TITLE
[core] Improve row ID reassignment under concurrent writes

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/append/dataevolution/DataEvolutionRowIdReassigner.java
+++ b/paimon-core/src/main/java/org/apache/paimon/append/dataevolution/DataEvolutionRowIdReassigner.java
@@ -43,6 +43,7 @@ import org.apache.paimon.table.SpecialFields;
 import org.apache.paimon.utils.CloseableIterator;
 import org.apache.paimon.utils.Pair;
 import org.apache.paimon.utils.Range;
+import org.apache.paimon.utils.RetryWaiter;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -68,7 +69,7 @@ public class DataEvolutionRowIdReassigner {
 
     private static final Logger LOG = LoggerFactory.getLogger(DataEvolutionRowIdReassigner.class);
     private static final String COMMIT_USER_PREFIX = "reassign-row-id";
-    private static final int MAX_COMMIT_ATTEMPTS = 3;
+    @VisibleForTesting static final int MAX_ASSIGNMENT_BATCHES = 4;
 
     private final FileStoreTable table;
     private final @Nullable PartitionPredicate partitionPredicate;
@@ -126,76 +127,126 @@ public class DataEvolutionRowIdReassigner {
 
         ManifestFile manifestFile = table.store().manifestFileFactory().create();
         ManifestList manifestList = table.store().manifestListFactory().create();
-        Optional<AssignmentPlan> optionalPlan =
-                planAssignment(manifestList.readDataManifests(latest));
-        if (!optionalPlan.isPresent()) {
+        Snapshot planningSnapshot = latest;
+        List<AssignmentPlan> assignmentPlans =
+                planAssignments(manifestList.readDataManifests(latest));
+        if (assignmentPlans.isEmpty()) {
             LOG.info(
                     "Skip reassigning row IDs for table {} because no partition requires reassignment.",
                     table.name());
             return Result.skipped(
                     latest.id(), nextRowId, "no partition requires row-id reassignment");
         }
-        AssignmentPlan assignmentPlan = optionalPlan.get();
 
-        for (int attempt = 1; attempt <= MAX_COMMIT_ATTEMPTS; attempt++) {
-            Assignment assignment = assignmentPlan.createAssignment(latest);
-            CommitAssignmentResult commitResult =
-                    commitAssignment(assignment, manifestFile, manifestList, commitUser);
-            if (commitResult.success) {
-                LOG.info(
-                        "Reassigned row IDs for table {} from {} to {}, partitions={}, files={}, rows={}.",
-                        table.name(),
-                        assignment.firstAssignedRowId,
-                        assignment.nextRowId,
-                        assignment.rowIdMappings.size(),
-                        commitResult.fileCount,
-                        assignment.logicalRowCount());
-                return new Result(
-                        assignment.snapshot.id(),
-                        assignment.snapshot.id() + 1,
-                        commitResult.fileCount,
-                        assignment.logicalRowCount(),
-                        commitResult.indexFileCount,
-                        assignment.firstAssignedRowId,
-                        assignment.nextRowId);
-            }
-
-            if (attempt == MAX_COMMIT_ATTEMPTS) {
+        long previousSnapshotId = -1L;
+        long newSnapshotId = -1L;
+        long firstAssignedRowId = -1L;
+        long reassignedFileCount = 0L;
+        long reassignedRowCount = 0L;
+        long reassignedIndexFileCount = 0L;
+        long reassignedNextRowId = nextRowId;
+        Set<Long> committedSnapshotIds = new HashSet<>();
+        for (int batch = 0; batch < assignmentPlans.size(); batch++) {
+            CommittedAssignment committed;
+            try {
+                AssignmentPlan assignmentPlan = assignmentPlans.get(batch);
+                if (latest.id() > planningSnapshot.id()) {
+                    assignmentPlan =
+                            advanceAssignmentPlan(
+                                    assignmentPlan,
+                                    planningSnapshot,
+                                    latest,
+                                    manifestFile,
+                                    manifestList,
+                                    committedSnapshotIds);
+                }
+                committed =
+                        commitAssignmentWithRetry(
+                                assignmentPlan, latest, manifestFile, manifestList, commitUser);
+            } catch (RuntimeException e) {
+                if (batch == 0) {
+                    throw e;
+                }
                 throw new RuntimeException(
-                        "Failed to reassign row IDs because a newer snapshot has been committed.");
+                        String.format(
+                                "Failed to finish row-id reassignment after completing %s of %s manifest-group batches. Rerun the operation to continue: %s",
+                                batch, assignmentPlans.size(), e.getMessage()),
+                        e);
             }
 
-            Snapshot newLatest = table.snapshotManager().latestSnapshot();
-            checkState(newLatest != null, "Latest snapshot disappeared while reassigning row IDs.");
-            assignmentPlan =
-                    advanceAssignmentPlan(
-                            assignmentPlan, latest, newLatest, manifestFile, manifestList);
+            Assignment assignment = committed.assignment;
+            CommitAssignmentResult commitResult = committed.commitResult;
+            long committedSnapshotId = assignment.snapshot.id() + 1;
+            latest = table.snapshotManager().snapshot(committedSnapshotId);
+            if (batch == 0) {
+                previousSnapshotId = assignment.snapshot.id();
+                firstAssignedRowId = assignment.firstAssignedRowId;
+            }
+            newSnapshotId = committedSnapshotId;
+            committedSnapshotIds.add(committedSnapshotId);
+            reassignedFileCount = Math.addExact(reassignedFileCount, commitResult.fileCount);
+            reassignedRowCount = Math.addExact(reassignedRowCount, assignment.logicalRowCount());
+            reassignedIndexFileCount =
+                    Math.addExact(reassignedIndexFileCount, commitResult.indexFileCount);
+            reassignedNextRowId = assignment.nextRowId;
             LOG.info(
-                    "Failed to commit row-id reassignment for table {} based on snapshot {} because snapshot {} has been committed. Retrying {}/{} with the updated assignment plan.",
+                    "Reassigned row IDs for table {} in manifest-group batch {}/{} from {} to {}, partitions={}, files={}, rows={}.",
                     table.name(),
-                    latest.id(),
-                    newLatest.id(),
-                    attempt + 1,
-                    MAX_COMMIT_ATTEMPTS);
-            latest = newLatest;
+                    batch + 1,
+                    assignmentPlans.size(),
+                    assignment.firstAssignedRowId,
+                    assignment.nextRowId,
+                    assignment.rowIdMappings.size(),
+                    commitResult.fileCount,
+                    assignment.logicalRowCount());
         }
 
-        throw new IllegalStateException("Unreachable retry state while reassigning row IDs.");
+        return new Result(
+                previousSnapshotId,
+                newSnapshotId,
+                reassignedFileCount,
+                reassignedRowCount,
+                reassignedIndexFileCount,
+                firstAssignedRowId,
+                reassignedNextRowId);
     }
 
     private Optional<AssignmentPlan> planAssignment(List<ManifestFileMeta> manifestMetas) {
-        List<List<ManifestFileMeta>> manifestGroups = manifestGroupsByPartition(manifestMetas);
+        return createAssignmentPlan(manifestMetas, includedManifestGroups(manifestMetas));
+    }
+
+    private List<AssignmentPlan> planAssignments(List<ManifestFileMeta> manifestMetas) {
+        List<List<ManifestFileMeta>> manifestGroups = includedManifestGroups(manifestMetas);
+        int batchCount = Math.min(manifestGroups.size(), MAX_ASSIGNMENT_BATCHES);
+        List<AssignmentPlan> result = new ArrayList<>();
+        for (int batch = 0; batch < batchCount; batch++) {
+            int from = batch * manifestGroups.size() / batchCount;
+            int to = (batch + 1) * manifestGroups.size() / batchCount;
+            createAssignmentPlan(manifestMetas, manifestGroups.subList(from, to))
+                    .ifPresent(result::add);
+        }
+        return result;
+    }
+
+    private List<List<ManifestFileMeta>> includedManifestGroups(
+            List<ManifestFileMeta> manifestMetas) {
         List<List<ManifestFileMeta>> includedGroups = new ArrayList<>();
-        for (List<ManifestFileMeta> manifestGroup : manifestGroups) {
+        for (List<ManifestFileMeta> manifestGroup : manifestGroupsByPartition(manifestMetas)) {
             if (!skipManifestGroupByPartitionFilter(manifestGroup)) {
                 includedGroups.add(manifestGroup);
             }
         }
+        return includedGroups;
+    }
 
+    private Optional<AssignmentPlan> createAssignmentPlan(
+            List<ManifestFileMeta> manifestMetas,
+            List<List<ManifestFileMeta>> includedManifestGroups) {
         DataEvolutionRowIdAssignmentPlanner planner =
                 new DataEvolutionRowIdAssignmentPlanner(
                         table, partitionPredicate, new ArrayList<>(manifestMetas));
-        DataEvolutionRowIdAssignmentPlanner.Result compactPlan = planner.plan(includedGroups);
+        DataEvolutionRowIdAssignmentPlanner.Result compactPlan =
+                planner.plan(includedManifestGroups);
         if (compactPlan.isEmpty()) {
             return Optional.empty();
         }
@@ -358,6 +409,65 @@ public class DataEvolutionRowIdReassigner {
         return partitionPredicate != null;
     }
 
+    private CommittedAssignment commitAssignmentWithRetry(
+            AssignmentPlan initialAssignmentPlan,
+            Snapshot initialSnapshot,
+            ManifestFile manifestFile,
+            ManifestList manifestList,
+            String commitUser) {
+        AssignmentPlan assignmentPlan = initialAssignmentPlan;
+        Snapshot latest = initialSnapshot;
+        int retryCount = 0;
+        long startMillis = System.currentTimeMillis();
+        CoreOptions options = table.coreOptions();
+        RetryWaiter retryWaiter =
+                new RetryWaiter(options.commitMinRetryWait(), options.commitMaxRetryWait());
+
+        while (true) {
+            Snapshot observedLatest = table.snapshotManager().latestSnapshot();
+            checkState(
+                    observedLatest != null,
+                    "Latest snapshot disappeared while reassigning row IDs.");
+            if (observedLatest.id() > latest.id()) {
+                assignmentPlan =
+                        advanceAssignmentPlan(
+                                assignmentPlan, latest, observedLatest, manifestFile, manifestList);
+                latest = observedLatest;
+            }
+
+            Assignment assignment = assignmentPlan.createAssignment(latest);
+            CommitAssignmentResult commitResult =
+                    commitAssignment(assignment, manifestFile, manifestList, commitUser);
+            if (commitResult.success) {
+                return new CommittedAssignment(assignment, commitResult);
+            }
+
+            if (System.currentTimeMillis() - startMillis > options.commitTimeout()
+                    || retryCount >= options.commitMaxRetries()) {
+                throw new RuntimeException(
+                        String.format(
+                                "Failed to reassign row IDs after %s millis with %s retries because newer snapshots kept being committed.",
+                                System.currentTimeMillis() - startMillis, retryCount));
+            }
+
+            Snapshot newLatest = table.snapshotManager().latestSnapshot();
+            checkState(newLatest != null, "Latest snapshot disappeared while reassigning row IDs.");
+            assignmentPlan =
+                    advanceAssignmentPlan(
+                            assignmentPlan, latest, newLatest, manifestFile, manifestList);
+            LOG.info(
+                    "Failed to commit row-id reassignment for table {} based on snapshot {} because snapshot {} has been committed. Retrying {}/{} with the updated assignment plan.",
+                    table.name(),
+                    latest.id(),
+                    newLatest.id(),
+                    retryCount + 1,
+                    options.commitMaxRetries());
+            retryWaiter.retryWait(retryCount);
+            retryCount++;
+            latest = newLatest;
+        }
+    }
+
     private CommitAssignmentResult commitAssignment(
             Assignment assignment,
             ManifestFile manifestFile,
@@ -396,6 +506,22 @@ public class DataEvolutionRowIdReassigner {
             Snapshot latest,
             ManifestFile manifestFile,
             ManifestList manifestList) {
+        return advanceAssignmentPlan(
+                assignmentPlan,
+                previous,
+                latest,
+                manifestFile,
+                manifestList,
+                Collections.emptySet());
+    }
+
+    private AssignmentPlan advanceAssignmentPlan(
+            AssignmentPlan assignmentPlan,
+            Snapshot previous,
+            Snapshot latest,
+            ManifestFile manifestFile,
+            ManifestList manifestList,
+            Set<Long> allowedOverwriteSnapshotIds) {
         checkState(
                 latest.id() > previous.id(),
                 "Cannot advance row-id assignment from snapshot %s to %s.",
@@ -423,14 +549,18 @@ public class DataEvolutionRowIdReassigner {
                         e);
             }
 
+            boolean allowedOverwrite =
+                    snapshot.commitKind() == Snapshot.CommitKind.OVERWRITE
+                            && allowedOverwriteSnapshotIds.contains(snapshot.id());
             if (snapshot.commitKind() == Snapshot.CommitKind.COMPACT
-                    || snapshot.commitKind() == Snapshot.CommitKind.OVERWRITE) {
+                    || (snapshot.commitKind() == Snapshot.CommitKind.OVERWRITE
+                            && !allowedOverwrite)) {
                 throw new RuntimeException(
                         String.format(
                                 "Abort row-id reassignment because %s snapshot %s was committed after snapshot %s.",
                                 snapshot.commitKind(), snapshot.id(), previous.id()));
             }
-            if (snapshot.commitKind() == Snapshot.CommitKind.ANALYZE) {
+            if (snapshot.commitKind() == Snapshot.CommitKind.ANALYZE || allowedOverwrite) {
                 continue;
             }
             checkState(
@@ -556,15 +686,21 @@ public class DataEvolutionRowIdReassigner {
             Map<String, List<ManifestFileMeta>> rewrittenManifestMetas,
             ManifestList manifestList) {
         List<ManifestFileMeta> baseManifestMetas = new ArrayList<>();
+        Set<String> unmatchedReplacements = new HashSet<>(rewrittenManifestMetas.keySet());
         for (ManifestFileMeta manifestMeta : manifestMetas) {
             List<ManifestFileMeta> replacement =
                     rewrittenManifestMetas.get(manifestMeta.fileName());
             if (replacement == null) {
                 baseManifestMetas.add(manifestMeta);
             } else {
+                unmatchedReplacements.remove(manifestMeta.fileName());
                 baseManifestMetas.addAll(replacement);
             }
         }
+        checkState(
+                unmatchedReplacements.isEmpty(),
+                "Cannot replace planned manifests %s because they are not in the current manifest list.",
+                unmatchedReplacements);
         return manifestList.write(baseManifestMetas);
     }
 
@@ -857,6 +993,16 @@ public class DataEvolutionRowIdReassigner {
                 Map<String, List<ManifestFileMeta>> manifestMetas, long fileCount) {
             this.manifestMetas = manifestMetas;
             this.fileCount = fileCount;
+        }
+    }
+
+    private static class CommittedAssignment {
+        private final Assignment assignment;
+        private final CommitAssignmentResult commitResult;
+
+        private CommittedAssignment(Assignment assignment, CommitAssignmentResult commitResult) {
+            this.assignment = assignment;
+            this.commitResult = commitResult;
         }
     }
 

--- a/paimon-core/src/main/java/org/apache/paimon/append/dataevolution/DataEvolutionRowIdReassigner.java
+++ b/paimon-core/src/main/java/org/apache/paimon/append/dataevolution/DataEvolutionRowIdReassigner.java
@@ -69,7 +69,6 @@ public class DataEvolutionRowIdReassigner {
 
     private static final Logger LOG = LoggerFactory.getLogger(DataEvolutionRowIdReassigner.class);
     private static final String COMMIT_USER_PREFIX = "reassign-row-id";
-    @VisibleForTesting static final int MAX_ASSIGNMENT_BATCHES = 4;
 
     private final FileStoreTable table;
     private final @Nullable PartitionPredicate partitionPredicate;
@@ -127,10 +126,9 @@ public class DataEvolutionRowIdReassigner {
 
         ManifestFile manifestFile = table.store().manifestFileFactory().create();
         ManifestList manifestList = table.store().manifestListFactory().create();
-        Snapshot planningSnapshot = latest;
-        List<AssignmentPlan> assignmentPlans =
-                planAssignments(manifestList.readDataManifests(latest));
-        if (assignmentPlans.isEmpty()) {
+        Optional<AssignmentPlan> optionalPlan =
+                planAssignment(manifestList.readDataManifests(latest));
+        if (!optionalPlan.isPresent()) {
             LOG.info(
                     "Skip reassigning row IDs for table {} because no partition requires reassignment.",
                     table.name());
@@ -138,115 +136,43 @@ public class DataEvolutionRowIdReassigner {
                     latest.id(), nextRowId, "no partition requires row-id reassignment");
         }
 
-        long previousSnapshotId = -1L;
-        long newSnapshotId = -1L;
-        long firstAssignedRowId = -1L;
-        long reassignedFileCount = 0L;
-        long reassignedRowCount = 0L;
-        long reassignedIndexFileCount = 0L;
-        long reassignedNextRowId = nextRowId;
-        Set<Long> committedSnapshotIds = new HashSet<>();
-        for (int batch = 0; batch < assignmentPlans.size(); batch++) {
-            CommittedAssignment committed;
-            try {
-                AssignmentPlan assignmentPlan = assignmentPlans.get(batch);
-                if (latest.id() > planningSnapshot.id()) {
-                    assignmentPlan =
-                            advanceAssignmentPlan(
-                                    assignmentPlan,
-                                    planningSnapshot,
-                                    latest,
-                                    manifestFile,
-                                    manifestList,
-                                    committedSnapshotIds);
-                }
-                committed =
-                        commitAssignmentWithRetry(
-                                assignmentPlan, latest, manifestFile, manifestList, commitUser);
-            } catch (RuntimeException e) {
-                if (batch == 0) {
-                    throw e;
-                }
-                throw new RuntimeException(
-                        String.format(
-                                "Failed to finish row-id reassignment after completing %s of %s manifest-group batches. Rerun the operation to continue: %s",
-                                batch, assignmentPlans.size(), e.getMessage()),
-                        e);
-            }
-
-            Assignment assignment = committed.assignment;
-            CommitAssignmentResult commitResult = committed.commitResult;
-            long committedSnapshotId = assignment.snapshot.id() + 1;
-            latest = table.snapshotManager().snapshot(committedSnapshotId);
-            if (batch == 0) {
-                previousSnapshotId = assignment.snapshot.id();
-                firstAssignedRowId = assignment.firstAssignedRowId;
-            }
-            newSnapshotId = committedSnapshotId;
-            committedSnapshotIds.add(committedSnapshotId);
-            reassignedFileCount = Math.addExact(reassignedFileCount, commitResult.fileCount);
-            reassignedRowCount = Math.addExact(reassignedRowCount, assignment.logicalRowCount());
-            reassignedIndexFileCount =
-                    Math.addExact(reassignedIndexFileCount, commitResult.indexFileCount);
-            reassignedNextRowId = assignment.nextRowId;
-            LOG.info(
-                    "Reassigned row IDs for table {} in manifest-group batch {}/{} from {} to {}, partitions={}, files={}, rows={}.",
-                    table.name(),
-                    batch + 1,
-                    assignmentPlans.size(),
-                    assignment.firstAssignedRowId,
-                    assignment.nextRowId,
-                    assignment.rowIdMappings.size(),
-                    commitResult.fileCount,
-                    assignment.logicalRowCount());
-        }
+        CommittedAssignment committed =
+                commitAssignmentWithRetry(
+                        optionalPlan.get(), latest, manifestFile, manifestList, commitUser);
+        Assignment assignment = committed.assignment;
+        CommitAssignmentResult commitResult = committed.commitResult;
+        LOG.info(
+                "Reassigned row IDs for table {} from {} to {}, partitions={}, files={}, rows={}.",
+                table.name(),
+                assignment.firstAssignedRowId,
+                assignment.nextRowId,
+                assignment.rowIdMappings.size(),
+                commitResult.fileCount,
+                assignment.logicalRowCount());
 
         return new Result(
-                previousSnapshotId,
-                newSnapshotId,
-                reassignedFileCount,
-                reassignedRowCount,
-                reassignedIndexFileCount,
-                firstAssignedRowId,
-                reassignedNextRowId);
+                assignment.snapshot.id(),
+                assignment.snapshot.id() + 1,
+                commitResult.fileCount,
+                assignment.logicalRowCount(),
+                commitResult.indexFileCount,
+                assignment.firstAssignedRowId,
+                assignment.nextRowId);
     }
 
     private Optional<AssignmentPlan> planAssignment(List<ManifestFileMeta> manifestMetas) {
-        return createAssignmentPlan(manifestMetas, includedManifestGroups(manifestMetas));
-    }
-
-    private List<AssignmentPlan> planAssignments(List<ManifestFileMeta> manifestMetas) {
-        List<List<ManifestFileMeta>> manifestGroups = includedManifestGroups(manifestMetas);
-        int batchCount = Math.min(manifestGroups.size(), MAX_ASSIGNMENT_BATCHES);
-        List<AssignmentPlan> result = new ArrayList<>();
-        for (int batch = 0; batch < batchCount; batch++) {
-            int from = batch * manifestGroups.size() / batchCount;
-            int to = (batch + 1) * manifestGroups.size() / batchCount;
-            createAssignmentPlan(manifestMetas, manifestGroups.subList(from, to))
-                    .ifPresent(result::add);
-        }
-        return result;
-    }
-
-    private List<List<ManifestFileMeta>> includedManifestGroups(
-            List<ManifestFileMeta> manifestMetas) {
+        List<List<ManifestFileMeta>> manifestGroups = manifestGroupsByPartition(manifestMetas);
         List<List<ManifestFileMeta>> includedGroups = new ArrayList<>();
-        for (List<ManifestFileMeta> manifestGroup : manifestGroupsByPartition(manifestMetas)) {
+        for (List<ManifestFileMeta> manifestGroup : manifestGroups) {
             if (!skipManifestGroupByPartitionFilter(manifestGroup)) {
                 includedGroups.add(manifestGroup);
             }
         }
-        return includedGroups;
-    }
 
-    private Optional<AssignmentPlan> createAssignmentPlan(
-            List<ManifestFileMeta> manifestMetas,
-            List<List<ManifestFileMeta>> includedManifestGroups) {
         DataEvolutionRowIdAssignmentPlanner planner =
                 new DataEvolutionRowIdAssignmentPlanner(
                         table, partitionPredicate, new ArrayList<>(manifestMetas));
-        DataEvolutionRowIdAssignmentPlanner.Result compactPlan =
-                planner.plan(includedManifestGroups);
+        DataEvolutionRowIdAssignmentPlanner.Result compactPlan = planner.plan(includedGroups);
         if (compactPlan.isEmpty()) {
             return Optional.empty();
         }
@@ -506,22 +432,6 @@ public class DataEvolutionRowIdReassigner {
             Snapshot latest,
             ManifestFile manifestFile,
             ManifestList manifestList) {
-        return advanceAssignmentPlan(
-                assignmentPlan,
-                previous,
-                latest,
-                manifestFile,
-                manifestList,
-                Collections.emptySet());
-    }
-
-    private AssignmentPlan advanceAssignmentPlan(
-            AssignmentPlan assignmentPlan,
-            Snapshot previous,
-            Snapshot latest,
-            ManifestFile manifestFile,
-            ManifestList manifestList,
-            Set<Long> allowedOverwriteSnapshotIds) {
         checkState(
                 latest.id() > previous.id(),
                 "Cannot advance row-id assignment from snapshot %s to %s.",
@@ -549,18 +459,14 @@ public class DataEvolutionRowIdReassigner {
                         e);
             }
 
-            boolean allowedOverwrite =
-                    snapshot.commitKind() == Snapshot.CommitKind.OVERWRITE
-                            && allowedOverwriteSnapshotIds.contains(snapshot.id());
             if (snapshot.commitKind() == Snapshot.CommitKind.COMPACT
-                    || (snapshot.commitKind() == Snapshot.CommitKind.OVERWRITE
-                            && !allowedOverwrite)) {
+                    || snapshot.commitKind() == Snapshot.CommitKind.OVERWRITE) {
                 throw new RuntimeException(
                         String.format(
                                 "Abort row-id reassignment because %s snapshot %s was committed after snapshot %s.",
                                 snapshot.commitKind(), snapshot.id(), previous.id()));
             }
-            if (snapshot.commitKind() == Snapshot.CommitKind.ANALYZE || allowedOverwrite) {
+            if (snapshot.commitKind() == Snapshot.CommitKind.ANALYZE) {
                 continue;
             }
             checkState(

--- a/paimon-core/src/main/java/org/apache/paimon/operation/FileStoreCommitImpl.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/FileStoreCommitImpl.java
@@ -1366,6 +1366,12 @@ public class FileStoreCommitImpl implements FileStoreCommit {
                 latest.nextRowId());
     }
 
+    /**
+     * Replaces the manifest lists exactly as supplied, without manifest compaction or sorting.
+     *
+     * <p>This is intended for metadata-only operations which have already produced their final
+     * manifest layout and must commit it without invoking {@link ManifestFileMerger}.
+     */
     public boolean replaceManifestList(
             Snapshot latest,
             long totalRecordCount,

--- a/paimon-core/src/test/java/org/apache/paimon/append/dataevolution/DataEvolutionRowIdReassignerTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/append/dataevolution/DataEvolutionRowIdReassignerTest.java
@@ -624,7 +624,7 @@ public class DataEvolutionRowIdReassignerTest extends TableTestBase {
 
         assertThat(result.reassigned).isTrue();
         assertThat(result.previousSnapshotId).isEqualTo(5L);
-        assertThat(result.newSnapshotId).isEqualTo(6L);
+        assertThat(result.newSnapshotId).isEqualTo(7L);
         assertThat(result.firstAssignedRowId).isEqualTo(5L);
         assertThat(result.nextRowId).isEqualTo(10L);
         assertThat(result.fileCount).isEqualTo(5L);
@@ -710,7 +710,7 @@ public class DataEvolutionRowIdReassignerTest extends TableTestBase {
         assertThat(appended).isTrue();
         assertThat(result.reassigned).isTrue();
         assertThat(result.previousSnapshotId).isEqualTo(before.id() + 1);
-        assertThat(result.newSnapshotId).isEqualTo(before.id() + 2);
+        assertThat(result.newSnapshotId).isEqualTo(before.id() + 3);
         assertThat(result.firstAssignedRowId).isEqualTo(6L);
         assertThat(result.nextRowId).isEqualTo(11L);
         assertThat(result.fileCount).isEqualTo(5L);
@@ -745,7 +745,7 @@ public class DataEvolutionRowIdReassignerTest extends TableTestBase {
                         .reassign("test-reassign-append-planned-partition");
 
         assertThat(result.previousSnapshotId).isEqualTo(before.id() + 1);
-        assertThat(result.newSnapshotId).isEqualTo(before.id() + 2);
+        assertThat(result.newSnapshotId).isEqualTo(before.id() + 3);
         assertThat(result.firstAssignedRowId).isEqualTo(6L);
         assertThat(result.nextRowId).isEqualTo(11L);
         assertThat(result.fileCount).isEqualTo(5L);
@@ -962,9 +962,9 @@ public class DataEvolutionRowIdReassignerTest extends TableTestBase {
                                 })
                         .reassign("test-reassign-multiple-append-conflicts");
 
-        assertThat(beforeCommits).hasValue(3);
+        assertThat(beforeCommits).hasValue(4);
         assertThat(result.previousSnapshotId).isEqualTo(before.id() + 3);
-        assertThat(result.newSnapshotId).isEqualTo(before.id() + 4);
+        assertThat(result.newSnapshotId).isEqualTo(before.id() + 5);
         assertThat(result.firstAssignedRowId).isEqualTo(8L);
         assertThat(result.nextRowId).isEqualTo(13L);
         assertThat(result.fileCount).isEqualTo(5L);
@@ -974,6 +974,186 @@ public class DataEvolutionRowIdReassignerTest extends TableTestBase {
                 .containsEntry("pt=b/", Arrays.asList(11L, 12L))
                 .containsEntry("pt=c/", Collections.singletonList(5L))
                 .containsEntry("pt=d/", Collections.singletonList(6L));
+    }
+
+    @Test
+    public void testReassignUsesConfiguredRetryBudget() throws Exception {
+        FileStoreTable table = createTableWithInterleavedPartitions();
+        Map<String, String> retryOptions = new HashMap<>();
+        retryOptions.put(CoreOptions.COMMIT_MAX_RETRIES.key(), "3");
+        retryOptions.put(CoreOptions.COMMIT_MIN_RETRY_WAIT.key(), "0ms");
+        retryOptions.put(CoreOptions.COMMIT_MAX_RETRY_WAIT.key(), "0ms");
+        FileStoreTable configured = table.copy(retryOptions);
+
+        AtomicInteger beforeCommits = new AtomicInteger();
+        DataEvolutionRowIdReassigner.Result result =
+                new DataEvolutionRowIdReassigner(
+                                configured,
+                                partitionPredicate(configured, "a"),
+                                () -> {
+                                    int attempt = beforeCommits.getAndIncrement();
+                                    if (attempt < 3) {
+                                        try {
+                                            writeOneRow(
+                                                    configured, "new-" + attempt, 100 + attempt);
+                                        } catch (Exception e) {
+                                            throw new RuntimeException(e);
+                                        }
+                                    }
+                                })
+                        .reassign("test-reassign-configured-retries");
+
+        assertThat(beforeCommits).hasValue(4);
+        assertThat(result.reassigned).isTrue();
+        assertThat(result.fileCount).isEqualTo(3L);
+        assertThat(result.rowCount).isEqualTo(3L);
+        assertThat(rowIdsByPartition(configured).get("pt=a/")).containsExactly(8L, 9L, 10L);
+    }
+
+    @Test
+    public void testLaterManifestGroupRebasesAcrossEarlierGroupRetry() throws Exception {
+        FileStoreTable originalTable = createTableWithThreeIndependentPartitions();
+        createBTreeIndex(originalTable);
+        List<String> originalManifestFiles = dataManifestFileNames(originalTable);
+        FileStoreTable table = withManifestMergeOnNextAppend(originalTable);
+        Snapshot before = table.snapshotManager().latestSnapshot();
+        AtomicBoolean updated = new AtomicBoolean();
+
+        DataEvolutionRowIdReassigner.Result result =
+                new DataEvolutionRowIdReassigner(
+                                table,
+                                null,
+                                () -> {
+                                    if (updated.compareAndSet(false, true)) {
+                                        try {
+                                            writePartialPayload(table, "b", 1L, "updated-1");
+                                            assertThat(dataManifestFileNames(table))
+                                                    .doesNotContainAnyElementsOf(
+                                                            originalManifestFiles);
+                                        } catch (Exception e) {
+                                            throw new RuntimeException(e);
+                                        }
+                                    }
+                                })
+                        .reassign("test-reassign-rebase-later-group");
+
+        assertThat(result.previousSnapshotId).isEqualTo(before.id() + 1);
+        assertThat(result.newSnapshotId).isEqualTo(before.id() + 4);
+        assertThat(result.firstAssignedRowId).isEqualTo(6L);
+        assertThat(result.nextRowId).isEqualTo(12L);
+        assertThat(result.fileCount).isEqualTo(7L);
+        assertThat(result.rowCount).isEqualTo(6L);
+        assertThat(result.indexFileCount).isEqualTo(6L);
+        assertThat(expandedRowIdsByPartition(table))
+                .containsEntry("pt=a/", Arrays.asList(6L, 7L))
+                .containsEntry("pt=b/", Arrays.asList(8L, 8L, 9L))
+                .containsEntry("pt=c/", Arrays.asList(10L, 11L));
+        assertThat(globalIndexRanges(table))
+                .containsExactly(
+                        new Range(6, 6),
+                        new Range(7, 7),
+                        new Range(8, 8),
+                        new Range(9, 9),
+                        new Range(10, 10),
+                        new Range(11, 11));
+        assertThat(readTableRows(table))
+                .containsExactly("0|a|v0", "1|b|updated-1", "2|c|v2", "3|a|v3", "4|b|v4", "5|c|v5");
+    }
+
+    @Test
+    public void testReassignCommitsIndependentManifestGroupsSeparately() throws Exception {
+        FileStoreTable table = createTableWithInterleavedPartitions();
+        Snapshot before = table.snapshotManager().latestSnapshot();
+
+        DataEvolutionRowIdReassigner.Result result =
+                new DataEvolutionRowIdReassigner(table)
+                        .reassign("test-reassign-independent-manifest-groups");
+
+        assertThat(result.previousSnapshotId).isEqualTo(before.id());
+        assertThat(result.newSnapshotId).isEqualTo(before.id() + 2);
+        assertThat(table.snapshotManager().snapshot(before.id() + 1).commitKind())
+                .isEqualTo(Snapshot.CommitKind.OVERWRITE);
+        assertThat(table.snapshotManager().snapshot(before.id() + 2).commitKind())
+                .isEqualTo(Snapshot.CommitKind.OVERWRITE);
+        assertThat(result.firstAssignedRowId).isEqualTo(5L);
+        assertThat(result.nextRowId).isEqualTo(10L);
+        assertThat(result.fileCount).isEqualTo(5L);
+        assertThat(result.rowCount).isEqualTo(5L);
+        assertThat(rowIdsByPartition(table))
+                .containsEntry("pt=a/", Arrays.asList(5L, 6L, 7L))
+                .containsEntry("pt=b/", Arrays.asList(8L, 9L));
+    }
+
+    @Test
+    public void testReassignCapsIndependentManifestGroupBatches() throws Exception {
+        createTableDefault();
+        FileStoreTable table = getTableDefault();
+        int partitionCount = DataEvolutionRowIdReassigner.MAX_ASSIGNMENT_BATCHES + 1;
+        for (int round = 0; round < 2; round++) {
+            for (int partition = 0; partition < partitionCount; partition++) {
+                writeOneRow(table, "p" + partition, round * partitionCount + partition);
+            }
+        }
+        Snapshot before = table.snapshotManager().latestSnapshot();
+
+        DataEvolutionRowIdReassigner.Result result =
+                new DataEvolutionRowIdReassigner(table)
+                        .reassign("test-reassign-capped-manifest-groups");
+
+        assertThat(result.previousSnapshotId).isEqualTo(before.id());
+        assertThat(result.newSnapshotId)
+                .isEqualTo(before.id() + DataEvolutionRowIdReassigner.MAX_ASSIGNMENT_BATCHES);
+        assertThat(result.firstAssignedRowId).isEqualTo(2L * partitionCount);
+        assertThat(result.nextRowId).isEqualTo(4L * partitionCount);
+        assertThat(result.fileCount).isEqualTo(2L * partitionCount);
+        assertThat(result.rowCount).isEqualTo(2L * partitionCount);
+
+        Map<String, List<Long>> reassignedRowIds = expandedRowIdsByPartition(table);
+        long expectedFirstRowId = result.firstAssignedRowId;
+        for (int partition = 0; partition < partitionCount; partition++) {
+            assertThat(reassignedRowIds.get("pt=p" + partition + "/"))
+                    .containsExactly(expectedFirstRowId, expectedFirstRowId + 1);
+            expectedFirstRowId += 2;
+        }
+    }
+
+    @Test
+    public void testReassignResumesAfterPartiallyCommittedBatches() throws Exception {
+        FileStoreTable table = createTableWithInterleavedPartitions();
+        AtomicInteger beforeCommits = new AtomicInteger();
+
+        assertThatThrownBy(
+                        () ->
+                                new DataEvolutionRowIdReassigner(
+                                                table,
+                                                null,
+                                                () -> {
+                                                    if (beforeCommits.getAndIncrement() == 1) {
+                                                        try {
+                                                            compactManifests(table);
+                                                        } catch (Exception e) {
+                                                            throw new RuntimeException(e);
+                                                        }
+                                                    }
+                                                })
+                                        .reassign("test-reassign-partial-batches"))
+                .isInstanceOf(RuntimeException.class)
+                .hasMessageContaining("completing 1 of 2 manifest-group batches")
+                .hasMessageContaining("COMPACT snapshot");
+
+        assertThat(rowIdsByPartition(table))
+                .containsEntry("pt=a/", Arrays.asList(5L, 6L, 7L))
+                .containsEntry("pt=b/", Arrays.asList(1L, 3L));
+
+        DataEvolutionRowIdReassigner.Result resumed =
+                new DataEvolutionRowIdReassigner(table)
+                        .reassign("test-reassign-resume-partial-batches");
+        assertThat(resumed.reassigned).isTrue();
+        assertThat(resumed.fileCount).isEqualTo(2L);
+        assertThat(resumed.rowCount).isEqualTo(2L);
+        assertThat(rowIdsByPartition(table))
+                .containsEntry("pt=a/", Arrays.asList(5L, 6L, 7L))
+                .containsEntry("pt=b/", Arrays.asList(8L, 9L));
     }
 
     @Test
@@ -1122,7 +1302,7 @@ public class DataEvolutionRowIdReassignerTest extends TableTestBase {
                         .reassign("test-reassign-analyze-conflict");
 
         assertThat(result.previousSnapshotId).isEqualTo(before.id() + 1);
-        assertThat(result.newSnapshotId).isEqualTo(before.id() + 2);
+        assertThat(result.newSnapshotId).isEqualTo(before.id() + 3);
         assertThat(result.firstAssignedRowId).isEqualTo(5L);
         assertThat(result.nextRowId).isEqualTo(10L);
         assertThat(table.snapshotManager().latestSnapshot().statistics()).isNotNull();
@@ -1285,6 +1465,43 @@ public class DataEvolutionRowIdReassignerTest extends TableTestBase {
         List<String> afterManifestFiles = dataManifestFileNames(table);
         assertThat(afterManifestFiles).containsAll(unaffectedManifests);
         assertThat(afterManifestFiles).doesNotContainAnyElementsOf(affectedManifests);
+    }
+
+    @Test
+    public void testReassignDoesNotCompactManifests() throws Exception {
+        testReassignSkipsManifestOptimization(false);
+    }
+
+    @Test
+    public void testReassignDoesNotSortManifests() throws Exception {
+        testReassignSkipsManifestOptimization(true);
+    }
+
+    private void testReassignSkipsManifestOptimization(boolean manifestSortEnabled)
+            throws Exception {
+        FileStoreTable table = createTableWithPartiallyOverlappedPartitions();
+        Map<String, Set<String>> partitionsByManifest = currentPartitionsByManifest(table);
+        List<String> unaffectedManifests = new ArrayList<>();
+        for (Map.Entry<String, Set<String>> entry : partitionsByManifest.entrySet()) {
+            if (!entry.getValue().contains("pt=a/")) {
+                unaffectedManifests.add(entry.getKey());
+            }
+        }
+        assertThat(unaffectedManifests).isNotEmpty();
+
+        Map<String, String> options = new HashMap<>();
+        options.put(CoreOptions.MANIFEST_SORT_ENABLED.key(), Boolean.toString(manifestSortEnabled));
+        options.put(CoreOptions.MANIFEST_MERGE_MIN_COUNT.key(), "1");
+        options.put(CoreOptions.MANIFEST_FULL_COMPACTION_FILE_SIZE.key(), "1B");
+        FileStoreTable configured = table.copy(options);
+
+        new DataEvolutionRowIdReassigner(configured)
+                .reassign(
+                        manifestSortEnabled
+                                ? "test-reassign-with-manifest-sort"
+                                : "test-reassign-with-manifest-compaction");
+
+        assertThat(dataManifestFileNames(configured)).containsAll(unaffectedManifests);
     }
 
     @Test
@@ -1565,8 +1782,8 @@ public class DataEvolutionRowIdReassignerTest extends TableTestBase {
                 new DataEvolutionRowIdReassigner(table).reassign("test-reassign-row-id-index-2");
 
         assertThat(secondResult.reassigned).isFalse();
-        assertThat(secondResult.previousSnapshotId).isEqualTo(7L);
-        assertThat(secondResult.newSnapshotId).isEqualTo(7L);
+        assertThat(secondResult.previousSnapshotId).isEqualTo(8L);
+        assertThat(secondResult.newSnapshotId).isEqualTo(8L);
         assertThat(secondResult.firstAssignedRowId).isEqualTo(10L);
         assertThat(secondResult.nextRowId).isEqualTo(10L);
         assertThat(secondResult.fileCount).isEqualTo(0L);
@@ -1628,7 +1845,7 @@ public class DataEvolutionRowIdReassignerTest extends TableTestBase {
 
         assertThat(indexed).isTrue();
         assertThat(result.previousSnapshotId).isEqualTo(before.id() + 1);
-        assertThat(result.newSnapshotId).isEqualTo(before.id() + 2);
+        assertThat(result.newSnapshotId).isEqualTo(before.id() + 3);
         assertThat(result.firstAssignedRowId).isEqualTo(6L);
         assertThat(result.nextRowId).isEqualTo(11L);
         assertThat(result.indexFileCount).isEqualTo(5L);
@@ -1667,7 +1884,7 @@ public class DataEvolutionRowIdReassignerTest extends TableTestBase {
         assertThat(result.reassigned).isTrue();
         assertThat(result.skipReason).isNull();
         assertThat(result.previousSnapshotId).isEqualTo(before.id());
-        assertThat(result.newSnapshotId).isEqualTo(before.id() + 1);
+        assertThat(result.newSnapshotId).isEqualTo(before.id() + 2);
         assertThat(result.firstAssignedRowId).isEqualTo(5L);
         assertThat(result.nextRowId).isEqualTo(10L);
         assertThat(result.fileCount).isEqualTo(5L);
@@ -1714,7 +1931,7 @@ public class DataEvolutionRowIdReassignerTest extends TableTestBase {
 
         assertThat(result.reassigned).isTrue();
         assertThat(result.previousSnapshotId).isEqualTo(before.id());
-        assertThat(result.newSnapshotId).isEqualTo(before.id() + 1);
+        assertThat(result.newSnapshotId).isEqualTo(before.id() + 4);
         assertThat(result.firstAssignedRowId).isEqualTo(scrambledNextRowId);
         assertThat(result.fileCount).isEqualTo(expectedFileCount);
         assertThat(result.rowCount).isEqualTo(expectedRows.size());
@@ -1831,6 +2048,18 @@ public class DataEvolutionRowIdReassignerTest extends TableTestBase {
         writeOneRow(table, "a", 2);
         writeOneRow(table, "b", 3);
         writeOneRow(table, "a", 4);
+        return table;
+    }
+
+    private FileStoreTable createTableWithThreeIndependentPartitions() throws Exception {
+        createTableDefault();
+        FileStoreTable table = getTableDefault();
+        writeOneRow(table, "a", 0);
+        writeOneRow(table, "b", 1);
+        writeOneRow(table, "c", 2);
+        writeOneRow(table, "a", 3);
+        writeOneRow(table, "b", 4);
+        writeOneRow(table, "c", 5);
         return table;
     }
 

--- a/paimon-core/src/test/java/org/apache/paimon/append/dataevolution/DataEvolutionRowIdReassignerTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/append/dataevolution/DataEvolutionRowIdReassignerTest.java
@@ -624,7 +624,7 @@ public class DataEvolutionRowIdReassignerTest extends TableTestBase {
 
         assertThat(result.reassigned).isTrue();
         assertThat(result.previousSnapshotId).isEqualTo(5L);
-        assertThat(result.newSnapshotId).isEqualTo(7L);
+        assertThat(result.newSnapshotId).isEqualTo(6L);
         assertThat(result.firstAssignedRowId).isEqualTo(5L);
         assertThat(result.nextRowId).isEqualTo(10L);
         assertThat(result.fileCount).isEqualTo(5L);
@@ -710,7 +710,7 @@ public class DataEvolutionRowIdReassignerTest extends TableTestBase {
         assertThat(appended).isTrue();
         assertThat(result.reassigned).isTrue();
         assertThat(result.previousSnapshotId).isEqualTo(before.id() + 1);
-        assertThat(result.newSnapshotId).isEqualTo(before.id() + 3);
+        assertThat(result.newSnapshotId).isEqualTo(before.id() + 2);
         assertThat(result.firstAssignedRowId).isEqualTo(6L);
         assertThat(result.nextRowId).isEqualTo(11L);
         assertThat(result.fileCount).isEqualTo(5L);
@@ -745,7 +745,7 @@ public class DataEvolutionRowIdReassignerTest extends TableTestBase {
                         .reassign("test-reassign-append-planned-partition");
 
         assertThat(result.previousSnapshotId).isEqualTo(before.id() + 1);
-        assertThat(result.newSnapshotId).isEqualTo(before.id() + 3);
+        assertThat(result.newSnapshotId).isEqualTo(before.id() + 2);
         assertThat(result.firstAssignedRowId).isEqualTo(6L);
         assertThat(result.nextRowId).isEqualTo(11L);
         assertThat(result.fileCount).isEqualTo(5L);
@@ -962,9 +962,9 @@ public class DataEvolutionRowIdReassignerTest extends TableTestBase {
                                 })
                         .reassign("test-reassign-multiple-append-conflicts");
 
-        assertThat(beforeCommits).hasValue(4);
+        assertThat(beforeCommits).hasValue(3);
         assertThat(result.previousSnapshotId).isEqualTo(before.id() + 3);
-        assertThat(result.newSnapshotId).isEqualTo(before.id() + 5);
+        assertThat(result.newSnapshotId).isEqualTo(before.id() + 4);
         assertThat(result.firstAssignedRowId).isEqualTo(8L);
         assertThat(result.nextRowId).isEqualTo(13L);
         assertThat(result.fileCount).isEqualTo(5L);
@@ -1008,152 +1008,6 @@ public class DataEvolutionRowIdReassignerTest extends TableTestBase {
         assertThat(result.fileCount).isEqualTo(3L);
         assertThat(result.rowCount).isEqualTo(3L);
         assertThat(rowIdsByPartition(configured).get("pt=a/")).containsExactly(8L, 9L, 10L);
-    }
-
-    @Test
-    public void testLaterManifestGroupRebasesAcrossEarlierGroupRetry() throws Exception {
-        FileStoreTable originalTable = createTableWithThreeIndependentPartitions();
-        createBTreeIndex(originalTable);
-        List<String> originalManifestFiles = dataManifestFileNames(originalTable);
-        FileStoreTable table = withManifestMergeOnNextAppend(originalTable);
-        Snapshot before = table.snapshotManager().latestSnapshot();
-        AtomicBoolean updated = new AtomicBoolean();
-
-        DataEvolutionRowIdReassigner.Result result =
-                new DataEvolutionRowIdReassigner(
-                                table,
-                                null,
-                                () -> {
-                                    if (updated.compareAndSet(false, true)) {
-                                        try {
-                                            writePartialPayload(table, "b", 1L, "updated-1");
-                                            assertThat(dataManifestFileNames(table))
-                                                    .doesNotContainAnyElementsOf(
-                                                            originalManifestFiles);
-                                        } catch (Exception e) {
-                                            throw new RuntimeException(e);
-                                        }
-                                    }
-                                })
-                        .reassign("test-reassign-rebase-later-group");
-
-        assertThat(result.previousSnapshotId).isEqualTo(before.id() + 1);
-        assertThat(result.newSnapshotId).isEqualTo(before.id() + 4);
-        assertThat(result.firstAssignedRowId).isEqualTo(6L);
-        assertThat(result.nextRowId).isEqualTo(12L);
-        assertThat(result.fileCount).isEqualTo(7L);
-        assertThat(result.rowCount).isEqualTo(6L);
-        assertThat(result.indexFileCount).isEqualTo(6L);
-        assertThat(expandedRowIdsByPartition(table))
-                .containsEntry("pt=a/", Arrays.asList(6L, 7L))
-                .containsEntry("pt=b/", Arrays.asList(8L, 8L, 9L))
-                .containsEntry("pt=c/", Arrays.asList(10L, 11L));
-        assertThat(globalIndexRanges(table))
-                .containsExactly(
-                        new Range(6, 6),
-                        new Range(7, 7),
-                        new Range(8, 8),
-                        new Range(9, 9),
-                        new Range(10, 10),
-                        new Range(11, 11));
-        assertThat(readTableRows(table))
-                .containsExactly("0|a|v0", "1|b|updated-1", "2|c|v2", "3|a|v3", "4|b|v4", "5|c|v5");
-    }
-
-    @Test
-    public void testReassignCommitsIndependentManifestGroupsSeparately() throws Exception {
-        FileStoreTable table = createTableWithInterleavedPartitions();
-        Snapshot before = table.snapshotManager().latestSnapshot();
-
-        DataEvolutionRowIdReassigner.Result result =
-                new DataEvolutionRowIdReassigner(table)
-                        .reassign("test-reassign-independent-manifest-groups");
-
-        assertThat(result.previousSnapshotId).isEqualTo(before.id());
-        assertThat(result.newSnapshotId).isEqualTo(before.id() + 2);
-        assertThat(table.snapshotManager().snapshot(before.id() + 1).commitKind())
-                .isEqualTo(Snapshot.CommitKind.OVERWRITE);
-        assertThat(table.snapshotManager().snapshot(before.id() + 2).commitKind())
-                .isEqualTo(Snapshot.CommitKind.OVERWRITE);
-        assertThat(result.firstAssignedRowId).isEqualTo(5L);
-        assertThat(result.nextRowId).isEqualTo(10L);
-        assertThat(result.fileCount).isEqualTo(5L);
-        assertThat(result.rowCount).isEqualTo(5L);
-        assertThat(rowIdsByPartition(table))
-                .containsEntry("pt=a/", Arrays.asList(5L, 6L, 7L))
-                .containsEntry("pt=b/", Arrays.asList(8L, 9L));
-    }
-
-    @Test
-    public void testReassignCapsIndependentManifestGroupBatches() throws Exception {
-        createTableDefault();
-        FileStoreTable table = getTableDefault();
-        int partitionCount = DataEvolutionRowIdReassigner.MAX_ASSIGNMENT_BATCHES + 1;
-        for (int round = 0; round < 2; round++) {
-            for (int partition = 0; partition < partitionCount; partition++) {
-                writeOneRow(table, "p" + partition, round * partitionCount + partition);
-            }
-        }
-        Snapshot before = table.snapshotManager().latestSnapshot();
-
-        DataEvolutionRowIdReassigner.Result result =
-                new DataEvolutionRowIdReassigner(table)
-                        .reassign("test-reassign-capped-manifest-groups");
-
-        assertThat(result.previousSnapshotId).isEqualTo(before.id());
-        assertThat(result.newSnapshotId)
-                .isEqualTo(before.id() + DataEvolutionRowIdReassigner.MAX_ASSIGNMENT_BATCHES);
-        assertThat(result.firstAssignedRowId).isEqualTo(2L * partitionCount);
-        assertThat(result.nextRowId).isEqualTo(4L * partitionCount);
-        assertThat(result.fileCount).isEqualTo(2L * partitionCount);
-        assertThat(result.rowCount).isEqualTo(2L * partitionCount);
-
-        Map<String, List<Long>> reassignedRowIds = expandedRowIdsByPartition(table);
-        long expectedFirstRowId = result.firstAssignedRowId;
-        for (int partition = 0; partition < partitionCount; partition++) {
-            assertThat(reassignedRowIds.get("pt=p" + partition + "/"))
-                    .containsExactly(expectedFirstRowId, expectedFirstRowId + 1);
-            expectedFirstRowId += 2;
-        }
-    }
-
-    @Test
-    public void testReassignResumesAfterPartiallyCommittedBatches() throws Exception {
-        FileStoreTable table = createTableWithInterleavedPartitions();
-        AtomicInteger beforeCommits = new AtomicInteger();
-
-        assertThatThrownBy(
-                        () ->
-                                new DataEvolutionRowIdReassigner(
-                                                table,
-                                                null,
-                                                () -> {
-                                                    if (beforeCommits.getAndIncrement() == 1) {
-                                                        try {
-                                                            compactManifests(table);
-                                                        } catch (Exception e) {
-                                                            throw new RuntimeException(e);
-                                                        }
-                                                    }
-                                                })
-                                        .reassign("test-reassign-partial-batches"))
-                .isInstanceOf(RuntimeException.class)
-                .hasMessageContaining("completing 1 of 2 manifest-group batches")
-                .hasMessageContaining("COMPACT snapshot");
-
-        assertThat(rowIdsByPartition(table))
-                .containsEntry("pt=a/", Arrays.asList(5L, 6L, 7L))
-                .containsEntry("pt=b/", Arrays.asList(1L, 3L));
-
-        DataEvolutionRowIdReassigner.Result resumed =
-                new DataEvolutionRowIdReassigner(table)
-                        .reassign("test-reassign-resume-partial-batches");
-        assertThat(resumed.reassigned).isTrue();
-        assertThat(resumed.fileCount).isEqualTo(2L);
-        assertThat(resumed.rowCount).isEqualTo(2L);
-        assertThat(rowIdsByPartition(table))
-                .containsEntry("pt=a/", Arrays.asList(5L, 6L, 7L))
-                .containsEntry("pt=b/", Arrays.asList(8L, 9L));
     }
 
     @Test
@@ -1302,7 +1156,7 @@ public class DataEvolutionRowIdReassignerTest extends TableTestBase {
                         .reassign("test-reassign-analyze-conflict");
 
         assertThat(result.previousSnapshotId).isEqualTo(before.id() + 1);
-        assertThat(result.newSnapshotId).isEqualTo(before.id() + 3);
+        assertThat(result.newSnapshotId).isEqualTo(before.id() + 2);
         assertThat(result.firstAssignedRowId).isEqualTo(5L);
         assertThat(result.nextRowId).isEqualTo(10L);
         assertThat(table.snapshotManager().latestSnapshot().statistics()).isNotNull();
@@ -1782,8 +1636,8 @@ public class DataEvolutionRowIdReassignerTest extends TableTestBase {
                 new DataEvolutionRowIdReassigner(table).reassign("test-reassign-row-id-index-2");
 
         assertThat(secondResult.reassigned).isFalse();
-        assertThat(secondResult.previousSnapshotId).isEqualTo(8L);
-        assertThat(secondResult.newSnapshotId).isEqualTo(8L);
+        assertThat(secondResult.previousSnapshotId).isEqualTo(7L);
+        assertThat(secondResult.newSnapshotId).isEqualTo(7L);
         assertThat(secondResult.firstAssignedRowId).isEqualTo(10L);
         assertThat(secondResult.nextRowId).isEqualTo(10L);
         assertThat(secondResult.fileCount).isEqualTo(0L);
@@ -1845,7 +1699,7 @@ public class DataEvolutionRowIdReassignerTest extends TableTestBase {
 
         assertThat(indexed).isTrue();
         assertThat(result.previousSnapshotId).isEqualTo(before.id() + 1);
-        assertThat(result.newSnapshotId).isEqualTo(before.id() + 3);
+        assertThat(result.newSnapshotId).isEqualTo(before.id() + 2);
         assertThat(result.firstAssignedRowId).isEqualTo(6L);
         assertThat(result.nextRowId).isEqualTo(11L);
         assertThat(result.indexFileCount).isEqualTo(5L);
@@ -1884,7 +1738,7 @@ public class DataEvolutionRowIdReassignerTest extends TableTestBase {
         assertThat(result.reassigned).isTrue();
         assertThat(result.skipReason).isNull();
         assertThat(result.previousSnapshotId).isEqualTo(before.id());
-        assertThat(result.newSnapshotId).isEqualTo(before.id() + 2);
+        assertThat(result.newSnapshotId).isEqualTo(before.id() + 1);
         assertThat(result.firstAssignedRowId).isEqualTo(5L);
         assertThat(result.nextRowId).isEqualTo(10L);
         assertThat(result.fileCount).isEqualTo(5L);
@@ -1931,7 +1785,7 @@ public class DataEvolutionRowIdReassignerTest extends TableTestBase {
 
         assertThat(result.reassigned).isTrue();
         assertThat(result.previousSnapshotId).isEqualTo(before.id());
-        assertThat(result.newSnapshotId).isEqualTo(before.id() + 4);
+        assertThat(result.newSnapshotId).isEqualTo(before.id() + 1);
         assertThat(result.firstAssignedRowId).isEqualTo(scrambledNextRowId);
         assertThat(result.fileCount).isEqualTo(expectedFileCount);
         assertThat(result.rowCount).isEqualTo(expectedRows.size());
@@ -2048,18 +1902,6 @@ public class DataEvolutionRowIdReassignerTest extends TableTestBase {
         writeOneRow(table, "a", 2);
         writeOneRow(table, "b", 3);
         writeOneRow(table, "a", 4);
-        return table;
-    }
-
-    private FileStoreTable createTableWithThreeIndependentPartitions() throws Exception {
-        createTableDefault();
-        FileStoreTable table = getTableDefault();
-        writeOneRow(table, "a", 0);
-        writeOneRow(table, "b", 1);
-        writeOneRow(table, "c", 2);
-        writeOneRow(table, "a", 3);
-        writeOneRow(table, "b", 4);
-        writeOneRow(table, "c", 5);
         return table;
     }
 


### PR DESCRIPTION
### Purpose

Improve metadata-only row ID reassignment for tables receiving continuous writes:

- bypass manifest compaction and sorting during reassignment;
- preflight newer snapshots and use configured commit retry/backoff settings;
- commit independent manifest groups in resumable batches, capped at four batches;
- lazily rebase each pending batch across concurrent APPEND snapshots and this operation own OVERWRITE snapshots;
- fail explicitly if a planned manifest replacement no longer matches the current manifest list.

### Tests

- DataEvolutionRowIdReassignerTest: 53 tests passed
- DataEvolutionDeletionVectorTest: 24 tests passed
- Flink DataEvolutionRowIdReassignerTest#testActionReassignRowIdsByPartition passed
- mvn -pl paimon-core -DskipTests compile
- git diff --check