### PR TITLE
[python] Add DataFusion extra for merge conditions

### DIFF
--- a/docs/docs/pypaimon/data-evolution.md
+++ b/docs/docs/pypaimon/data-evolution.md
@@ -448,8 +448,8 @@ messages = table_update.merge_into(
 
 Conditions use SQL-style expressions with `s.` (source) and `t.` (target)
 column prefixes. `WhenNotMatched` conditions may only reference source columns
-(`s.*`). Condition evaluation uses DataFusion through the PyPaimon SQL extra.
-Install the extra before using conditions: `pip install pypaimon[sql]`.
+(`s.*`). Condition evaluation uses the PyPaimon DataFusion extra.
+Install it before using conditions: `pip install pypaimon[datafusion]`.
 
 ```python
 messages = table_update.merge_into(

--- a/docs/docs/pypaimon/data-evolution.md
+++ b/docs/docs/pypaimon/data-evolution.md
@@ -449,7 +449,8 @@ messages = table_update.merge_into(
 Conditions use SQL-style expressions with `s.` (source) and `t.` (target)
 column prefixes. `WhenNotMatched` conditions may only reference source columns
 (`s.*`). Condition evaluation uses the PyPaimon DataFusion extra.
-Install it before using conditions: `pip install pypaimon[datafusion]`.
+Python 3.10 or newer is required. Install it with
+`pip install 'pypaimon[datafusion]'`.
 
 ```python
 messages = table_update.merge_into(

--- a/docs/docs/pypaimon/multimodal-api.mdx
+++ b/docs/docs/pypaimon/multimodal-api.mdx
@@ -426,8 +426,9 @@ docs.merge("id") \
 ```
 
 Clause predicates use `where` for update and delete clauses. Refer to source
-rows with `source.<column>` and target rows with `target.<column>`. Install
-`pypaimon[datafusion]` when using merge clause predicates.
+rows with `source.<column>` and target rows with `target.<column>`. Merge clause
+predicates require Python 3.10 or newer and
+`pip install 'pypaimon[datafusion]'`.
 
 When source and target key names differ, pass a mapping from target column to
 source column:

--- a/docs/docs/pypaimon/multimodal-api.mdx
+++ b/docs/docs/pypaimon/multimodal-api.mdx
@@ -427,7 +427,7 @@ docs.merge("id") \
 
 Clause predicates use `where` for update and delete clauses. Refer to source
 rows with `source.<column>` and target rows with `target.<column>`. Install
-`pypaimon[sql]` when using merge clause predicates.
+`pypaimon[datafusion]` when using merge clause predicates.
 
 When source and target key names differ, pass a mapping from target column to
 source column:

--- a/docs/docs/pypaimon/ray-data.md
+++ b/docs/docs/pypaimon/ray-data.md
@@ -486,8 +486,8 @@ merge_into(
 
 Conditions use SQL-style expressions with `s.` (source) and `t.` (target)
 column prefixes. `WhenNotMatched` conditions may only reference source
-columns (`s.*`). Condition evaluation uses DataFusion through the PyPaimon SQL
-extra. Install the extra before using conditions: `pip install pypaimon[sql]`.
+columns (`s.*`). Condition evaluation uses the PyPaimon DataFusion extra.
+Install it before using conditions: `pip install pypaimon[datafusion]`.
 
 - `update` / `delete` / `insert`: `WhenMatched.update(...)` updates matched
   rows, `WhenMatched.delete()` deletes matched rows, and

--- a/docs/docs/pypaimon/ray-data.md
+++ b/docs/docs/pypaimon/ray-data.md
@@ -487,7 +487,8 @@ merge_into(
 Conditions use SQL-style expressions with `s.` (source) and `t.` (target)
 column prefixes. `WhenNotMatched` conditions may only reference source
 columns (`s.*`). Condition evaluation uses the PyPaimon DataFusion extra.
-Install it before using conditions: `pip install pypaimon[datafusion]`.
+Python 3.10 or newer is required. Install it with
+`pip install 'pypaimon[datafusion]'`.
 
 - `update` / `delete` / `insert`: `WhenMatched.update(...)` updates matched
   rows, `WhenMatched.delete()` deletes matched rows, and

--- a/paimon-python/pypaimon/ray/merge_condition.py
+++ b/paimon-python/pypaimon/ray/merge_condition.py
@@ -18,6 +18,7 @@
 
 import logging
 import re
+import sys
 from typing import Mapping, Optional, Set
 
 import pyarrow as pa
@@ -32,13 +33,17 @@ logger = logging.getLogger(__name__)
 
 
 def _load_datafusion():
+    if sys.version_info[:2] < (3, 10):
+        raise ImportError(
+            "merge_into condition expressions require Python 3.10 or newer"
+        )
     try:
         import datafusion
         return datafusion
     except ImportError:
         raise ImportError(
             "merge_into condition expressions require DataFusion. "
-            "Install it with: pip install pypaimon[datafusion]"
+            "Install it with: pip install 'pypaimon[datafusion]'"
         )
 
 

--- a/paimon-python/pypaimon/ray/merge_condition.py
+++ b/paimon-python/pypaimon/ray/merge_condition.py
@@ -37,9 +37,8 @@ def _load_datafusion():
         return datafusion
     except ImportError:
         raise ImportError(
-            "merge_into condition expressions require the PyPaimon SQL "
-            "extra, which provides DataFusion support. Install it with: "
-            "pip install pypaimon[sql]"
+            "merge_into condition expressions require DataFusion. "
+            "Install it with: pip install pypaimon[datafusion]"
         )
 
 

--- a/paimon-python/pypaimon/tests/ray_data_evolution_merge_into_test.py
+++ b/paimon-python/pypaimon/tests/ray_data_evolution_merge_into_test.py
@@ -41,7 +41,7 @@ except ImportError:
     _HAS_DATAFUSION = False
 
 _SKIP_CONDITION = not _HAS_DATAFUSION
-_SKIP_REASON = "pypaimon[sql] is required for condition expressions"
+_SKIP_REASON = "pypaimon[datafusion] is required for condition expressions"
 
 _TEST_NUM_PARTITIONS = 2
 

--- a/paimon-python/pypaimon/tests/table_merge_into_test.py
+++ b/paimon-python/pypaimon/tests/table_merge_into_test.py
@@ -52,7 +52,14 @@ class TableMergeIntoTest(BatchModeMixin, DataEvolutionTestBase, unittest.TestCas
 
         with patch.dict("sys.modules", {"datafusion": None}):
             with self.assertRaisesRegex(
-                    ImportError, r"pip install pypaimon\[datafusion\]"):
+                    ImportError, r"pip install 'pypaimon\[datafusion\]'"):
+                _load_datafusion()
+
+    def test_datafusion_conditions_require_python_310(self):
+        from pypaimon.ray.merge_condition import _load_datafusion
+
+        with patch("sys.version_info", (3, 9)):
+            with self.assertRaisesRegex(ImportError, "Python 3.10 or newer"):
                 _load_datafusion()
 
     def _read_sorted(self, table):

--- a/paimon-python/pypaimon/tests/table_merge_into_test.py
+++ b/paimon-python/pypaimon/tests/table_merge_into_test.py
@@ -42,10 +42,18 @@ except ImportError:
     _HAS_DATAFUSION = False
 
 _SKIP_CONDITION = not _HAS_DATAFUSION
-_SKIP_REASON = "pypaimon[sql] is required for condition expressions"
+_SKIP_REASON = "pypaimon[datafusion] is required for condition expressions"
 
 
 class TableMergeIntoTest(BatchModeMixin, DataEvolutionTestBase, unittest.TestCase):
+
+    def test_missing_datafusion_error_suggests_datafusion_extra(self):
+        from pypaimon.ray.merge_condition import _load_datafusion
+
+        with patch.dict("sys.modules", {"datafusion": None}):
+            with self.assertRaisesRegex(
+                    ImportError, r"pip install pypaimon\[datafusion\]"):
+                _load_datafusion()
 
     def _read_sorted(self, table):
         return self._read_all(table).sort_by("id").to_pydict()

--- a/paimon-python/setup.py
+++ b/paimon-python/setup.py
@@ -280,6 +280,9 @@ setup(
             'datasketches>=4,<5; python_version<"3.9"',
             'datasketches>=5,<6; python_version>="3.9"',
         ],
+        'datafusion': [
+            'datafusion>=54,<55; python_version>="3.10"',
+        ],
         'sql': [
             'pypaimon-rust>=0.3.0; python_version>="3.10"',
             'datafusion>=54,<55; python_version>="3.10"',


### PR DESCRIPTION
## Purpose

`merge_into` condition expressions use the Python DataFusion package but currently direct users to `pypaimon[sql]`, which also installs `pypaimon-rust`. This makes the condition dependency unnecessarily coupled to the full SQL stack.

## Changes

- Add `pypaimon[datafusion]` with only `datafusion>=54,<55` on Python 3.10+.
- Keep `pypaimon[sql]` unchanged for the full Rust and DataFusion SQL stack.
- Point merge condition errors and documentation to the new extra.
- Fail with an explicit Python upgrade message on Python 3.6-3.9.
- Quote the installation command for shells such as zsh.

## Validation

- Merge condition tests: 13 passed, 36 skipped, 109 deselected.
- Missing-dependency and unsupported-Python regression tests passed.
- Generated package metadata contains the new `datafusion` extra while `sql` retains both dependencies.
- flake8 and `git diff --check` passed.