### PR TITLE
[metrics] Add totalFileCount and minAvgFileSize metrics to detect small file problem

### DIFF
--- a/docs/docs/maintenance/metrics.md
+++ b/docs/docs/maintenance/metrics.md
@@ -408,6 +408,21 @@ Lookup metrics are available for local partial lookup. They are reported at look
             <td>The average total file size of all active (currently being written) buckets.</td>
         </tr>
         <tr>
+            <td>maxTotalFileCount</td>
+            <td>Gauge</td>
+            <td>The maximum total file count of an active (currently being written) bucket.</td>
+        </tr>
+        <tr>
+            <td>avgTotalFileCount</td>
+            <td>Gauge</td>
+            <td>The average total file count of all active (currently being written) buckets.</td>
+        </tr>
+        <tr>
+            <td>minAvgFileSize</td>
+            <td>Gauge</td>
+            <td>The minimum average file size across all active buckets, computed as total file size divided by total file count per bucket. Directly indicates if any bucket has a small file problem. Only reported for primary-key tables.</td>
+        </tr>
+        <tr>
             <td>maxSortBufferUsedBytes</td>
             <td>Gauge</td>
             <td>The maximum sort buffer memory currently used across all active compaction buckets, in bytes. High values relative to <code>maxSortBufferTotalBytes</code> indicate memory pressure during compaction; consider lowering <code>sort-spill-threshold</code> or reducing <code>sort-spill-buffer-size</code>.</td>

--- a/paimon-core/src/main/java/org/apache/paimon/mergetree/Levels.java
+++ b/paimon-core/src/main/java/org/apache/paimon/mergetree/Levels.java
@@ -150,6 +150,10 @@ public class Levels {
                 + levels.stream().mapToLong(SortedRun::totalSize).sum();
     }
 
