### PR TITLE
[format] Fix ORC zstd compression option inconsistent across writers

### DIFF
--- a/paimon-format/src/main/java/org/apache/orc/impl/PhysicalFsWriter.java
+++ b/paimon-format/src/main/java/org/apache/orc/impl/PhysicalFsWriter.java
@@ -140,9 +140,8 @@ public class PhysicalFsWriter implements PhysicalWriter {
         CompressionCodec codec = OrcCodecPool.getCodec(opts.getCompress());
         if (codec != null) {
             CompressionCodec.Options tempOptions = codec.getDefaultOptions();
-            if (codec instanceof ZstdCodec
-                    && codec.getDefaultOptions() instanceof ZstdCodec.ZstdOptions) {
-                ZstdCodec.ZstdOptions options = (ZstdCodec.ZstdOptions) codec.getDefaultOptions();
+            if (codec instanceof ZstdCodec && tempOptions instanceof ZstdCodec.ZstdOptions) {
+                ZstdCodec.ZstdOptions options = (ZstdCodec.ZstdOptions) tempOptions;
                 OrcFile.ZstdCompressOptions zstdCompressOptions = opts.getZstdCompressOptions();
                 if (zstdCompressOptions != null) {
                     options.setLevel(zstdCompressOptions.getCompressionZstdLevel());

--- a/paimon-format/src/main/java/org/apache/orc/impl/ZstdCodec.java
+++ b/paimon-format/src/main/java/org/apache/orc/impl/ZstdCodec.java
@@ -165,7 +165,7 @@ public class ZstdCodec implements CompressionCodec, DirectDecompressionCodec {
 
     @Override
     public Options getDefaultOptions() {
-        return DEFAULT_OPTIONS;
+        return DEFAULT_OPTIONS.copy();
     }
 
     /**

--- a/paimon-format/src/test/java/org/apache/paimon/format/orc/writer/OrcZstdTest.java
+++ b/paimon-format/src/test/java/org/apache/paimon/format/orc/writer/OrcZstdTest.java
@@ -39,6 +39,7 @@ import org.apache.orc.CompressionCodec;
 import org.apache.orc.CompressionKind;
 import org.apache.orc.OrcFile;
 import org.apache.orc.Reader;
+import org.apache.orc.impl.OrcCodecPool;
 import org.apache.orc.impl.ZstdCodec;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -58,6 +59,9 @@ class OrcZstdTest {
 
     @Test
     void testWriteOrcWithZstd(@TempDir java.nio.file.Path tempDir) throws IOException {
+        CompressionCodec zstdCodec = OrcCodecPool.getCodec(CompressionKind.ZSTD);
+        int originalHashCode = zstdCodec.getDefaultOptions().hashCode();
+
         Options options = new Options();
         options.set("orc.compress", "zstd");
         options.set("orc.stripe.size", "31457280");
@@ -90,6 +94,7 @@ class OrcZstdTest {
         FormatWriter formatWriter = writerFactory.create(out, "zstd");
 
         Assertions.assertThat(formatWriter).isInstanceOf(OrcBulkWriter.class);
+        Assertions.assertThat(zstdCodec.getDefaultOptions().hashCode()).isEqualTo(originalHashCode);
 
         Options optionsWithLowLevel = new Options();
         optionsWithLowLevel.set("orc.compress", "zstd");


### PR DESCRIPTION
### Purpose
 - Multiple ORC writers on same JVM share the options. When writers use different compression settings, one writer overwrites the settings used by another.
 - Paimon applies each writer’s compression level and window size directly to the shared defaults, making the resulting compression depend on writer creation order.
 - Ensure each writer gets it's own copy

### Tests
 - UT