### PR TITLE
[hive] Fix query failure when dynamic filters are unavailable

### DIFF
--- a/paimon-hive/paimon-hive-connector-common/src/main/java/org/apache/paimon/hive/SearchArgumentToPredicateConverter.java
+++ b/paimon-hive/paimon-hive-connector-common/src/main/java/org/apache/paimon/hive/SearchArgumentToPredicateConverter.java
@@ -158,6 +158,9 @@ public class SearchArgumentToPredicateConverter {
                                 .collect(Collectors.toList()));
             case BETWEEN:
                 List<Object> literalList = leaf.getLiteralList();
+                if (literalList == null || literalList.size() < 2) {
+                    throw new UnsupportedOperationException("BETWEEN literals are not available.");
+                }
                 return builder.between(
                         idx,
                         toLiteral(columnType, literalList.get(0)),

--- a/paimon-hive/paimon-hive-connector-common/src/test/java/org/apache/paimon/hive/SearchArgumentToPredicateConverterTest.java
+++ b/paimon-hive/paimon-hive-connector-common/src/test/java/org/apache/paimon/hive/SearchArgumentToPredicateConverterTest.java
@@ -31,6 +31,7 @@ import org.apache.hadoop.hive.common.type.HiveDecimal;
 import org.apache.hadoop.hive.ql.io.sarg.PredicateLeaf;
 import org.apache.hadoop.hive.ql.io.sarg.SearchArgument;
 import org.apache.hadoop.hive.ql.io.sarg.SearchArgumentFactory;
+import org.apache.hadoop.hive.ql.io.sarg.SearchArgumentImpl.PredicateLeafImpl;
 import org.apache.hadoop.hive.serde2.io.HiveDecimalWritable;
 import org.junit.jupiter.api.Test;
 
@@ -256,6 +257,28 @@ public class SearchArgumentToPredicateConverterTest {
                 builder.between("f_bigint", PredicateLeaf.Type.LONG, 100L, 200L).build();
         Predicate expected = BUILDER.between(1, 100L, 200L);
         assertExpected(sarg, expected);
+    }
+
+    @Test
+    public void testUnavailableBetween() {
+        SearchArgument.Builder builder = SearchArgumentFactory.newBuilder();
+        SearchArgument sarg =
+                builder.startAnd()
+                        .between("f_bigint", PredicateLeaf.Type.LONG, 100L, 200L)
+                        .lessThanEquals("f_int", PredicateLeaf.Type.LONG, 10L)
+                        .end()
+                        .build();
+        sarg.getLeaves()
+                .set(
+                        0,
+                        new PredicateLeafImpl(
+                                PredicateLeaf.Operator.BETWEEN,
+                                PredicateLeaf.Type.LONG,
+                                "f_bigint",
+                                null,
+                                Collections.emptyList()));
+
+        assertExpected(sarg, BUILDER.lessOrEqual(0, 10));
     }
 
     @Test


### PR DESCRIPTION
### Purpose
 - Fix user reported bug #9440.
 - When Tez initializes Paimon input splits, the between predicate (min/max) is not available. Paimon access this and fails with IndexOutOfBoundsException
 - Skip pushdown when the bound is unavailable.

### Tests
 - UT