### PR TITLE
[common] Forward close through PluginFileIO and ResolvingFileIO

### DIFF
--- a/paimon-common/src/main/java/org/apache/paimon/fs/BaseMultiPartUploadCommitter.java
+++ b/paimon-common/src/main/java/org/apache/paimon/fs/BaseMultiPartUploadCommitter.java
@@ -59,8 +59,9 @@ public abstract class BaseMultiPartUploadCommitter<T, C> implements TwoPhaseOutp
 
     @Override
     public void commit(FileIO fileIO) throws IOException {
-        try {
-            MultiPartUploadStore<T, C> multiPartUploadStore = multiPartUploadStore(fileIO);
+        try (RESTTokenFileIO.Lease lease = RESTTokenFileIO.lease(fileIO)) {
+            MultiPartUploadStore<T, C> multiPartUploadStore =
+                    multiPartUploadStore(lease.fileIO(), targetPath());
             multiPartUploadStore.completeMultipartUpload(
                     objectName, uploadId, uploadedParts, byteLength);
         } catch (Exception e) {
@@ -101,15 +102,10 @@ public abstract class BaseMultiPartUploadCommitter<T, C> implements TwoPhaseOutp
     public void clean(FileIO fileIO) throws IOException {}
 
     private void abortMultipartUpload(FileIO fileIO) throws IOException {
-        MultiPartUploadStore<T, C> multiPartUploadStore = multiPartUploadStore(fileIO);
-        multiPartUploadStore.abortMultipartUpload(objectName, uploadId);
-    }
-
-    private MultiPartUploadStore<T, C> multiPartUploadStore(FileIO fileIO) throws IOException {
-        if (fileIO instanceof RESTTokenFileIO) {
-            RESTTokenFileIO restTokenFileIO = (RESTTokenFileIO) fileIO;
-            fileIO = restTokenFileIO.fileIO();
+        try (RESTTokenFileIO.Lease lease = RESTTokenFileIO.lease(fileIO)) {
+            MultiPartUploadStore<T, C> multiPartUploadStore =
+                    multiPartUploadStore(lease.fileIO(), targetPath());
+            multiPartUploadStore.abortMultipartUpload(objectName, uploadId);
         }
-        return multiPartUploadStore(fileIO, targetPath());
     }
 }

--- a/paimon-common/src/main/java/org/apache/paimon/fs/PluginFileIO.java
+++ b/paimon-common/src/main/java/org/apache/paimon/fs/PluginFileIO.java
@@ -37,6 +37,8 @@ public abstract class PluginFileIO implements FileIO, HadoopOptionsProvider {
 
     private transient volatile FileIO lazyFileIO;
 
+    private transient volatile boolean closed;
+
     @Override
     public void configure(CatalogContext context) {
         // Do not get Hadoop Configuration in CatalogOptions
@@ -108,14 +110,37 @@ public abstract class PluginFileIO implements FileIO, HadoopOptionsProvider {
     }
 
     private FileIO fileIO(Path path) throws IOException {
-        if (lazyFileIO == null) {
+        FileIO fileIO = lazyFileIO;
+        if (fileIO == null) {
             synchronized (this) {
-                if (lazyFileIO == null) {
-                    lazyFileIO = wrap(() -> createFileIO(path));
+                if (closed) {
+                    throw new IOException("This FileIO is closed.");
+                }
+                fileIO = lazyFileIO;
+                if (fileIO == null) {
+                    fileIO = wrap(() -> createFileIO(path));
+                    lazyFileIO = fileIO;
                 }
             }
         }
-        return lazyFileIO;
+        return fileIO;
+    }
+
+    @Override
+    public void close() throws IOException {
+        FileIO fileIO;
+        synchronized (this) {
+            closed = true;
+            fileIO = lazyFileIO;
+            lazyFileIO = null;
+        }
+        if (fileIO != null) {
+            wrap(
+                    () -> {
+                        fileIO.close();
+                        return null;
+                    });
+        }
     }
 
     protected abstract FileIO createFileIO(Path path);

--- a/paimon-common/src/main/java/org/apache/paimon/fs/ResolvingFileIO.java
+++ b/paimon-common/src/main/java/org/apache/paimon/fs/ResolvingFileIO.java
@@ -23,10 +23,13 @@ import org.apache.paimon.catalog.CatalogContext;
 import org.apache.paimon.data.BlobDescriptor;
 import org.apache.paimon.options.CatalogOptions;
 import org.apache.paimon.options.Options;
+import org.apache.paimon.utils.IOUtils;
 
 import java.io.IOException;
 import java.io.Serializable;
 import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
@@ -44,6 +47,8 @@ public class ResolvingFileIO implements FileIO {
     private final Map<CacheKey, FileIO> fileIOMap = new ConcurrentHashMap<>();
 
     private CatalogContext context;
+
+    private transient volatile boolean closed;
 
     // TODO, how to decide the real fileio is object store or not?
     @Override
@@ -127,15 +132,46 @@ public class ResolvingFileIO implements FileIO {
 
     @VisibleForTesting
     public FileIO fileIO(Path path) throws IOException {
+        if (closed) {
+            throw new IOException("This FileIO is closed.");
+        }
         CacheKey cacheKey = new CacheKey(path.toUri().getScheme(), path.toUri().getAuthority());
-        return fileIOMap.computeIfAbsent(
-                cacheKey,
-                k -> {
+        FileIO fileIO =
+                fileIOMap.computeIfAbsent(
+                        cacheKey,
+                        k -> {
+                            try {
+                                return FileIO.get(path, context);
+                            } catch (IOException e) {
+                                throw new RuntimeException(e);
+                            }
+                        });
+        if (closed) {
+            fileIOMap.remove(cacheKey, fileIO);
+            IOUtils.closeQuietly(fileIO);
+            throw new IOException("This FileIO is closed.");
+        }
+        return fileIO;
+    }
+
+    @Override
+    public void close() throws IOException {
+        closed = true;
+        List<FileIO> toClose = new ArrayList<>();
+        for (CacheKey key : fileIOMap.keySet()) {
+            FileIO fileIO = fileIOMap.remove(key);
+            if (fileIO != null) {
+                toClose.add(fileIO);
+            }
+        }
+        wrap(
+                () -> {
                     try {
-                        return FileIO.get(path, context);
-                    } catch (IOException e) {
-                        throw new RuntimeException(e);
+                        IOUtils.closeAll(toClose);
+                    } catch (Exception e) {
+                        throw new IOException("Failed to close the resolved file IOs", e);
                     }
+                    return null;
                 });
     }
 

--- a/paimon-common/src/main/java/org/apache/paimon/rest/RESTTokenFileIO.java
+++ b/paimon-common/src/main/java/org/apache/paimon/rest/RESTTokenFileIO.java
@@ -18,16 +18,21 @@
 
 package org.apache.paimon.rest;
 
+import org.apache.paimon.annotation.VisibleForTesting;
 import org.apache.paimon.catalog.CatalogContext;
 import org.apache.paimon.catalog.Identifier;
 import org.apache.paimon.data.BlobDescriptor;
 import org.apache.paimon.fs.FileIO;
+import org.apache.paimon.fs.FileRange;
 import org.apache.paimon.fs.FileStatus;
 import org.apache.paimon.fs.Path;
 import org.apache.paimon.fs.PositionOutputStream;
+import org.apache.paimon.fs.PositionOutputStreamWrapper;
 import org.apache.paimon.fs.RemoteIterator;
 import org.apache.paimon.fs.SeekableInputStream;
+import org.apache.paimon.fs.SeekableInputStreamWrapper;
 import org.apache.paimon.fs.TwoPhaseOutputStream;
+import org.apache.paimon.fs.VectoredReadable;
 import org.apache.paimon.options.ConfigOption;
 import org.apache.paimon.options.ConfigOptions;
 import org.apache.paimon.options.Options;
@@ -44,12 +49,18 @@ import org.apache.paimon.shade.guava30.com.google.common.collect.Maps;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import javax.annotation.Nullable;
+
+import java.io.Closeable;
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.time.Duration;
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.apache.paimon.options.CatalogOptions.FILE_IO_ALLOW_CACHE;
 import static org.apache.paimon.rest.RESTApi.TOKEN_EXPIRATION_SAFE_TIME_MILLIS;
@@ -67,12 +78,11 @@ public class RESTTokenFileIO implements FileIO {
                     .defaultValue(false)
                     .withDescription("Whether to support data token provided by the REST server.");
 
-    private static final Cache<RESTToken, FileIO> FILE_IO_CACHE =
+    private static final Cache<RESTToken, CachedFileIO> FILE_IO_CACHE =
             Caffeine.newBuilder()
                     .maximumSize(1000)
                     .expireAfterAccess(10, TimeUnit.HOURS)
-                    .removalListener(
-                            (ignored, value, cause) -> IOUtils.closeQuietly((FileIO) value))
+                    .removalListener((ignored, value, cause) -> ((CachedFileIO) value).release())
                     .scheduler(
                             Scheduler.forScheduledExecutorService(
                                     Executors.newSingleThreadScheduledExecutor(
@@ -109,62 +119,126 @@ public class RESTTokenFileIO implements FileIO {
 
     @Override
     public SeekableInputStream newInputStream(Path path) throws IOException {
-        return fileIO().newInputStream(path);
+        Lease lease = acquire();
+        boolean opened = false;
+        try {
+            SeekableInputStream delegate = lease.fileIO().newInputStream(path);
+            SeekableInputStream in =
+                    delegate instanceof VectoredReadable
+                            ? new LeasedVectoredInputStream(delegate, lease)
+                            : new LeasedSeekableInputStream(delegate, lease);
+            opened = true;
+            return in;
+        } finally {
+            if (!opened) {
+                lease.close();
+            }
+        }
     }
 
     @Override
     public PositionOutputStream newOutputStream(Path path, boolean overwrite) throws IOException {
-        return fileIO().newOutputStream(path, overwrite);
+        Lease lease = acquire();
+        boolean opened = false;
+        try {
+            PositionOutputStream out =
+                    new LeasedPositionOutputStream(
+                            lease.fileIO().newOutputStream(path, overwrite), lease);
+            opened = true;
+            return out;
+        } finally {
+            if (!opened) {
+                lease.close();
+            }
+        }
     }
 
     @Override
     public TwoPhaseOutputStream newTwoPhaseOutputStream(Path path, boolean overwrite)
             throws IOException {
-        return fileIO().newTwoPhaseOutputStream(path, overwrite);
+        Lease lease = acquire();
+        boolean opened = false;
+        try {
+            TwoPhaseOutputStream out =
+                    new LeasedTwoPhaseOutputStream(
+                            lease.fileIO().newTwoPhaseOutputStream(path, overwrite), lease);
+            opened = true;
+            return out;
+        } finally {
+            if (!opened) {
+                lease.close();
+            }
+        }
     }
 
     @Override
     public FileStatus getFileStatus(Path path) throws IOException {
-        return fileIO().getFileStatus(path);
+        try (Lease lease = acquire()) {
+            return lease.fileIO().getFileStatus(path);
+        }
     }
 
     @Override
     public FileStatus[] listStatus(Path path) throws IOException {
-        return fileIO().listStatus(path);
+        try (Lease lease = acquire()) {
+            return lease.fileIO().listStatus(path);
+        }
     }
 
     @Override
     public RemoteIterator<FileStatus> listFilesIterative(Path path, boolean recursive)
             throws IOException {
         // the interface default would hide the inner FileIO's iterative listing override
-        return fileIO().listFilesIterative(path, recursive);
+        Lease lease = acquire();
+        boolean listing = false;
+        try {
+            RemoteIterator<FileStatus> iterator =
+                    new LeasedRemoteIterator(
+                            lease.fileIO().listFilesIterative(path, recursive), lease);
+            listing = true;
+            return iterator;
+        } finally {
+            if (!listing) {
+                lease.close();
+            }
+        }
     }
 
     @Override
     public boolean exists(Path path) throws IOException {
-        return fileIO().exists(path);
+        try (Lease lease = acquire()) {
+            return lease.fileIO().exists(path);
+        }
     }
 
     @Override
     public boolean delete(Path path, boolean recursive) throws IOException {
-        return fileIO().delete(path, recursive);
+        try (Lease lease = acquire()) {
+            return lease.fileIO().delete(path, recursive);
+        }
     }
 
     @Override
     public boolean mkdirs(Path path) throws IOException {
-        return fileIO().mkdirs(path);
+        try (Lease lease = acquire()) {
+            return lease.fileIO().mkdirs(path);
+        }
     }
 
     @Override
     public boolean rename(Path src, Path dst) throws IOException {
-        return fileIO().rename(src, dst);
+        try (Lease lease = acquire()) {
+            return lease.fileIO().rename(src, dst);
+        }
     }
 
     @Override
     public boolean tryToWriteAtomic(Path path, String content) throws IOException {
         // the interface default (temp file + rename) would bypass the inner FileIO's atomic
         // override
-        return fileIO().tryToWriteAtomic(path, content);
+        try (Lease lease = acquire()) {
+            return lease.fileIO().tryToWriteAtomic(path, content);
+        }
     }
 
     @Override
@@ -173,49 +247,89 @@ public class RESTTokenFileIO implements FileIO {
         if (!path.equals(tableRoot)) {
             throw new IOException("Table root does not match RESTTokenFileIO bound table root.");
         }
-        return fileIO().createBlobPresignedUrl(tableRoot, descriptor, validity);
+        try (Lease lease = acquire()) {
+            return lease.fileIO().createBlobPresignedUrl(tableRoot, descriptor, validity);
+        }
     }
 
     @Override
     public boolean isObjectStore() {
-        try {
-            return fileIO().isObjectStore();
+        try (Lease lease = acquire()) {
+            return lease.fileIO().isObjectStore();
         } catch (IOException e) {
             throw new RuntimeException(e);
         }
     }
 
-    public FileIO fileIO() throws IOException {
+    public Lease acquire() throws IOException {
         tryToRefreshToken();
 
-        FileIO fileIO = FILE_IO_CACHE.getIfPresent(token);
-        if (fileIO != null) {
-            return fileIO;
-        }
-
-        synchronized (FILE_IO_CACHE) {
-            fileIO = FILE_IO_CACHE.getIfPresent(token);
-            if (fileIO != null) {
-                return fileIO;
+        while (true) {
+            RESTToken currentToken = token;
+            CachedFileIO cached = FILE_IO_CACHE.getIfPresent(currentToken);
+            if (cached != null) {
+                Lease lease = cached.acquire();
+                if (lease != null) {
+                    return lease;
+                }
+                FILE_IO_CACHE.asMap().remove(currentToken, cached);
             }
 
-            Options options = catalogContext.options();
-            options = new Options(RESTUtil.merge(options.toMap(), token.token()));
-            options.set(FILE_IO_ALLOW_CACHE, false);
-            CatalogContext context =
-                    CatalogContext.create(
-                            options,
-                            catalogContext.hadoopConf(),
-                            catalogContext.preferIO(),
-                            catalogContext.fallbackIO());
-            try {
-                fileIO = FileIO.get(path, context);
-            } catch (IOException e) {
-                throw new UncheckedIOException(e);
+            synchronized (FILE_IO_CACHE) {
+                cached = FILE_IO_CACHE.getIfPresent(currentToken);
+                if (cached != null) {
+                    Lease lease = cached.acquire();
+                    if (lease != null) {
+                        return lease;
+                    }
+                    FILE_IO_CACHE.asMap().remove(currentToken, cached);
+                    continue;
+                }
+
+                Options options = catalogContext.options();
+                options = new Options(RESTUtil.merge(options.toMap(), currentToken.token()));
+                options.set(FILE_IO_ALLOW_CACHE, false);
+                CatalogContext context =
+                        CatalogContext.create(
+                                options,
+                                catalogContext.hadoopConf(),
+                                catalogContext.preferIO(),
+                                catalogContext.fallbackIO());
+                FileIO fileIO;
+                try {
+                    fileIO = FileIO.get(path, context);
+                } catch (IOException e) {
+                    throw new UncheckedIOException(e);
+                }
+                cached = new CachedFileIO(fileIO);
+                Lease lease = cached.acquire();
+                FILE_IO_CACHE.put(currentToken, cached);
+                return lease;
             }
-            FILE_IO_CACHE.put(token, fileIO);
-            return fileIO;
         }
+    }
+
+    public static Lease lease(FileIO fileIO) throws IOException {
+        if (fileIO instanceof RESTTokenFileIO) {
+            return ((RESTTokenFileIO) fileIO).acquire();
+        }
+        return new Lease(fileIO, null);
+    }
+
+    /**
+     * Pins the cache entry for the life of the process.
+     *
+     * @deprecated use {@link #acquire()} and work inside the lease.
+     */
+    @Deprecated
+    public FileIO fileIO() throws IOException {
+        return acquire().fileIO();
+    }
+
+    @VisibleForTesting
+    static void invalidateFileIOCache() {
+        FILE_IO_CACHE.invalidateAll();
+        FILE_IO_CACHE.cleanUp();
     }
 
     private void tryToRefreshToken() {
@@ -281,5 +395,231 @@ public class RESTTokenFileIO implements FileIO {
     public RESTToken validToken() {
         tryToRefreshToken();
         return token;
+    }
+
+    /** A cached {@link FileIO} and the number of references still outstanding on it. */
+    @VisibleForTesting
+    static class CachedFileIO {
+
+        private final FileIO fileIO;
+        private final AtomicInteger references = new AtomicInteger(1);
+
+        CachedFileIO(FileIO fileIO) {
+            this.fileIO = fileIO;
+        }
+
+        @Nullable
+        Lease acquire() {
+            while (true) {
+                int current = references.get();
+                if (current <= 0) {
+                    return null;
+                }
+                if (references.compareAndSet(current, current + 1)) {
+                    return new Lease(fileIO, this);
+                }
+            }
+        }
+
+        void release() {
+            if (references.decrementAndGet() == 0) {
+                IOUtils.closeQuietly(fileIO);
+            }
+        }
+    }
+
+    /** The right to use a {@link FileIO} until this lease is closed. */
+    public static class Lease implements Closeable {
+
+        private final FileIO fileIO;
+        @Nullable private final CachedFileIO cached;
+        private final AtomicBoolean released = new AtomicBoolean();
+
+        private Lease(FileIO fileIO, @Nullable CachedFileIO cached) {
+            this.fileIO = fileIO;
+            this.cached = cached;
+        }
+
+        public FileIO fileIO() {
+            return fileIO;
+        }
+
+        @Override
+        public void close() {
+            if (cached != null && released.compareAndSet(false, true)) {
+                cached.release();
+            }
+        }
+    }
+
+    private static class LeasedSeekableInputStream extends SeekableInputStreamWrapper {
+
+        private final Lease lease;
+
+        private LeasedSeekableInputStream(SeekableInputStream in, Lease lease) {
+            super(in);
+            this.lease = lease;
+        }
+
+        @Override
+        public void close() throws IOException {
+            try {
+                super.close();
+            } finally {
+                lease.close();
+            }
+        }
+    }
+
+    private static class LeasedVectoredInputStream extends LeasedSeekableInputStream
+            implements VectoredReadable {
+
+        private LeasedVectoredInputStream(SeekableInputStream in, Lease lease) {
+            super(in, lease);
+        }
+
+        private VectoredReadable vectored() {
+            return (VectoredReadable) in;
+        }
+
+        @Override
+        public int pread(long position, byte[] buffer, int offset, int length) throws IOException {
+            return vectored().pread(position, buffer, offset, length);
+        }
+
+        @Override
+        public void preadFully(long position, byte[] buffer, int offset, int length)
+                throws IOException {
+            vectored().preadFully(position, buffer, offset, length);
+        }
+
+        @Override
+        public int minSeekForVectorReads() {
+            return vectored().minSeekForVectorReads();
+        }
+
+        @Override
+        public int batchSizeForVectorReads() {
+            return vectored().batchSizeForVectorReads();
+        }
+
+        @Override
+        public int parallelismForVectorReads() {
+            return vectored().parallelismForVectorReads();
+        }
+
+        @Override
+        public void readVectored(List<? extends FileRange> ranges) throws IOException {
+            vectored().readVectored(ranges);
+        }
+    }
+
+    private static class LeasedPositionOutputStream extends PositionOutputStreamWrapper {
+
+        private final Lease lease;
+
+        private LeasedPositionOutputStream(PositionOutputStream out, Lease lease) {
+            super(out);
+            this.lease = lease;
+        }
+
+        @Override
+        public void close() throws IOException {
+            try {
+                super.close();
+            } finally {
+                lease.close();
+            }
+        }
+    }
+
+    private static class LeasedTwoPhaseOutputStream extends TwoPhaseOutputStream {
+
+        private final TwoPhaseOutputStream out;
+        private final Lease lease;
+
+        private LeasedTwoPhaseOutputStream(TwoPhaseOutputStream out, Lease lease) {
+            this.out = out;
+            this.lease = lease;
+        }
+
+        @Override
+        public long getPos() throws IOException {
+            return out.getPos();
+        }
+
+        @Override
+        public void write(int b) throws IOException {
+            out.write(b);
+        }
+
+        @Override
+        public void write(byte[] b) throws IOException {
+            out.write(b);
+        }
+
+        @Override
+        public void write(byte[] b, int off, int len) throws IOException {
+            out.write(b, off, len);
+        }
+
+        @Override
+        public void flush() throws IOException {
+            out.flush();
+        }
+
+        @Override
+        public Committer closeForCommit() throws IOException {
+            try {
+                return out.closeForCommit();
+            } finally {
+                lease.close();
+            }
+        }
+
+        @Override
+        public void close() throws IOException {
+            try {
+                out.close();
+            } finally {
+                lease.close();
+            }
+        }
+    }
+
+    private static class LeasedRemoteIterator implements RemoteIterator<FileStatus> {
+
+        private final RemoteIterator<FileStatus> iterator;
+        private final Lease lease;
+
+        private LeasedRemoteIterator(RemoteIterator<FileStatus> iterator, Lease lease) {
+            this.iterator = iterator;
+            this.lease = lease;
+        }
+
+        @Override
+        public boolean hasNext() throws IOException {
+            boolean hasNext;
+            try {
+                hasNext = iterator.hasNext();
+            } catch (Throwable t) {
+                lease.close();
+                throw t;
+            }
+            if (!hasNext) {
+                lease.close();
+            }
+            return hasNext;
+        }
+
+        @Override
+        public FileStatus next() throws IOException {
+            try {
+                return iterator.next();
+            } catch (Throwable t) {
+                lease.close();
+                throw t;
+            }
+        }
     }
 }

--- a/paimon-common/src/test/java/org/apache/paimon/fs/PluginFileIOTest.java
+++ b/paimon-common/src/test/java/org/apache/paimon/fs/PluginFileIOTest.java
@@ -26,7 +26,11 @@ import java.io.IOException;
 import java.time.Duration;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 /** Tests for {@link PluginFileIO}. */
@@ -56,11 +60,55 @@ class PluginFileIOTest {
         assertThat(Thread.currentThread().getContextClassLoader()).isSameAs(original);
     }
 
+    @Test
+    void testCloseReleasesTheDelegateUnderThePluginClassLoader() throws IOException {
+        FileIO delegate = mock(FileIO.class);
+        ClassLoader pluginClassLoader = new ClassLoader() {};
+        TestPluginFileIO fileIO = new TestPluginFileIO(delegate, pluginClassLoader);
+        ClassLoader original = Thread.currentThread().getContextClassLoader();
+        doAnswer(
+                        ignored -> {
+                            assertThat(Thread.currentThread().getContextClassLoader())
+                                    .isSameAs(pluginClassLoader);
+                            return null;
+                        })
+                .when(delegate)
+                .close();
+
+        new TestPluginFileIO(delegate, pluginClassLoader).close();
+        verify(delegate, never()).close();
+
+        fileIO.exists(new Path("oss://bucket/table/file"));
+        fileIO.close();
+
+        verify(delegate).close();
+        assertThat(Thread.currentThread().getContextClassLoader()).isSameAs(original);
+
+        fileIO.close();
+        verify(delegate).close();
+    }
+
+    @Test
+    void testUseAfterCloseFailsWithIOExceptionRatherThanNpe() throws IOException {
+        FileIO delegate = mock(FileIO.class);
+        TestPluginFileIO fileIO = new TestPluginFileIO(delegate, new ClassLoader() {});
+        Path path = new Path("oss://bucket/table/file");
+
+        fileIO.exists(path);
+        fileIO.close();
+
+        assertThatThrownBy(() -> fileIO.exists(path))
+                .isInstanceOf(IOException.class)
+                .hasMessageContaining("closed");
+        assertThat(fileIO.createdCount).isEqualTo(1);
+    }
+
     private static class TestPluginFileIO extends PluginFileIO {
 
         private final FileIO delegate;
         private final ClassLoader classLoader;
         private Path createdFor;
+        private int createdCount;
 
         private TestPluginFileIO(FileIO delegate, ClassLoader classLoader) {
             this.delegate = delegate;
@@ -75,6 +123,7 @@ class PluginFileIOTest {
         @Override
         protected FileIO createFileIO(Path path) {
             createdFor = path;
+            createdCount++;
             return delegate;
         }
 

--- a/paimon-common/src/test/java/org/apache/paimon/fs/ResolvingFileIOTest.java
+++ b/paimon-common/src/test/java/org/apache/paimon/fs/ResolvingFileIOTest.java
@@ -29,17 +29,23 @@ import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -144,6 +150,68 @@ public class ResolvingFileIOTest {
         assertNotNull(hdfsFileIOAgain);
         assertEquals(localFileIO, localFileIOAgain);
         assertEquals(hdfsFileIO, hdfsFileIOAgain);
+    }
+
+    @Test
+    public void testCloseReleasesEveryResolvedFileIO() throws Exception {
+        List<FileIO> loaded = new ArrayList<>();
+        configureWithFreshDelegates(loaded, false);
+
+        FileIO first = resolvingFileIO.fileIO(new Path("oss://bucket-1/table"));
+        FileIO second = resolvingFileIO.fileIO(new Path("oss://bucket-2/table"));
+        assertNotEquals(first, second);
+
+        resolvingFileIO.close();
+
+        verify(first, times(1)).close();
+        verify(second, times(1)).close();
+    }
+
+    @Test
+    public void testCloseKeepsGoingWhenADelegateFails() throws Exception {
+        List<FileIO> loaded = new ArrayList<>();
+        configureWithFreshDelegates(loaded, true);
+
+        FileIO first = resolvingFileIO.fileIO(new Path("oss://bucket-1/table"));
+        FileIO second = resolvingFileIO.fileIO(new Path("oss://bucket-2/table"));
+
+        assertThrows(IOException.class, () -> resolvingFileIO.close());
+
+        verify(first, times(1)).close();
+        verify(second, times(1)).close();
+    }
+
+    @Test
+    public void testUseAfterCloseIsRejectedAndTheMapIsEmptied() throws Exception {
+        List<FileIO> loaded = new ArrayList<>();
+        configureWithFreshDelegates(loaded, false);
+
+        FileIO delegate = resolvingFileIO.fileIO(new Path("oss://bucket-1/table"));
+        resolvingFileIO.close();
+
+        resolvingFileIO.close();
+        verify(delegate, times(1)).close();
+
+        assertThrows(
+                IOException.class, () -> resolvingFileIO.fileIO(new Path("oss://bucket-1/table")));
+    }
+
+    private void configureWithFreshDelegates(List<FileIO> loaded, boolean failOnClose)
+            throws IOException {
+        FileIOLoader loader = mock(FileIOLoader.class);
+        when(loader.getScheme()).thenReturn("oss");
+        when(loader.load(any()))
+                .thenAnswer(
+                        ignored -> {
+                            FileIO delegate = mock(FileIO.class);
+                            when(delegate.exists(any())).thenReturn(true);
+                            if (failOnClose) {
+                                doThrow(new IOException("cannot close")).when(delegate).close();
+                            }
+                            loaded.add(delegate);
+                            return delegate;
+                        });
+        resolvingFileIO.configure(CatalogContext.create(new Options(), loader, null));
     }
 
     @Test

--- a/paimon-common/src/test/java/org/apache/paimon/rest/RESTTokenFileIOTest.java
+++ b/paimon-common/src/test/java/org/apache/paimon/rest/RESTTokenFileIOTest.java
@@ -21,31 +21,58 @@ package org.apache.paimon.rest;
 import org.apache.paimon.catalog.CatalogContext;
 import org.apache.paimon.catalog.Identifier;
 import org.apache.paimon.data.BlobDescriptor;
+import org.apache.paimon.fs.BaseMultiPartUploadCommitter;
 import org.apache.paimon.fs.FileIO;
 import org.apache.paimon.fs.FileIOLoader;
 import org.apache.paimon.fs.FileStatus;
+import org.apache.paimon.fs.MultiPartUploadStore;
 import org.apache.paimon.fs.Path;
+import org.apache.paimon.fs.PositionOutputStream;
 import org.apache.paimon.fs.RemoteIterator;
+import org.apache.paimon.fs.SeekableInputStream;
+import org.apache.paimon.fs.TwoPhaseOutputStream;
+import org.apache.paimon.fs.VectoredReadable;
 import org.apache.paimon.options.Options;
 import org.apache.paimon.rest.responses.GetTableTokenResponse;
 
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
 
 import java.io.IOException;
 import java.time.Duration;
 import java.util.Collections;
 import java.util.UUID;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.after;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.timeout;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 /** Tests for {@link RESTTokenFileIO}. */
 class RESTTokenFileIOTest {
+
+    private static final Path TABLE_ROOT = new Path("oss://bucket/table");
+    private static final Path FILE = new Path("oss://bucket/table/bucket-0/data");
+
+    private static final long CLOSED_MILLIS = 30_000;
+
+    private static final long NOT_CLOSED_MILLIS = 500;
+
+    @BeforeEach
+    @AfterEach
+    void clearFileIOCache() {
+        RESTTokenFileIO.invalidateFileIOCache();
+    }
 
     @Test
     void testCreateBlobPresignedUrlRequiresBoundRootAndDelegates() throws IOException {
@@ -163,5 +190,290 @@ class RESTTokenFileIOTest {
         verify(delegate).listFilesIterative(tableRoot, false);
         // the interface default would construct its own iterator backed by listStatus
         verify(delegate, never()).listStatus(any());
+    }
+
+    @Test
+    void testEvictionKeepsALeasedFileIOAlive() throws Exception {
+        RESTTokenFileIO fileIO = fileIO("leased");
+
+        RESTTokenFileIO.Lease lease = fileIO.acquire();
+        FileIO delegate = cachedDelegate(fileIO);
+        assertThat(lease.fileIO()).isSameAs(delegate);
+
+        RESTTokenFileIO.invalidateFileIOCache();
+
+        verify(delegate, after(NOT_CLOSED_MILLIS).never()).close();
+        assertThat(lease.fileIO().exists(FILE)).isTrue();
+
+        lease.close();
+
+        verify(delegate, timeout(CLOSED_MILLIS).times(1)).close();
+    }
+
+    @Test
+    void testEvictionClosesAnUnleasedFileIO() throws Exception {
+        RESTTokenFileIO fileIO = fileIO("unleased");
+
+        FileIO delegate = cachedDelegate(fileIO);
+        fileIO.exists(FILE);
+
+        RESTTokenFileIO.invalidateFileIOCache();
+
+        verify(delegate, timeout(CLOSED_MILLIS).times(1)).close();
+    }
+
+    @Test
+    void testAnOpenStreamKeepsTheFileIOAlive() throws Exception {
+        RESTTokenFileIO fileIO = fileIO("stream");
+        fileIO.exists(FILE);
+        FileIO delegate = cachedDelegate(fileIO);
+        SeekableInputStream delegateStream = mock(SeekableInputStream.class);
+        when(delegate.newInputStream(FILE)).thenReturn(delegateStream);
+
+        SeekableInputStream in = fileIO.newInputStream(FILE);
+        RESTTokenFileIO.invalidateFileIOCache();
+
+        verify(delegate, after(NOT_CLOSED_MILLIS).never()).close();
+
+        in.close();
+
+        verify(delegateStream, times(1)).close();
+        verify(delegate, timeout(CLOSED_MILLIS).times(1)).close();
+    }
+
+    @Test
+    void testAnOutputStreamKeepsTheFileIOAlive() throws Exception {
+        RESTTokenFileIO fileIO = fileIO("output");
+        fileIO.exists(FILE);
+        FileIO delegate = cachedDelegate(fileIO);
+        PositionOutputStream delegateStream = mock(PositionOutputStream.class);
+        when(delegate.newOutputStream(FILE, false)).thenReturn(delegateStream);
+
+        PositionOutputStream out = fileIO.newOutputStream(FILE, false);
+        RESTTokenFileIO.invalidateFileIOCache();
+
+        verify(delegate, after(NOT_CLOSED_MILLIS).never()).close();
+
+        out.close();
+
+        verify(delegateStream, times(1)).close();
+        verify(delegate, timeout(CLOSED_MILLIS).times(1)).close();
+    }
+
+    @Test
+    void testTheLeasedStreamKeepsTheVectoredReadCapability() throws Exception {
+        RESTTokenFileIO fileIO = fileIO("vectored");
+        fileIO.exists(FILE);
+        FileIO delegate = cachedDelegate(fileIO);
+        VectoredSeekableInputStream delegateStream = mock(VectoredSeekableInputStream.class);
+        when(delegate.newInputStream(FILE)).thenReturn(delegateStream);
+        when(delegateStream.pread(1L, new byte[0], 2, 3)).thenReturn(7);
+        when(delegateStream.parallelismForVectorReads()).thenReturn(11);
+
+        SeekableInputStream in = fileIO.newInputStream(FILE);
+        assertThat(in).isInstanceOf(VectoredReadable.class);
+        VectoredReadable vectored = (VectoredReadable) in;
+        assertThat(vectored.pread(1L, new byte[0], 2, 3)).isEqualTo(7);
+        assertThat(vectored.parallelismForVectorReads()).isEqualTo(11);
+
+        RESTTokenFileIO.invalidateFileIOCache();
+        verify(delegate, after(NOT_CLOSED_MILLIS).never()).close();
+        in.close();
+        verify(delegate, timeout(CLOSED_MILLIS).times(1)).close();
+    }
+
+    @Test
+    void testAPlainStreamIsNotDressedUpAsVectored() throws Exception {
+        RESTTokenFileIO fileIO = fileIO("plainstream");
+        fileIO.exists(FILE);
+        FileIO delegate = cachedDelegate(fileIO);
+        when(delegate.newInputStream(FILE)).thenReturn(mock(SeekableInputStream.class));
+
+        try (SeekableInputStream in = fileIO.newInputStream(FILE)) {
+            assertThat(in).isNotInstanceOf(VectoredReadable.class);
+        }
+    }
+
+    @Test
+    void testATwoPhaseStreamReleasesItsLeaseOnCloseForCommit() throws Exception {
+        RESTTokenFileIO fileIO = fileIO("twophasecommit");
+        fileIO.exists(FILE);
+        FileIO delegate = cachedDelegate(fileIO);
+        when(delegate.newTwoPhaseOutputStream(FILE, false))
+                .thenReturn(mock(TwoPhaseOutputStream.class));
+
+        TwoPhaseOutputStream out = fileIO.newTwoPhaseOutputStream(FILE, false);
+        RESTTokenFileIO.invalidateFileIOCache();
+        verify(delegate, after(NOT_CLOSED_MILLIS).never()).close();
+
+        out.closeForCommit();
+
+        verify(delegate, timeout(CLOSED_MILLIS).times(1)).close();
+    }
+
+    @Test
+    void testATwoPhaseStreamReleasesItsLeaseOnClose() throws Exception {
+        RESTTokenFileIO fileIO = fileIO("twophaseclose");
+        fileIO.exists(FILE);
+        FileIO delegate = cachedDelegate(fileIO);
+        when(delegate.newTwoPhaseOutputStream(FILE, false))
+                .thenReturn(mock(TwoPhaseOutputStream.class));
+
+        TwoPhaseOutputStream out = fileIO.newTwoPhaseOutputStream(FILE, false);
+        RESTTokenFileIO.invalidateFileIOCache();
+        verify(delegate, after(NOT_CLOSED_MILLIS).never()).close();
+
+        out.close();
+
+        verify(delegate, timeout(CLOSED_MILLIS).times(1)).close();
+    }
+
+    @Test
+    void testAFailedOpenHandsTheLeaseBack() throws Exception {
+        RESTTokenFileIO fileIO = fileIO("failedopen");
+        fileIO.exists(FILE);
+        FileIO delegate = cachedDelegate(fileIO);
+        when(delegate.newInputStream(FILE)).thenThrow(new IOException("cannot open"));
+
+        assertThatThrownBy(() -> fileIO.newInputStream(FILE)).isInstanceOf(IOException.class);
+
+        RESTTokenFileIO.invalidateFileIOCache();
+        verify(delegate, timeout(CLOSED_MILLIS).times(1)).close();
+    }
+
+    @Test
+    void testAClosedFileIOIsRebuiltRatherThanHandedOut() throws Exception {
+        RESTTokenFileIO fileIO = fileIO("rebuild");
+
+        FileIO first = cachedDelegate(fileIO);
+        RESTTokenFileIO.invalidateFileIOCache();
+        verify(first, timeout(CLOSED_MILLIS).times(1)).close();
+
+        FileIO second = cachedDelegate(fileIO);
+
+        assertThat(second).isNotSameAs(first);
+        verify(second, never()).close();
+    }
+
+    @Test
+    void testClosingALeaseTwiceReleasesOnce() throws Exception {
+        RESTTokenFileIO fileIO = fileIO("idempotent");
+
+        RESTTokenFileIO.Lease lease = fileIO.acquire();
+        FileIO delegate = lease.fileIO();
+        lease.close();
+        lease.close();
+
+        verify(delegate, after(NOT_CLOSED_MILLIS).never()).close();
+
+        RESTTokenFileIO.invalidateFileIOCache();
+        verify(delegate, timeout(CLOSED_MILLIS).times(1)).close();
+    }
+
+    @Test
+    void testHolderRefusesToHandOutAReleasedFileIO() throws IOException {
+        FileIO delegate = mock(FileIO.class);
+        RESTTokenFileIO.CachedFileIO cached = new RESTTokenFileIO.CachedFileIO(delegate);
+
+        RESTTokenFileIO.Lease lease = cached.acquire();
+        assertThat(lease).isNotNull();
+
+        cached.release();
+        verify(delegate, after(NOT_CLOSED_MILLIS).never()).close();
+
+        lease.close();
+        verify(delegate, timeout(CLOSED_MILLIS).times(1)).close();
+
+        assertThat(cached.acquire()).isNull();
+    }
+
+    @Test
+    void testLeaseOnAPlainFileIODoesNothing() throws IOException {
+        FileIO plain = mock(FileIO.class);
+
+        try (RESTTokenFileIO.Lease lease = RESTTokenFileIO.lease(plain)) {
+            assertThat(lease.fileIO()).isSameAs(plain);
+        }
+
+        verify(plain, never()).close();
+    }
+
+    @Test
+    void testMultiPartUploadCommitterHoldsALeaseAcrossTheCall() throws Exception {
+        RESTTokenFileIO fileIO = fileIO("committer");
+        fileIO.exists(FILE);
+        FileIO delegate = cachedDelegate(fileIO);
+
+        @SuppressWarnings("unchecked")
+        MultiPartUploadStore<String, String> store = mock(MultiPartUploadStore.class);
+        AtomicBoolean closedDuringUpload = new AtomicBoolean();
+        when(store.completeMultipartUpload(any(), any(), any(), anyLong()))
+                .thenAnswer(
+                        ignored -> {
+                            RESTTokenFileIO.invalidateFileIOCache();
+                            Thread.sleep(NOT_CLOSED_MILLIS);
+                            closedDuringUpload.set(
+                                    Mockito.mockingDetails(delegate).getInvocations().stream()
+                                            .anyMatch(
+                                                    i -> "close".equals(i.getMethod().getName())));
+                            return "done";
+                        });
+
+        TestCommitter<String, String> committer = new TestCommitter<>(store, FILE);
+        committer.commit(fileIO);
+
+        verify(store, times(1)).completeMultipartUpload(any(), any(), any(), anyLong());
+        assertThat(closedDuringUpload).isFalse();
+        verify(delegate, timeout(CLOSED_MILLIS).times(1)).close();
+        assertThat(committer.received).isSameAs(delegate);
+    }
+
+    private static FileIO cachedDelegate(RESTTokenFileIO fileIO) throws IOException {
+        try (RESTTokenFileIO.Lease lease = fileIO.acquire()) {
+            return lease.fileIO();
+        }
+    }
+
+    private RESTTokenFileIO fileIO(String tokenValue) {
+        FileIOLoader loader = mock(FileIOLoader.class);
+        when(loader.getScheme()).thenReturn("oss");
+        when(loader.load(any()))
+                .thenAnswer(
+                        ignored -> {
+                            FileIO delegate = mock(FileIO.class);
+                            when(delegate.exists(any())).thenReturn(true);
+                            return delegate;
+                        });
+        RESTApi api = mock(RESTApi.class);
+        Identifier identifier = Identifier.create("db", "table");
+        when(api.loadTableToken(identifier))
+                .thenReturn(
+                        new GetTableTokenResponse(
+                                Collections.singletonMap("token", tokenValue), Long.MAX_VALUE));
+        return new RESTTokenFileIO(
+                CatalogContext.create(new Options(), loader, null), api, identifier, TABLE_ROOT);
+    }
+
+    private abstract static class VectoredSeekableInputStream extends SeekableInputStream
+            implements VectoredReadable {}
+
+    private static class TestCommitter<T, C> extends BaseMultiPartUploadCommitter<T, C> {
+
+        private static final long serialVersionUID = 1L;
+
+        private final transient MultiPartUploadStore<T, C> store;
+
+        private transient FileIO received;
+
+        private TestCommitter(MultiPartUploadStore<T, C> store, Path targetPath) {
+            super("upload-id", Collections.emptyList(), "object", 0L, targetPath);
+            this.store = store;
+        }
+
+        @Override
+        protected MultiPartUploadStore<T, C> multiPartUploadStore(FileIO fileIO, Path targetPath) {
+            received = fileIO;
+            return store;
+        }
     }
 }

--- a/paimon-lance/src/main/java/org/apache/paimon/format/lance/LanceUtils.java
+++ b/paimon-lance/src/main/java/org/apache/paimon/format/lance/LanceUtils.java
@@ -67,21 +67,7 @@ public class LanceUtils {
         URI uri = path.toUri();
         String schema = uri.getScheme();
 
-        if (fileIO instanceof RESTTokenFileIO) {
-            try {
-                fileIO = ((RESTTokenFileIO) fileIO).fileIO();
-            } catch (IOException e) {
-                throw new RuntimeException("Can't get fileIO from RESTTokenFileIO", e);
-            }
-        }
-
-        Options originOptions;
-        if (fileIO instanceof HadoopOptionsProvider) {
-            originOptions =
-                    ((HadoopOptionsProvider) fileIO).hadoopOptions(path, isRead ? "read" : "write");
-        } else {
-            originOptions = new Options();
-        }
+        Options originOptions = hadoopOptions(fileIO, path, isRead);
 
         Path converted = path;
         Map<String, String> storageOptions = new HashMap<>();
@@ -127,5 +113,23 @@ public class LanceUtils {
         }
 
         return Pair.of(converted, storageOptions);
+    }
+
+    private static Options hadoopOptions(FileIO fileIO, Path path, boolean isRead) {
+        String opType = isRead ? "read" : "write";
+        if (fileIO instanceof RESTTokenFileIO) {
+            try (RESTTokenFileIO.Lease lease = ((RESTTokenFileIO) fileIO).acquire()) {
+                return hadoopOptions(lease.fileIO(), path, opType);
+            } catch (IOException e) {
+                throw new RuntimeException("Can't get fileIO from RESTTokenFileIO", e);
+            }
+        }
+        return hadoopOptions(fileIO, path, opType);
+    }
+
+    private static Options hadoopOptions(FileIO fileIO, Path path, String opType) {
+        return fileIO instanceof HadoopOptionsProvider
+                ? ((HadoopOptionsProvider) fileIO).hadoopOptions(path, opType)
+                : new Options();
     }
 }

--- a/paimon-vortex/paimon-vortex-format/src/main/java/org/apache/paimon/format/vortex/VortexUtils.java
+++ b/paimon-vortex/paimon-vortex-format/src/main/java/org/apache/paimon/format/vortex/VortexUtils.java
@@ -48,21 +48,7 @@ public class VortexUtils {
         URI uri = path.toUri();
         String schema = uri.getScheme();
 
-        if (fileIO instanceof RESTTokenFileIO) {
-            try {
-                fileIO = ((RESTTokenFileIO) fileIO).fileIO();
-            } catch (IOException e) {
-                throw new RuntimeException("Can't get fileIO from RESTTokenFileIO", e);
-            }
-        }
-
-        Options originOptions;
-        if (fileIO instanceof HadoopOptionsProvider) {
-            originOptions =
-                    ((HadoopOptionsProvider) fileIO).hadoopOptions(path, isRead ? "read" : "write");
-        } else {
-            originOptions = new Options();
-        }
+        Options originOptions = hadoopOptions(fileIO, path, isRead);
 
         Path converted = path;
         Map<String, String> storageOptions = new HashMap<>();
@@ -80,5 +66,23 @@ public class VortexUtils {
         }
 
         return Pair.of(converted, storageOptions);
+    }
+
+    private static Options hadoopOptions(FileIO fileIO, Path path, boolean isRead) {
+        String opType = isRead ? "read" : "write";
+        if (fileIO instanceof RESTTokenFileIO) {
+            try (RESTTokenFileIO.Lease lease = ((RESTTokenFileIO) fileIO).acquire()) {
+                return hadoopOptions(lease.fileIO(), path, opType);
+            } catch (IOException e) {
+                throw new RuntimeException("Can't get fileIO from RESTTokenFileIO", e);
+            }
+        }
+        return hadoopOptions(fileIO, path, opType);
+    }
+
+    private static Options hadoopOptions(FileIO fileIO, Path path, String opType) {
+        return fileIO instanceof HadoopOptionsProvider
+                ? ((HadoopOptionsProvider) fileIO).hadoopOptions(path, opType)
+                : new Options();
     }
 }


### PR DESCRIPTION
### Purpose

Split out of #8962 at @JingsongLi's request. Answers [this review comment](https://github.com/apache/paimon/pull/8962#discussion_r3703449620).

`PluginFileIO` and `ResolvingFileIO` never forwarded `close()` to their delegates, unlike `CachingFileIO`, so `OSSFileIO.close()` has never run and `RESTCatalog`'s `try (FileIO fileIO = fileIOFromOptions(path))` releases nothing. Both forward now, and `close()` is terminal so the wrappers cannot silently rebuild a delegate nobody will release.

That also makes `RESTTokenFileIO`'s removal listener close a delegate for real. Its cache is JVM wide and hands out raw `FileIO`s and streams, so an eviction could close an OSS file system while another table is still reading through it. Values are reference counted now: the listener hands back only the cache's own reference, and the delegate is closed when the last lease goes. Leases cover each operation and the lifetime of every stream and listing handed out, and the caller's lease is taken before the put, since the admission policy can evict a just-inserted entry.

`BaseMultiPartUploadCommitter`, `LanceUtils` and `VortexUtils` work inside a lease instead of unwrapping the cached instance. `fileIO()` is deprecated, since a raw reference carries no lifetime to track, but kept because engines cast the result to their own implementation.

Cut from current master and shares no file with #8962 or #9471, so the three can be reviewed in any order.

### Tests

`RESTTokenFileIOTest` (new): an eviction keeps a leased `FileIO` alive and closes an unleased one; an open input, output or two-phase stream keeps its delegate alive until the stream ends; the wrapper carries `VectoredReadable` through and does not fake it; a failed open hands the lease back; a spent entry is rebuilt; a lease closed twice releases once; the multipart committer holds a lease across the call. `PluginFileIOTest`, `ResolvingFileIOTest`: close releases every delegate under the plugin classloader, keeps going when one fails, and use after close is rejected.