+    public long totalFileCount() {
+        return level0.size() + levels.stream().mapToInt(r -> r.files().size()).sum();
+    }
+
     public List<DataFileMeta> allFiles() {
         List<DataFileMeta> files = new ArrayList<>();
         List<LevelSortedRun> runs = levelSortedRuns();

--- a/paimon-core/src/main/java/org/apache/paimon/mergetree/compact/MergeTreeCompactManager.java
+++ b/paimon-core/src/main/java/org/apache/paimon/mergetree/compact/MergeTreeCompactManager.java
@@ -298,6 +298,7 @@ public class MergeTreeCompactManager extends CompactFutureManager {
         if (metricsReporter != null) {
             metricsReporter.reportLevel0FileCount(levels.level0().size());
             metricsReporter.reportTotalFileSize(levels.totalFileSize());
+            metricsReporter.reportTotalFileCount(levels.totalFileCount());
         }
     }
 

--- a/paimon-core/src/main/java/org/apache/paimon/operation/metrics/CompactionMetrics.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/metrics/CompactionMetrics.java
@@ -51,6 +51,9 @@ public class CompactionMetrics {
     public static final String AVG_COMPACTION_OUTPUT_SIZE = "avgCompactionOutputSize";
     public static final String MAX_TOTAL_FILE_SIZE = "maxTotalFileSize";
     public static final String AVG_TOTAL_FILE_SIZE = "avgTotalFileSize";
+    public static final String MAX_TOTAL_FILE_COUNT = "maxTotalFileCount";
+    public static final String AVG_TOTAL_FILE_COUNT = "avgTotalFileCount";
+    public static final String MIN_AVG_FILE_SIZE = "minAvgFileSize";
 
     public static final String MAX_SORT_BUFFER_USED_BYTES = "maxSortBufferUsedBytes";
     public static final String AVG_SORT_BUFFER_USED_BYTES = "avgSortBufferUsedBytes";
@@ -107,6 +110,10 @@ public class CompactionMetrics {
 
         metricGroup.gauge(MAX_TOTAL_FILE_SIZE, () -> getTotalFileSizeStream().max().orElse(-1));
         metricGroup.gauge(AVG_TOTAL_FILE_SIZE, () -> getTotalFileSizeStream().average().orElse(-1));
+        metricGroup.gauge(MAX_TOTAL_FILE_COUNT, () -> getTotalFileCountStream().max().orElse(-1));
+        metricGroup.gauge(
+                AVG_TOTAL_FILE_COUNT, () -> getTotalFileCountStream().average().orElse(-1));
+        metricGroup.gauge(MIN_AVG_FILE_SIZE, () -> getAvgFileSizeStream().min().orElse(-1));
 
         metricGroup.gauge(
                 MAX_SORT_BUFFER_USED_BYTES, () -> getSortBufferUsedBytesStream().max().orElse(-1));
@@ -147,6 +154,18 @@ public class CompactionMetrics {
         return reporters.values().stream().mapToLong(r -> r.totalFileSize);
     }
 
+    @VisibleForTesting
+    public LongStream getTotalFileCountStream() {
+        return reporters.values().stream().mapToLong(r -> r.totalFileCount);
+    }
+
+    @VisibleForTesting
+    public LongStream getAvgFileSizeStream() {
+        return reporters.values().stream()
+                .filter(r -> r.totalFileCount > 0)
+                .mapToLong(r -> r.totalFileSize / r.totalFileCount);
+    }
+
     private LongStream getSortBufferUsedBytesStream() {
         return reporters.values().stream().mapToLong(r -> r.sortBufferUsedBytes);
     }
@@ -182,6 +201,8 @@ public class CompactionMetrics {
 
         void reportTotalFileSize(long bytes);
 
+        void reportTotalFileCount(long count);
+
         void reportSortBufferMetrics(long usedBytes, long totalBytes);
 
         void unregister();
@@ -194,6 +215,7 @@ public class CompactionMetrics {
         private long compactionInputSize = 0;
         private long compactionOutputSize = 0;
         private long totalFileSize = 0;
+        private long totalFileCount = 0;
         private long sortBufferUsedBytes = 0;
         private double sortBufferUtilisationPercent = 0.0;
 
@@ -232,6 +254,11 @@ public class CompactionMetrics {
         @Override
         public void reportTotalFileSize(long bytes) {
             this.totalFileSize = bytes;
+        }
+
+        @Override
+        public void reportTotalFileCount(long count) {
+            this.totalFileCount = count;
         }
 
         @Override

--- a/paimon-core/src/test/java/org/apache/paimon/operation/metrics/CompactionMetricsTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/operation/metrics/CompactionMetricsTest.java
@@ -132,6 +132,23 @@ public class CompactionMetricsTest {
         assertThat(getMetric(metrics, CompactionMetrics.MAX_LEVEL0_FILE_COUNT)).isEqualTo(8L);
         assertThat(getMetric(metrics, CompactionMetrics.AVG_LEVEL0_FILE_COUNT)).isEqualTo(5.0);
 
+        reporters[0].reportTotalFileCount(10);
+        reporters[1].reportTotalFileCount(6);
+        reporters[2].reportTotalFileCount(8);
+        assertThat(getMetric(metrics, CompactionMetrics.MAX_TOTAL_FILE_COUNT)).isEqualTo(10L);
+        assertThat(getMetric(metrics, CompactionMetrics.AVG_TOTAL_FILE_COUNT)).isEqualTo(8.0);
+
+        reporters[0].reportTotalFileCount(15);
+        assertThat(getMetric(metrics, CompactionMetrics.MAX_TOTAL_FILE_COUNT)).isEqualTo(15L);
+        assertThat(getMetric(metrics, CompactionMetrics.AVG_TOTAL_FILE_COUNT))
+                .isEqualTo(29.0 / 3.0);
+
+        // report file sizes to test minAvgFileSize
+        reporters[0].reportTotalFileSize(150_000_000); // 150MB / 15 files = 10MB avg
+        reporters[1].reportTotalFileSize(6_000_000); // 6MB / 6 files = 1MB avg (smallest)
+        reporters[2].reportTotalFileSize(80_000_000); // 80MB / 8 files = 10MB avg
+        assertThat(getMetric(metrics, CompactionMetrics.MIN_AVG_FILE_SIZE)).isEqualTo(1_000_000L);
+
         reporters[0].reportCompactionTime(300000);
         reporters[0].reportCompactionTime(250000);
         reporters[0].reportCompactionTime(270000);
@@ -216,6 +233,12 @@ public class CompactionMetricsTest {
                         dataSplit.dataFiles().stream().mapToLong(DataFileMeta::fileSize).sum();
             }
 
+            long[] totalFileCounts = new long[bucketNum];
+            for (Split split : table.newScan().plan().splits()) {
+                DataSplit dataSplit = (DataSplit) split;
+                totalFileCounts[dataSplit.bucket()] += dataSplit.dataFiles().size();
+            }
+
             CompactionMetrics metrics =
                     ((AbstractFileStoreWrite<?>) write.getWrite()).compactionMetrics();
             assertThat(metrics.getTotalFileSizeStream()).hasSize(bucketNum);
@@ -223,6 +246,11 @@ public class CompactionMetricsTest {
                     .isEqualTo(Arrays.stream(totalFileSizes).max().orElse(0));
             assertThat(getMetric(metrics, CompactionMetrics.AVG_TOTAL_FILE_SIZE))
                     .isEqualTo(Arrays.stream(totalFileSizes).average().orElse(0));
+            assertThat(metrics.getTotalFileCountStream()).hasSize(bucketNum);
+            assertThat(getMetric(metrics, CompactionMetrics.MAX_TOTAL_FILE_COUNT))
+                    .isEqualTo(Arrays.stream(totalFileCounts).max().orElse(0));
+            assertThat(getMetric(metrics, CompactionMetrics.AVG_TOTAL_FILE_COUNT))
+                    .isEqualTo(Arrays.stream(totalFileCounts).average().orElse(0));
         }
 
         write.close();


### PR DESCRIPTION

### Purpose
- Adds `totalFileCount` metric to track the total number of data files across all levels
- Adds `minAvgFileSize` metric to surface when average file size drops below a healthy threshold
- These metrics help detect the small file problem early, enabling proactive compaction tuning

### Tests
- Unit test added in `CompactionMetricsTest`
- Documentation updated in `docs/maintenance/metrics.md`