### PR TITLE
[api] Fix race condition causing queued tasks to execute after SequentialBatchIterator close

### DIFF
--- a/paimon-api/src/main/java/org/apache/paimon/utils/ThreadPoolUtils.java
+++ b/paimon-api/src/main/java/org/apache/paimon/utils/ThreadPoolUtils.java
@@ -229,7 +229,7 @@ public class ThreadPoolUtils {
 
         private Iterator<T> activeResults = Collections.<T>emptyList().iterator();
         private T next;
-        private boolean closed;
+        private volatile boolean closed;
 
         private SequentialBatchIterator(
                 ExecutorService executor,
@@ -243,7 +243,7 @@ public class ThreadPoolUtils {
 
         @Override
         public boolean hasNext() {
-            if (!closed) {
+            if (!isClosed()) {
                 advanceIfNeeded();
             }
             return next != null;
@@ -257,6 +257,10 @@ public class ThreadPoolUtils {
             T result = next;
             next = null;
             return result;
+        }
+
+        private boolean isClosed() {
+            return closed;
         }
 
         private void advanceIfNeeded() {
@@ -286,7 +290,7 @@ public class ThreadPoolUtils {
         private void submitBatch(List<U> batch) {
             ClassLoader classLoader = Thread.currentThread().getContextClassLoader();
             for (U input : batch) {
-                BatchTask<T, U> task = new BatchTask<>(processor, input, classLoader);
+                BatchTask<T, U> task = new BatchTask<>(this, processor, input, classLoader);
                 executor.execute(task);
                 activeTasks.add(task);
             }
@@ -343,6 +347,7 @@ public class ThreadPoolUtils {
         private static final int CANCELLED = 2;
         private static final int FINISHED = 3;
 
+        private final SequentialBatchIterator<T, U> iterator;
         private final Function<U, List<T>> processor;
         private final U input;
         private final ClassLoader classLoader;
@@ -354,7 +359,12 @@ public class ThreadPoolUtils {
         private Throwable failure;
         private volatile boolean failureReported;
 
-        private BatchTask(Function<U, List<T>> processor, U input, ClassLoader classLoader) {
+        private BatchTask(
+                SequentialBatchIterator<T, U> iterator,
+                Function<U, List<T>> processor,
+                U input,
+                ClassLoader classLoader) {
+            this.iterator = iterator;
             this.processor = processor;
             this.input = input;
             this.classLoader = classLoader;
@@ -363,7 +373,7 @@ public class ThreadPoolUtils {
         @Override
         public void run() {
             synchronized (this) {
-                if (state == CANCELLED) {
+                if (isCanceled()) {
                     state = FINISHED;
                     completion.countDown();
                     return;
@@ -384,6 +394,10 @@ public class ThreadPoolUtils {
                 }
                 completion.countDown();
             }
+        }
+
+        private boolean isCanceled() {
+            return state == CANCELLED || iterator.isClosed();
         }
 
         private synchronized void cancel() {


### PR DESCRIPTION

### Purpose
  `ThreadPoolUtils.SequentialBatchIterator.close()` is supposed to cancel queued tasks and wait for running tasks. Under high load, however, a queued task can  start executing before it is marked `CANCELLED`, which makes `ThreadPoolUtilsTest#testCloseCancelsQueuedTasksAndWaitsUninterruptibly` fail intermittently with
  `AtomicInteger(3) expected 2`.
 see https://github.com/apache/paimon/actions/runs/32989842446/job/98244565156?pr=9389

- Normal flow
```
  worker:  run task 0  ->  FINISHED
  worker:  run task 1  ->  blocks on allowSecondToExit
  closer:  close() starts
  closer:  cancel(task 0)  ->  no-op
  closer:  cancel(task 1)  ->  interrupt worker
  closer:  cancel(task 2)  ->  CREATED -> CANCELLED
  worker:  task 1 returns
  worker:  run task 2  ->  sees CANCELLED -> skips
```
Result: `executions == 2`, test passes.

- Abnormal flow
```
  worker:  run task 0  ->  FINISHED
  worker:  run task 1  ->  blocks on allowSecondToExit
  closer:  close() starts
  closer:  cancel(task 0)  ->  no-op
  closer:  cancel(task 1)  ->  interrupt worker
          <-- closer thread is preempted -->
  worker:  task 1 wakes and returns
  worker:  run task 2  ->  sees CREATED -> RUNNING -> executes processor
          <-- closer thread resumes -->
  closer:  cancel(task 2)  ->  sees RUNNING -> calls runner.interrupt(), but cannot stop a RUNNING task; must wait for it to finish

```
The root cause is that task 2 started executing before `close()` could mark it as `CANCELLED`, it runs to completion and `executions` becomes 3.





### Tests
