### PR TITLE
[flink] Fix decimal column analysis with null statistics

### DIFF
--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/utils/TableStatsUtil.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/utils/TableStatsUtil.java
@@ -212,17 +212,23 @@ public class TableStatsUtil {
                         null,
                         null);
             } else if (typeRoot.equals(DataTypeRoot.DECIMAL)) {
-                BigDecimal max = BigDecimal.valueOf(doubleColumnStatsData.getMax());
-                BigDecimal min = BigDecimal.valueOf(doubleColumnStatsData.getMin());
+                BigDecimal max =
+                        doubleColumnStatsData.getMax() == null
+                                ? null
+                                : BigDecimal.valueOf(doubleColumnStatsData.getMax());
+                BigDecimal min =
+                        doubleColumnStatsData.getMin() == null
+                                ? null
+                                : BigDecimal.valueOf(doubleColumnStatsData.getMin());
                 return ColStats.newColStats(
                         field.id(),
                         null != doubleColumnStatsData.getNdv()
                                 ? doubleColumnStatsData.getNdv()
                                 : null,
-                        null != doubleColumnStatsData.getMin()
+                        min != null
                                 ? Decimal.fromBigDecimal(min, min.precision(), min.scale())
                                 : null,
-                        null != doubleColumnStatsData.getMax()
+                        max != null
                                 ? Decimal.fromBigDecimal(max, max.precision(), max.scale())
                                 : null,
                         null != doubleColumnStatsData.getNullCount()

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/FlinkAnalyzeTableITCase.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/FlinkAnalyzeTableITCase.java
@@ -76,6 +76,17 @@ public class FlinkAnalyzeTableITCase extends CatalogITCaseBase {
     }
 
     @Test
+    public void testAnalyzeAllNullDecimalColumn() throws Catalog.TableNotExistException {
+        sql("CREATE TABLE T (id INT, amount DECIMAL(10, 2))");
+        sql("INSERT INTO T VALUES (1, CAST(NULL AS DECIMAL(10, 2)))");
+
+        sql("ANALYZE TABLE T COMPUTE STATISTICS FOR ALL COLUMNS");
+
+        ColStats<?> decimalStats = paimonTable("T").statistics().get().colStats().get("amount");
+        assertThat(decimalStats).isEqualTo(ColStats.newColStats(1, 0L, null, null, 1L, null, null));
+    }
+
+    @Test
     public void testAnalyzeTableColumn() throws Catalog.TableNotExistException {
         sql(
                 "CREATE TABLE T ("


### PR DESCRIPTION
### Purpose
 - Analyzing a table causes query failure when a decimal column contains only null values.
 - Flink reports null min/max, but read attempts a conversion to decimal, causing NPE.
 - Preserve the null min/max values and convert the remaining available decimal statistics.

### Tests
 - UT