### PR TITLE
[python] Default multimodal vector files to Parquet

### DIFF
--- a/docs/docs/pypaimon/multimodal-api.mdx
+++ b/docs/docs/pypaimon/multimodal-api.mdx
@@ -36,10 +36,10 @@ scalar, text, vector, and blob data.
 Creating a multimodal table enables `row-tracking.enabled`,
 `data-evolution.enabled`, `deletion-vectors.enabled`, and
 `blob-as-descriptor` by default. Global index scans use full fallback coverage
-through `global-index.search-mode` set to `FULL`. Data files use Vortex by
-default through `file.format = vortex`, and vector columns are stored in
-dedicated Vortex files through `vector.file.format` set to `vortex`. Install
-the Vortex extra when writing or reading default multimodal tables from Python:
+through `global-index.search-mode` set to `FULL`. Data files use Paimon's
+default Parquet format, and vector columns are stored in dedicated Parquet
+files through `vector.file.format` set to `parquet`. Vortex remains available
+when explicitly configured; install the Vortex extra when using it from Python:
 
 ```shell
 pip install pypaimon[vortex]

--- a/docs/docs/pypaimon/multimodal-api.mdx
+++ b/docs/docs/pypaimon/multimodal-api.mdx
@@ -38,12 +38,14 @@ Creating a multimodal table enables `row-tracking.enabled`,
 `blob-as-descriptor` by default. Global index scans use full fallback coverage
 through `global-index.search-mode` set to `FULL`. Data files use Paimon's
 default Parquet format, and vector columns are stored in dedicated Parquet
-files through `vector.file.format` set to `parquet`. Vortex remains available
-when explicitly configured; install the Vortex extra when using it from Python:
+files through `vector.file.format` set to `parquet`. These defaults require no
+file-format extra:
 
 ```shell
-pip install pypaimon[vortex]
+pip install pypaimon
 ```
+
+Vortex remains available as an optional format when explicitly configured.
 
 ## Connect
 

--- a/paimon-python/pypaimon/multimodal/connection.py
+++ b/paimon-python/pypaimon/multimodal/connection.py
@@ -34,7 +34,7 @@ _DEFAULT_OPTIONS = {
     "deletion-vectors.enabled": "true",
     "blob-as-descriptor": "true",
     "global-index.search-mode": "full",
-    "vector.file.format": "vortex",
+    "vector.file.format": "parquet",
 }
 
 _DEFAULT_DATABASE = Catalog.DEFAULT_DATABASE

--- a/paimon-python/pypaimon/tests/multimodal_table_test.py
+++ b/paimon-python/pypaimon/tests/multimodal_table_test.py
@@ -112,7 +112,7 @@ class MultimodalTableTest(unittest.TestCase):
         self.assertEqual("true", options["blob-as-descriptor"])
         self.assertNotIn("data-evolution.row-sidecar.enabled", options)
         self.assertEqual("full", options["global-index.search-mode"])
-        self.assertEqual("vortex", options["vector.file.format"])
+        self.assertEqual("parquet", options["vector.file.format"])
         self.assertEqual("default.docs", self.conn.get_table("docs").identifier)
         self.assertEqual(["id", "content", "embedding", "payload"],
                          [field.name for field in table.raw_table.fields])


### PR DESCRIPTION
## Purpose

Use Parquet instead of Vortex as the default dedicated vector file format for pypaimon.multimodal tables. Explicit Vortex configuration remains supported.

The multimodal API documentation is updated to reflect the Parquet defaults and describe Vortex as opt-in.

## Tests

- python3 -m unittest pypaimon.tests.multimodal_table_test.MultimodalTableTest.test_create_table_defaults_data_evolution_options pypaimon.tests.multimodal_table_test.MultimodalTableTest.test_create_table_uses_options_and_partitioned
- yarn docusaurus build