### PR TITLE
[core][python] Support multiple packed video fields

### DIFF
--- a/docs/docs/multimodal-table/blob.mdx
+++ b/docs/docs/multimodal-table/blob.mdx
@@ -114,7 +114,7 @@ Flink, Spark, and Python.
       <td>No</td>
       <td style={{wordWrap: "break-word"}}>-</td>
       <td>String</td>
-      <td>Names one scalar BLOB field whose logical values are frames in complete encoded videos packed into <code>.video</code> files. This first version supports append-only tables and exact <code>VideoFrameDescriptor</code>-backed input only.</td>
+      <td>Names scalar BLOB fields whose logical values are frames in complete encoded videos packed into <code>.video</code> files. Multiple fields are comma-separated. This first version supports append-only tables and exact <code>VideoFrameDescriptor</code>-backed input only.</td>
     </tr>
     <tr>
       <td><h5>blob-as-descriptor</h5></td>
@@ -306,10 +306,10 @@ entry per row. NULL and data-evolution placeholders use negative run references.
 
 Physical reuse uses exact payload descriptor identity (URI, offset, and length), not a content
 hash. It is local to each `.video` file: every pack is self-contained and never points at payloads
-owned by another Paimon data file. A pack can contain multiple MP4 payloads. After a size or row
-target is reached, rolling waits for the current physical video group to end, making the target
-soft for large videos. A later commit or an earlier roll can store another physical copy of the
-same source video.
+owned by another Paimon data file. Each configured field rolls independently. A pack can contain
+multiple MP4 payloads. After a size or row target is reached, rolling waits for the current physical
+video group to end, making the target soft for large videos. A later commit or an earlier roll can
+store another physical copy of the same source video.
 
 Compaction byte-copies the complete encoded-video ranges into a new self-contained `.video` pack
 and rebuilds the embedded indexes; it does not decode or re-encode frames. The aligned normal data
@@ -319,7 +319,6 @@ frame mapping in the `.video` descriptor/index path.
 Current restrictions:
 
 - Append-only tables only; primary-key tables continue to use managed BLOB storage.
-- At most one `video-frame-field` per table.
 - The field must be a scalar `BLOB`; `ARRAY<BLOB>` and `MAP<K, BLOB>` continue to use `.blob`.
 - Non-null writes must be exact descriptor-backed `BlobRef` values containing a
   `VideoFrameDescriptor`. Inline bytes and ordinary `BlobDescriptor` values are rejected.

--- a/docs/docs/pypaimon/multimodal-api.mdx
+++ b/docs/docs/pypaimon/multimodal-api.mdx
@@ -197,7 +197,7 @@ docs.add([
 
 ## Video Frame Storage
 
-For a frame table, set `video-frame-field` on one scalar BLOB column. Paimon
+For a frame table, set `video-frame-field` on one or more scalar BLOB columns. Paimon
 stores the frame ordinal in `VideoFrameDescriptor` and the compact `.video`
 index, so the normal data file does not need a `frame_index` or
 `frame_timestamp` column:

--- a/docs/generated/core_configuration.html
+++ b/docs/generated/core_configuration.html
@@ -1895,7 +1895,7 @@ The size strategy ranges by the data size allocated to each sorting task, which 
             <td><h5>video-frame-field</h5></td>
             <td style="word-wrap: break-word;">(none)</td>
             <td>String</td>
-            <td>Specifies one scalar BLOB field whose logical rows are video frames. Complete encoded videos and embedded frame-run indexes are packed into '.video' files. The first version supports append-only data-evolution tables and exact VideoFrameDescriptor input.</td>
+            <td>Specifies scalar BLOB fields whose logical rows are video frames. Complete encoded videos and embedded frame-run indexes are packed into '.video' files. The first version supports append-only data-evolution tables and exact VideoFrameDescriptor input.</td>
         </tr>
         <tr>
             <td><h5>visibility-callback.check-interval</h5></td>

--- a/paimon-api/src/main/java/org/apache/paimon/CoreOptions.java
+++ b/paimon-api/src/main/java/org/apache/paimon/CoreOptions.java
@@ -2695,7 +2695,7 @@ public class CoreOptions implements Serializable {
                     .stringType()
                     .noDefaultValue()
                     .withDescription(
-                            "Specifies one scalar BLOB field whose logical rows are video frames. "
+                            "Specifies scalar BLOB fields whose logical rows are video frames. "
                                     + "Complete encoded videos and embedded frame-run indexes are "
                                     + "packed into '.video' files. The first version supports "
                                     + "append-only data-evolution tables and exact "
@@ -3598,15 +3598,9 @@ public class CoreOptions implements Serializable {
         return parseCommaSeparatedSet(BLOB_DESCRIPTOR_FIELD);
     }
 
-    /** Resolve the scalar BLOB field stored as frame runs in video pack files. */
-    public Optional<String> videoFrameField() {
-        Set<String> fields = parseCommaSeparatedSet(VIDEO_FRAME_FIELD);
-        checkArgument(
-                fields.size() <= 1,
-                "'%s' currently supports exactly one field, but found %s.",
-                VIDEO_FRAME_FIELD.key(),
-                fields);
-        return fields.stream().findFirst();
+    /** Resolve scalar BLOB fields stored as frame runs in video pack files. */
+    public Set<String> videoFrameFields() {
+        return parseCommaSeparatedSet(VIDEO_FRAME_FIELD);
     }
 
     /**

--- a/paimon-common/src/main/java/org/apache/paimon/format/FormatReaderContext.java
+++ b/paimon-common/src/main/java/org/apache/paimon/format/FormatReaderContext.java
@@ -26,6 +26,8 @@ import org.apache.paimon.utils.RoaringBitmap32;
 
 import javax.annotation.Nullable;
 
+import java.util.Map;
+
 /** the context for creating RecordReader {@link RecordReader}. */
 public class FormatReaderContext implements FormatReaderFactory.Context {
 
@@ -34,6 +36,7 @@ public class FormatReaderContext implements FormatReaderFactory.Context {
     private final long fileSize;
     @Nullable private final RoaringBitmap32 selection;
     @Nullable private final ReadBatchSizer readBatchSizer;
+    @Nullable private final Map<Path, Object> metadataCache;
 
     public FormatReaderContext(
             FileIO fileIO,
@@ -41,11 +44,22 @@ public class FormatReaderContext implements FormatReaderFactory.Context {
             long fileSize,
             @Nullable RoaringBitmap32 selection,
             @Nullable ReadBatchSizer readBatchSizer) {
+        this(fileIO, file, fileSize, selection, readBatchSizer, null);
+    }
+
+    public FormatReaderContext(
+            FileIO fileIO,
+            Path file,
+            long fileSize,
+            @Nullable RoaringBitmap32 selection,
+            @Nullable ReadBatchSizer readBatchSizer,
+            @Nullable Map<Path, Object> metadataCache) {
         this.fileIO = fileIO;
         this.file = file;
         this.fileSize = fileSize;
         this.selection = selection;
         this.readBatchSizer = readBatchSizer;
+        this.metadataCache = metadataCache;
     }
 
     @Override
@@ -73,5 +87,11 @@ public class FormatReaderContext implements FormatReaderFactory.Context {
     @Override
     public ReadBatchSizer readBatchSizer() {
         return readBatchSizer;
+    }
+
+    @Nullable
+    @Override
+    public Map<Path, Object> metadataCache() {
+        return metadataCache;
     }
 }

--- a/paimon-common/src/main/java/org/apache/paimon/format/FormatReaderFactory.java
+++ b/paimon-common/src/main/java/org/apache/paimon/format/FormatReaderFactory.java
@@ -29,6 +29,7 @@ import org.apache.paimon.utils.RoaringBitmap32;
 import javax.annotation.Nullable;
 
 import java.io.IOException;
+import java.util.Map;
 
 /** A factory to create {@link RecordReader} for file. */
 public interface FormatReaderFactory {
@@ -58,6 +59,12 @@ public interface FormatReaderFactory {
         /** Sizer shared by readers that support dynamic read batch sizing. */
         @Nullable
         default ReadBatchSizer readBatchSizer() {
+            return null;
+        }
+
+        /** Metadata shared by readers of the same physical file within one split. */
+        @Nullable
+        default Map<Path, Object> metadataCache() {
             return null;
         }
     }

--- a/paimon-core/src/main/java/org/apache/paimon/append/DedicatedFormatRollingFileWriter.java
+++ b/paimon-core/src/main/java/org/apache/paimon/append/DedicatedFormatRollingFileWriter.java
@@ -453,10 +453,18 @@ public class DedicatedFormatRollingFileWriter
             return;
         }
 
-        closeNormalAndVectorWriters();
+        DataFileMeta mainDataFileMeta = currentWriter == null ? null : closeMainWriter();
         List<DataFileMeta> blobMetas = closeBlobWriter();
+        List<DataFileMeta> vectorStoreMetas = closeVectorStoreWriter();
+        if (mainDataFileMeta != null) {
+            validateFileConsistency(mainDataFileMeta, Collections.emptyList(), vectorStoreMetas);
+            results.add(mainDataFileMeta);
+        }
         validateBlobConsistency(blobMetas);
         results.addAll(blobMetas);
+        results.addAll(vectorStoreMetas);
+        currentWriter = null;
+        currentFileRecordCount = 0;
     }
 
     private void closeNormalAndVectorWriters() throws IOException {

--- a/paimon-core/src/main/java/org/apache/paimon/append/DedicatedFormatRollingFileWriter.java
+++ b/paimon-core/src/main/java/org/apache/paimon/append/DedicatedFormatRollingFileWriter.java
@@ -18,9 +18,7 @@
 
 package org.apache.paimon.append;
 
-import org.apache.paimon.data.BlobDescriptor;
 import org.apache.paimon.data.InternalRow;
-import org.apache.paimon.data.VideoFrameDescriptor;
 import org.apache.paimon.fileindex.FileIndexOptions;
 import org.apache.paimon.format.FileFormat;
 import org.apache.paimon.fs.FileIO;
@@ -52,7 +50,6 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import java.util.Set;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
@@ -76,9 +73,8 @@ import static org.apache.paimon.types.VectorType.fieldsInVectorFile;
  *       lance)
  * </ul>
  *
- * <p>File rolling is triggered based on the target file size for each type. When rolling occurs,
- * all active writers are closed together to maintain consistency. One normal data file may
- * correspond to multiple blob/vector files.
+ * <p>Normal and vector files roll together. Blob files roll independently so an encoded video
+ * payload is never duplicated just to match a normal-file boundary.
  *
  * <pre>
  * Example file structure:
@@ -113,7 +109,7 @@ public class DedicatedFormatRollingFileWriter
             vectorStoreWriterFactory;
     private final long targetFileSize;
     private final long targetFileRowNum;
-    private final int videoFrameFieldIndex;
+    private final Set<String> blobFileFields;
 
     // State management
     private final List<FileWriterAbortExecutor> closedWriters;
@@ -127,8 +123,6 @@ public class DedicatedFormatRollingFileWriter
             vectorStoreWriter;
     private long recordCount = 0;
     private long currentFileRecordCount = 0;
-    private @Nullable BlobDescriptor currentVideoGroup;
-    private boolean pendingGroupAwareRoll;
     private boolean closed = false;
 
     public DedicatedFormatRollingFileWriter(
@@ -156,7 +150,6 @@ public class DedicatedFormatRollingFileWriter
                 targetFileRowNum);
         this.targetFileSize = targetFileSize;
         this.targetFileRowNum = targetFileRowNum;
-        this.videoFrameFieldIndex = videoFrameFieldIndex(writeSchema, context);
         this.results = new ArrayList<>();
         this.closedWriters = new ArrayList<>();
 
@@ -169,8 +162,10 @@ public class DedicatedFormatRollingFileWriter
         Set<String> fieldsInDedicatedFile =
                 fieldNamesInVectorFile(writeSchema, vectorFileFormat != null);
         if (context != null) {
-            fieldsInDedicatedFile.addAll(
-                    fieldNamesInBlobFile(writeSchema, context.blobInlineFields()));
+            this.blobFileFields = fieldNamesInBlobFile(writeSchema, context.blobInlineFields());
+            fieldsInDedicatedFile.addAll(blobFileFields);
+        } else {
+            this.blobFileFields = Collections.emptySet();
         }
         List<DataField> fieldsInNormalFile = new ArrayList<>();
         for (DataField field : writeSchema.getFields()) {
@@ -212,6 +207,7 @@ public class DedicatedFormatRollingFileWriter
                                     asyncFileWrite,
                                     statsDenseStore,
                                     blobTargetFileSize,
+                                    targetFileRowNum,
                                     context);
         } else {
             this.blobWriterFactory = null;
@@ -348,10 +344,6 @@ public class DedicatedFormatRollingFileWriter
     @Override
     public void write(InternalRow row) throws IOException {
         try {
-            BlobDescriptor nextVideoGroup = videoPayloadDescriptor(row);
-            if (pendingGroupAwareRoll && !Objects.equals(currentVideoGroup, nextVideoGroup)) {
-                closeCurrentWriter();
-            }
             if (writerFactory != null && currentWriter == null) {
                 currentWriter = writerFactory.get();
             }
@@ -372,14 +364,9 @@ public class DedicatedFormatRollingFileWriter
             }
             recordCount++;
             currentFileRecordCount++;
-            currentVideoGroup = nextVideoGroup;
 
             if (rollingFile()) {
-                if (nextVideoGroup == null) {
-                    closeCurrentWriter();
-                } else {
-                    pendingGroupAwareRoll = true;
-                }
+                closeNormalAndVectorWriters();
             }
         } catch (Throwable e) {
             handleWriteException(e);
@@ -442,8 +429,8 @@ public class DedicatedFormatRollingFileWriter
     }
 
     /**
-     * Checks if the current file should be rolled. The row cap applies even when there is no main
-     * writer (all fields dedicated), so blob/vector writers roll together.
+     * Checks if the current normal/vector range should be rolled. Blob writers manage their own
+     * rolling.
      */
     private boolean rollingFile() throws IOException {
         if (currentFileRecordCount >= targetFileRowNum) {
@@ -457,8 +444,7 @@ public class DedicatedFormatRollingFileWriter
     }
 
     /**
-     * Closes the current writer and processes the results. Validates consistency between main and
-     * blob files.
+     * Closes the current writers and processes their results.
      *
      * @throws IOException if closing fails
      */
@@ -467,46 +453,22 @@ public class DedicatedFormatRollingFileWriter
             return;
         }
 
-        // Close main writer and get metadata
-        DataFileMeta mainDataFileMeta = currentWriter == null ? null : closeMainWriter();
-
-        // Close blob writer and process blob metadata
+        closeNormalAndVectorWriters();
         List<DataFileMeta> blobMetas = closeBlobWriter();
+        validateBlobConsistency(blobMetas);
+        results.addAll(blobMetas);
+    }
 
-        // Close vector-store writer and process vector-store metadata
+    private void closeNormalAndVectorWriters() throws IOException {
+        DataFileMeta mainDataFileMeta = currentWriter == null ? null : closeMainWriter();
         List<DataFileMeta> vectorStoreMetas = closeVectorStoreWriter();
-
         if (mainDataFileMeta != null) {
-            // Validate consistency between main and blob files
-            validateFileConsistency(mainDataFileMeta, blobMetas, vectorStoreMetas);
+            validateFileConsistency(mainDataFileMeta, Collections.emptyList(), vectorStoreMetas);
             results.add(mainDataFileMeta);
         }
-
-        // Add results to the results list
-        results.addAll(blobMetas);
         results.addAll(vectorStoreMetas);
-
-        // Reset current writer
         currentWriter = null;
         currentFileRecordCount = 0;
-        currentVideoGroup = null;
-        pendingGroupAwareRoll = false;
-    }
-
-    private static int videoFrameFieldIndex(
-            RowType writeSchema, @Nullable BlobFileContext context) {
-        if (context == null || context.videoFrameField() == null) {
-            return -1;
-        }
-        String field = context.videoFrameField();
-        return writeSchema.containsField(field) ? writeSchema.getFieldIndex(field) : -1;
-    }
-
-    private @Nullable BlobDescriptor videoPayloadDescriptor(InternalRow row) {
-        if (videoFrameFieldIndex < 0 || row.isNullAt(videoFrameFieldIndex)) {
-            return null;
-        }
-        return VideoFrameDescriptor.payloadDescriptor(row.getBlob(videoFrameFieldIndex));
     }
 
     /** Closes the main writer and returns its metadata. */
@@ -571,6 +533,22 @@ public class DedicatedFormatRollingFileWriter
                             "This is a bug: The row count of main file and vector-store files does not match. "
                                     + "Main file: %s (row count: %d), vector-store files: %s (total row count: %d)",
                             mainDataFileMeta, mainRowCount, vectorStoreMetas, vectorStoreRowCount));
+        }
+    }
+
+    private void validateBlobConsistency(List<DataFileMeta> blobMetas) {
+        Map<String, Long> blobRowCounts = new HashMap<>();
+        for (DataFileMeta file : blobMetas) {
+            blobRowCounts.merge(file.writeCols().get(0), file.rowCount(), Long::sum);
+        }
+        for (String field : blobFileFields) {
+            long rowCount = blobRowCounts.getOrDefault(field, 0L);
+            if (rowCount != recordCount) {
+                throw new IllegalStateException(
+                        String.format(
+                                "This is a bug: blob field %s contains %d rows, expected %d.",
+                                field, rowCount, recordCount));
+            }
         }
     }
 

--- a/paimon-core/src/main/java/org/apache/paimon/append/MultipleBlobFileWriter.java
+++ b/paimon-core/src/main/java/org/apache/paimon/append/MultipleBlobFileWriter.java
@@ -61,12 +61,13 @@ public class MultipleBlobFileWriter implements Closeable {
             boolean asyncFileWrite,
             boolean statsDenseStore,
             long targetFileSize,
+            long targetFileRowNum,
             BlobFileContext context) {
         RowType blobRowType =
                 new RowType(fieldsInBlobFile(writeSchema, context.blobInlineFields()));
         this.blobWriters = new ArrayList<>();
         for (String blobFieldName : blobRowType.getFieldNames()) {
-            boolean video = blobFieldName.equals(context.videoFrameField());
+            boolean video = context.videoFrameFields().contains(blobFieldName);
             FileFormat blobFileFormat;
             if (video) {
                 if (context.blobConsumer() != null) {
@@ -114,9 +115,10 @@ public class MultipleBlobFileWriter implements Closeable {
                                     null);
             RollingFileWriterImpl<InternalRow, DataFileMeta> rollingWriter =
                     video
-                            ? new VideoRollingFileWriter<>(writerFactory, targetFileSize)
+                            ? new VideoRollingFileWriter<>(
+                                    writerFactory, targetFileSize, targetFileRowNum)
                             : new RollingFileWriterImpl<>(
-                                    writerFactory, targetFileSize, Long.MAX_VALUE);
+                                    writerFactory, targetFileSize, targetFileRowNum);
             blobWriters.add(
                     new BlobProjectedFileWriter(
                             rollingWriter,

--- a/paimon-core/src/main/java/org/apache/paimon/append/VideoRollingFileWriter.java
+++ b/paimon-core/src/main/java/org/apache/paimon/append/VideoRollingFileWriter.java
@@ -46,8 +46,9 @@ class VideoRollingFileWriter<R> extends RollingFileWriterImpl<InternalRow, R> {
 
     VideoRollingFileWriter(
             Supplier<? extends SingleFileWriter<InternalRow, R>> writerFactory,
-            long targetFileSize) {
-        super(writerFactory, targetFileSize, Long.MAX_VALUE);
+            long targetFileSize,
+            long targetFileRowNum) {
+        super(writerFactory, targetFileSize, targetFileRowNum);
     }
 
     @Override

--- a/paimon-core/src/main/java/org/apache/paimon/append/VideoRollingFileWriter.java
+++ b/paimon-core/src/main/java/org/apache/paimon/append/VideoRollingFileWriter.java
@@ -66,8 +66,12 @@ class VideoRollingFileWriter<R> extends RollingFileWriterImpl<InternalRow, R> {
     }
 
     @Override
-    protected void onRollingCondition(InternalRow row) {
-        pendingRoll = true;
+    protected void onRollingCondition(InternalRow row) throws IOException {
+        if (currentVideo == null) {
+            closeCurrentWriter();
+        } else {
+            pendingRoll = true;
+        }
     }
 
     @Override

--- a/paimon-core/src/main/java/org/apache/paimon/append/dataevolution/DataEvolutionBlobCompactTask.java
+++ b/paimon-core/src/main/java/org/apache/paimon/append/dataevolution/DataEvolutionBlobCompactTask.java
@@ -130,7 +130,7 @@ public class DataEvolutionBlobCompactTask extends DataEvolutionCompactTask {
             RowType blobWriteType,
             String blobFieldName,
             DataFilePathFactory pathFactory) {
-        boolean video = options.videoFrameField().map(blobFieldName::equals).orElse(false);
+        boolean video = options.videoFrameFields().contains(blobFieldName);
         FileFormat blobFileFormat =
                 video
                         ? new VideoFileFormat(options.blobCopyBufferSize())

--- a/paimon-core/src/main/java/org/apache/paimon/operation/BlobFileContext.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/BlobFileContext.java
@@ -34,7 +34,7 @@ public class BlobFileContext {
 
     private final Set<String> blobDescriptorFields;
     private final Set<String> blobInlineFields;
-    private final @Nullable String videoFrameField;
+    private final Set<String> videoFrameFields;
     private final boolean writeNullOnMissingFile;
     private final boolean writeNullOnFetchFailure;
     private final int copyBufferSize;
@@ -45,13 +45,13 @@ public class BlobFileContext {
     private BlobFileContext(
             Set<String> blobDescriptorFields,
             Set<String> blobInlineFields,
-            @Nullable String videoFrameField,
+            Set<String> videoFrameFields,
             boolean writeNullOnMissingFile,
             boolean writeNullOnFetchFailure,
             int copyBufferSize) {
         this.blobDescriptorFields = blobDescriptorFields;
         this.blobInlineFields = blobInlineFields;
-        this.videoFrameField = videoFrameField;
+        this.videoFrameFields = videoFrameFields;
         this.writeNullOnMissingFile = writeNullOnMissingFile;
         this.writeNullOnFetchFailure = writeNullOnFetchFailure;
         this.copyBufferSize = copyBufferSize;
@@ -77,7 +77,7 @@ public class BlobFileContext {
         return new BlobFileContext(
                 descriptorFields,
                 inlineFields,
-                options.videoFrameField().orElse(null),
+                options.videoFrameFields(),
                 options.blobWriteNullOnMissingFile(),
                 options.blobWriteNullOnFetchFailure(),
                 options.blobCopyBufferSize());
@@ -109,8 +109,8 @@ public class BlobFileContext {
         return blobInlineFields;
     }
 
-    public @Nullable String videoFrameField() {
-        return videoFrameField;
+    public Set<String> videoFrameFields() {
+        return videoFrameFields;
     }
 
     @Nullable

--- a/paimon-core/src/main/java/org/apache/paimon/operation/DataEvolutionFileStoreScan.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/DataEvolutionFileStoreScan.java
@@ -48,6 +48,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
+import java.util.IdentityHashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Queue;
@@ -61,6 +62,7 @@ import static org.apache.paimon.format.blob.BlobFileFormat.isBlobFile;
 import static org.apache.paimon.manifest.ManifestFileMeta.allContainsRowId;
 import static org.apache.paimon.types.VectorType.isVectorStoreFile;
 import static org.apache.paimon.utils.DataEvolutionUtils.fileFieldIds;
+import static org.apache.paimon.utils.DataEvolutionUtils.groupByNormalFileRange;
 import static org.apache.paimon.utils.DataEvolutionUtils.retrieveAnchorFile;
 import static org.apache.paimon.utils.InternalRowUtils.compare;
 import static org.apache.paimon.utils.InternalRowUtils.get;
@@ -189,16 +191,21 @@ public class DataEvolutionFileStoreScan extends AppendOnlyFileStoreScan {
     @Override
     protected List<ManifestEntry> postFilterManifestEntries(List<ManifestEntry> entries) {
         if (inputFilter != null || readType != null) {
-            // group by row id range
-            RangeHelper<ManifestEntry> rangeHelper =
-                    new RangeHelper<>(e -> e.file().nonNullRowIdRange());
-            List<List<ManifestEntry>> splitByRowId = rangeHelper.mergeOverlappingRanges(entries);
-
-            return splitByRowId.stream()
-                    .filter(group -> inputFilter == null || filterByStats(group))
-                    .flatMap(group -> pruneByReadType(group).stream())
-                    .map(entry -> dropStats ? dropStats(entry) : entry)
-                    .collect(Collectors.toList());
+            List<List<ManifestEntry>> splitByRowId =
+                    groupByNormalFileRange(entries, ManifestEntry::file);
+            Set<ManifestEntry> seen = Collections.newSetFromMap(new IdentityHashMap<>());
+            List<ManifestEntry> result = new ArrayList<>();
+            for (List<ManifestEntry> group : splitByRowId) {
+                if (inputFilter != null && !filterByStats(group)) {
+                    continue;
+                }
+                for (ManifestEntry entry : pruneByReadType(group)) {
+                    if (seen.add(entry)) {
+                        result.add(dropStats ? dropStats(entry) : entry);
+                    }
+                }
+            }
+            return result;
         } else if (dropStats) {
             return entries.stream().map(this::dropStats).collect(Collectors.toList());
         } else {
@@ -230,8 +237,15 @@ public class DataEvolutionFileStoreScan extends AppendOnlyFileStoreScan {
         if (readType == null || group.size() <= 1) {
             return group;
         }
+        boolean hasNormalFile =
+                group.stream()
+                        .map(ManifestEntry::file)
+                        .anyMatch(
+                                file ->
+                                        !isBlobFile(file.fileName())
+                                                && !isVectorStoreFile(file.fileName()));
         ManifestEntry anchor =
-                deletionVectorsEnabled ? retrieveAnchorFile(group, ManifestEntry::file) : null;
+                hasNormalFile ? retrieveAnchorFile(group, ManifestEntry::file) : null;
         Set<Integer> readFieldIds = new HashSet<>();
         for (DataField f : readType.getFields()) {
             readFieldIds.add(f.id());
@@ -246,12 +260,14 @@ public class DataEvolutionFileStoreScan extends AppendOnlyFileStoreScan {
                 }
             }
         }
-        if (anchor != null && !kept.contains(anchor)) {
+        if (deletionVectorsEnabled && anchor != null && !kept.contains(anchor)) {
             kept.add(anchor);
         }
         // Group must contribute at least one file so the reader sees rowCount and can NULL-fill
         // missing columns for the projection's rows.
-        return kept.isEmpty() ? Collections.singletonList(group.get(0)) : kept;
+        return kept.isEmpty()
+                ? Collections.singletonList(anchor == null ? group.get(0) : anchor)
+                : kept;
     }
 
     private Set<Integer> fileFieldIdsForEntry(ManifestEntry entry) {
@@ -266,15 +282,23 @@ public class DataEvolutionFileStoreScan extends AppendOnlyFileStoreScan {
             Function<Long, TableSchema> scanTableSchema,
             List<ManifestEntry> metas,
             EvolutionStatsCache evolutionStatsCache) {
-        long groupStart =
+        List<ManifestEntry> rangeMetas =
                 metas.stream()
+                        .filter(entry -> !isBlobFile(entry.file().fileName()))
+                        .filter(entry -> !isVectorStoreFile(entry.file().fileName()))
+                        .collect(Collectors.toList());
+        if (rangeMetas.isEmpty()) {
+            rangeMetas = metas;
+        }
+        long groupStart =
+                rangeMetas.stream()
                         .map(ManifestEntry::file)
                         .map(DataFileMeta::nonNullRowIdRange)
                         .mapToLong(range -> range.from)
                         .min()
                         .orElseThrow(() -> new IllegalArgumentException("Empty evolution group."));
         long groupEnd =
-                metas.stream()
+                rangeMetas.stream()
                         .map(ManifestEntry::file)
                         .map(DataFileMeta::nonNullRowIdRange)
                         .mapToLong(range -> range.to)

--- a/paimon-core/src/main/java/org/apache/paimon/operation/DataEvolutionFileStoreScan.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/DataEvolutionFileStoreScan.java
@@ -249,21 +249,6 @@ public class DataEvolutionFileStoreScan extends AppendOnlyFileStoreScan {
         if (anchor != null && !kept.contains(anchor)) {
             kept.add(anchor);
         }
-        if (kept.stream()
-                .map(ManifestEntry::file)
-                .anyMatch(
-                        file ->
-                                isBlobFile(file.fileName())
-                                        || isVectorStoreFile(file.fileName()))) {
-            for (ManifestEntry entry : group) {
-                DataFileMeta file = entry.file();
-                if (!isBlobFile(file.fileName())
-                        && !isVectorStoreFile(file.fileName())
-                        && !kept.contains(entry)) {
-                    kept.add(entry);
-                }
-            }
-        }
         // Group must contribute at least one file so the reader sees rowCount and can NULL-fill
         // missing columns for the projection's rows.
         return kept.isEmpty() ? Collections.singletonList(group.get(0)) : kept;

--- a/paimon-core/src/main/java/org/apache/paimon/operation/DataEvolutionFileStoreScan.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/DataEvolutionFileStoreScan.java
@@ -249,6 +249,21 @@ public class DataEvolutionFileStoreScan extends AppendOnlyFileStoreScan {
         if (anchor != null && !kept.contains(anchor)) {
             kept.add(anchor);
         }
+        if (kept.stream()
+                .map(ManifestEntry::file)
+                .anyMatch(
+                        file ->
+                                isBlobFile(file.fileName())
+                                        || isVectorStoreFile(file.fileName()))) {
+            for (ManifestEntry entry : group) {
+                DataFileMeta file = entry.file();
+                if (!isBlobFile(file.fileName())
+                        && !isVectorStoreFile(file.fileName())
+                        && !kept.contains(entry)) {
+                    kept.add(entry);
+                }
+            }
+        }
         // Group must contribute at least one file so the reader sees rowCount and can NULL-fill
         // missing columns for the projection's rows.
         return kept.isEmpty() ? Collections.singletonList(group.get(0)) : kept;

--- a/paimon-core/src/main/java/org/apache/paimon/operation/DataEvolutionSplitRead.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/DataEvolutionSplitRead.java
@@ -227,6 +227,7 @@ public class DataEvolutionSplitRead implements SplitRead<InternalRow> {
         DataFilePathFactory dataFilePathFactory =
                 pathFactory.createDataFilePathFactory(partition, dataSplit.bucket());
         List<ReaderSupplier<InternalRow>> suppliers = new ArrayList<>();
+        Map<Path, Object> metadataCache = new HashMap<>();
 
         // the merge path builds its readers with filter push down disabled, so the shared builder
         // carries no filters, the single file path creates its own with per file filters
@@ -251,7 +252,8 @@ public class DataEvolutionSplitRead implements SplitRead<InternalRow> {
                                     filters,
                                     effectiveRowRanges,
                                     readRowType,
-                                    deletionVector);
+                                    deletionVector,
+                                    metadataCache);
                         });
 
             } else {
@@ -269,7 +271,8 @@ public class DataEvolutionSplitRead implements SplitRead<InternalRow> {
                                     formatBuilder,
                                     effectiveRowRanges,
                                     readRowType,
-                                    deletionVector);
+                                    deletionVector,
+                                    metadataCache);
                         });
             }
         }
@@ -293,7 +296,8 @@ public class DataEvolutionSplitRead implements SplitRead<InternalRow> {
             Builder formatBuilder,
             List<Range> rowRanges,
             RowType readRowType,
-            @Nullable DeletionVectorWithRange deletionVector)
+            @Nullable DeletionVectorWithRange deletionVector,
+            Map<Path, Object> metadataCache)
             throws IOException {
         List<FieldBunch> fieldsFiles =
                 splitFieldBunches(
@@ -390,7 +394,8 @@ public class DataEvolutionSplitRead implements SplitRead<InternalRow> {
                                         formatReaderMapping,
                                         rowRanges,
                                         partialReadRowType,
-                                        deletionVector));
+                                        deletionVector,
+                                        metadataCache));
             }
         }
 
@@ -414,7 +419,8 @@ public class DataEvolutionSplitRead implements SplitRead<InternalRow> {
             FormatReaderMapping formatReaderMapping,
             List<Range> rowRanges,
             RowType readRowType,
-            @Nullable DeletionVectorWithRange deletionVector)
+            @Nullable DeletionVectorWithRange deletionVector,
+            Map<Path, Object> metadataCache)
             throws IOException {
         if (bunch instanceof DataBunch) {
             // for data bunch, directly read the single file
@@ -425,7 +431,8 @@ public class DataEvolutionSplitRead implements SplitRead<InternalRow> {
                     formatReaderMapping,
                     rowRanges,
                     readRowType,
-                    deletionVector);
+                    deletionVector,
+                    metadataCache);
         } else if (bunch instanceof VectorFileBunch) {
             // for vector bunch, sequential read all data files and concat them
             return sequentialReadFiles(
@@ -434,7 +441,8 @@ public class DataEvolutionSplitRead implements SplitRead<InternalRow> {
                     dataFilePathFactory,
                     formatReaderMapping,
                     rowRanges,
-                    deletionVector);
+                    deletionVector,
+                    metadataCache);
         } else if (bunch instanceof BlobFileBunch) {
             // for blob bunch, fallback on placeholders
             BlobFileBunch blobBunch = (BlobFileBunch) bunch;
@@ -450,7 +458,8 @@ public class DataEvolutionSplitRead implements SplitRead<InternalRow> {
                                     formatReaderMapping,
                                     rowRanges,
                                     readRowType,
-                                    deletionVector),
+                                    deletionVector,
+                                    metadataCache),
                     (reader, range) ->
                             applyDeletionVector(reader, range, rowRanges, deletionVector),
                     blobBunch.logicalRange(),
@@ -468,7 +477,8 @@ public class DataEvolutionSplitRead implements SplitRead<InternalRow> {
             DataFilePathFactory dataFilePathFactory,
             FormatReaderMapping formatReaderMapping,
             List<Range> rowRanges,
-            @Nullable DeletionVectorWithRange deletionVector)
+            @Nullable DeletionVectorWithRange deletionVector,
+            Map<Path, Object> metadataCache)
             throws IOException {
         List<ReaderSupplier<InternalRow>> readerSuppliers = new ArrayList<>();
         for (DataFileMeta file : files) {
@@ -485,7 +495,8 @@ public class DataEvolutionSplitRead implements SplitRead<InternalRow> {
                                             dataFilePathFactory.toPath(file),
                                             file.fileSize()),
                                     deletionVector,
-                                    null));
+                                    null,
+                                    metadataCache));
         }
         return ConcatRecordReader.create(readerSuppliers);
     }
@@ -506,7 +517,8 @@ public class DataEvolutionSplitRead implements SplitRead<InternalRow> {
             @Nullable List<Predicate> filters,
             List<Range> rowRanges,
             RowType readRowType,
-            @Nullable DeletionVectorWithRange deletionVector)
+            @Nullable DeletionVectorWithRange deletionVector,
+            Map<Path, Object> metadataCache)
             throws IOException {
         FileReadTarget readTarget = readTarget(file, dataFilePathFactory, rowRanges);
         String formatIdentifier = readTarget.formatIdentifier;
@@ -549,7 +561,8 @@ public class DataEvolutionSplitRead implements SplitRead<InternalRow> {
                 readRowType,
                 readTarget,
                 deletionVector,
-                fileIndexResult);
+                fileIndexResult,
+                metadataCache);
     }
 
     private FileRecordReader<InternalRow> createFileReader(
@@ -559,7 +572,8 @@ public class DataEvolutionSplitRead implements SplitRead<InternalRow> {
             FormatReaderMapping formatReaderMapping,
             List<Range> rowRanges,
             RowType readRowType,
-            @Nullable DeletionVectorWithRange deletionVector)
+            @Nullable DeletionVectorWithRange deletionVector,
+            Map<Path, Object> metadataCache)
             throws IOException {
         return createFileReader(
                 partition,
@@ -569,7 +583,8 @@ public class DataEvolutionSplitRead implements SplitRead<InternalRow> {
                 readRowType,
                 readTarget(file, dataFilePathFactory, rowRanges),
                 deletionVector,
-                null);
+                null,
+                metadataCache);
     }
 
     private FileRecordReader<InternalRow> createFileReader(
@@ -580,7 +595,8 @@ public class DataEvolutionSplitRead implements SplitRead<InternalRow> {
             RowType readRowType,
             FileReadTarget readTarget,
             @Nullable DeletionVectorWithRange deletionVector,
-            @Nullable FileIndexResult fileIndexResult)
+            @Nullable FileIndexResult fileIndexResult,
+            Map<Path, Object> metadataCache)
             throws IOException {
         RoaringBitmap32 selection = file.toFileSelection(rowRanges);
         BitmapIndexResult bitmapIndexResult =
@@ -600,7 +616,12 @@ public class DataEvolutionSplitRead implements SplitRead<InternalRow> {
 
         FormatReaderContext formatReaderContext =
                 new FormatReaderContext(
-                        fileIO, readTarget.path, readTarget.fileSize, selection, readBatchSizer);
+                        fileIO,
+                        readTarget.path,
+                        readTarget.fileSize,
+                        selection,
+                        readBatchSizer,
+                        metadataCache);
         FileRecordReader<InternalRow> fileRecordReader =
                 new DataFileRecordReader(
                         readRowType,

--- a/paimon-core/src/main/java/org/apache/paimon/operation/DataEvolutionSplitRead.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/DataEvolutionSplitRead.java
@@ -93,6 +93,7 @@ import static org.apache.paimon.predicate.PredicateVisitor.collectFieldNames;
 import static org.apache.paimon.table.SpecialFields.rowTypeWithRowTracking;
 import static org.apache.paimon.types.BlobType.isBlobFileField;
 import static org.apache.paimon.types.VectorType.isVectorStoreFile;
+import static org.apache.paimon.utils.DataEvolutionUtils.groupByNormalFileRange;
 import static org.apache.paimon.utils.DataEvolutionUtils.retrieveAnchorFile;
 import static org.apache.paimon.utils.ListUtils.isNullOrEmpty;
 import static org.apache.paimon.utils.Preconditions.checkArgument;
@@ -236,6 +237,7 @@ public class DataEvolutionSplitRead implements SplitRead<InternalRow> {
 
         List<List<DataFileMeta>> splitByRowId = mergeRangesAndSort(files);
         for (List<DataFileMeta> needMergeFiles : splitByRowId) {
+            List<Range> effectiveRowRanges = anchoredRowRanges(needMergeFiles, rowRanges);
             if (needMergeFiles.size() == 1 || readRowType.getFields().isEmpty()) {
                 // No need to merge fields, just create a single file reader
                 suppliers.add(
@@ -247,7 +249,7 @@ public class DataEvolutionSplitRead implements SplitRead<InternalRow> {
                                     dataFilePathFactory,
                                     needMergeFiles.get(0),
                                     filters,
-                                    rowRanges,
+                                    effectiveRowRanges,
                                     readRowType,
                                     deletionVector);
                         });
@@ -265,7 +267,7 @@ public class DataEvolutionSplitRead implements SplitRead<InternalRow> {
                                     partition,
                                     dataFilePathFactory,
                                     formatBuilder,
-                                    rowRanges,
+                                    effectiveRowRanges,
                                     readRowType,
                                     deletionVector);
                         });
@@ -1107,11 +1109,20 @@ public class DataEvolutionSplitRead implements SplitRead<InternalRow> {
             List<Range> merged = Range.sortAndMergeOverlap(ranges, true);
             if (expectedRowRange != null) {
                 for (Range range : merged) {
-                    Preconditions.checkState(
-                            range.from >= expectedRowRange.from && range.to <= expectedRowRange.to,
-                            "Blob file range %s should be within normal file range %s.",
-                            range,
-                            expectedRowRange);
+                    if (rowIdPushdown) {
+                        Preconditions.checkState(
+                                range.hasIntersection(expectedRowRange),
+                                "Blob file range %s should intersect normal file range %s.",
+                                range,
+                                expectedRowRange);
+                    } else {
+                        Preconditions.checkState(
+                                range.from >= expectedRowRange.from
+                                        && range.to <= expectedRowRange.to,
+                                "Blob file range %s should be within normal file range %s.",
+                                range,
+                                expectedRowRange);
+                    }
                 }
                 return expectedRowRange.count();
             }
@@ -1231,7 +1242,7 @@ public class DataEvolutionSplitRead implements SplitRead<InternalRow> {
         // group by row id range
         ToLongFunction<DataFileMeta> maxSeqF = DataFileMeta::maxSequenceNumber;
         RangeHelper<DataFileMeta> rangeHelper = new RangeHelper<>(DataFileMeta::nonNullRowIdRange);
-        List<List<DataFileMeta>> result = rangeHelper.mergeOverlappingRanges(files);
+        List<List<DataFileMeta>> result = groupByNormalFileRange(files, Function.identity());
 
         // in group, sort by blob/vector-store file and max_seq
         for (List<DataFileMeta> group : result) {
@@ -1274,6 +1285,51 @@ public class DataEvolutionSplitRead implements SplitRead<InternalRow> {
         }
 
         return result;
+    }
+
+    private static List<Range> anchoredRowRanges(
+            List<DataFileMeta> files, @Nullable List<Range> requestedRanges) {
+        Range anchor = null;
+        for (DataFileMeta file : files) {
+            if (!isBlobFile(file.fileName()) && !isVectorStoreFile(file.fileName())) {
+                Range range = file.nonNullRowIdRange();
+                if (anchor == null) {
+                    anchor = range;
+                } else {
+                    checkArgument(
+                            anchor.equals(range),
+                            "Normal data files should have the same row range: %s and %s.",
+                            anchor,
+                            range);
+                }
+            }
+        }
+        if (anchor == null) {
+            return requestedRanges;
+        }
+        if (requestedRanges == null) {
+            Range anchorRange = anchor;
+            boolean hasSpanningSidecar =
+                    files.stream()
+                            .filter(
+                                    file ->
+                                            isBlobFile(file.fileName())
+                                                    || isVectorStoreFile(file.fileName()))
+                            .map(DataFileMeta::nonNullRowIdRange)
+                            .anyMatch(
+                                    range ->
+                                            range.from < anchorRange.from
+                                                    || range.to > anchorRange.to);
+            return hasSpanningSidecar ? Collections.singletonList(anchorRange) : null;
+        }
+        List<Range> intersections = new ArrayList<>();
+        for (Range requested : requestedRanges) {
+            Range intersection = Range.intersection(anchor, requested);
+            if (intersection != null) {
+                intersections.add(intersection);
+            }
+        }
+        return intersections;
     }
 
     static final class VectorStoreBunchKey implements Comparable<VectorStoreBunchKey> {

--- a/paimon-core/src/main/java/org/apache/paimon/operation/FileStoreCommitImpl.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/FileStoreCommitImpl.java
@@ -566,6 +566,7 @@ public class FileStoreCommitImpl implements FileStoreCommit {
                         tryOverwritePartition(
                                 partitionFilter,
                                 changes.appendTableFiles,
+                                changes.appendTableFileGroups,
                                 changes.appendIndexFiles,
                                 committable.identifier(),
                                 committable.watermark(),
@@ -689,13 +690,25 @@ public class FileStoreCommitImpl implements FileStoreCommit {
         }
 
         tryOverwritePartition(
-                partitionFilter, emptyList(), emptyList(), commitIdentifier, null, new HashMap<>());
+                partitionFilter,
+                emptyList(),
+                Collections.emptyMap(),
+                emptyList(),
+                commitIdentifier,
+                null,
+                new HashMap<>());
     }
 
     @Override
     public void truncateTable(long commitIdentifier) {
         tryOverwritePartition(
-                null, emptyList(), emptyList(), commitIdentifier, null, new HashMap<>());
+                null,
+                emptyList(),
+                Collections.emptyMap(),
+                emptyList(),
+                commitIdentifier,
+                null,
+                new HashMap<>());
     }
 
     @Override
@@ -938,13 +951,14 @@ public class FileStoreCommitImpl implements FileStoreCommit {
     private int tryOverwritePartition(
             @Nullable PartitionPredicate partitionFilter,
             List<ManifestEntry> changes,
+            Map<FileEntry.Identifier, Integer> changeGroups,
             List<IndexManifestEntry> indexFiles,
             long identifier,
             @Nullable Long watermark,
             Map<String, String> properties) {
         return tryCommit(
                 scanner.overwriteChangesProvider(
-                        options.bucket(), changes, indexFiles, partitionFilter),
+                        options.bucket(), changes, changeGroups, indexFiles, partitionFilter),
                 identifier,
                 watermark,
                 properties,

--- a/paimon-core/src/main/java/org/apache/paimon/operation/FileStoreCommitImpl.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/FileStoreCommitImpl.java
@@ -376,7 +376,8 @@ public class FileStoreCommitImpl implements FileStoreCommit {
                                 CommitChangesProvider.provider(
                                         changes.appendTableFiles,
                                         changes.appendChangelog,
-                                        changes.appendIndexFiles),
+                                        changes.appendIndexFiles,
+                                        changes.appendTableFileGroups),
                                 committable.identifier(),
                                 committable.watermark(),
                                 committable.properties(),
@@ -847,6 +848,7 @@ public class FileStoreCommitImpl implements FileStoreCommit {
                             changes.tableFiles,
                             changes.changelogFiles,
                             changes.indexFiles,
+                            changes.tableFileGroups,
                             identifier,
                             watermark,
                             properties,
@@ -968,6 +970,36 @@ public class FileStoreCommitImpl implements FileStoreCommit {
             List<ManifestEntry> deltaFiles,
             List<ManifestEntry> changelogFiles,
             List<IndexManifestEntry> indexFiles,
+            long identifier,
+            @Nullable Long watermark,
+            Map<String, String> properties,
+            CommitKind commitKind,
+            boolean allowRollback,
+            @Nullable Snapshot latestSnapshot,
+            boolean detectConflicts,
+            @Nullable String newStatsFileName) {
+        return tryCommitOnce(
+                retryResult,
+                deltaFiles,
+                changelogFiles,
+                indexFiles,
+                Collections.emptyMap(),
+                identifier,
+                watermark,
+                properties,
+                commitKind,
+                allowRollback,
+                latestSnapshot,
+                detectConflicts,
+                newStatsFileName);
+    }
+
+    private CommitResult tryCommitOnce(
+            @Nullable RetryCommitResult retryResult,
+            List<ManifestEntry> deltaFiles,
+            List<ManifestEntry> changelogFiles,
+            List<IndexManifestEntry> indexFiles,
+            Map<FileEntry.Identifier, Integer> rowTrackingGroups,
             long identifier,
             @Nullable Long watermark,
             Map<String, String> properties,
@@ -1159,7 +1191,8 @@ public class FileStoreCommitImpl implements FileStoreCommit {
                                     .collect(Collectors.toList());
                 }
                 RowTrackingAssigned assigned =
-                        assignRowTracking(newSnapshotId, firstRowIdStart, deltaFiles);
+                        assignRowTracking(
+                                newSnapshotId, firstRowIdStart, deltaFiles, rowTrackingGroups);
                 nextRowIdStart = assigned.nextRowIdStart;
                 deltaFiles = assigned.assignedEntries;
             }

--- a/paimon-core/src/main/java/org/apache/paimon/operation/commit/CommitChanges.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/commit/CommitChanges.java
@@ -18,10 +18,13 @@
 
 package org.apache.paimon.operation.commit;
 
+import org.apache.paimon.manifest.FileEntry;
 import org.apache.paimon.manifest.IndexManifestEntry;
 import org.apache.paimon.manifest.ManifestEntry;
 
+import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 
 /** Commit changes. */
 public class CommitChanges {
@@ -29,13 +32,23 @@ public class CommitChanges {
     public final List<ManifestEntry> tableFiles;
     public final List<ManifestEntry> changelogFiles;
     public final List<IndexManifestEntry> indexFiles;
+    public final Map<FileEntry.Identifier, Integer> tableFileGroups;
 
     public CommitChanges(
             List<ManifestEntry> tableFiles,
             List<ManifestEntry> changelogFiles,
             List<IndexManifestEntry> indexFiles) {
+        this(tableFiles, changelogFiles, indexFiles, Collections.emptyMap());
+    }
+
+    public CommitChanges(
+            List<ManifestEntry> tableFiles,
+            List<ManifestEntry> changelogFiles,
+            List<IndexManifestEntry> indexFiles,
+            Map<FileEntry.Identifier, Integer> tableFileGroups) {
         this.tableFiles = tableFiles;
         this.changelogFiles = changelogFiles;
         this.indexFiles = indexFiles;
+        this.tableFileGroups = tableFileGroups;
     }
 }

--- a/paimon-core/src/main/java/org/apache/paimon/operation/commit/CommitChangesProvider.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/commit/CommitChangesProvider.java
@@ -19,12 +19,14 @@
 package org.apache.paimon.operation.commit;
 
 import org.apache.paimon.Snapshot;
+import org.apache.paimon.manifest.FileEntry;
 import org.apache.paimon.manifest.IndexManifestEntry;
 import org.apache.paimon.manifest.ManifestEntry;
 
 import javax.annotation.Nullable;
 
 import java.util.List;
+import java.util.Map;
 
 /** Provider to provide {@link CommitChanges}. */
 @FunctionalInterface
@@ -37,5 +39,13 @@ public interface CommitChangesProvider {
             List<ManifestEntry> changelogFiles,
             List<IndexManifestEntry> indexFiles) {
         return s -> new CommitChanges(tableFiles, changelogFiles, indexFiles);
+    }
+
+    static CommitChangesProvider provider(
+            List<ManifestEntry> tableFiles,
+            List<ManifestEntry> changelogFiles,
+            List<IndexManifestEntry> indexFiles,
+            Map<FileEntry.Identifier, Integer> tableFileGroups) {
+        return s -> new CommitChanges(tableFiles, changelogFiles, indexFiles, tableFileGroups);
     }
 }

--- a/paimon-core/src/main/java/org/apache/paimon/operation/commit/CommitScanner.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/commit/CommitScanner.java
@@ -21,6 +21,7 @@ package org.apache.paimon.operation.commit;
 import org.apache.paimon.CoreOptions;
 import org.apache.paimon.Snapshot;
 import org.apache.paimon.data.BinaryRow;
+import org.apache.paimon.manifest.FileEntry;
 import org.apache.paimon.manifest.IndexManifestEntry;
 import org.apache.paimon.manifest.IndexManifestFile;
 import org.apache.paimon.manifest.ManifestEntry;
@@ -179,6 +180,7 @@ public class CommitScanner {
     public CommitChangesProvider overwriteChangesProvider(
             int numBucket,
             List<ManifestEntry> changes,
+            Map<FileEntry.Identifier, Integer> changeGroups,
             List<IndexManifestEntry> indexFiles,
             @Nullable PartitionPredicate partitionFilter) {
         return new OverwriteChangesProvider(
@@ -188,6 +190,7 @@ public class CommitScanner {
                 dropStats,
                 numBucket,
                 changes,
+                changeGroups,
                 indexFiles,
                 partitionFilter);
     }

--- a/paimon-core/src/main/java/org/apache/paimon/operation/commit/ManifestEntryChanges.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/commit/ManifestEntryChanges.java
@@ -29,7 +29,9 @@ import org.apache.paimon.table.sink.CommitMessageImpl;
 
 import java.util.ArrayList;
 import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 import static org.apache.paimon.deletionvectors.DeletionVectorsIndexFile.DELETION_VECTORS_INDEX;
@@ -40,15 +42,18 @@ public class ManifestEntryChanges {
     private final int defaultNumBucket;
 
     public List<ManifestEntry> appendTableFiles;
+    public Map<FileEntry.Identifier, Integer> appendTableFileGroups;
     public List<ManifestEntry> appendChangelog;
     public List<IndexManifestEntry> appendIndexFiles;
     public List<ManifestEntry> compactTableFiles;
     public List<ManifestEntry> compactChangelog;
     public List<IndexManifestEntry> compactIndexFiles;
+    private int nextAppendTableFileGroup;
 
     public ManifestEntryChanges(int defaultNumBucket) {
         this.defaultNumBucket = defaultNumBucket;
         this.appendTableFiles = new ArrayList<>();
+        this.appendTableFileGroups = new LinkedHashMap<>();
         this.appendChangelog = new ArrayList<>();
         this.appendIndexFiles = new ArrayList<>();
         this.compactTableFiles = new ArrayList<>();
@@ -58,10 +63,16 @@ public class ManifestEntryChanges {
 
     public void collect(CommitMessage message) {
         CommitMessageImpl commitMessage = (CommitMessageImpl) message;
+        int appendTableFileGroup = nextAppendTableFileGroup++;
         commitMessage
                 .newFilesIncrement()
                 .newFiles()
-                .forEach(m -> appendTableFiles.add(makeEntry(FileKind.ADD, commitMessage, m)));
+                .forEach(
+                        m -> {
+                            ManifestEntry entry = makeEntry(FileKind.ADD, commitMessage, m);
+                            appendTableFiles.add(entry);
+                            appendTableFileGroups.put(entry.identifier(), appendTableFileGroup);
+                        });
         commitMessage
                 .newFilesIncrement()
                 .deletedFiles()

--- a/paimon-core/src/main/java/org/apache/paimon/operation/commit/OverwriteChangesProvider.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/commit/OverwriteChangesProvider.java
@@ -21,6 +21,7 @@ package org.apache.paimon.operation.commit;
 import org.apache.paimon.Snapshot;
 import org.apache.paimon.Snapshot.CommitKind;
 import org.apache.paimon.annotation.VisibleForTesting;
+import org.apache.paimon.manifest.FileEntry;
 import org.apache.paimon.manifest.FileKind;
 import org.apache.paimon.manifest.IndexManifestEntry;
 import org.apache.paimon.manifest.IndexManifestFile;
@@ -40,6 +41,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.function.Supplier;
 
@@ -60,6 +62,7 @@ public class OverwriteChangesProvider implements CommitChangesProvider {
     private final boolean dropStats;
     private final int numBucket;
     private final List<ManifestEntry> newChanges;
+    private final Map<FileEntry.Identifier, Integer> newChangeGroups;
     private final List<IndexManifestEntry> newIndexFiles;
     @Nullable private final PartitionPredicate partitionFilter;
 
@@ -78,6 +81,7 @@ public class OverwriteChangesProvider implements CommitChangesProvider {
             boolean dropStats,
             int numBucket,
             List<ManifestEntry> newChanges,
+            Map<FileEntry.Identifier, Integer> newChangeGroups,
             List<IndexManifestEntry> newIndexFiles,
             @Nullable PartitionPredicate partitionFilter) {
         this.scanSupplier = scanSupplier;
@@ -86,6 +90,7 @@ public class OverwriteChangesProvider implements CommitChangesProvider {
         this.dropStats = dropStats;
         this.numBucket = numBucket;
         this.newChanges = newChanges;
+        this.newChangeGroups = newChangeGroups;
         this.newIndexFiles = newIndexFiles;
         this.partitionFilter = partitionFilter;
     }
@@ -93,7 +98,8 @@ public class OverwriteChangesProvider implements CommitChangesProvider {
     @Override
     public CommitChanges provide(@Nullable Snapshot latestSnapshot) {
         if (latestSnapshot == null) {
-            return new CommitChanges(newChanges, Collections.emptyList(), newIndexFiles);
+            return new CommitChanges(
+                    newChanges, Collections.emptyList(), newIndexFiles, newChangeGroups);
         }
 
         if (cachedSnapshot == null) {
@@ -225,6 +231,9 @@ public class OverwriteChangesProvider implements CommitChangesProvider {
         indexChangesWithOverwrite.addAll(newIndexFiles);
 
         return new CommitChanges(
-                changesWithOverwrite, Collections.emptyList(), indexChangesWithOverwrite);
+                changesWithOverwrite,
+                Collections.emptyList(),
+                indexChangesWithOverwrite,
+                newChangeGroups);
     }
 }

--- a/paimon-core/src/main/java/org/apache/paimon/operation/commit/RowTrackingCommitUtils.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/commit/RowTrackingCommitUtils.java
@@ -24,6 +24,7 @@ import org.apache.paimon.table.SpecialFields;
 
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.IdentityHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -76,9 +77,24 @@ public class RowTrackingCommitUtils {
         if (deltaFiles.isEmpty()) {
             return firstRowIdStart;
         }
-        // assign row id for new files
+        // Normal files own the appended row range. Assign them first so independently rolling
+        // Blob files may span any number of normal files without depending on metadata order.
         long start = firstRowIdStart;
-        long blobStartDefault = firstRowIdStart;
+        Map<ManifestEntry, Long> normalStarts = new IdentityHashMap<>();
+        for (ManifestEntry entry : deltaFiles) {
+            List<String> writeCols = entry.file().writeCols();
+            boolean containsRowId =
+                    writeCols != null && writeCols.contains(SpecialFields.ROW_ID.name());
+            if (entry.file().fileSource().orElse(null) == FileSource.APPEND
+                    && entry.file().firstRowId() == null
+                    && !containsRowId
+                    && !isBlobFile(entry.file().fileName())
+                    && !isVectorStoreFile(entry.file().fileName())) {
+                normalStarts.put(entry, start);
+                start += entry.file().rowCount();
+            }
+        }
+
         Map<String, Long> blobStarts = new HashMap<>();
         long vectorStoreStart = firstRowIdStart;
         for (ManifestEntry entry : deltaFiles) {
@@ -95,7 +111,7 @@ public class RowTrackingCommitUtils {
                 long rowCount = entry.file().rowCount();
                 if (isBlobFile(entry.file().fileName())) {
                     String blobFieldName = entry.file().writeCols().get(0);
-                    long blobStart = blobStarts.getOrDefault(blobFieldName, blobStartDefault);
+                    long blobStart = blobStarts.getOrDefault(blobFieldName, firstRowIdStart);
                     if (blobStart >= start) {
                         throw new IllegalStateException(
                                 String.format(
@@ -114,10 +130,7 @@ public class RowTrackingCommitUtils {
                     rowIdAssigned.add(entry.assignFirstRowId(vectorStoreStart));
                     vectorStoreStart += rowCount;
                 } else {
-                    rowIdAssigned.add(entry.assignFirstRowId(start));
-                    blobStartDefault = start;
-                    blobStarts.clear();
-                    start += rowCount;
+                    rowIdAssigned.add(entry.assignFirstRowId(normalStarts.get(entry)));
                 }
             } else {
                 // for compact file, do not assign first row id.

--- a/paimon-core/src/main/java/org/apache/paimon/operation/commit/RowTrackingCommitUtils.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/commit/RowTrackingCommitUtils.java
@@ -18,13 +18,16 @@
 
 package org.apache.paimon.operation.commit;
 
+import org.apache.paimon.manifest.FileEntry;
 import org.apache.paimon.manifest.FileSource;
 import org.apache.paimon.manifest.ManifestEntry;
 import org.apache.paimon.table.SpecialFields;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.IdentityHashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -38,13 +41,22 @@ public class RowTrackingCommitUtils {
 
     public static RowTrackingAssigned assignRowTracking(
             long newSnapshotId, long firstRowIdStart, List<ManifestEntry> deltaFiles) {
+        return assignRowTracking(
+                newSnapshotId, firstRowIdStart, deltaFiles, Collections.emptyMap());
+    }
+
+    public static RowTrackingAssigned assignRowTracking(
+            long newSnapshotId,
+            long firstRowIdStart,
+            List<ManifestEntry> deltaFiles,
+            Map<FileEntry.Identifier, Integer> fileGroups) {
         // assigned snapshot id to delta files
         List<ManifestEntry> snapshotAssigned = new ArrayList<>();
         assignSnapshotId(newSnapshotId, deltaFiles, snapshotAssigned);
         // assign row id for new files
         List<ManifestEntry> rowIdAssigned = new ArrayList<>();
         long nextRowIdStart =
-                assignRowTrackingMeta(firstRowIdStart, snapshotAssigned, rowIdAssigned);
+                assignRowTrackingMeta(firstRowIdStart, snapshotAssigned, fileGroups, rowIdAssigned);
         return new RowTrackingAssigned(nextRowIdStart, rowIdAssigned);
     }
 
@@ -73,21 +85,43 @@ public class RowTrackingCommitUtils {
     private static long assignRowTrackingMeta(
             long firstRowIdStart,
             List<ManifestEntry> deltaFiles,
+            Map<FileEntry.Identifier, Integer> fileGroups,
             List<ManifestEntry> rowIdAssigned) {
         if (deltaFiles.isEmpty()) {
             return firstRowIdStart;
         }
-        // Normal files own the appended row range. Assign them first so independently rolling
-        // Blob files may span any number of normal files without depending on metadata order.
+
+        Object defaultGroup = new Object();
+        Map<Object, List<ManifestEntry>> groupedFiles = new LinkedHashMap<>();
+        for (ManifestEntry entry : deltaFiles) {
+            Object group = fileGroups.isEmpty() ? defaultGroup : fileGroups.get(entry.identifier());
+            // Entries not produced by an original CommitMessage do not share an implicit range.
+            if (group == null) {
+                group = entry;
+            }
+            groupedFiles.computeIfAbsent(group, ignored -> new ArrayList<>()).add(entry);
+        }
+
+        Map<ManifestEntry, ManifestEntry> assigned = new IdentityHashMap<>();
+        long start = firstRowIdStart;
+        for (List<ManifestEntry> group : groupedFiles.values()) {
+            start = assignRowTrackingGroup(start, group, assigned);
+        }
+
+        for (ManifestEntry entry : deltaFiles) {
+            rowIdAssigned.add(assigned.get(entry));
+        }
+        return start;
+    }
+
+    private static long assignRowTrackingGroup(
+            long firstRowIdStart,
+            List<ManifestEntry> deltaFiles,
+            Map<ManifestEntry, ManifestEntry> assigned) {
         long start = firstRowIdStart;
         Map<ManifestEntry, Long> normalStarts = new IdentityHashMap<>();
         for (ManifestEntry entry : deltaFiles) {
-            List<String> writeCols = entry.file().writeCols();
-            boolean containsRowId =
-                    writeCols != null && writeCols.contains(SpecialFields.ROW_ID.name());
-            if (entry.file().fileSource().orElse(null) == FileSource.APPEND
-                    && entry.file().firstRowId() == null
-                    && !containsRowId
+            if (isUnassignedAppend(entry)
                     && !isBlobFile(entry.file().fileName())
                     && !isVectorStoreFile(entry.file().fileName())) {
                 normalStarts.put(entry, start);
@@ -118,7 +152,7 @@ public class RowTrackingCommitUtils {
                                         "This is a bug, blobStart %d should be less than start %d when assigning a blob entry file.",
                                         blobStart, start));
                     }
-                    rowIdAssigned.add(entry.assignFirstRowId(blobStart));
+                    assigned.put(entry, entry.assignFirstRowId(blobStart));
                     blobStarts.put(blobFieldName, blobStart + rowCount);
                 } else if (isVectorStoreFile(entry.file().fileName())) {
                     if (vectorStoreStart >= start) {
@@ -127,17 +161,26 @@ public class RowTrackingCommitUtils {
                                         "This is a bug, vectorStoreStart %d should be less than start %d when assigning a vector-store entry file.",
                                         vectorStoreStart, start));
                     }
-                    rowIdAssigned.add(entry.assignFirstRowId(vectorStoreStart));
+                    assigned.put(entry, entry.assignFirstRowId(vectorStoreStart));
                     vectorStoreStart += rowCount;
                 } else {
-                    rowIdAssigned.add(entry.assignFirstRowId(normalStarts.get(entry)));
+                    assigned.put(entry, entry.assignFirstRowId(normalStarts.get(entry)));
                 }
             } else {
                 // for compact file, do not assign first row id.
-                rowIdAssigned.add(entry);
+                assigned.put(entry, entry);
             }
         }
         return start;
+    }
+
+    private static boolean isUnassignedAppend(ManifestEntry entry) {
+        List<String> writeCols = entry.file().writeCols();
+        boolean containsRowId =
+                writeCols != null && writeCols.contains(SpecialFields.ROW_ID.name());
+        return entry.file().fileSource().orElse(null) == FileSource.APPEND
+                && entry.file().firstRowId() == null
+                && !containsRowId;
     }
 
     /** Assigned results. */

--- a/paimon-core/src/main/java/org/apache/paimon/schema/SchemaValidation.java
+++ b/paimon-core/src/main/java/org/apache/paimon/schema/SchemaValidation.java
@@ -1684,9 +1684,8 @@ public class SchemaValidation {
             CoreOptions options,
             Set<String> blobDescriptorFields,
             Set<String> blobViewFields) {
-        Optional<String> configured = options.videoFrameField();
-        if (configured.isPresent()) {
-            String field = configured.get();
+        Set<String> configured = options.videoFrameFields();
+        for (String field : configured) {
             checkArgument(
                     rowType.containsField(field)
                             && rowType.getTypeAt(rowType.getFieldIndex(field)).getTypeRoot()
@@ -1708,7 +1707,7 @@ public class SchemaValidation {
                     CoreOptions.BLOB_VIEW_FIELD.key());
         }
         checkArgument(
-                !configured.isPresent() || schema.primaryKeys().isEmpty(),
+                configured.isEmpty() || schema.primaryKeys().isEmpty(),
                 "'%s' only supports append-only tables.",
                 CoreOptions.VIDEO_FRAME_FIELD.key());
     }

--- a/paimon-core/src/main/java/org/apache/paimon/table/source/DataEvolutionSplitGenerator.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/source/DataEvolutionSplitGenerator.java
@@ -110,13 +110,19 @@ public class DataEvolutionSplitGenerator implements SplitGenerator {
         long currentWeight = 0;
 
         for (List<DataFileMeta> range : ranges) {
-            long weight = incrementalRangeWeight(range, seenSidecars, sharedSidecars);
+            long weight = incrementalRangeWeight(range, seenSidecars, Collections.emptySet());
+            if (current.isEmpty() && weight > targetSplitSize) {
+                weight = incrementalRangeWeight(range, seenSidecars, sharedSidecars);
+            }
             if (!current.isEmpty() && currentWeight + weight > targetSplitSize) {
                 packed.add(current);
                 current = new ArrayList<>();
                 seenSidecars = Collections.newSetFromMap(new IdentityHashMap<>());
                 currentWeight = 0;
-                weight = incrementalRangeWeight(range, seenSidecars, sharedSidecars);
+                weight = incrementalRangeWeight(range, seenSidecars, Collections.emptySet());
+                if (weight > targetSplitSize) {
+                    weight = incrementalRangeWeight(range, seenSidecars, sharedSidecars);
+                }
             }
             current.add(range);
             currentWeight += weight;
@@ -134,14 +140,14 @@ public class DataEvolutionSplitGenerator implements SplitGenerator {
     private long incrementalRangeWeight(
             List<DataFileMeta> files,
             Set<DataFileMeta> seenSidecars,
-            Set<DataFileMeta> sharedSidecars) {
+            Set<DataFileMeta> ignoredSidecars) {
         Set<DataFileMeta> seenInRange = Collections.newSetFromMap(new IdentityHashMap<>());
         long size =
                 files.stream()
                         .filter(
                                 file ->
                                         !isSidecar(file)
-                                                || (!sharedSidecars.contains(file)
+                                                || (!ignoredSidecars.contains(file)
                                                         && !seenSidecars.contains(file)
                                                         && seenInRange.add(file)))
                         .mapToLong(this::fileWeight)

--- a/paimon-core/src/main/java/org/apache/paimon/table/source/DataEvolutionSplitGenerator.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/source/DataEvolutionSplitGenerator.java
@@ -87,9 +87,7 @@ public class DataEvolutionSplitGenerator implements SplitGenerator {
         return packed.stream()
                 .map(
                         f -> {
-                            boolean rawConvertible =
-                                    !hasSpanningSidecar
-                                            && f.stream().allMatch(file -> file.size() == 1);
+                            boolean rawConvertible = f.stream().allMatch(file -> file.size() == 1);
                             Set<DataFileMeta> unique =
                                     Collections.newSetFromMap(new IdentityHashMap<>());
                             List<DataFileMeta> groupFiles =

--- a/paimon-core/src/main/java/org/apache/paimon/table/source/DataEvolutionSplitGenerator.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/source/DataEvolutionSplitGenerator.java
@@ -22,6 +22,7 @@ import org.apache.paimon.format.blob.BlobFileFormat;
 import org.apache.paimon.io.DataFileMeta;
 import org.apache.paimon.utils.BinPacking;
 
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.IdentityHashMap;
@@ -57,10 +58,15 @@ public class DataEvolutionSplitGenerator implements SplitGenerator {
         List<List<DataFileMeta>> ranges = groupByNormalFileRange(input, Function.identity());
         Set<DataFileMeta> seen = Collections.newSetFromMap(new IdentityHashMap<>());
         boolean hasSpanningSidecar =
-                ranges.stream().flatMap(Collection::stream).anyMatch(file -> !seen.add(file));
-        Function<List<DataFileMeta>, Long> weightFunc =
-                files -> rangeWeight(files, hasSpanningSidecar);
-        return BinPacking.packForOrdered(ranges, weightFunc, targetSplitSize).stream()
+                ranges.stream()
+                        .flatMap(Collection::stream)
+                        .filter(DataEvolutionSplitGenerator::isSidecar)
+                        .anyMatch(file -> !seen.add(file));
+        List<List<List<DataFileMeta>>> packed =
+                hasSpanningSidecar
+                        ? packWithUniqueSidecars(ranges)
+                        : BinPacking.packForOrdered(ranges, this::rangeWeight, targetSplitSize);
+        return packed.stream()
                 .map(
                         f -> {
                             boolean rawConvertible =
@@ -80,24 +86,56 @@ public class DataEvolutionSplitGenerator implements SplitGenerator {
                 .collect(Collectors.toList());
     }
 
-    private long rangeWeight(List<DataFileMeta> files, boolean hasSpanningSidecar) {
-        if (hasSpanningSidecar) {
-            List<DataFileMeta> normalFiles =
-                    files.stream().filter(file -> !isSidecar(file)).collect(Collectors.toList());
-            if (!normalFiles.isEmpty()) {
-                return Math.max(
-                        normalFiles.stream().mapToLong(DataFileMeta::fileSize).sum(), openFileCost);
+    private List<List<List<DataFileMeta>>> packWithUniqueSidecars(List<List<DataFileMeta>> ranges) {
+        List<List<List<DataFileMeta>>> packed = new ArrayList<>();
+        List<List<DataFileMeta>> current = new ArrayList<>();
+        Set<DataFileMeta> seenSidecars = Collections.newSetFromMap(new IdentityHashMap<>());
+        long currentWeight = 0;
+
+        for (List<DataFileMeta> range : ranges) {
+            long weight = incrementalRangeWeight(range, seenSidecars);
+            if (!current.isEmpty() && currentWeight + weight > targetSplitSize) {
+                packed.add(current);
+                current = new ArrayList<>();
+                seenSidecars = Collections.newSetFromMap(new IdentityHashMap<>());
+                currentWeight = 0;
+                weight = incrementalRangeWeight(range, seenSidecars);
             }
+            current.add(range);
+            currentWeight += weight;
+            range.stream()
+                    .filter(DataEvolutionSplitGenerator::isSidecar)
+                    .forEach(seenSidecars::add);
         }
-        return Math.max(
+
+        if (!current.isEmpty()) {
+            packed.add(current);
+        }
+        return packed;
+    }
+
+    private long incrementalRangeWeight(List<DataFileMeta> files, Set<DataFileMeta> seenSidecars) {
+        Set<DataFileMeta> seenInRange = Collections.newSetFromMap(new IdentityHashMap<>());
+        long size =
                 files.stream()
-                        .mapToLong(
+                        .filter(
                                 file ->
-                                        BlobFileFormat.isBlobFile(file.fileName())
-                                                ? countBlobSize ? file.fileSize() : openFileCost
-                                                : file.fileSize())
-                        .sum(),
-                openFileCost);
+                                        !isSidecar(file)
+                                                || (!seenSidecars.contains(file)
+                                                        && seenInRange.add(file)))
+                        .mapToLong(this::fileWeight)
+                        .sum();
+        return Math.max(size, openFileCost);
+    }
+
+    private long rangeWeight(List<DataFileMeta> files) {
+        return Math.max(files.stream().mapToLong(this::fileWeight).sum(), openFileCost);
+    }
+
+    private long fileWeight(DataFileMeta file) {
+        return BlobFileFormat.isBlobFile(file.fileName())
+                ? countBlobSize ? file.fileSize() : openFileCost
+                : file.fileSize();
     }
 
     private static boolean isSidecar(DataFileMeta file) {

--- a/paimon-core/src/main/java/org/apache/paimon/table/source/DataEvolutionSplitGenerator.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/source/DataEvolutionSplitGenerator.java
@@ -107,22 +107,42 @@ public class DataEvolutionSplitGenerator implements SplitGenerator {
         List<List<List<DataFileMeta>>> packed = new ArrayList<>();
         List<List<DataFileMeta>> current = new ArrayList<>();
         Set<DataFileMeta> seenSidecars = Collections.newSetFromMap(new IdentityHashMap<>());
+        Set<DataFileMeta> fixedComponent = Collections.newSetFromMap(new IdentityHashMap<>());
         long currentWeight = 0;
 
         for (List<DataFileMeta> range : ranges) {
-            long weight = incrementalRangeWeight(range, seenSidecars, Collections.emptySet());
-            if (current.isEmpty() && weight > targetSplitSize) {
-                weight = incrementalRangeWeight(range, seenSidecars, sharedSidecars);
+            Set<DataFileMeta> rangeSharedSidecars =
+                    range.stream()
+                            .filter(sharedSidecars::contains)
+                            .collect(
+                                    Collectors.toCollection(
+                                            () ->
+                                                    Collections.newSetFromMap(
+                                                            new IdentityHashMap<>())));
+            if (!current.isEmpty()
+                    && !fixedComponent.isEmpty()
+                    && Collections.disjoint(fixedComponent, rangeSharedSidecars)) {
+                packed.add(current);
+                current = new ArrayList<>();
+                seenSidecars = Collections.newSetFromMap(new IdentityHashMap<>());
+                fixedComponent = Collections.newSetFromMap(new IdentityHashMap<>());
+                currentWeight = 0;
             }
+
+            long weight =
+                    current.isEmpty()
+                            ? initialRangeWeight(
+                                    range, seenSidecars, sharedSidecars, fixedComponent)
+                            : incrementalRangeWeight(range, seenSidecars, Collections.emptySet());
             if (!current.isEmpty() && currentWeight + weight > targetSplitSize) {
                 packed.add(current);
                 current = new ArrayList<>();
                 seenSidecars = Collections.newSetFromMap(new IdentityHashMap<>());
+                fixedComponent = Collections.newSetFromMap(new IdentityHashMap<>());
                 currentWeight = 0;
-                weight = incrementalRangeWeight(range, seenSidecars, Collections.emptySet());
-                if (weight > targetSplitSize) {
-                    weight = incrementalRangeWeight(range, seenSidecars, sharedSidecars);
-                }
+                weight = initialRangeWeight(range, seenSidecars, sharedSidecars, fixedComponent);
+            } else if (!fixedComponent.isEmpty()) {
+                fixedComponent.addAll(rangeSharedSidecars);
             }
             current.add(range);
             currentWeight += weight;
@@ -135,6 +155,24 @@ public class DataEvolutionSplitGenerator implements SplitGenerator {
             packed.add(current);
         }
         return packed;
+    }
+
+    private long initialRangeWeight(
+            List<DataFileMeta> files,
+            Set<DataFileMeta> seenSidecars,
+            Set<DataFileMeta> sharedSidecars,
+            Set<DataFileMeta> fixedComponent) {
+        long weight = incrementalRangeWeight(files, seenSidecars, Collections.emptySet());
+        if (weight <= targetSplitSize) {
+            return weight;
+        }
+
+        long marginalWeight = incrementalRangeWeight(files, seenSidecars, sharedSidecars);
+        if (marginalWeight <= targetSplitSize) {
+            files.stream().filter(sharedSidecars::contains).forEach(fixedComponent::add);
+            return marginalWeight;
+        }
+        return weight;
     }
 
     private long incrementalRangeWeight(

--- a/paimon-core/src/main/java/org/apache/paimon/table/source/DataEvolutionSplitGenerator.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/source/DataEvolutionSplitGenerator.java
@@ -21,12 +21,16 @@ package org.apache.paimon.table.source;
 import org.apache.paimon.format.blob.BlobFileFormat;
 import org.apache.paimon.io.DataFileMeta;
 import org.apache.paimon.utils.BinPacking;
-import org.apache.paimon.utils.RangeHelper;
 
 import java.util.Collection;
+import java.util.Collections;
+import java.util.IdentityHashMap;
 import java.util.List;
+import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
+
+import static org.apache.paimon.utils.DataEvolutionUtils.groupByNormalFileRange;
 
 /** Append data evolution table split generator, which implementation of {@link SplitGenerator}. */
 public class DataEvolutionSplitGenerator implements SplitGenerator {
@@ -49,8 +53,15 @@ public class DataEvolutionSplitGenerator implements SplitGenerator {
 
     @Override
     public List<SplitGroup> splitForBatch(List<DataFileMeta> input) {
-        RangeHelper<DataFileMeta> rangeHelper = new RangeHelper<>(DataFileMeta::nonNullRowIdRange);
-        List<List<DataFileMeta>> ranges = rangeHelper.mergeOverlappingRanges(input);
+        List<List<DataFileMeta>> ranges = groupByNormalFileRange(input, Function.identity());
+        Set<DataFileMeta> seen = Collections.newSetFromMap(new IdentityHashMap<>());
+        boolean hasSpanningSidecar =
+                ranges.stream().flatMap(Collection::stream).anyMatch(file -> !seen.add(file));
+        if (hasSpanningSidecar) {
+            return ranges.stream()
+                    .map(SplitGroup::nonRawConvertibleGroup)
+                    .collect(Collectors.toList());
+        }
         Function<List<DataFileMeta>, Long> weightFunc =
                 file ->
                         Math.max(

--- a/paimon-core/src/main/java/org/apache/paimon/table/source/DataEvolutionSplitGenerator.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/source/DataEvolutionSplitGenerator.java
@@ -30,6 +30,7 @@ import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
+import static org.apache.paimon.types.VectorType.isVectorStoreFile;
 import static org.apache.paimon.utils.DataEvolutionUtils.groupByNormalFileRange;
 
 /** Append data evolution table split generator, which implementation of {@link SplitGenerator}. */
@@ -57,37 +58,50 @@ public class DataEvolutionSplitGenerator implements SplitGenerator {
         Set<DataFileMeta> seen = Collections.newSetFromMap(new IdentityHashMap<>());
         boolean hasSpanningSidecar =
                 ranges.stream().flatMap(Collection::stream).anyMatch(file -> !seen.add(file));
-        if (hasSpanningSidecar) {
-            return ranges.stream()
-                    .map(SplitGroup::nonRawConvertibleGroup)
-                    .collect(Collectors.toList());
-        }
         Function<List<DataFileMeta>, Long> weightFunc =
-                file ->
-                        Math.max(
-                                file.stream()
-                                        .mapToLong(
-                                                meta ->
-                                                        BlobFileFormat.isBlobFile(meta.fileName())
-                                                                ? countBlobSize
-                                                                        ? meta.fileSize()
-                                                                        : openFileCost
-                                                                : meta.fileSize())
-                                        .sum(),
-                                openFileCost);
+                files -> rangeWeight(files, hasSpanningSidecar);
         return BinPacking.packForOrdered(ranges, weightFunc, targetSplitSize).stream()
                 .map(
                         f -> {
-                            boolean rawConvertible = f.stream().allMatch(file -> file.size() == 1);
+                            boolean rawConvertible =
+                                    !hasSpanningSidecar
+                                            && f.stream().allMatch(file -> file.size() == 1);
+                            Set<DataFileMeta> unique =
+                                    Collections.newSetFromMap(new IdentityHashMap<>());
                             List<DataFileMeta> groupFiles =
                                     f.stream()
                                             .flatMap(Collection::stream)
+                                            .filter(unique::add)
                                             .collect(Collectors.toList());
                             return rawConvertible
                                     ? SplitGroup.rawConvertibleGroup(groupFiles)
                                     : SplitGroup.nonRawConvertibleGroup(groupFiles);
                         })
                 .collect(Collectors.toList());
+    }
+
+    private long rangeWeight(List<DataFileMeta> files, boolean hasSpanningSidecar) {
+        if (hasSpanningSidecar) {
+            List<DataFileMeta> normalFiles =
+                    files.stream().filter(file -> !isSidecar(file)).collect(Collectors.toList());
+            if (!normalFiles.isEmpty()) {
+                return Math.max(
+                        normalFiles.stream().mapToLong(DataFileMeta::fileSize).sum(), openFileCost);
+            }
+        }
+        return Math.max(
+                files.stream()
+                        .mapToLong(
+                                file ->
+                                        BlobFileFormat.isBlobFile(file.fileName())
+                                                ? countBlobSize ? file.fileSize() : openFileCost
+                                                : file.fileSize())
+                        .sum(),
+                openFileCost);
+    }
+
+    private static boolean isSidecar(DataFileMeta file) {
+        return BlobFileFormat.isBlobFile(file.fileName()) || isVectorStoreFile(file.fileName());
     }
 
     @Override

--- a/paimon-core/src/main/java/org/apache/paimon/table/source/DataEvolutionSplitGenerator.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/source/DataEvolutionSplitGenerator.java
@@ -27,6 +27,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.IdentityHashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
@@ -56,15 +57,32 @@ public class DataEvolutionSplitGenerator implements SplitGenerator {
     @Override
     public List<SplitGroup> splitForBatch(List<DataFileMeta> input) {
         List<List<DataFileMeta>> ranges = groupByNormalFileRange(input, Function.identity());
-        Set<DataFileMeta> seen = Collections.newSetFromMap(new IdentityHashMap<>());
-        boolean hasSpanningSidecar =
-                ranges.stream()
-                        .flatMap(Collection::stream)
-                        .filter(DataEvolutionSplitGenerator::isSidecar)
-                        .anyMatch(file -> !seen.add(file));
+        Map<DataFileMeta, Integer> sidecarOccurrences = new IdentityHashMap<>();
+        for (List<DataFileMeta> range : ranges) {
+            Set<DataFileMeta> rangeSidecars =
+                    range.stream()
+                            .filter(DataEvolutionSplitGenerator::isSidecar)
+                            .collect(
+                                    Collectors.toCollection(
+                                            () ->
+                                                    Collections.newSetFromMap(
+                                                            new IdentityHashMap<>())));
+            rangeSidecars.forEach(
+                    file ->
+                            sidecarOccurrences.put(
+                                    file, sidecarOccurrences.getOrDefault(file, 0) + 1));
+        }
+        Set<DataFileMeta> sharedSidecars = Collections.newSetFromMap(new IdentityHashMap<>());
+        sidecarOccurrences.forEach(
+                (file, occurrences) -> {
+                    if (occurrences > 1) {
+                        sharedSidecars.add(file);
+                    }
+                });
+        boolean hasSpanningSidecar = !sharedSidecars.isEmpty();
         List<List<List<DataFileMeta>>> packed =
                 hasSpanningSidecar
-                        ? packWithUniqueSidecars(ranges)
+                        ? packWithUniqueSidecars(ranges, sharedSidecars)
                         : BinPacking.packForOrdered(ranges, this::rangeWeight, targetSplitSize);
         return packed.stream()
                 .map(
@@ -86,20 +104,21 @@ public class DataEvolutionSplitGenerator implements SplitGenerator {
                 .collect(Collectors.toList());
     }
 
-    private List<List<List<DataFileMeta>>> packWithUniqueSidecars(List<List<DataFileMeta>> ranges) {
+    private List<List<List<DataFileMeta>>> packWithUniqueSidecars(
+            List<List<DataFileMeta>> ranges, Set<DataFileMeta> sharedSidecars) {
         List<List<List<DataFileMeta>>> packed = new ArrayList<>();
         List<List<DataFileMeta>> current = new ArrayList<>();
         Set<DataFileMeta> seenSidecars = Collections.newSetFromMap(new IdentityHashMap<>());
         long currentWeight = 0;
 
         for (List<DataFileMeta> range : ranges) {
-            long weight = incrementalRangeWeight(range, seenSidecars);
+            long weight = incrementalRangeWeight(range, seenSidecars, sharedSidecars);
             if (!current.isEmpty() && currentWeight + weight > targetSplitSize) {
                 packed.add(current);
                 current = new ArrayList<>();
                 seenSidecars = Collections.newSetFromMap(new IdentityHashMap<>());
                 currentWeight = 0;
-                weight = incrementalRangeWeight(range, seenSidecars);
+                weight = incrementalRangeWeight(range, seenSidecars, sharedSidecars);
             }
             current.add(range);
             currentWeight += weight;
@@ -114,14 +133,18 @@ public class DataEvolutionSplitGenerator implements SplitGenerator {
         return packed;
     }
 
-    private long incrementalRangeWeight(List<DataFileMeta> files, Set<DataFileMeta> seenSidecars) {
+    private long incrementalRangeWeight(
+            List<DataFileMeta> files,
+            Set<DataFileMeta> seenSidecars,
+            Set<DataFileMeta> sharedSidecars) {
         Set<DataFileMeta> seenInRange = Collections.newSetFromMap(new IdentityHashMap<>());
         long size =
                 files.stream()
                         .filter(
                                 file ->
                                         !isSidecar(file)
-                                                || (!seenSidecars.contains(file)
+                                                || (!sharedSidecars.contains(file)
+                                                        && !seenSidecars.contains(file)
                                                         && seenInRange.add(file)))
                         .mapToLong(this::fileWeight)
                         .sum();

--- a/paimon-core/src/main/java/org/apache/paimon/table/source/DataSplit.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/source/DataSplit.java
@@ -40,7 +40,6 @@ import org.apache.paimon.types.DataField;
 import org.apache.paimon.types.DataTypes;
 import org.apache.paimon.utils.FunctionWithIOException;
 import org.apache.paimon.utils.InternalRowUtils;
-import org.apache.paimon.utils.RangeHelper;
 import org.apache.paimon.utils.SerializationUtils;
 
 import javax.annotation.Nullable;
@@ -56,7 +55,10 @@ import java.util.OptionalLong;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
+import static org.apache.paimon.format.blob.BlobFileFormat.isBlobFile;
 import static org.apache.paimon.io.DataFilePathFactory.INDEX_PATH_SUFFIX;
+import static org.apache.paimon.types.VectorType.isVectorStoreFile;
+import static org.apache.paimon.utils.DataEvolutionUtils.groupByNormalFileRange;
 import static org.apache.paimon.utils.Preconditions.checkArgument;
 
 /** Input splits. Needed by most batch computation engines. */
@@ -187,14 +189,17 @@ public class DataSplit implements Split {
 
     private long dataEvolutionMergedRowCount() {
         long sum = 0L;
-        RangeHelper<DataFileMeta> rangeHelper = new RangeHelper<>(DataFileMeta::nonNullRowIdRange);
-        List<List<DataFileMeta>> ranges = rangeHelper.mergeOverlappingRanges(dataFiles);
+        List<List<DataFileMeta>> ranges = groupByNormalFileRange(dataFiles, file -> file);
         for (List<DataFileMeta> group : ranges) {
+            long maxNormalCount = 0;
             long maxCount = 0;
             for (DataFileMeta file : group) {
                 maxCount = Math.max(maxCount, file.rowCount());
+                if (!isBlobFile(file.fileName()) && !isVectorStoreFile(file.fileName())) {
+                    maxNormalCount = Math.max(maxNormalCount, file.rowCount());
+                }
             }
-            sum += maxCount;
+            sum += maxNormalCount == 0 ? maxCount : maxNormalCount;
         }
         if (dataDeletionFiles != null) {
             for (DeletionFile deletionFile : dataDeletionFiles) {

--- a/paimon-core/src/main/java/org/apache/paimon/utils/DataEvolutionUtils.java
+++ b/paimon-core/src/main/java/org/apache/paimon/utils/DataEvolutionUtils.java
@@ -32,6 +32,7 @@ import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.IdentityHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -200,5 +201,108 @@ public class DataEvolutionUtils {
                 "Data evolution compact files",
                 merged);
         return merged.get(0);
+    }
+
+    /**
+     * Groups data-evolution files by normal-file row ranges.
+     *
+     * <p>Blob and vector files may span several adjacent normal files. Such sidecar files are
+     * included in every anchor group they intersect, so each group can select just its normal-file
+     * range without duplicating the physical sidecar.
+     */
+    public static <T> List<List<T>> groupByNormalFileRange(
+            List<T> entries, Function<T, DataFileMeta> fileMetaFunc) {
+        Map<T, Integer> originalOrder = new IdentityHashMap<>();
+        List<T> normal = new ArrayList<>();
+        List<T> sidecars = new ArrayList<>();
+        for (int i = 0; i < entries.size(); i++) {
+            T entry = entries.get(i);
+            originalOrder.put(entry, i);
+            DataFileMeta file = fileMetaFunc.apply(entry);
+            if (isBlobFile(file.fileName()) || isVectorStoreFile(file.fileName())) {
+                sidecars.add(entry);
+            } else {
+                normal.add(entry);
+            }
+        }
+
+        if (normal.isEmpty()) {
+            return new RangeHelper<T>(entry -> fileMetaFunc.apply(entry).nonNullRowIdRange())
+                    .mergeOverlappingRanges(entries);
+        }
+
+        normal.sort(
+                Comparator.<T>comparingLong(entry -> fileMetaFunc.apply(entry).nonNullFirstRowId())
+                        .thenComparingLong(
+                                entry -> fileMetaFunc.apply(entry).nonNullRowIdRange().to));
+        List<List<T>> groups = new ArrayList<>();
+        List<Range> groupRanges = new ArrayList<>();
+        for (T entry : normal) {
+            Range range = fileMetaFunc.apply(entry).nonNullRowIdRange();
+            if (groups.isEmpty() || !range.equals(groupRanges.get(groupRanges.size() - 1))) {
+                if (!groupRanges.isEmpty()) {
+                    Range previous = groupRanges.get(groupRanges.size() - 1);
+                    checkArgument(
+                            !previous.hasIntersection(range),
+                            "Normal data files have overlapping but different row ranges: %s and %s.",
+                            previous,
+                            range);
+                }
+                groups.add(new ArrayList<>());
+                groupRanges.add(range);
+            }
+            groups.get(groups.size() - 1).add(entry);
+        }
+
+        List<T> unanchored = new ArrayList<>();
+        for (T sidecar : sidecars) {
+            Range sidecarRange = fileMetaFunc.apply(sidecar).nonNullRowIdRange();
+            int first = firstRangeEndingAtOrAfter(groupRanges, sidecarRange.from);
+            boolean attached = false;
+            for (int i = first;
+                    i < groupRanges.size() && groupRanges.get(i).from <= sidecarRange.to;
+                    i++) {
+                if (groupRanges.get(i).hasIntersection(sidecarRange)) {
+                    groups.get(i).add(sidecar);
+                    attached = true;
+                }
+            }
+            if (!attached) {
+                unanchored.add(sidecar);
+            }
+        }
+
+        if (!unanchored.isEmpty()) {
+            groups.addAll(
+                    new RangeHelper<T>(entry -> fileMetaFunc.apply(entry).nonNullRowIdRange())
+                            .mergeOverlappingRanges(unanchored));
+            groups.sort(
+                    Comparator.comparingLong(
+                            group ->
+                                    group.stream()
+                                            .map(fileMetaFunc)
+                                            .map(DataFileMeta::nonNullRowIdRange)
+                                            .mapToLong(range -> range.from)
+                                            .min()
+                                            .orElse(Long.MAX_VALUE)));
+        }
+        for (List<T> group : groups) {
+            group.sort(Comparator.comparingInt(originalOrder::get));
+        }
+        return groups;
+    }
+
+    private static int firstRangeEndingAtOrAfter(List<Range> ranges, long rowId) {
+        int low = 0;
+        int high = ranges.size();
+        while (low < high) {
+            int middle = (low + high) >>> 1;
+            if (ranges.get(middle).to < rowId) {
+                low = middle + 1;
+            } else {
+                high = middle;
+            }
+        }
+        return low;
     }
 }

--- a/paimon-core/src/main/java/org/apache/paimon/utils/DataEvolutionUtils.java
+++ b/paimon-core/src/main/java/org/apache/paimon/utils/DataEvolutionUtils.java
@@ -231,28 +231,26 @@ public class DataEvolutionUtils {
                     .mergeOverlappingRanges(entries);
         }
 
-        normal.sort(
-                Comparator.<T>comparingLong(entry -> fileMetaFunc.apply(entry).nonNullFirstRowId())
-                        .thenComparingLong(
-                                entry -> fileMetaFunc.apply(entry).nonNullRowIdRange().to));
-        List<List<T>> groups = new ArrayList<>();
-        List<Range> groupRanges = new ArrayList<>();
-        for (T entry : normal) {
-            Range range = fileMetaFunc.apply(entry).nonNullRowIdRange();
-            if (groups.isEmpty() || !range.equals(groupRanges.get(groupRanges.size() - 1))) {
-                if (!groupRanges.isEmpty()) {
-                    Range previous = groupRanges.get(groupRanges.size() - 1);
-                    checkArgument(
-                            !previous.hasIntersection(range),
-                            "Normal data files have overlapping but different row ranges: %s and %s.",
-                            previous,
-                            range);
-                }
-                groups.add(new ArrayList<>());
-                groupRanges.add(range);
-            }
-            groups.get(groups.size() - 1).add(entry);
-        }
+        List<List<T>> groups =
+                new RangeHelper<T>(entry -> fileMetaFunc.apply(entry).nonNullRowIdRange())
+                        .mergeOverlappingRanges(normal);
+        List<Range> groupRanges =
+                groups.stream()
+                        .map(
+                                group ->
+                                        new Range(
+                                                group.stream()
+                                                        .map(fileMetaFunc)
+                                                        .mapToLong(DataFileMeta::nonNullFirstRowId)
+                                                        .min()
+                                                        .orElseThrow(IllegalStateException::new),
+                                                group.stream()
+                                                        .map(fileMetaFunc)
+                                                        .map(DataFileMeta::nonNullRowIdRange)
+                                                        .mapToLong(range -> range.to)
+                                                        .max()
+                                                        .orElseThrow(IllegalStateException::new)))
+                        .collect(Collectors.toList());
 
         List<T> unanchored = new ArrayList<>();
         for (T sidecar : sidecars) {

--- a/paimon-core/src/test/java/org/apache/paimon/CoreOptionsTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/CoreOptionsTest.java
@@ -277,7 +277,7 @@ public class CoreOptionsTest {
         options.set(CoreOptions.VIDEO_FRAME_FIELD, "video");
 
         assertThat(CoreOptions.blobField(options.toMap())).containsExactly("image", "video");
-        assertThat(new CoreOptions(options).videoFrameField()).contains("video");
+        assertThat(new CoreOptions(options).videoFrameFields()).containsExactly("video");
     }
 
     @Test

--- a/paimon-core/src/test/java/org/apache/paimon/append/BlobTableTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/append/BlobTableTest.java
@@ -1611,6 +1611,111 @@ public class BlobTableTest extends TableTestBase {
                 .isEqualTo(Arrays.asList(2L, 3L));
     }
 
+    @Test
+    public void testMultipleVideoFieldsRollIndependentlyAcrossNormalFiles() throws Exception {
+        Schema.Builder schemaBuilder = Schema.newBuilder();
+        schemaBuilder.column("id", DataTypes.INT());
+        schemaBuilder.column("camera_a", DataTypes.BLOB());
+        schemaBuilder.column("camera_b", DataTypes.BLOB());
+        schemaBuilder.option(CoreOptions.TARGET_FILE_SIZE.key(), "1 GB");
+        schemaBuilder.option(CoreOptions.BLOB_TARGET_FILE_SIZE.key(), "1 GB");
+        schemaBuilder.option(CoreOptions.TARGET_FILE_ROW_NUM.key(), "2");
+        schemaBuilder.option(CoreOptions.ROW_TRACKING_ENABLED.key(), "true");
+        schemaBuilder.option(CoreOptions.DATA_EVOLUTION_ENABLED.key(), "true");
+        schemaBuilder.option(CoreOptions.VIDEO_FRAME_FIELD.key(), "camera_a,camera_b");
+        catalog.createTable(identifier(), schemaBuilder.build(), true);
+
+        byte[][] payloads = {
+            "camera-a-0".getBytes(),
+            "camera-a-1".getBytes(),
+            "camera-b-0".getBytes(),
+            "camera-b-1".getBytes()
+        };
+        String[] uris = new String[payloads.length];
+        for (int i = 0; i < payloads.length; i++) {
+            java.nio.file.Path source = tempPath.resolve("video-source-" + i + ".mp4");
+            java.nio.file.Files.write(source, payloads[i]);
+            uris[i] = new Path(source.toUri()).toString();
+        }
+        UriReader sourceReader = UriReader.fromFile(LocalFileIO.create());
+        List<InternalRow> input = new ArrayList<>();
+        for (int row = 0; row < 6; row++) {
+            int cameraA = row < 4 ? 0 : 1;
+            int cameraB = row < 2 ? 2 : 3;
+            int frameA = row < 4 ? row : row - 4;
+            int frameB = row < 2 ? row : row - 2;
+            input.add(
+                    GenericRow.of(
+                            row,
+                            Blob.fromDescriptor(
+                                    sourceReader,
+                                    new VideoFrameDescriptor(
+                                            uris[cameraA], 0, payloads[cameraA].length, frameA)),
+                            Blob.fromDescriptor(
+                                    sourceReader,
+                                    new VideoFrameDescriptor(
+                                            uris[cameraB], 0, payloads[cameraB].length, frameB))));
+        }
+        writeRows(getTableDefault(), input);
+
+        FileStoreTable table = getTableDefault();
+        List<DataFileMeta> files =
+                table.store().newScan().plan().files().stream()
+                        .map(ManifestEntry::file)
+                        .collect(Collectors.toList());
+        assertThat(
+                        files.stream()
+                                .filter(file -> !file.fileName().endsWith(".video"))
+                                .map(DataFileMeta::rowCount)
+                                .sorted()
+                                .collect(Collectors.toList()))
+                .isEqualTo(Arrays.asList(2L, 2L, 2L));
+        List<DataFileMeta> videos =
+                files.stream()
+                        .filter(file -> file.fileName().endsWith(".video"))
+                        .collect(Collectors.toList());
+        assertThat(videos.size()).isEqualTo(4);
+        Map<String, Long> rowsByCamera =
+                videos.stream()
+                        .collect(
+                                Collectors.groupingBy(
+                                        file -> file.writeCols().get(0),
+                                        Collectors.summingLong(DataFileMeta::rowCount)));
+        assertThat(rowsByCamera.get("camera_a")).isEqualTo(6L);
+        assertThat(rowsByCamera.get("camera_b")).isEqualTo(6L);
+
+        Map<String, String> readOptions = new HashMap<>();
+        readOptions.put(CoreOptions.BLOB_AS_DESCRIPTOR.key(), "true");
+        Table descriptorTable = table.copy(readOptions);
+        ReadBuilder readBuilder = descriptorTable.newReadBuilder();
+        List<InternalRow> rows = new ArrayList<>();
+        InternalRowSerializer serializer = new InternalRowSerializer(descriptorTable.rowType());
+        try (RecordReader<InternalRow> reader =
+                readBuilder.newRead().createReader(readBuilder.newScan().plan())) {
+            reader.forEachRemaining(row -> rows.add(serializer.copy(row)));
+        }
+        rows.sort((left, right) -> Integer.compare(left.getInt(0), right.getInt(0)));
+        assertThat(rows.size()).isEqualTo(6);
+        for (int row = 0; row < rows.size(); row++) {
+            int cameraA = row < 4 ? 0 : 1;
+            int cameraB = row < 2 ? 2 : 3;
+            assertThat(rows.get(row).getBlob(1).toData()).isEqualTo(payloads[cameraA]);
+            assertThat(rows.get(row).getBlob(2).toData()).isEqualTo(payloads[cameraB]);
+        }
+
+        ReadBuilder cameraOnly = descriptorTable.newReadBuilder().withProjection(new int[] {1});
+        AtomicInteger cameraRows = new AtomicInteger();
+        try (RecordReader<InternalRow> reader =
+                cameraOnly.newRead().createReader(cameraOnly.newScan().plan())) {
+            reader.forEachRemaining(
+                    row -> {
+                        assertThat(row.getBlob(0).toData()).isNotNull();
+                        cameraRows.incrementAndGet();
+                    });
+        }
+        assertThat(cameraRows.get()).isEqualTo(6);
+    }
+
     private List<DataFileMeta> liveVideoFiles(FileStoreTable table) {
         return table.store().newScan().plan().files().stream()
                 .map(ManifestEntry::file)

--- a/paimon-core/src/test/java/org/apache/paimon/append/BlobTableTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/append/BlobTableTest.java
@@ -1612,6 +1612,36 @@ public class BlobTableTest extends TableTestBase {
     }
 
     @Test
+    public void testNullVideoRowsRespectRowRollingLimit() throws Exception {
+        Schema.Builder schemaBuilder = Schema.newBuilder();
+        schemaBuilder.column("id", DataTypes.INT());
+        schemaBuilder.column("video", DataTypes.BLOB());
+        schemaBuilder.option(CoreOptions.TARGET_FILE_SIZE.key(), "1 GB");
+        schemaBuilder.option(CoreOptions.BLOB_TARGET_FILE_SIZE.key(), "1 GB");
+        schemaBuilder.option(CoreOptions.TARGET_FILE_ROW_NUM.key(), "2");
+        schemaBuilder.option(CoreOptions.ROW_TRACKING_ENABLED.key(), "true");
+        schemaBuilder.option(CoreOptions.DATA_EVOLUTION_ENABLED.key(), "true");
+        schemaBuilder.option(CoreOptions.VIDEO_FRAME_FIELD.key(), "video");
+        catalog.createTable(identifier(), schemaBuilder.build(), true);
+
+        writeRows(
+                getTableDefault(),
+                Arrays.asList(
+                        GenericRow.of(0, null),
+                        GenericRow.of(1, null),
+                        GenericRow.of(2, null),
+                        GenericRow.of(3, null),
+                        GenericRow.of(4, null)));
+
+        assertThat(
+                        liveVideoFiles(getTableDefault()).stream()
+                                .map(DataFileMeta::rowCount)
+                                .sorted()
+                                .collect(Collectors.toList()))
+                .isEqualTo(Arrays.asList(1L, 2L, 2L));
+    }
+
+    @Test
     public void testMultipleVideoFieldsRollIndependentlyAcrossNormalFiles() throws Exception {
         Schema.Builder schemaBuilder = Schema.newBuilder();
         schemaBuilder.column("id", DataTypes.INT());

--- a/paimon-core/src/test/java/org/apache/paimon/append/MultipleBlobTableTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/append/MultipleBlobTableTest.java
@@ -32,6 +32,9 @@ import org.apache.paimon.schema.Schema;
 import org.apache.paimon.schema.SchemaChange;
 import org.apache.paimon.table.FileStoreTable;
 import org.apache.paimon.table.TableTestBase;
+import org.apache.paimon.table.sink.BatchTableCommit;
+import org.apache.paimon.table.sink.BatchTableWrite;
+import org.apache.paimon.table.sink.BatchWriteBuilder;
 import org.apache.paimon.table.sink.CommitMessage;
 import org.apache.paimon.types.DataTypes;
 import org.apache.paimon.types.RowType;
@@ -93,6 +96,41 @@ public class MultipleBlobTableTest extends TableTestBase {
                 });
 
         assertThat(integer.get()).isEqualTo(1000);
+    }
+
+    @Test
+    public void testOverwriteKeepsBlobCommitMessageRange() throws Exception {
+        createTableDefault();
+        commitDefault(writeDataDefault(1, 1));
+        FileStoreTable table = getTableDefault();
+        BatchWriteBuilder builder = table.newBatchWriteBuilder().withOverwrite();
+        List<CommitMessage> messages = new ArrayList<>();
+
+        RowType normalType = schemaDefault().rowType().project(Arrays.asList("f0", "f1"));
+        try (BatchTableWrite write = builder.newWrite().withWriteType(normalType)) {
+            write.write(GenericRow.of(1, BinaryString.fromString("normal-only")));
+            messages.addAll(write.prepareCommit());
+        }
+        try (BatchTableWrite write = builder.newWrite()) {
+            write.write(
+                    GenericRow.of(
+                            2,
+                            BinaryString.fromString("with-blobs"),
+                            new BlobData(blobBytes1),
+                            new BlobData(blobBytes2)));
+            messages.addAll(write.prepareCommit());
+        }
+        try (BatchTableCommit commit = builder.newCommit()) {
+            commit.commit(messages);
+        }
+
+        List<InternalRow> rows = read(table);
+        rows.sort((a, b) -> Integer.compare(a.getInt(0), b.getInt(0)));
+        assertThat(rows.size()).isEqualTo(2);
+        assertThat(rows.get(0).isNullAt(2)).isTrue();
+        assertThat(rows.get(0).isNullAt(3)).isTrue();
+        assertThat(rows.get(1).getBlob(2).toData()).isEqualTo(blobBytes1);
+        assertThat(rows.get(1).getBlob(3).toData()).isEqualTo(blobBytes2);
     }
 
     @Test

--- a/paimon-core/src/test/java/org/apache/paimon/operation/DataEvolutionFileStoreScanTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/operation/DataEvolutionFileStoreScanTest.java
@@ -607,6 +607,32 @@ public class DataEvolutionFileStoreScanTest {
     }
 
     @Test
+    public void testSpanningSidecarDoesNotExpandStatsRange() {
+        Schema schema = createSchema("f0");
+        TableSchema tableSchema = TableSchema.create(0L, schema);
+        schemas.put(0L, tableSchema);
+        SimpleStats stats =
+                createSimpleStats(
+                        GenericRow.of(0),
+                        GenericRow.of(9),
+                        createBinaryArray(new int[] {0}),
+                        new int[] {0});
+
+        EvolutionStats result =
+                DataEvolutionFileStoreScan.evolutionStats(
+                        tableSchema,
+                        scanTableSchema,
+                        Arrays.asList(
+                                createManifestEntry(0L, stats, "normal.parquet", 0L, 0L, 10L),
+                                createManifestEntry(0L, stats, "camera.video", 0L, 0L, 20L)),
+                        new EvolutionStatsCache());
+
+        assertThat(result.rowCount()).isEqualTo(10);
+        assertThat(result.minValues().getInt(0)).isEqualTo(0);
+        assertThat(result.maxValues().getInt(0)).isEqualTo(9);
+    }
+
+    @Test
     public void testInvalidProviderStatsAreUnknown() {
         Schema schema = createSchema("f0");
         TableSchema tableSchema = TableSchema.create(0L, schema);

--- a/paimon-core/src/test/java/org/apache/paimon/operation/DataEvolutionSplitReadTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/operation/DataEvolutionSplitReadTest.java
@@ -145,6 +145,23 @@ class DataEvolutionSplitReadTest {
     }
 
     @Test
+    public void testSpanningBlobFileIsAttachedToEachNormalRange() {
+        DataFileMeta normal1 = createFile("file1.parquet", 0L, 5, 1);
+        DataFileMeta normal2 = createFile("file2.parquet", 5L, 5, 1);
+        DataFileMeta spanning = createFile("camera-a.video", 0L, 10, 100);
+        DataFileMeta cameraB1 = createFile("camera-b1.video", 0L, 3, 30);
+        DataFileMeta cameraB2 = createFile("camera-b2.video", 3L, 7, 70);
+
+        List<List<DataFileMeta>> result =
+                DataEvolutionSplitRead.mergeRangesAndSort(
+                        Arrays.asList(normal1, spanning, cameraB1, normal2, cameraB2));
+
+        assertEquals(2, result.size());
+        assertEquals(Arrays.asList(normal1, spanning, cameraB1, cameraB2), result.get(0));
+        assertEquals(Arrays.asList(normal2, spanning, cameraB2), result.get(1));
+    }
+
+    @Test
     public void testSplitWithMultipleVectorStoreFilesPerGroup() {
         DataFileMeta file1 = createFile("file1.parquet", 1L, 10, 1);
         DataFileMeta file2 = createFile("file2.vector.json", 1L, 1, 1);

--- a/paimon-core/src/test/java/org/apache/paimon/operation/commit/OverwriteChangesProviderTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/operation/commit/OverwriteChangesProviderTest.java
@@ -268,6 +268,7 @@ public class OverwriteChangesProviderTest {
                 store.options().manifestDeleteFileDropStats(),
                 store.options().bucket(),
                 newChanges,
+                Collections.emptyMap(),
                 Collections.emptyList(),
                 partitionFilter);
     }

--- a/paimon-core/src/test/java/org/apache/paimon/operation/commit/RowTrackingCommitUtilsTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/operation/commit/RowTrackingCommitUtilsTest.java
@@ -1,0 +1,94 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.operation.commit;
+
+import org.apache.paimon.data.BinaryRow;
+import org.apache.paimon.io.CompactIncrement;
+import org.apache.paimon.io.DataFileMeta;
+import org.apache.paimon.io.DataIncrement;
+import org.apache.paimon.manifest.FileSource;
+import org.apache.paimon.stats.SimpleStats;
+import org.apache.paimon.table.sink.CommitMessageImpl;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Tests for {@link RowTrackingCommitUtils}. */
+public class RowTrackingCommitUtilsTest {
+
+    @Test
+    public void testBlobStartsFromItsCommitMessageRange() {
+        DataFileMeta normalOnly = file("normal-0.parquet", 1, null);
+        DataFileMeta normalWithBlob = file("normal-1.parquet", 1, null);
+        DataFileMeta blob = file("camera-0.video", 1, Collections.singletonList("camera"));
+        ManifestEntryChanges changes = new ManifestEntryChanges(1);
+        changes.collect(
+                new CommitMessageImpl(
+                        BinaryRow.EMPTY_ROW,
+                        0,
+                        1,
+                        new DataIncrement(
+                                Collections.singletonList(normalOnly),
+                                Collections.emptyList(),
+                                Collections.emptyList()),
+                        CompactIncrement.emptyIncrement()));
+        changes.collect(
+                new CommitMessageImpl(
+                        BinaryRow.EMPTY_ROW,
+                        0,
+                        1,
+                        new DataIncrement(
+                                Arrays.asList(normalWithBlob, blob),
+                                Collections.emptyList(),
+                                Collections.emptyList()),
+                        CompactIncrement.emptyIncrement()));
+
+        RowTrackingCommitUtils.RowTrackingAssigned assigned =
+                RowTrackingCommitUtils.assignRowTracking(
+                        1, 10, changes.appendTableFiles, changes.appendTableFileGroups);
+
+        assertThat(assigned.nextRowIdStart).isEqualTo(12);
+        assertThat(assigned.assignedEntries)
+                .extracting(entry -> entry.file().firstRowId())
+                .containsExactly(10L, 11L, 11L);
+    }
+
+    private static DataFileMeta file(String name, long rowCount, List<String> writeCols) {
+        return DataFileMeta.forAppend(
+                name,
+                1,
+                rowCount,
+                SimpleStats.EMPTY_STATS,
+                0,
+                0,
+                0,
+                Collections.emptyList(),
+                null,
+                FileSource.APPEND,
+                null,
+                null,
+                null,
+                writeCols);
+    }
+}

--- a/paimon-core/src/test/java/org/apache/paimon/schema/SchemaValidationTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/schema/SchemaValidationTest.java
@@ -476,8 +476,7 @@ class SchemaValidationTest {
         assertThatCode(() -> validateTableSchema(schema)).doesNotThrowAnyException();
 
         options.put(CoreOptions.VIDEO_FRAME_FIELD.key(), "video,other_video");
-        assertThatThrownBy(() -> validateTableSchema(schema))
-                .hasMessageContaining("currently supports exactly one field");
+        assertThatCode(() -> validateTableSchema(schema)).doesNotThrowAnyException();
 
         options.put(CoreOptions.VIDEO_FRAME_FIELD.key(), "video");
         options.put(CoreOptions.BLOB_DESCRIPTOR_FIELD.key(), "video");

--- a/paimon-core/src/test/java/org/apache/paimon/table/source/DataEvolutionSplitGeneratorTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/table/source/DataEvolutionSplitGeneratorTest.java
@@ -89,6 +89,23 @@ public class DataEvolutionSplitGeneratorTest {
     }
 
     @Test
+    public void testSpanningBlobDoesNotDisableRawConversionForUnrelatedSplit() {
+        DataFileMeta normal1 = newFile("file1.parquet", 0L, 1L, 10L);
+        DataFileMeta normal2 = newFile("file2.parquet", 1L, 1L, 10L);
+        DataFileMeta normal3 = newFile("file3.parquet", 2L, 1L, 10L);
+        DataFileMeta video = newFile("camera.video", 0L, 2L, 100L);
+
+        DataEvolutionSplitGenerator generator = new DataEvolutionSplitGenerator(10L, 1L, false);
+        List<SplitGenerator.SplitGroup> splits =
+                generator.splitForBatch(Arrays.asList(normal1, video, normal2, normal3));
+
+        assertThat(splits).hasSize(3);
+        assertThat(splits)
+                .extracting(split -> split.rawConvertible)
+                .containsExactly(false, false, true);
+    }
+
+    @Test
     public void testSpanningBlobDoesNotHideDistinctSidecarWeights() {
         long videoSize = 64L * 1024 * 1024;
         List<DataFileMeta> files = new ArrayList<>();

--- a/paimon-core/src/test/java/org/apache/paimon/table/source/DataEvolutionSplitGeneratorTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/table/source/DataEvolutionSplitGeneratorTest.java
@@ -166,6 +166,25 @@ public class DataEvolutionSplitGeneratorTest {
     }
 
     @Test
+    public void testOversizedSpanningBlobEndsAtCoverageBoundary() {
+        long mb = 1024L * 1024;
+        List<DataFileMeta> files = new ArrayList<>();
+        for (int row = 0; row < 4; row++) {
+            files.add(newFile("normal-" + row + ".parquet", row, 1L, 1L));
+        }
+        files.add(newFile("camera-0.video", 0L, 2L, 200L * mb));
+        files.add(newFile("camera-1.video", 2L, 2L, 100L * mb));
+
+        DataEvolutionSplitGenerator generator =
+                new DataEvolutionSplitGenerator(128L * mb, 1L, true);
+        List<SplitGenerator.SplitGroup> splits = generator.splitForBatch(files);
+
+        assertThat(splits).hasSize(2);
+        assertThat(splits.get(0).files).contains(files.get(4)).doesNotContain(files.get(5));
+        assertThat(splits.get(1).files).contains(files.get(5)).doesNotContain(files.get(4));
+    }
+
+    @Test
     public void testOverlappingNormalRangesRemainGrouped() {
         DataFileMeta update = newFile("update.parquet", 0L, 5L, 10L);
         DataFileMeta base = newFile("base.parquet", 0L, 1000L, 100L);

--- a/paimon-core/src/test/java/org/apache/paimon/table/source/DataEvolutionSplitGeneratorTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/table/source/DataEvolutionSplitGeneratorTest.java
@@ -75,10 +75,10 @@ public class DataEvolutionSplitGeneratorTest {
         }
         files.add(video);
 
-        DataEvolutionSplitGenerator generator = new DataEvolutionSplitGenerator(200_000L, 1L, true);
+        DataEvolutionSplitGenerator generator = new DataEvolutionSplitGenerator(500L, 1L, true);
         List<SplitGenerator.SplitGroup> splits = generator.splitForBatch(files);
 
-        assertThat(splits).hasSize(1);
+        assertThat(splits).hasSize(2);
         assertThat(splits)
                 .allSatisfy(
                         split -> {

--- a/paimon-core/src/test/java/org/apache/paimon/table/source/DataEvolutionSplitGeneratorTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/table/source/DataEvolutionSplitGeneratorTest.java
@@ -51,6 +51,20 @@ public class DataEvolutionSplitGeneratorTest {
         assertThat(splits.size()).isEqualTo(1);
     }
 
+    @Test
+    public void testSpanningBlobDoesNotCollapseNormalRanges() {
+        DataFileMeta normal1 = newFile("file1.parquet", 0L, 5L, 10L);
+        DataFileMeta normal2 = newFile("file2.parquet", 5L, 5L, 10L);
+        DataFileMeta video = newFile("camera.video", 0L, 10L, 100L);
+
+        DataEvolutionSplitGenerator generator = new DataEvolutionSplitGenerator(1L, 1L, false);
+        List<SplitGenerator.SplitGroup> splits =
+                generator.splitForBatch(Arrays.asList(normal1, video, normal2));
+
+        assertThat(splits).hasSize(2);
+        assertThat(splits).allSatisfy(split -> assertThat(split.files).contains(video));
+    }
+
     private static DataFileMeta newFile(
             String name, long firstRowId, long rowCount, long fileSize) {
         return DataFileMeta.create(

--- a/paimon-core/src/test/java/org/apache/paimon/table/source/DataEvolutionSplitGeneratorTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/table/source/DataEvolutionSplitGeneratorTest.java
@@ -137,6 +137,35 @@ public class DataEvolutionSplitGeneratorTest {
     }
 
     @Test
+    public void testDistinctSpanningBlobsRemainInPackingWeight() {
+        long videoSize = 64L * 1024 * 1024;
+        List<DataFileMeta> files = new ArrayList<>();
+        for (int i = 0; i < 10; i++) {
+            long firstRowId = i * 2L;
+            files.add(newFile("normal-" + firstRowId + ".parquet", firstRowId, 1L, 1L));
+            files.add(newFile("normal-" + (firstRowId + 1) + ".parquet", firstRowId + 1, 1L, 1L));
+            files.add(newFile("camera-" + i + ".video", firstRowId, 2L, videoSize));
+        }
+
+        DataEvolutionSplitGenerator generator =
+                new DataEvolutionSplitGenerator(130L * 1024 * 1024, 1L, true);
+        List<SplitGenerator.SplitGroup> splits = generator.splitForBatch(files);
+
+        assertThat(splits).hasSize(5);
+        assertThat(splits)
+                .allSatisfy(
+                        split ->
+                                assertThat(
+                                                split.files.stream()
+                                                        .filter(
+                                                                file ->
+                                                                        file.fileName()
+                                                                                .endsWith(
+                                                                                        ".video")))
+                                        .hasSize(2));
+    }
+
+    @Test
     public void testOverlappingNormalRangesRemainGrouped() {
         DataFileMeta update = newFile("update.parquet", 0L, 5L, 10L);
         DataFileMeta base = newFile("base.parquet", 0L, 1000L, 100L);

--- a/paimon-core/src/test/java/org/apache/paimon/table/source/DataEvolutionSplitGeneratorTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/table/source/DataEvolutionSplitGeneratorTest.java
@@ -65,6 +65,18 @@ public class DataEvolutionSplitGeneratorTest {
         assertThat(splits).allSatisfy(split -> assertThat(split.files).contains(video));
     }
 
+    @Test
+    public void testOverlappingNormalRangesRemainGrouped() {
+        DataFileMeta update = newFile("update.parquet", 0L, 5L, 10L);
+        DataFileMeta base = newFile("base.parquet", 0L, 1000L, 100L);
+
+        DataEvolutionSplitGenerator generator = new DataEvolutionSplitGenerator(1L, 1L, false);
+        List<SplitGenerator.SplitGroup> splits =
+                generator.splitForBatch(Arrays.asList(update, base));
+
+        assertThat(splits).singleElement().satisfies(split -> assertThat(split.files).hasSize(2));
+    }
+
     private static DataFileMeta newFile(
             String name, long firstRowId, long rowCount, long fileSize) {
         return DataFileMeta.create(

--- a/paimon-core/src/test/java/org/apache/paimon/table/source/DataEvolutionSplitGeneratorTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/table/source/DataEvolutionSplitGeneratorTest.java
@@ -75,16 +75,47 @@ public class DataEvolutionSplitGeneratorTest {
         }
         files.add(video);
 
-        DataEvolutionSplitGenerator generator = new DataEvolutionSplitGenerator(500L, 1L, true);
+        DataEvolutionSplitGenerator generator = new DataEvolutionSplitGenerator(200_000L, 1L, true);
         List<SplitGenerator.SplitGroup> splits = generator.splitForBatch(files);
 
-        assertThat(splits).hasSize(2);
+        assertThat(splits).hasSize(1);
         assertThat(splits)
                 .allSatisfy(
                         split -> {
                             assertThat(split.files.stream().filter(file -> file == video))
                                     .hasSize(1);
                             assertThat(split.rawConvertible).isFalse();
+                        });
+    }
+
+    @Test
+    public void testSpanningBlobDoesNotHideDistinctSidecarWeights() {
+        long videoSize = 64L * 1024 * 1024;
+        List<DataFileMeta> files = new ArrayList<>();
+        for (int i = 0; i < 10; i++) {
+            files.add(newFile("file-" + i + ".parquet", i, 1L, 1L));
+            files.add(newFile("camera-" + i + ".video", i, 1L, videoSize));
+        }
+        DataFileMeta spanning = newFile("spanning.video", 0L, 10L, 1L);
+        files.add(spanning);
+
+        DataEvolutionSplitGenerator generator =
+                new DataEvolutionSplitGenerator(130L * 1024 * 1024, 1L, true);
+        List<SplitGenerator.SplitGroup> splits = generator.splitForBatch(files);
+
+        assertThat(splits).hasSize(5);
+        assertThat(splits)
+                .allSatisfy(
+                        split -> {
+                            assertThat(
+                                            split.files.stream()
+                                                    .filter(
+                                                            file ->
+                                                                    file.fileName()
+                                                                            .startsWith("camera-")))
+                                    .hasSize(2);
+                            assertThat(split.files.stream().filter(file -> file == spanning))
+                                    .hasSize(1);
                         });
     }
 

--- a/paimon-core/src/test/java/org/apache/paimon/table/source/DataEvolutionSplitGeneratorTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/table/source/DataEvolutionSplitGeneratorTest.java
@@ -23,6 +23,7 @@ import org.apache.paimon.manifest.FileSource;
 
 import org.junit.jupiter.api.Test;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
@@ -63,6 +64,28 @@ public class DataEvolutionSplitGeneratorTest {
 
         assertThat(splits).hasSize(2);
         assertThat(splits).allSatisfy(split -> assertThat(split.files).contains(video));
+    }
+
+    @Test
+    public void testSpanningBlobKeepsSplitPacking() {
+        DataFileMeta video = newFile("camera.video", 0L, 100L, 100_000L);
+        List<DataFileMeta> files = new ArrayList<>();
+        for (int i = 0; i < 100; i++) {
+            files.add(newFile("file-" + i + ".parquet", i, 1L, 10L));
+        }
+        files.add(video);
+
+        DataEvolutionSplitGenerator generator = new DataEvolutionSplitGenerator(500L, 1L, true);
+        List<SplitGenerator.SplitGroup> splits = generator.splitForBatch(files);
+
+        assertThat(splits).hasSize(2);
+        assertThat(splits)
+                .allSatisfy(
+                        split -> {
+                            assertThat(split.files.stream().filter(file -> file == video))
+                                    .hasSize(1);
+                            assertThat(split.rawConvertible).isFalse();
+                        });
     }
 
     @Test

--- a/paimon-core/src/test/java/org/apache/paimon/table/source/DataSplitCompatibleTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/table/source/DataSplitCompatibleTest.java
@@ -94,6 +94,16 @@ public class DataSplitCompatibleTest {
     }
 
     @Test
+    public void testSpanningSidecarDoesNotInflateMergedRowCount() {
+        DataFileMeta normal = newDataFile("normal.parquet", 2).assignFirstRowId(0);
+        DataFileMeta video = newDataFile("camera.video", 4).assignFirstRowId(0);
+
+        DataSplit split = newDataSplit(false, Arrays.asList(normal, video), null);
+
+        assertThat(split.mergedRowCount()).hasValue(2L);
+    }
+
+    @Test
     public void testDeletionFilesSerialize() throws Exception {
         List<DataFileMeta> dataFiles =
                 Collections.singletonList(
@@ -877,13 +887,25 @@ public class DataSplitCompatibleTest {
     }
 
     private DataFileMeta newDataFile(long rowCount) {
-        return newDataFile(rowCount, null, null);
+        return newDataFile("my_data_file.parquet", rowCount);
+    }
+
+    private DataFileMeta newDataFile(String fileName, long rowCount) {
+        return newDataFile(fileName, rowCount, null, null);
     }
 
     private DataFileMeta newDataFile(
             long rowCount, SimpleStats rowStats, @Nullable List<String> valueStatsCols) {
+        return newDataFile("my_data_file.parquet", rowCount, rowStats, valueStatsCols);
+    }
+
+    private DataFileMeta newDataFile(
+            String fileName,
+            long rowCount,
+            SimpleStats rowStats,
+            @Nullable List<String> valueStatsCols) {
         return DataFileMeta.forAppend(
-                "my_data_file.parquet",
+                fileName,
                 1024 * 1024,
                 rowCount,
                 rowStats,

--- a/paimon-format/src/main/java/org/apache/paimon/format/blob/BlobFileFormat.java
+++ b/paimon-format/src/main/java/org/apache/paimon/format/blob/BlobFileFormat.java
@@ -43,6 +43,7 @@ import javax.annotation.Nullable;
 
 import java.io.IOException;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
 import static org.apache.paimon.utils.Preconditions.checkArgument;
@@ -159,7 +160,16 @@ public class BlobFileFormat extends FileFormat {
             SeekableInputStream in = fileIO.newInputStream(filePath);
             BlobFileMeta fileMeta;
             try {
-                fileMeta = new BlobFileMeta(in, context.fileSize(), context.selection());
+                Map<Path, Object> metadataCache = context.metadataCache();
+                BlobFileMeta baseMeta =
+                        metadataCache == null ? null : (BlobFileMeta) metadataCache.get(filePath);
+                if (baseMeta == null) {
+                    baseMeta = new BlobFileMeta(in, context.fileSize(), null);
+                    if (metadataCache != null) {
+                        metadataCache.put(filePath, baseMeta);
+                    }
+                }
+                fileMeta = baseMeta.select(context.selection());
             } catch (Exception e) {
                 IOUtils.closeQuietly(in);
                 throw e;

--- a/paimon-format/src/main/java/org/apache/paimon/format/blob/BlobFileFormat.java
+++ b/paimon-format/src/main/java/org/apache/paimon/format/blob/BlobFileFormat.java
@@ -157,17 +157,23 @@ public class BlobFileFormat extends FileFormat {
         public FileRecordReader<InternalRow> createReader(Context context) throws IOException {
             FileIO fileIO = context.fileIO();
             Path filePath = context.filePath();
-            SeekableInputStream in = fileIO.newInputStream(filePath);
+            SeekableInputStream in = null;
             BlobFileMeta fileMeta;
             try {
                 Map<Path, Object> metadataCache = context.metadataCache();
                 BlobFileMeta baseMeta =
                         metadataCache == null ? null : (BlobFileMeta) metadataCache.get(filePath);
                 if (baseMeta == null) {
+                    in = fileIO.newInputStream(filePath);
                     baseMeta = new BlobFileMeta(in, context.fileSize(), null);
                     if (metadataCache != null) {
                         metadataCache.put(filePath, baseMeta);
                     }
+                }
+                if (in == null
+                        && BlobElementSerializerFactory.create(blobFieldType)
+                                .requiresReadInputStream(blobAsDescriptor)) {
+                    in = fileIO.newInputStream(filePath);
                 }
                 fileMeta = baseMeta.select(context.selection());
             } catch (Exception e) {

--- a/paimon-format/src/main/java/org/apache/paimon/format/blob/BlobFileMeta.java
+++ b/paimon-format/src/main/java/org/apache/paimon/format/blob/BlobFileMeta.java
@@ -106,55 +106,71 @@ public class BlobFileMeta {
                             offset, indexStart));
         }
 
-        int[] returnedPositions = null;
-        if (selection != null) {
-            long selectionCardinality = selection.getCardinality();
-            if (selectionCardinality > blobLengths.length) {
-                throw new IOException(
-                        String.format(
-                                "Invalid blob selection: cardinality %s exceeds record count %s.",
-                                selectionCardinality, blobLengths.length));
-            }
-            int cardinality = (int) selectionCardinality;
-            returnedPositions = new int[cardinality];
-            long[] newLengths = new long[cardinality];
-            long[] newOffsets = new long[cardinality];
-            Iterator<Integer> iterator = selection.iterator();
-            for (int i = 0; i < cardinality; i++) {
-                Integer next = iterator.next();
-                if (next < 0 || next >= blobLengths.length) {
-                    throw new IOException(
-                            String.format(
-                                    "Invalid blob selection: position %s is outside record count %s.",
-                                    next, blobLengths.length));
-                }
-                newLengths[i] = blobLengths[next];
-                newOffsets[i] = blobOffsets[next];
-                returnedPositions[i] = next;
-            }
-            blobLengths = newLengths;
-            blobOffsets = newOffsets;
-        }
-
-        this.returnedPositions = returnedPositions;
         this.blobLengths = blobLengths;
         this.blobOffsets = blobOffsets;
+        this.returnedPositions = selectedPositions(selection, blobLengths.length);
+    }
+
+    private BlobFileMeta(
+            long[] blobLengths, long[] blobOffsets, @Nullable int[] returnedPositions) {
+        this.blobLengths = blobLengths;
+        this.blobOffsets = blobOffsets;
+        this.returnedPositions = returnedPositions;
+    }
+
+    public BlobFileMeta select(@Nullable RoaringBitmap32 selection) throws IOException {
+        return selection == null
+                ? this
+                : new BlobFileMeta(
+                        blobLengths, blobOffsets, selectedPositions(selection, blobLengths.length));
+    }
+
+    @Nullable
+    private static int[] selectedPositions(@Nullable RoaringBitmap32 selection, int recordCount)
+            throws IOException {
+        if (selection == null) {
+            return null;
+        }
+        long selectionCardinality = selection.getCardinality();
+        if (selectionCardinality > recordCount) {
+            throw new IOException(
+                    String.format(
+                            "Invalid blob selection: cardinality %s exceeds record count %s.",
+                            selectionCardinality, recordCount));
+        }
+        int[] positions = new int[(int) selectionCardinality];
+        Iterator<Integer> iterator = selection.iterator();
+        for (int i = 0; i < positions.length; i++) {
+            int position = iterator.next();
+            if (position < 0 || position >= recordCount) {
+                throw new IOException(
+                        String.format(
+                                "Invalid blob selection: position %s is outside record count %s.",
+                                position, recordCount));
+            }
+            positions[i] = position;
+        }
+        return positions;
+    }
+
+    private int logicalPosition(int returnedPosition) {
+        return returnedPositions == null ? returnedPosition : returnedPositions[returnedPosition];
     }
 
     public boolean isNull(int i) {
-        return blobLengths[i] == BlobFormatWriter.NULL_LENGTH;
+        return blobLengths[logicalPosition(i)] == BlobFormatWriter.NULL_LENGTH;
     }
 
     public boolean isPlaceHolder(int i) {
-        return blobLengths[i] == BlobFormatWriter.PLACE_HOLDER_LENGTH;
+        return blobLengths[logicalPosition(i)] == BlobFormatWriter.PLACE_HOLDER_LENGTH;
     }
 
     public long blobLength(int i) {
-        return blobLengths[i];
+        return blobLengths[logicalPosition(i)];
     }
 
     public long blobOffset(int i) {
-        return blobOffsets[i];
+        return blobOffsets[logicalPosition(i)];
     }
 
     public int returnedPosition(int i) {
@@ -162,6 +178,6 @@ public class BlobFileMeta {
     }
 
     public int recordNumber() {
-        return blobLengths.length;
+        return returnedPositions == null ? blobLengths.length : returnedPositions.length;
     }
 }

--- a/paimon-format/src/main/java/org/apache/paimon/format/blob/VideoFileFormat.java
+++ b/paimon-format/src/main/java/org/apache/paimon/format/blob/VideoFileFormat.java
@@ -42,6 +42,7 @@ import javax.annotation.Nullable;
 
 import java.io.IOException;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
 import static org.apache.paimon.utils.Preconditions.checkArgument;
@@ -136,13 +137,21 @@ public class VideoFileFormat extends FileFormat {
         public FileRecordReader<InternalRow> createReader(Context context) throws IOException {
             FileIO fileIO = context.fileIO();
             Path filePath = context.filePath();
-            SeekableInputStream in = fileIO.newInputStream(filePath);
-            VideoFileMeta fileMeta;
-            try {
-                fileMeta = new VideoFileMeta(in, context.fileSize(), context.selection());
-            } finally {
-                IOUtils.closeQuietly(in);
+            Map<Path, Object> metadataCache = context.metadataCache();
+            VideoFileMeta baseMeta =
+                    metadataCache == null ? null : (VideoFileMeta) metadataCache.get(filePath);
+            if (baseMeta == null) {
+                SeekableInputStream in = fileIO.newInputStream(filePath);
+                try {
+                    baseMeta = new VideoFileMeta(in, context.fileSize(), null);
+                    if (metadataCache != null) {
+                        metadataCache.put(filePath, baseMeta);
+                    }
+                } finally {
+                    IOUtils.closeQuietly(in);
+                }
             }
+            VideoFileMeta fileMeta = baseMeta.select(context.selection());
             return new VideoFormatReader(fileIO, filePath, fileMeta, fieldCount, blobIndex);
         }
 

--- a/paimon-format/src/main/java/org/apache/paimon/format/blob/VideoFileMeta.java
+++ b/paimon-format/src/main/java/org/apache/paimon/format/blob/VideoFileMeta.java
@@ -137,36 +137,71 @@ public class VideoFileMeta {
             runEnds[i] = rows;
         }
 
-        int[] selectedPositions = null;
-        if (selection != null) {
-            long cardinality = selection.getCardinality();
-            if (cardinality > rows) {
-                throw new IOException(
-                        String.format(
-                                "Invalid video selection: cardinality %s exceeds row count %s.",
-                                cardinality, rows));
-            }
-            selectedPositions = new int[(int) cardinality];
-            Iterator<Integer> iterator = selection.iterator();
-            for (int i = 0; i < selectedPositions.length; i++) {
-                int position = iterator.next();
-                if (position < 0 || position >= rows) {
-                    throw new IOException(
-                            String.format(
-                                    "Invalid video selection: position %s is outside row count %s.",
-                                    position, rows));
-                }
-                selectedPositions[i] = position;
-            }
-        }
-
         this.physicalVideoLengths = physicalVideoLengths;
         this.physicalVideoOffsets = physicalVideoOffsets;
         this.runEnds = runEnds;
         this.runReferences = runReferences;
         this.runFirstFrames = runFirstFrames;
         this.rowCount = (int) rows;
+        this.selectedPositions = selectedPositions(selection, rowCount);
+    }
+
+    private VideoFileMeta(
+            long[] physicalVideoLengths,
+            long[] physicalVideoOffsets,
+            long[] runEnds,
+            long[] runReferences,
+            long[] runFirstFrames,
+            int rowCount,
+            @Nullable int[] selectedPositions) {
+        this.physicalVideoLengths = physicalVideoLengths;
+        this.physicalVideoOffsets = physicalVideoOffsets;
+        this.runEnds = runEnds;
+        this.runReferences = runReferences;
+        this.runFirstFrames = runFirstFrames;
+        this.rowCount = rowCount;
         this.selectedPositions = selectedPositions;
+    }
+
+    public VideoFileMeta select(@Nullable RoaringBitmap32 selection) throws IOException {
+        return selection == null
+                ? this
+                : new VideoFileMeta(
+                        physicalVideoLengths,
+                        physicalVideoOffsets,
+                        runEnds,
+                        runReferences,
+                        runFirstFrames,
+                        rowCount,
+                        selectedPositions(selection, rowCount));
+    }
+
+    @Nullable
+    private static int[] selectedPositions(@Nullable RoaringBitmap32 selection, int rowCount)
+            throws IOException {
+        if (selection == null) {
+            return null;
+        }
+        long cardinality = selection.getCardinality();
+        if (cardinality > rowCount) {
+            throw new IOException(
+                    String.format(
+                            "Invalid video selection: cardinality %s exceeds row count %s.",
+                            cardinality, rowCount));
+        }
+        int[] positions = new int[(int) cardinality];
+        Iterator<Integer> iterator = selection.iterator();
+        for (int i = 0; i < positions.length; i++) {
+            int position = iterator.next();
+            if (position < 0 || position >= rowCount) {
+                throw new IOException(
+                        String.format(
+                                "Invalid video selection: position %s is outside row count %s.",
+                                position, rowCount));
+            }
+            positions[i] = position;
+        }
+        return positions;
     }
 
     public boolean isNull(int returnedRow) {

--- a/paimon-format/src/test/java/org/apache/paimon/format/blob/BlobFileFormatTest.java
+++ b/paimon-format/src/test/java/org/apache/paimon/format/blob/BlobFileFormatTest.java
@@ -878,8 +878,7 @@ public class BlobFileFormatTest {
 
     @Test
     public void testReadersShareCachedMetadata() throws IOException {
-        BlobFileFormat format =
-                new BlobFileFormat(false, BlobFormatWriter.DEFAULT_COPY_BUFFER_SIZE);
+        BlobFileFormat format = new BlobFileFormat(true, BlobFormatWriter.DEFAULT_COPY_BUFFER_SIZE);
         RowType rowType = RowType.of(DataTypes.BLOB());
         try (PositionOutputStream out = fileIO.newOutputStream(file, false)) {
             FormatWriter writer = format.createWriterFactory(rowType).create(out, null);
@@ -888,15 +887,16 @@ public class BlobFileFormatTest {
             writer.close();
         }
 
+        TrackingLocalFileIO trackingFileIO = new TrackingLocalFileIO();
         FormatReaderFactory readerFactory = format.createReaderFactory(null, rowType, null);
         Map<Path, Object> metadataCache = new HashMap<>();
         RoaringBitmap32 firstSelection = new RoaringBitmap32();
         firstSelection.add(0);
         FormatReaderContext firstContext =
                 new FormatReaderContext(
-                        fileIO,
+                        trackingFileIO,
                         file,
-                        fileIO.getFileSize(file),
+                        trackingFileIO.getFileSize(file),
                         firstSelection,
                         null,
                         metadataCache);
@@ -906,15 +906,15 @@ public class BlobFileFormatTest {
         }
         Object cachedMetadata = metadataCache.get(file);
         assertThat(rows).hasSize(1);
-        assertThat(rows.get(0).getBlob(0).toData()).isEqualTo("first".getBytes());
+        assertThat(rows.get(0).getBlob(0)).isInstanceOf(BlobRef.class);
 
         RoaringBitmap32 secondSelection = new RoaringBitmap32();
         secondSelection.add(1);
         FormatReaderContext secondContext =
                 new FormatReaderContext(
-                        fileIO,
+                        trackingFileIO,
                         file,
-                        fileIO.getFileSize(file),
+                        trackingFileIO.getFileSize(file),
                         secondSelection,
                         null,
                         metadataCache);
@@ -924,7 +924,8 @@ public class BlobFileFormatTest {
         }
         assertThat(metadataCache.get(file)).isSameAs(cachedMetadata);
         assertThat(rows).hasSize(1);
-        assertThat(rows.get(0).getBlob(0).toData()).isEqualTo("second".getBytes());
+        assertThat(rows.get(0).getBlob(0)).isInstanceOf(BlobRef.class);
+        assertThat(trackingFileIO.inputStreamCount).isEqualTo(1);
     }
 
     private void assertMalformedArrayPayload(
@@ -1223,9 +1224,11 @@ public class BlobFileFormatTest {
     private static class TrackingLocalFileIO extends LocalFileIO {
 
         private TrackingSeekableInputStream lastInputStream;
+        private int inputStreamCount;
 
         @Override
         public SeekableInputStream newInputStream(Path path) throws IOException {
+            inputStreamCount++;
             this.lastInputStream = new TrackingSeekableInputStream(super.newInputStream(path));
             return lastInputStream;
         }

--- a/paimon-format/src/test/java/org/apache/paimon/format/blob/BlobFileFormatTest.java
+++ b/paimon-format/src/test/java/org/apache/paimon/format/blob/BlobFileFormatTest.java
@@ -62,6 +62,7 @@ import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -873,6 +874,57 @@ public class BlobFileFormatTest {
         // assert
         assertThat(result).hasSize(1);
         assertThat(result.get(0)).isSameAs(BlobPlaceholder.INSTANCE);
+    }
+
+    @Test
+    public void testReadersShareCachedMetadata() throws IOException {
+        BlobFileFormat format =
+                new BlobFileFormat(false, BlobFormatWriter.DEFAULT_COPY_BUFFER_SIZE);
+        RowType rowType = RowType.of(DataTypes.BLOB());
+        try (PositionOutputStream out = fileIO.newOutputStream(file, false)) {
+            FormatWriter writer = format.createWriterFactory(rowType).create(out, null);
+            writer.addElement(GenericRow.of(new BlobData("first".getBytes())));
+            writer.addElement(GenericRow.of(new BlobData("second".getBytes())));
+            writer.close();
+        }
+
+        FormatReaderFactory readerFactory = format.createReaderFactory(null, rowType, null);
+        Map<Path, Object> metadataCache = new HashMap<>();
+        RoaringBitmap32 firstSelection = new RoaringBitmap32();
+        firstSelection.add(0);
+        FormatReaderContext firstContext =
+                new FormatReaderContext(
+                        fileIO,
+                        file,
+                        fileIO.getFileSize(file),
+                        firstSelection,
+                        null,
+                        metadataCache);
+        List<InternalRow> rows = new ArrayList<>();
+        try (FileRecordReader<InternalRow> reader = readerFactory.createReader(firstContext)) {
+            reader.forEachRemaining(rows::add);
+        }
+        Object cachedMetadata = metadataCache.get(file);
+        assertThat(rows).hasSize(1);
+        assertThat(rows.get(0).getBlob(0).toData()).isEqualTo("first".getBytes());
+
+        RoaringBitmap32 secondSelection = new RoaringBitmap32();
+        secondSelection.add(1);
+        FormatReaderContext secondContext =
+                new FormatReaderContext(
+                        fileIO,
+                        file,
+                        fileIO.getFileSize(file),
+                        secondSelection,
+                        null,
+                        metadataCache);
+        rows.clear();
+        try (FileRecordReader<InternalRow> reader = readerFactory.createReader(secondContext)) {
+            reader.forEachRemaining(rows::add);
+        }
+        assertThat(metadataCache.get(file)).isSameAs(cachedMetadata);
+        assertThat(rows).hasSize(1);
+        assertThat(rows.get(0).getBlob(0).toData()).isEqualTo("second".getBytes());
     }
 
     private void assertMalformedArrayPayload(

--- a/paimon-format/src/test/java/org/apache/paimon/format/blob/VideoFileFormatTest.java
+++ b/paimon-format/src/test/java/org/apache/paimon/format/blob/VideoFileFormatTest.java
@@ -51,7 +51,9 @@ import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import static org.apache.paimon.utils.StreamUtils.intToLittleEndian;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -179,6 +181,47 @@ public class VideoFileFormatTest {
             assertThat(iterator.returnedPosition()).isEqualTo(3L);
             assertThat(iterator.next()).isNull();
         }
+    }
+
+    @Test
+    public void testReadersShareCachedMetadata() throws IOException {
+        byte[] bytes = "first-mp4".getBytes();
+        write(sourceFrame("first.mp4", bytes, 0), sourceFrame("first.mp4", bytes, 1));
+
+        VideoFileFormat format = new VideoFileFormat(BlobFormatWriter.DEFAULT_COPY_BUFFER_SIZE);
+        FormatReaderFactory readerFactory = format.createReaderFactory(null, rowType, null);
+        Map<Path, Object> metadataCache = new HashMap<>();
+        RoaringBitmap32 firstSelection = new RoaringBitmap32();
+        firstSelection.add(0);
+        FormatReaderContext firstContext =
+                new FormatReaderContext(
+                        fileIO,
+                        file,
+                        fileIO.getFileSize(file),
+                        firstSelection,
+                        null,
+                        metadataCache);
+        try (FileRecordReader<InternalRow> reader = readerFactory.createReader(firstContext)) {
+            FileRecordIterator<InternalRow> iterator = reader.readBatch();
+            assertThat(descriptor(iterator.next()).frameIndex()).isZero();
+        }
+        Object cachedMetadata = metadataCache.get(file);
+
+        RoaringBitmap32 secondSelection = new RoaringBitmap32();
+        secondSelection.add(1);
+        FormatReaderContext secondContext =
+                new FormatReaderContext(
+                        fileIO,
+                        file,
+                        fileIO.getFileSize(file),
+                        secondSelection,
+                        null,
+                        metadataCache);
+        try (FileRecordReader<InternalRow> reader = readerFactory.createReader(secondContext)) {
+            FileRecordIterator<InternalRow> iterator = reader.readBatch();
+            assertThat(descriptor(iterator.next()).frameIndex()).isOne();
+        }
+        assertThat(metadataCache.get(file)).isSameAs(cachedMetadata);
     }
 
     @Test

--- a/paimon-python/pypaimon/common/options/core_options.py
+++ b/paimon-python/pypaimon/common/options/core_options.py
@@ -406,7 +406,7 @@ class CoreOptions:
         .string_type()
         .no_default_value()
         .with_description(
-            "One scalar BLOB field whose logical values are frames in encoded "
+            "Scalar BLOB fields whose logical values are frames in encoded "
             "videos packed into '.video' files."
         )
     )
@@ -1247,20 +1247,9 @@ class CoreOptions:
         value = self.options.get(CoreOptions.BLOB_FIELD, default)
         return CoreOptions._parse_field_set(value)
 
-    def video_frame_field(self, default=None) -> Optional[str]:
-        value = self.options.get(CoreOptions.VIDEO_FRAME_FIELD, default)
-        fields = CoreOptions._parse_field_set(value)
-        if len(fields) > 1:
-            raise ValueError(
-                "'video-frame-field' currently supports exactly one field, "
-                f"but found {sorted(fields)}."
-            )
-        return next(iter(fields)) if fields else None
-
     def video_frame_fields(self, default=None):
-        """Compatibility accessor; internal code should use ``video_frame_field``."""
-        field = self.video_frame_field(default)
-        return {field} if field is not None else set()
+        value = self.options.get(CoreOptions.VIDEO_FRAME_FIELD, default)
+        return CoreOptions._parse_field_set(value)
 
     def blob_view_resolve_enabled(self, default=True):
         return self.options.get(CoreOptions.BLOB_VIEW_RESOLVE_ENABLED, default)

--- a/paimon-python/pypaimon/globalindex/indexed_split.py
+++ b/paimon-python/pypaimon/globalindex/indexed_split.py
@@ -24,6 +24,9 @@ from typing import List, Optional
 from pypaimon.read.split import Split
 
 
+_UNSET = object()
+
+
 class IndexedSplit(Split):
 
     def __init__(
@@ -31,12 +34,16 @@ class IndexedSplit(Split):
         data_split: 'Split',
         row_ranges: List['Range'],
         scores: Optional[List[float]] = None,
-        exact_merged_row_count: Optional[int] = None,
+        exact_merged_row_count=_UNSET,
     ):
         self._data_split = data_split
         self._row_ranges = row_ranges
         self._scores = scores
-        self._exact_merged_row_count = exact_merged_row_count
+        self._merged_row_count_set = exact_merged_row_count is not _UNSET
+        self._exact_merged_row_count = (
+            None if exact_merged_row_count is _UNSET
+            else exact_merged_row_count
+        )
 
     def data_split(self) -> 'Split':
         """Return the underlying data split."""
@@ -78,7 +85,7 @@ class IndexedSplit(Split):
         return sum(r.count() for r in self._row_ranges)
 
     def merged_row_count(self):
-        if self._exact_merged_row_count is not None:
+        if self._merged_row_count_set:
             return self._exact_merged_row_count
         return self.row_count
 
@@ -142,6 +149,7 @@ class IndexedSplit(Split):
             and self._row_ranges == other._row_ranges
             and self._scores == other._scores
             and self._exact_merged_row_count == other._exact_merged_row_count
+            and self._merged_row_count_set == other._merged_row_count_set
         )
 
     def __hash__(self):
@@ -151,9 +159,11 @@ class IndexedSplit(Split):
             tuple(self._row_ranges),
             scores_hash,
             self._exact_merged_row_count,
+            self._merged_row_count_set,
         ))
 
     def __repr__(self):
         return (f"IndexedSplit(data_split={self._data_split}, "
                 f"row_ranges={self._row_ranges}, scores={self._scores}, "
-                f"exact_merged_row_count={self._exact_merged_row_count})")
+                f"exact_merged_row_count={self._exact_merged_row_count}, "
+                f"merged_row_count_set={self._merged_row_count_set})")

--- a/paimon-python/pypaimon/multimodal/table.py
+++ b/paimon-python/pypaimon/multimodal/table.py
@@ -171,13 +171,18 @@ class MultimodalTable:
         return self.add_batches(frame_batches())
 
     def _resolve_video_frame_column(self, requested):
-        configured = self.raw_table.options.video_frame_field()
-        if configured is None:
+        configured = self.raw_table.options.video_frame_fields()
+        if not configured:
             raise ValueError(
                 "add_video requires table option 'video-frame-field'."
             )
-        column = requested or configured
-        if column != configured:
+        if requested is None and len(configured) > 1:
+            raise ValueError(
+                "video_column is required when 'video-frame-field' configures "
+                "multiple fields."
+            )
+        column = requested or next(iter(configured))
+        if column not in configured:
             raise ValueError(
                 "Video column %r is not configured by 'video-frame-field'."
                 % column
@@ -254,13 +259,14 @@ class MultimodalTable:
         return self
 
     def update(self, where, values):
-        video_column = self.raw_table.options.video_frame_field()
+        video_columns = self.raw_table.options.video_frame_fields()
         if isinstance(values, Mapping):
-            if video_column is not None and video_column in values:
+            assigned_video_columns = video_columns.intersection(values)
+            if assigned_video_columns:
                 raise ValueError(
                     "update() cannot write video-frame-field %r; use "
                     "replace_video() with a complete encoded video."
-                    % video_column
+                    % sorted(assigned_video_columns)[0]
                 )
         query = self.scan().where(where)
         predicate = query._predicate

--- a/paimon-python/pypaimon/read/reader/field_bunch.py
+++ b/paimon-python/pypaimon/read/reader/field_bunch.py
@@ -171,16 +171,20 @@ class BlobBunch(_SpecialFieldBunch):
         physical_row_count = sum(row_range.count() for row_range in merged)
         if self.expected_row_range is not None:
             for row_range in merged:
-                if self.row_id_push_down:
-                    if not row_range.overlaps(self.expected_row_range):
-                        raise ValueError(
-                            f"Blob file range {row_range} should intersect normal "
-                            f"file range {self.expected_row_range}."
-                        )
-                elif (row_range.from_ < self.expected_row_range.from_
-                      or row_range.to > self.expected_row_range.to):
+                nested = (
+                    row_range.contains(self.expected_row_range.from_)
+                    and row_range.contains(self.expected_row_range.to)
+                ) or (
+                    self.expected_row_range.contains(row_range.from_)
+                    and self.expected_row_range.contains(row_range.to)
+                )
+                valid = (
+                    row_range.overlaps(self.expected_row_range)
+                    if self.row_id_push_down else nested
+                )
+                if not valid:
                     raise ValueError(
-                        f"Blob file range {row_range} should be within normal "
+                        f"Blob file range {row_range} should contain or be within normal "
                         f"file range {self.expected_row_range}."
                     )
             self._row_count = self.expected_row_range.count()

--- a/paimon-python/pypaimon/read/reader/field_bunch.py
+++ b/paimon-python/pypaimon/read/reader/field_bunch.py
@@ -171,8 +171,14 @@ class BlobBunch(_SpecialFieldBunch):
         physical_row_count = sum(row_range.count() for row_range in merged)
         if self.expected_row_range is not None:
             for row_range in merged:
-                if (row_range.from_ < self.expected_row_range.from_
-                        or row_range.to > self.expected_row_range.to):
+                if self.row_id_push_down:
+                    if not row_range.overlaps(self.expected_row_range):
+                        raise ValueError(
+                            f"Blob file range {row_range} should intersect normal "
+                            f"file range {self.expected_row_range}."
+                        )
+                elif (row_range.from_ < self.expected_row_range.from_
+                      or row_range.to > self.expected_row_range.to):
                     raise ValueError(
                         f"Blob file range {row_range} should be within normal "
                         f"file range {self.expected_row_range}."

--- a/paimon-python/pypaimon/read/reader/format_blob_reader.py
+++ b/paimon-python/pypaimon/read/reader/format_blob_reader.py
@@ -96,11 +96,9 @@ class FormatBlobReader(RecordBatchReader):
             elif self._is_video:
                 self._video_meta = copy(cached_index)
             else:
-                self._input_stream = file_io.new_input_stream(file_path)
                 self.blob_lengths, self.blob_offsets = cached_index
             self._apply_row_indices(row_indices)
 
-            # Set up fields and schema before deciding whether the stream can be dropped.
             if len(read_fields) > 1:
                 raise RuntimeError("Blob reader only supports one field.")
             self._fields = read_fields
@@ -116,20 +114,24 @@ class FormatBlobReader(RecordBatchReader):
                 )
             self._is_array_blob = is_array_blob_type(self._data_field.type)
             self._is_map_blob = is_map_blob_type(self._data_field.type)
-            self._schema = PyarrowFieldParser.from_paimon_schema(projected_data_fields)
-
-            # Drop the shared stream: descriptor/concurrent reads yield BlobRefs
-            # that each open their own stream (one stream isn't thread-safe).
-            # Nested Blob formats need the stream to read their keys and indexes.
-            if (
-                not self._is_array_blob
-                and not self._is_map_blob
+            self._schema = PyarrowFieldParser.from_paimon_schema(
+                projected_data_fields
+            )
+            requires_input_stream = (
+                not self._is_video
                 and (
-                    self._is_video
-                    or self._blob_as_descriptor
-                    or self._blob_parallelism > 1
+                    self._is_array_blob
+                    or self._is_map_blob
+                    or (
+                        not self._blob_as_descriptor
+                        and self._blob_parallelism <= 1
+                    )
                 )
-            ):
+            )
+
+            if requires_input_stream and self._input_stream is None:
+                self._input_stream = file_io.new_input_stream(file_path)
+            elif not requires_input_stream:
                 if self._input_stream is not None:
                     self._input_stream.close()
                     self._input_stream = None

--- a/paimon-python/pypaimon/read/reader/format_blob_reader.py
+++ b/paimon-python/pypaimon/read/reader/format_blob_reader.py
@@ -16,6 +16,7 @@
 # under the License.
 
 import struct
+from copy import copy
 from typing import List, Optional, Any, Iterator, BinaryIO
 
 import pyarrow as pa
@@ -50,7 +51,8 @@ class FormatBlobReader(RecordBatchReader):
     def __init__(self, file_io: FileIO, file_path: str, read_fields: List[str],
                  full_fields: List[DataField], push_down_predicate: Any, blob_as_descriptor: bool,
                  batch_size: int = 1024, row_indices: Optional[Any] = None,
-                 blob_parallelism: int = 1, file_size: Optional[int] = None):
+                 blob_parallelism: int = 1, file_size: Optional[int] = None,
+                 video_meta_cache: Optional[dict] = None):
         self._file_io = file_io
         self._file_path = file_path
         self._push_down_predicate = push_down_predicate
@@ -74,8 +76,18 @@ class FormatBlobReader(RecordBatchReader):
                 if file_size is not None and file_size > 0
                 else file_io.get_file_size(file_path)
             )
-            self._input_stream = file_io.new_input_stream(file_path)
-            self._read_index()
+            cached_video_meta = (
+                video_meta_cache.get(file_path)
+                if self._is_video and video_meta_cache is not None
+                else None
+            )
+            if cached_video_meta is None:
+                self._input_stream = file_io.new_input_stream(file_path)
+                self._read_index()
+                if self._is_video and video_meta_cache is not None:
+                    video_meta_cache[file_path] = copy(self._video_meta)
+            else:
+                self._video_meta = copy(cached_video_meta)
             self._apply_row_indices(row_indices)
 
             # Set up fields and schema before deciding whether the stream can be dropped.
@@ -108,8 +120,9 @@ class FormatBlobReader(RecordBatchReader):
                     or self._blob_parallelism > 1
                 )
             ):
-                self._input_stream.close()
-                self._input_stream = None
+                if self._input_stream is not None:
+                    self._input_stream.close()
+                    self._input_stream = None
         except Exception:
             self.close()
             raise

--- a/paimon-python/pypaimon/read/reader/format_blob_reader.py
+++ b/paimon-python/pypaimon/read/reader/format_blob_reader.py
@@ -17,7 +17,7 @@
 
 import struct
 from copy import copy
-from typing import List, Optional, Any, Iterator, BinaryIO
+from typing import List, Optional, Any, Iterator, BinaryIO, Sequence
 
 import pyarrow as pa
 import pyarrow.dataset as ds
@@ -52,7 +52,7 @@ class FormatBlobReader(RecordBatchReader):
                  full_fields: List[DataField], push_down_predicate: Any, blob_as_descriptor: bool,
                  batch_size: int = 1024, row_indices: Optional[Any] = None,
                  blob_parallelism: int = 1, file_size: Optional[int] = None,
-                 video_meta_cache: Optional[dict] = None):
+                 blob_index_cache: Optional[dict] = None):
         self._file_io = file_io
         self._file_path = file_path
         self._push_down_predicate = push_down_predicate
@@ -64,8 +64,8 @@ class FormatBlobReader(RecordBatchReader):
 
         # Initialize the low-level blob format reader
         self.file_path = file_path
-        self.blob_lengths: List[int] = []
-        self.blob_offsets: List[int] = []
+        self.blob_lengths: Sequence[int] = []
+        self.blob_offsets: Sequence[int] = []
         self.returned = False
         self._input_stream = None
         self._blob_iterator = None
@@ -76,18 +76,28 @@ class FormatBlobReader(RecordBatchReader):
                 if file_size is not None and file_size > 0
                 else file_io.get_file_size(file_path)
             )
-            cached_video_meta = (
-                video_meta_cache.get(file_path)
-                if self._is_video and video_meta_cache is not None
+            cached_index = (
+                blob_index_cache.get(file_path)
+                if blob_index_cache is not None
                 else None
             )
-            if cached_video_meta is None:
+            if cached_index is None:
                 self._input_stream = file_io.new_input_stream(file_path)
                 self._read_index()
-                if self._is_video and video_meta_cache is not None:
-                    video_meta_cache[file_path] = copy(self._video_meta)
+                if blob_index_cache is not None:
+                    if self._is_video:
+                        blob_index_cache[file_path] = copy(self._video_meta)
+                    else:
+                        cached_index = (
+                            tuple(self.blob_lengths), tuple(self.blob_offsets)
+                        )
+                        blob_index_cache[file_path] = cached_index
+                        self.blob_lengths, self.blob_offsets = cached_index
+            elif self._is_video:
+                self._video_meta = copy(cached_index)
             else:
-                self._video_meta = copy(cached_video_meta)
+                self._input_stream = file_io.new_input_stream(file_path)
+                self.blob_lengths, self.blob_offsets = cached_index
             self._apply_row_indices(row_indices)
 
             # Set up fields and schema before deciding whether the stream can be dropped.
@@ -444,8 +454,8 @@ class BlobRecordIterator:
     NULL_LENGTH = -1
     PLACE_HOLDER_LENGTH = -2
 
-    def __init__(self, file_io: FileIO, file_path: str, blob_lengths: List[int],
-                 blob_offsets: List[int], field,
+    def __init__(self, file_io: FileIO, file_path: str, blob_lengths: Sequence[int],
+                 blob_offsets: Sequence[int], field,
                  input_stream: Optional[BinaryIO] = None,
                  blob_as_descriptor: bool = False):
         self.file_io = file_io

--- a/paimon-python/pypaimon/read/scanner/data_evolution_split_generator.py
+++ b/paimon-python/pypaimon/read/scanner/data_evolution_split_generator.py
@@ -131,19 +131,34 @@ class DataEvolutionSplitGenerator(AbstractSplitGenerator):
     def _pack_with_unique_sidecars(
             self, groups: List[List[DataFileMeta]]
     ) -> List[List[List[DataFileMeta]]]:
+        sidecar_occurrences = defaultdict(int)
+        for group in groups:
+            for identity in {
+                id(file) for file in group if self._is_sidecar(file)
+            }:
+                sidecar_occurrences[identity] += 1
+        shared_sidecars = {
+            identity for identity, count in sidecar_occurrences.items()
+            if count > 1
+        }
+
         packed = []
         current = []
         current_weight = 0
         seen_sidecars = set()
 
         for group in groups:
-            weight = self._incremental_group_weight(group, seen_sidecars)
+            weight = self._incremental_group_weight(
+                group, seen_sidecars, shared_sidecars
+            )
             if current and current_weight + weight > self.target_split_size:
                 packed.append(current)
                 current = []
                 current_weight = 0
                 seen_sidecars = set()
-                weight = self._incremental_group_weight(group, seen_sidecars)
+                weight = self._incremental_group_weight(
+                    group, seen_sidecars, shared_sidecars
+                )
 
             current.append(group)
             current_weight += weight
@@ -156,13 +171,16 @@ class DataEvolutionSplitGenerator(AbstractSplitGenerator):
         return packed
 
     def _incremental_group_weight(
-            self, group: List[DataFileMeta], seen_sidecars: set
+            self, group: List[DataFileMeta], seen_sidecars: set,
+            shared_sidecars: set,
     ) -> int:
         seen_in_group = set()
         size = 0
         for file in group:
             if self._is_sidecar(file):
                 identity = id(file)
+                if identity in shared_sidecars:
+                    continue
                 if identity in seen_sidecars or identity in seen_in_group:
                     continue
                 seen_in_group.add(identity)

--- a/paimon-python/pypaimon/read/scanner/data_evolution_split_generator.py
+++ b/paimon-python/pypaimon/read/scanner/data_evolution_split_generator.py
@@ -146,27 +146,40 @@ class DataEvolutionSplitGenerator(AbstractSplitGenerator):
         current = []
         current_weight = 0
         seen_sidecars = set()
+        fixed_component = set()
 
         for group in groups:
-            weight = self._incremental_group_weight(
-                group, seen_sidecars, set()
-            )
-            if not current and weight > self.target_split_size:
-                weight = self._incremental_group_weight(
-                    group, seen_sidecars, shared_sidecars
+            group_shared_sidecars = {
+                id(file) for file in group if id(file) in shared_sidecars
+            }
+            if (current and fixed_component
+                    and fixed_component.isdisjoint(group_shared_sidecars)):
+                packed.append(current)
+                current = []
+                current_weight = 0
+                seen_sidecars = set()
+                fixed_component = set()
+
+            weight = (
+                self._initial_group_weight(
+                    group, seen_sidecars, shared_sidecars, fixed_component
                 )
+                if not current
+                else self._incremental_group_weight(
+                    group, seen_sidecars, set()
+                )
+            )
             if current and current_weight + weight > self.target_split_size:
                 packed.append(current)
                 current = []
                 current_weight = 0
                 seen_sidecars = set()
-                weight = self._incremental_group_weight(
-                    group, seen_sidecars, set()
+                fixed_component = set()
+                weight = self._initial_group_weight(
+                    group, seen_sidecars, shared_sidecars, fixed_component
                 )
-                if weight > self.target_split_size:
-                    weight = self._incremental_group_weight(
-                        group, seen_sidecars, shared_sidecars
-                    )
+            elif fixed_component:
+                fixed_component.update(group_shared_sidecars)
 
             current.append(group)
             current_weight += weight
@@ -177,6 +190,24 @@ class DataEvolutionSplitGenerator(AbstractSplitGenerator):
         if current:
             packed.append(current)
         return packed
+
+    def _initial_group_weight(
+            self, group: List[DataFileMeta], seen_sidecars: set,
+            shared_sidecars: set, fixed_component: set,
+    ) -> int:
+        weight = self._incremental_group_weight(group, seen_sidecars, set())
+        if weight <= self.target_split_size:
+            return weight
+
+        marginal_weight = self._incremental_group_weight(
+            group, seen_sidecars, shared_sidecars
+        )
+        if marginal_weight <= self.target_split_size:
+            fixed_component.update(
+                id(file) for file in group if id(file) in shared_sidecars
+            )
+            return marginal_weight
+        return weight
 
     def _incremental_group_weight(
             self, group: List[DataFileMeta], seen_sidecars: set,

--- a/paimon-python/pypaimon/read/scanner/data_evolution_split_generator.py
+++ b/paimon-python/pypaimon/read/scanner/data_evolution_split_generator.py
@@ -149,16 +149,24 @@ class DataEvolutionSplitGenerator(AbstractSplitGenerator):
 
         for group in groups:
             weight = self._incremental_group_weight(
-                group, seen_sidecars, shared_sidecars
+                group, seen_sidecars, set()
             )
+            if not current and weight > self.target_split_size:
+                weight = self._incremental_group_weight(
+                    group, seen_sidecars, shared_sidecars
+                )
             if current and current_weight + weight > self.target_split_size:
                 packed.append(current)
                 current = []
                 current_weight = 0
                 seen_sidecars = set()
                 weight = self._incremental_group_weight(
-                    group, seen_sidecars, shared_sidecars
+                    group, seen_sidecars, set()
                 )
+                if weight > self.target_split_size:
+                    weight = self._incremental_group_weight(
+                        group, seen_sidecars, shared_sidecars
+                    )
 
             current.append(group)
             current_weight += weight
@@ -172,14 +180,14 @@ class DataEvolutionSplitGenerator(AbstractSplitGenerator):
 
     def _incremental_group_weight(
             self, group: List[DataFileMeta], seen_sidecars: set,
-            shared_sidecars: set,
+            ignored_sidecars: set,
     ) -> int:
         seen_in_group = set()
         size = 0
         for file in group:
             if self._is_sidecar(file):
                 identity = id(file)
-                if identity in shared_sidecars:
+                if identity in ignored_sidecars:
                     continue
                 if identity in seen_sidecars or identity in seen_in_group:
                     continue

--- a/paimon-python/pypaimon/read/scanner/data_evolution_split_generator.py
+++ b/paimon-python/pypaimon/read/scanner/data_evolution_split_generator.py
@@ -20,11 +20,11 @@ from typing import List, Optional, Tuple
 
 from pypaimon.globalindex.indexed_split import IndexedSplit
 from pypaimon.utils.range import Range
-from pypaimon.utils.range_helper import RangeHelper
 from pypaimon.manifest.schema.data_file_meta import DataFileMeta
 from pypaimon.manifest.schema.manifest_entry import ManifestEntry
 from pypaimon.read.scanner.split_generator import AbstractSplitGenerator
 from pypaimon.read.split import DataSplit, Split
+from pypaimon.utils.data_evolution_utils import group_by_normal_file_range
 
 
 class DataEvolutionSplitGenerator(AbstractSplitGenerator):
@@ -63,9 +63,6 @@ class DataEvolutionSplitGenerator(AbstractSplitGenerator):
             # Filter files by Row ID range
             partitioned_files = self._filter_files_by_row_ranges(partitioned_files, slice_row_ranges)
 
-        def weight_func(file_list: List[DataFileMeta]) -> int:
-            return max(sum(f.file_size for f in file_list), self.open_file_cost)
-
         splits = []
         for key, entries_list in partitioned_files.items():
             if not entries_list:
@@ -80,15 +77,27 @@ class DataEvolutionSplitGenerator(AbstractSplitGenerator):
                     group for group in split_by_row_id
                     if self.group_stats_filter.may_match(group)
                 ]
+
+            file_ids = [id(file) for group in split_by_row_id for file in group]
+            has_spanning_sidecar = len(file_ids) != len(set(file_ids))
+            if self.group_stats_filter is not None:
                 split_by_row_id = [
                     [file.copy_without_stats() for file in group]
                     for group in split_by_row_id
                 ]
 
-            # Pack the split groups for optimal split sizes
-            packed_files = self._pack_for_ordered(
-                split_by_row_id, weight_func, self.target_split_size
-            )
+            if has_spanning_sidecar:
+                # A spanning sidecar is shared by metadata. Keep each anchor
+                # range separate so it is not added twice to one DataSplit.
+                packed_files = [[group] for group in split_by_row_id]
+            else:
+                packed_files = self._pack_for_ordered(
+                    split_by_row_id,
+                    lambda group: max(
+                        sum(file.file_size for file in group), self.open_file_cost
+                    ),
+                    self.target_split_size,
+                )
 
             # Flatten the packed files and build splits
             flatten_packed_files: List[List[DataFileMeta]] = [
@@ -96,9 +105,15 @@ class DataEvolutionSplitGenerator(AbstractSplitGenerator):
                 for pack in packed_files
             ]
 
-            splits += self._build_split_from_pack_for_data_evolution(
+            new_splits = self._build_split_from_pack_for_data_evolution(
                 flatten_packed_files, packed_files, entries_list
             )
+            if has_spanning_sidecar and slice_row_ranges is None and self.row_ranges is None:
+                new_splits = [
+                    IndexedSplit(split, [self._normal_range(split)])
+                    for split in new_splits
+                ]
+            splits += new_splits
 
         # merge slice_row_ranges and self.row_ranges
         if slice_row_ranges is None:
@@ -111,6 +126,23 @@ class DataEvolutionSplitGenerator(AbstractSplitGenerator):
             splits = self._wrap_to_indexed_splits(splits, slice_row_ranges)
 
         return splits
+
+    @staticmethod
+    def _normal_range(split: DataSplit) -> Range:
+        normal_ranges = [
+            file.row_id_range()
+            for file in split.files
+            if (not DataFileMeta.is_blob_file(file.file_name)
+                and not DataFileMeta.is_vector_file(file.file_name))
+        ]
+        if not normal_ranges:
+            raise ValueError(
+                "Expected at least one normal-file row range."
+            )
+        return Range(
+            min(row_range.from_ for row_range in normal_ranges),
+            max(row_range.to for row_range in normal_ranges),
+        )
 
     def _build_split_from_pack_for_data_evolution(
         self,
@@ -302,9 +334,10 @@ class DataEvolutionSplitGenerator(AbstractSplitGenerator):
 
     @staticmethod
     def _split_by_row_id(files: List[DataFileMeta]) -> List[List[DataFileMeta]]:
-        """Group data-evolution files with overlapping row-id ranges (an original file and its
-        column deltas) via the shared RangeHelper; fails fast on a file missing first_row_id."""
-        return RangeHelper(lambda f: f.non_null_row_id_range()).merge_overlapping_ranges(files)
+        """Group sidecars by the normal-file ranges they intersect."""
+        return group_by_normal_file_range(
+            files, lambda file: file.non_null_row_id_range()
+        )
 
     def _wrap_to_indexed_splits(self, splits: List[Split], row_ranges: List[Range]) -> List[Split]:
         """
@@ -313,7 +346,15 @@ class DataEvolutionSplitGenerator(AbstractSplitGenerator):
         indexed_splits = []
         for split in splits:
             # Calculate file ranges for this split
-            file_ranges = [file.row_id_range() for file in split.files]
+            normal_ranges = [
+                file.row_id_range()
+                for file in split.files
+                if (not DataFileMeta.is_blob_file(file.file_name)
+                    and not DataFileMeta.is_vector_file(file.file_name))
+            ]
+            file_ranges = normal_ranges or [
+                file.row_id_range() for file in split.files
+            ]
 
             if not file_ranges:
                 # No row IDs, keep original split

--- a/paimon-python/pypaimon/read/scanner/data_evolution_split_generator.py
+++ b/paimon-python/pypaimon/read/scanner/data_evolution_split_generator.py
@@ -94,11 +94,7 @@ class DataEvolutionSplitGenerator(AbstractSplitGenerator):
                     for group in split_by_row_id
                 ]
 
-            packed_files = self._pack_for_ordered(
-                split_by_row_id,
-                self._normal_group_weight,
-                self.target_split_size,
-            )
+            packed_files = self._pack_with_unique_sidecars(split_by_row_id)
 
             # Flatten the packed files and build splits
             flatten_packed_files: List[List[DataFileMeta]] = [
@@ -111,7 +107,11 @@ class DataEvolutionSplitGenerator(AbstractSplitGenerator):
             )
             if has_spanning_sidecar and slice_row_ranges is None and self.row_ranges is None:
                 new_splits = [
-                    IndexedSplit(split, self._normal_ranges(pack))
+                    IndexedSplit(
+                        split,
+                        self._normal_ranges(pack),
+                        exact_merged_row_count=split.merged_row_count(),
+                    )
                     for split, pack in zip(new_splits, packed_files)
                 ]
             splits += new_splits
@@ -128,14 +128,51 @@ class DataEvolutionSplitGenerator(AbstractSplitGenerator):
 
         return splits
 
-    def _normal_group_weight(self, group: List[DataFileMeta]) -> int:
-        normal_files = [
-            file for file in group
-            if (not DataFileMeta.is_blob_file(file.file_name)
-                and not DataFileMeta.is_vector_file(file.file_name))
-        ]
-        files = normal_files or group
-        return max(sum(file.file_size for file in files), self.open_file_cost)
+    def _pack_with_unique_sidecars(
+            self, groups: List[List[DataFileMeta]]
+    ) -> List[List[List[DataFileMeta]]]:
+        packed = []
+        current = []
+        current_weight = 0
+        seen_sidecars = set()
+
+        for group in groups:
+            weight = self._incremental_group_weight(group, seen_sidecars)
+            if current and current_weight + weight > self.target_split_size:
+                packed.append(current)
+                current = []
+                current_weight = 0
+                seen_sidecars = set()
+                weight = self._incremental_group_weight(group, seen_sidecars)
+
+            current.append(group)
+            current_weight += weight
+            seen_sidecars.update(
+                id(file) for file in group if self._is_sidecar(file)
+            )
+
+        if current:
+            packed.append(current)
+        return packed
+
+    def _incremental_group_weight(
+            self, group: List[DataFileMeta], seen_sidecars: set
+    ) -> int:
+        seen_in_group = set()
+        size = 0
+        for file in group:
+            if self._is_sidecar(file):
+                identity = id(file)
+                if identity in seen_sidecars or identity in seen_in_group:
+                    continue
+                seen_in_group.add(identity)
+            size += file.file_size
+        return max(size, self.open_file_cost)
+
+    @staticmethod
+    def _is_sidecar(file: DataFileMeta) -> bool:
+        return (DataFileMeta.is_blob_file(file.file_name)
+                or DataFileMeta.is_vector_file(file.file_name))
 
     @staticmethod
     def _has_spanning_sidecar(groups: List[List[DataFileMeta]]) -> bool:

--- a/paimon-python/pypaimon/read/scanner/data_evolution_split_generator.py
+++ b/paimon-python/pypaimon/read/scanner/data_evolution_split_generator.py
@@ -78,30 +78,31 @@ class DataEvolutionSplitGenerator(AbstractSplitGenerator):
                     if self.group_stats_filter.may_match(group)
                 ]
 
-            file_ids = [id(file) for group in split_by_row_id for file in group]
-            has_spanning_sidecar = len(file_ids) != len(set(file_ids))
+            has_spanning_sidecar = self._has_spanning_sidecar(split_by_row_id)
             if self.group_stats_filter is not None:
+                copies = {}
+
+                def without_stats(file):
+                    copy = copies.get(id(file))
+                    if copy is None:
+                        copy = file.copy_without_stats()
+                        copies[id(file)] = copy
+                    return copy
+
                 split_by_row_id = [
-                    [file.copy_without_stats() for file in group]
+                    [without_stats(file) for file in group]
                     for group in split_by_row_id
                 ]
 
-            if has_spanning_sidecar:
-                # A spanning sidecar is shared by metadata. Keep each anchor
-                # range separate so it is not added twice to one DataSplit.
-                packed_files = [[group] for group in split_by_row_id]
-            else:
-                packed_files = self._pack_for_ordered(
-                    split_by_row_id,
-                    lambda group: max(
-                        sum(file.file_size for file in group), self.open_file_cost
-                    ),
-                    self.target_split_size,
-                )
+            packed_files = self._pack_for_ordered(
+                split_by_row_id,
+                self._normal_group_weight,
+                self.target_split_size,
+            )
 
             # Flatten the packed files and build splits
             flatten_packed_files: List[List[DataFileMeta]] = [
-                [file for sub_pack in pack for file in sub_pack]
+                self._unique_files(pack)
                 for pack in packed_files
             ]
 
@@ -110,8 +111,8 @@ class DataEvolutionSplitGenerator(AbstractSplitGenerator):
             )
             if has_spanning_sidecar and slice_row_ranges is None and self.row_ranges is None:
                 new_splits = [
-                    IndexedSplit(split, [self._normal_range(split)])
-                    for split in new_splits
+                    IndexedSplit(split, self._normal_ranges(pack))
+                    for split, pack in zip(new_splits, packed_files)
                 ]
             splits += new_splits
 
@@ -127,11 +128,42 @@ class DataEvolutionSplitGenerator(AbstractSplitGenerator):
 
         return splits
 
+    def _normal_group_weight(self, group: List[DataFileMeta]) -> int:
+        normal_files = [
+            file for file in group
+            if (not DataFileMeta.is_blob_file(file.file_name)
+                and not DataFileMeta.is_vector_file(file.file_name))
+        ]
+        files = normal_files or group
+        return max(sum(file.file_size for file in files), self.open_file_cost)
+
     @staticmethod
-    def _normal_range(split: DataSplit) -> Range:
+    def _has_spanning_sidecar(groups: List[List[DataFileMeta]]) -> bool:
+        for group in groups:
+            normal_ranges = [
+                file.row_id_range()
+                for file in group
+                if (not DataFileMeta.is_blob_file(file.file_name)
+                    and not DataFileMeta.is_vector_file(file.file_name))
+            ]
+            if not normal_ranges:
+                continue
+            start = min(row_range.from_ for row_range in normal_ranges)
+            end = max(row_range.to for row_range in normal_ranges)
+            for file in group:
+                if (DataFileMeta.is_blob_file(file.file_name)
+                        or DataFileMeta.is_vector_file(file.file_name)):
+                    row_range = file.row_id_range()
+                    if row_range.from_ < start or row_range.to > end:
+                        return True
+        return False
+
+    @staticmethod
+    def _normal_ranges(pack: List[List[DataFileMeta]]) -> List[Range]:
         normal_ranges = [
             file.row_id_range()
-            for file in split.files
+            for group in pack
+            for file in group
             if (not DataFileMeta.is_blob_file(file.file_name)
                 and not DataFileMeta.is_vector_file(file.file_name))
         ]
@@ -139,10 +171,18 @@ class DataEvolutionSplitGenerator(AbstractSplitGenerator):
             raise ValueError(
                 "Expected at least one normal-file row range."
             )
-        return Range(
-            min(row_range.from_ for row_range in normal_ranges),
-            max(row_range.to for row_range in normal_ranges),
-        )
+        return Range.merge_sorted_as_possible(normal_ranges)
+
+    @staticmethod
+    def _unique_files(pack: List[List[DataFileMeta]]) -> List[DataFileMeta]:
+        seen = set()
+        result = []
+        for group in pack:
+            for file in group:
+                if id(file) not in seen:
+                    seen.add(id(file))
+                    result.append(file)
+        return result
 
     def _build_split_from_pack_for_data_evolution(
         self,

--- a/paimon-python/pypaimon/read/scanner/data_evolution_stats.py
+++ b/paimon-python/pypaimon/read/scanner/data_evolution_stats.py
@@ -73,10 +73,6 @@ class DataEvolutionGroupStatsFilter:
             return True
 
     def _group_stats(self, files):
-        group_start = min(file.non_null_row_id_range().from_ for file in files)
-        group_end = max(file.non_null_row_id_range().to for file in files)
-        row_count = group_end - group_start + 1
-
         normal_files = []
         special_field_ids = set()
         for file in files:
@@ -86,6 +82,13 @@ class DataEvolutionGroupStatsFilter:
                 special_field_ids.update(layout.data_fields)
             else:
                 normal_files.append((file, layout))
+        range_files = [file for file, unused_layout in normal_files] or files
+        group_start = min(
+            file.non_null_row_id_range().from_ for file in range_files)
+        group_end = max(
+            file.non_null_row_id_range().to for file in range_files)
+        row_count = group_end - group_start + 1
+
         providers = {}
         for file, layout in normal_files:
             for field_id in layout.data_fields:

--- a/paimon-python/pypaimon/read/split.py
+++ b/paimon-python/pypaimon/read/split.py
@@ -198,9 +198,14 @@ class DataSplit(Split):
         if not self._files:
             return 0
         
-        file_ranges = []
-        for file in self._files:
-            file_ranges.append(file.row_id_range())
+        file_ranges = [
+            file.row_id_range()
+            for file in self._files
+            if (not DataFileMeta.is_blob_file(file.file_name)
+                and not DataFileMeta.is_vector_file(file.file_name))
+        ]
+        if not file_ranges:
+            file_ranges = [file.row_id_range() for file in self._files]
         
         if not file_ranges:
             return 0

--- a/paimon-python/pypaimon/read/split_read.py
+++ b/paimon-python/pypaimon/read/split_read.py
@@ -80,7 +80,8 @@ from pypaimon.read.sliced_split import SlicedSplit
 from pypaimon.schema.data_types import DataField, PyarrowFieldParser
 from pypaimon.table.special_fields import SpecialFields
 from pypaimon.globalindex.indexed_split import IndexedSplit
-from pypaimon.utils.data_evolution_utils import retrieve_anchor_file
+from pypaimon.utils.data_evolution_utils import (
+    group_by_normal_file_range, retrieve_anchor_file)
 
 KEY_PREFIX = "_KEY_"
 KEY_FIELD_ID_START = 1000000
@@ -485,8 +486,8 @@ class SplitRead(ABC):
     def _read_blob_as_descriptor(self, field_names: List[str]) -> bool:
         if CoreOptions.blob_as_descriptor(self.table.options):
             return True
-        video_field = CoreOptions.video_frame_field(self.table.options)
-        if video_field in field_names:
+        video_fields = CoreOptions.video_frame_fields(self.table.options)
+        if video_fields.intersection(field_names):
             return True
         deferred_fields = getattr(self, '_deferred_blob_fields', set())
         return any(field_name in deferred_fields for field_name in field_names)
@@ -1274,49 +1275,26 @@ class DataEvolutionSplitRead(SplitRead):
         return prescan_read._create_raw_reader()
 
     def _split_by_row_id(self, files: List[DataFileMeta]) -> List[List[DataFileMeta]]:
-        """Split files by firstRowId for data evolution."""
+        """Group sidecars by every normal-file range they intersect."""
+        files_without_row_id = [file for file in files if file.first_row_id is None]
+        ranged_files = [file for file in files if file.first_row_id is not None]
+        groups = [[file] for file in files_without_row_id]
+        groups.extend(group_by_normal_file_range(
+            ranged_files, lambda file: file.row_id_range()))
 
-        # Sort files by firstRowId and then by maxSequenceNumber
-        def sort_key(file: DataFileMeta) -> tuple:
-            first_row_id = file.first_row_id if file.first_row_id is not None else float('-inf')
-            is_special = 1 if (DataFileMeta.is_blob_file(file.file_name)
-                               or DataFileMeta.is_vector_file(file.file_name)) else 0
-            max_seq = file.max_sequence_number
-            return (first_row_id, is_special, -max_seq)
-
-        sorted_files = sorted(files, key=sort_key)
-
-        # Split files by firstRowId
-        split_by_row_id = []
-        last_row_id = -1
-        check_row_id_start = 0
-        current_split = []
-
-        for file in sorted_files:
-            first_row_id = file.first_row_id
-            if first_row_id is None:
-                split_by_row_id.append([file])
-                continue
-
-            if (not DataFileMeta.is_blob_file(file.file_name)
-                    and not DataFileMeta.is_vector_file(file.file_name)
-                    and first_row_id != last_row_id):
-                if current_split:
-                    split_by_row_id.append(current_split)
-                if first_row_id < check_row_id_start:
-                    raise ValueError(
-                        f"There are overlapping files in the split: {files}, "
-                        f"the wrong file is: {file}"
-                    )
-                current_split = []
-                last_row_id = first_row_id
-                check_row_id_start = first_row_id + file.row_count
-            current_split.append(file)
-
-        if current_split:
-            split_by_row_id.append(current_split)
-
-        return split_by_row_id
+        for group in groups:
+            group.sort(key=lambda file: (
+                1 if DataFileMeta.is_blob_file(file.file_name)
+                else 2 if DataFileMeta.is_vector_file(file.file_name)
+                else 0,
+                file.first_row_id,
+                -file.max_sequence_number,
+            ))
+        groups.sort(key=lambda group: min(
+            file.first_row_id if file.first_row_id is not None else float('-inf')
+            for file in group
+        ))
+        return groups
 
     def _create_union_reader(self, need_merge_files: List[DataFileMeta], deletion_vector=None) -> RecordReader:
         """Create a DataEvolutionFileReader for merging multiple files."""

--- a/paimon-python/pypaimon/read/split_read.py
+++ b/paimon-python/pypaimon/read/split_read.py
@@ -344,7 +344,9 @@ class SplitRead(ABC):
                                              batch_size=batch_size,
                                              row_indices=row_indices,
                                              blob_parallelism=blob_parallelism,
-                                             file_size=file.file_size)
+                                             file_size=file.file_size,
+                                             video_meta_cache=getattr(
+                                                 self, '_video_meta_cache', None))
         elif file_format == CoreOptions.FILE_FORMAT_LANCE:
             if has_nested:
                 raise NotImplementedError(
@@ -1093,6 +1095,7 @@ class DataEvolutionSplitRead(SplitRead):
             nested_name_paths=nested_name_paths,
             limit=limit,
         )
+        self._video_meta_cache = {}
         self.outer_extract_name_paths = outer_extract_name_paths
         self.outer_flat_read_type = outer_flat_read_type
         self._post_merge_filter = post_merge_filter
@@ -1459,6 +1462,7 @@ class DataEvolutionSplitRead(SplitRead):
             row_indices=row_indices,
             blob_parallelism=blob_parallelism,
             file_size=file.file_size,
+            video_meta_cache=self._video_meta_cache,
         )
 
     def _split_field_bunches(self, need_merge_files: List[DataFileMeta]) -> List[FieldBunch]:

--- a/paimon-python/pypaimon/read/split_read.py
+++ b/paimon-python/pypaimon/read/split_read.py
@@ -345,8 +345,8 @@ class SplitRead(ABC):
                                              row_indices=row_indices,
                                              blob_parallelism=blob_parallelism,
                                              file_size=file.file_size,
-                                             video_meta_cache=getattr(
-                                                 self, '_video_meta_cache', None))
+                                             blob_index_cache=getattr(
+                                                 self, '_blob_index_cache', None))
         elif file_format == CoreOptions.FILE_FORMAT_LANCE:
             if has_nested:
                 raise NotImplementedError(
@@ -1095,7 +1095,7 @@ class DataEvolutionSplitRead(SplitRead):
             nested_name_paths=nested_name_paths,
             limit=limit,
         )
-        self._video_meta_cache = {}
+        self._blob_index_cache = {}
         self.outer_extract_name_paths = outer_extract_name_paths
         self.outer_flat_read_type = outer_flat_read_type
         self._post_merge_filter = post_merge_filter
@@ -1462,7 +1462,7 @@ class DataEvolutionSplitRead(SplitRead):
             row_indices=row_indices,
             blob_parallelism=blob_parallelism,
             file_size=file.file_size,
-            video_meta_cache=self._video_meta_cache,
+            blob_index_cache=self._blob_index_cache,
         )
 
     def _split_field_bunches(self, need_merge_files: List[DataFileMeta]) -> List[FieldBunch]:

--- a/paimon-python/pypaimon/schema/schema_manager.py
+++ b/paimon-python/pypaimon/schema/schema_manager.py
@@ -393,8 +393,7 @@ def _validate_blob_fields(
 
     descriptor_fields = core_options.blob_descriptor_fields()
     view_fields = core_options.blob_view_fields()
-    video_field = core_options.video_frame_field()
-    video_fields = {video_field} if video_field is not None else set()
+    video_fields = core_options.video_frame_fields()
     non_scalar_video_fields = video_fields.difference(scalar_blob_field_names)
     if non_scalar_video_fields:
         raise ValueError(

--- a/paimon-python/pypaimon/tests/blob_test.py
+++ b/paimon-python/pypaimon/tests/blob_test.py
@@ -1603,26 +1603,38 @@ class BlobEndToEndTest(unittest.TestCase):
 
         cache = {}
         readers = []
-        with patch.object(
+        input_stream_patch = patch.object(
+            file_io, "new_input_stream", wraps=file_io.new_input_stream
+        )
+        decompress_patch = patch.object(
             DeltaVarintCompressor,
             "decompress",
             wraps=DeltaVarintCompressor.decompress,
-        ) as decompress:
-            for row_indices in ([0, 2], [1]):
+        )
+        with input_stream_patch as new_input_stream, decompress_patch as decompress:
+            for row_indices, blob_as_descriptor, parallelism in (
+                ([0, 2], True, 1),
+                ([1], True, 1),
+                ([0], False, 2),
+            ):
                 readers.append(FormatBlobReader(
                     file_io=file_io,
                     file_path=_to_url(path),
                     read_fields=[field.name],
                     full_fields=[field],
                     push_down_predicate=None,
-                    blob_as_descriptor=True,
+                    blob_as_descriptor=blob_as_descriptor,
                     row_indices=row_indices,
+                    blob_parallelism=parallelism,
                     blob_index_cache=cache,
                 ))
             self.assertEqual(1, decompress.call_count)
+            self.assertEqual(1, new_input_stream.call_count)
 
         try:
-            self.assertEqual([2, 1], [reader.record_count for reader in readers])
+            self.assertEqual(
+                [2, 1, 1], [reader.record_count for reader in readers]
+            )
         finally:
             for reader in readers:
                 reader.close()

--- a/paimon-python/pypaimon/tests/blob_test.py
+++ b/paimon-python/pypaimon/tests/blob_test.py
@@ -1633,19 +1633,28 @@ class BlobEndToEndTest(unittest.TestCase):
             table, None, [field], split, False)
 
         with patch("pypaimon.read.split_read.FormatBlobReader") as reader_cls:
-            def assert_file_size():
+            def assert_reader_arguments(expected_cache=None):
                 args, kwargs = reader_cls.call_args
                 arguments = inspect.signature(FormatBlobReader).bind_partial(
                     *args, **kwargs
                 ).arguments
                 self.assertEqual(123, arguments.get("file_size"))
+                self.assertIs(
+                    expected_cache, arguments.get("video_meta_cache")
+                )
 
             raw_read.file_reader_supplier(file, False, [field.name], False)
-            assert_file_size()
+            assert_reader_arguments()
+
+            reader_cls.reset_mock()
+            evolution_read.file_reader_supplier(
+                file, False, [field.name], False
+            )
+            assert_reader_arguments(evolution_read._video_meta_cache)
 
             reader_cls.reset_mock()
             evolution_read._create_raw_blob_file_reader(file, [field.name])
-            assert_file_size()
+            assert_reader_arguments(evolution_read._video_meta_cache)
 
     def test_blob_reader_row_indices_pushdown(self):
         file_io = LocalFileIO(self.temp_dir, Options({}))

--- a/paimon-python/pypaimon/tests/blob_test.py
+++ b/paimon-python/pypaimon/tests/blob_test.py
@@ -1588,6 +1588,45 @@ class BlobEndToEndTest(unittest.TestCase):
                 finally:
                     reader.close()
 
+    def test_blob_readers_share_cached_index(self):
+        file_io = LocalFileIO(self.temp_dir, Options({}))
+        field = DataField(0, "blob_field", AtomicType("BLOB"))
+        path = Path(self.temp_dir) / "cached-index.blob"
+        from pypaimon.write.blob_format_writer import BlobFormatWriter
+        with open(path, "wb") as output:
+            writer = BlobFormatWriter(output)
+            for value in (b"zero", b"one", b"two"):
+                writer.add_element(GenericRow(
+                    [BlobData(value)], [field], RowKind.INSERT
+                ))
+            writer.close()
+
+        cache = {}
+        readers = []
+        with patch.object(
+            DeltaVarintCompressor,
+            "decompress",
+            wraps=DeltaVarintCompressor.decompress,
+        ) as decompress:
+            for row_indices in ([0, 2], [1]):
+                readers.append(FormatBlobReader(
+                    file_io=file_io,
+                    file_path=_to_url(path),
+                    read_fields=[field.name],
+                    full_fields=[field],
+                    push_down_predicate=None,
+                    blob_as_descriptor=True,
+                    row_indices=row_indices,
+                    blob_index_cache=cache,
+                ))
+            self.assertEqual(1, decompress.call_count)
+
+        try:
+            self.assertEqual([2, 1], [reader.record_count for reader in readers])
+        finally:
+            for reader in readers:
+                reader.close()
+
     def test_split_read_passes_blob_file_size(self):
         from pypaimon.read.split import DataSplit
         from pypaimon.read.split_read import (
@@ -1640,7 +1679,7 @@ class BlobEndToEndTest(unittest.TestCase):
                 ).arguments
                 self.assertEqual(123, arguments.get("file_size"))
                 self.assertIs(
-                    expected_cache, arguments.get("video_meta_cache")
+                    expected_cache, arguments.get("blob_index_cache")
                 )
 
             raw_read.file_reader_supplier(file, False, [field.name], False)
@@ -1650,11 +1689,11 @@ class BlobEndToEndTest(unittest.TestCase):
             evolution_read.file_reader_supplier(
                 file, False, [field.name], False
             )
-            assert_reader_arguments(evolution_read._video_meta_cache)
+            assert_reader_arguments(evolution_read._blob_index_cache)
 
             reader_cls.reset_mock()
             evolution_read._create_raw_blob_file_reader(file, [field.name])
-            assert_reader_arguments(evolution_read._video_meta_cache)
+            assert_reader_arguments(evolution_read._blob_index_cache)
 
     def test_blob_reader_row_indices_pushdown(self):
         file_io = LocalFileIO(self.temp_dir, Options({}))

--- a/paimon-python/pypaimon/tests/data_evolution_group_stats_test.py
+++ b/paimon-python/pypaimon/tests/data_evolution_group_stats_test.py
@@ -302,6 +302,23 @@ class DataEvolutionGroupStatsFilterTest(unittest.TestCase):
             builder.equal('payload', b'not-present'), {0: fields}, 0
         ).may_match([base, vector]))
 
+    def test_spanning_special_file_does_not_expand_normal_group_range(self):
+        fields = [
+            DataField(0, 'id', AtomicType('INT')),
+            DataField(1, 'payload', AtomicType('BYTES')),
+        ]
+        base = _file(
+            'base.parquet', 0, 10, fields, [0], [9],
+            write_cols=['id'])
+        video = _file(
+            'payload.video', 0, 20, fields, [b'a'], [b'z'],
+            write_cols=['payload'])
+
+        stats_filter = self._filter(
+            PredicateBuilder(fields).equal('id', 50), {0: fields}, 0)
+
+        self.assertFalse(stats_filter.may_match([base, video]))
+
     def test_partial_newer_file_fails_open(self):
         fields = [DataField(0, 'value', AtomicType('INT'))]
         base = _file('base.parquet', 0, 10, fields, [0], [9])

--- a/paimon-python/pypaimon/tests/data_evolution_row_rolling_test.py
+++ b/paimon-python/pypaimon/tests/data_evolution_row_rolling_test.py
@@ -20,15 +20,12 @@ import shutil
 import tempfile
 import unittest
 import uuid
-from unittest.mock import Mock
 
 import pyarrow as pa
 
 from pypaimon import CatalogFactory, Schema
 from pypaimon.common.uri_reader import FileUriReader
 from pypaimon.table.row.blob import Blob, BlobDescriptor, VideoFrameDescriptor
-from pypaimon.write.writer.dedicated_format_writer import DedicatedFormatWriter
-from pypaimon.write.writer.video_group import VideoGroupRollingPolicy
 
 
 class DataEvolutionRowRollingTest(unittest.TestCase):
@@ -42,6 +39,11 @@ class DataEvolutionRowRollingTest(unittest.TestCase):
     blob_schema = pa.schema([
         ('id', pa.int32()),
         ('payload', pa.large_binary()),
+    ])
+    multi_video_schema = pa.schema([
+        ('id', pa.int32()),
+        ('camera_a', pa.large_binary()),
+        ('camera_b', pa.large_binary()),
     ])
     vector_schema = pa.schema([
         ('id', pa.int32()),
@@ -250,44 +252,83 @@ class DataEvolutionRowRollingTest(unittest.TestCase):
             f.row_count for f in files if not f.file_name.endswith('.video')
         )
         self.assertEqual([2, 3], video_rows)
-        self.assertEqual([2, 3], normal_rows)
+        self.assertEqual([1, 1, 1, 1, 1], normal_rows)
         self.assertEqual(list(range(5)), self._read_ids(table))
 
-    def test_video_batches_are_preserved_at_payload_boundaries(self):
-        first = BlobDescriptor("file:/first.mp4", 0, 11)
-        second = BlobDescriptor("file:/second.mp4", 0, 12)
-        data = pa.Table.from_pydict(
+    def test_multiple_video_fields_roll_independently(self):
+        paths = [os.path.join(self.tempdir, f'camera-{index}.mp4')
+                 for index in range(4)]
+        payloads = [f'camera-video-{index}'.encode() for index in range(4)]
+        for path, payload in zip(paths, payloads):
+            with open(path, 'wb') as output:
+                output.write(payload)
+        descriptors = [
+            BlobDescriptor(path, 0, len(payload))
+            for path, payload in zip(paths, payloads)
+        ]
+
+        table = self._create_with_schema(
+            self.multi_video_schema,
             {
-                'id': list(range(5)),
-                'payload': [
+                **self.de_options,
+                'target-file-row-num': '2',
+                'video-frame-field': 'camera_a,camera_b',
+                'blob-as-descriptor': 'true',
+            },
+        )
+        rows = pa.Table.from_pydict(
+            {
+                'id': list(range(6)),
+                'camera_a': [
                     VideoFrameDescriptor(
-                        first.uri, first.offset, first.length, frame
+                        descriptors[0 if row < 4 else 1].uri,
+                        0,
+                        descriptors[0 if row < 4 else 1].length,
+                        row if row < 4 else row - 4,
                     ).serialize()
-                    for frame in range(3)
-                ] + [
+                    for row in range(6)
+                ],
+                'camera_b': [
                     VideoFrameDescriptor(
-                        second.uri, second.offset, second.length, frame
+                        descriptors[2 if row < 2 else 3].uri,
+                        0,
+                        descriptors[2 if row < 2 else 3].length,
+                        row if row < 2 else row - 2,
                     ).serialize()
-                    for frame in range(2)
+                    for row in range(6)
                 ],
             },
-            schema=self.blob_schema,
+            schema=self.multi_video_schema,
         )
-        writer = object.__new__(DedicatedFormatWriter)
-        writer.video_frame_column = 'payload'
-        writer._video_group_policy = VideoGroupRollingPolicy()
-        writer._roll_before_video_group = Mock()
-        writer._write_batch = Mock()
-        writer._write_bounded_batches = Mock()
 
-        writer._write_video_batches(data.to_batches()[0])
-
-        self.assertEqual(2, writer._write_batch.call_count)
+        files = self._write_files(table, rows)
         self.assertEqual(
-            [3, 2],
-            [call.args[0].num_rows for call in writer._write_batch.call_args_list],
+            [2, 2, 2],
+            sorted(f.row_count for f in files
+                   if not f.file_name.endswith('.video')),
         )
-        writer._write_bounded_batches.assert_not_called()
+        video_files = [f for f in files if f.file_name.endswith('.video')]
+        self.assertEqual(4, len(video_files))
+        self.assertEqual(
+            {'camera_a': 6, 'camera_b': 6},
+            {
+                field: sum(f.row_count for f in video_files
+                           if f.write_cols == [field])
+                for field in ('camera_a', 'camera_b')
+            },
+        )
+
+        descriptor_table = table.copy({'blob-as-descriptor': 'true'})
+        read = descriptor_table.new_read_builder()
+        result = read.new_read().to_arrow(read.new_scan().plan().splits())
+        self.assertEqual(list(range(6)), result['id'].to_pylist())
+        for row in range(6):
+            camera_a = VideoFrameDescriptor.deserialize(
+                result['camera_a'][row].as_py())
+            camera_b = VideoFrameDescriptor.deserialize(
+                result['camera_b'][row].as_py())
+            self.assertEqual(row if row < 4 else row - 4, camera_a.frame_index)
+            self.assertEqual(row if row < 2 else row - 2, camera_b.frame_index)
 
     def test_blob_consumer_descriptors_survive_abort_after_rolling(self):
         table = self._create_with_schema(

--- a/paimon-python/pypaimon/tests/data_evolution_row_rolling_test.py
+++ b/paimon-python/pypaimon/tests/data_evolution_row_rolling_test.py
@@ -201,6 +201,50 @@ class DataEvolutionRowRollingTest(unittest.TestCase):
         self.assertEqual([1, 3, 3], blob_rows)
         self.assertEqual(list(range(7)), self._read_ids(table))
 
+    def test_blob_writer_is_reused_across_prepare_commit_rounds(self):
+        table = self._create_with_schema(
+            self.blob_schema,
+            {**self.de_options, 'target-file-row-num': '2'})
+        write_builder = table.new_stream_write_builder()
+        writer = write_builder.new_write()
+        commit = write_builder.new_commit()
+        messages = []
+
+        for commit_identifier, start in enumerate(range(0, 6, 2)):
+            rows = pa.Table.from_pydict(
+                {
+                    'id': [start, start + 1],
+                    'payload': [
+                        f'blob-{start}'.encode(),
+                        f'blob-{start + 1}'.encode(),
+                    ],
+                },
+                schema=self.blob_schema,
+            )
+            writer.write_arrow(rows)
+            messages = writer.prepare_commit(commit_identifier)
+            sidecars = [
+                file
+                for message in messages
+                for file in message.new_files
+                if file.file_name.endswith('.blob')
+            ]
+            self.assertEqual(
+                start + 2, sum(file.row_count for file in sidecars))
+
+        commit.commit(messages, commit_identifier)
+
+        writer.close()
+        commit.close()
+        read_builder = table.new_read_builder()
+        result = read_builder.new_read().to_arrow(
+            read_builder.new_scan().plan().splits()).sort_by('id')
+        self.assertEqual(list(range(6)), result['id'].to_pylist())
+        self.assertEqual(
+            [f'blob-{row}'.encode() for row in range(6)],
+            result['payload'].to_pylist(),
+        )
+
     def test_video_writer_rolls_between_payload_groups(self):
         first = os.path.join(self.tempdir, 'first.mp4')
         second = os.path.join(self.tempdir, 'second.mp4')

--- a/paimon-python/pypaimon/tests/data_evolution_split_generator_test.py
+++ b/paimon-python/pypaimon/tests/data_evolution_split_generator_test.py
@@ -300,6 +300,36 @@ class SplitOrderTest(unittest.TestCase):
                 130 * 1024 * 1024,
             )
 
+    def test_distinct_spanning_sidecars_remain_in_packing_weight(self):
+        video_size = 64 * 1024 * 1024
+        entries = []
+        sequence_number = 0
+        for video in range(10):
+            first_row = video * 2
+            for row in (first_row, first_row + 1):
+                entries.append(self._entry(
+                    f'normal-{row}.parquet', sequence_number,
+                    first_row_id=row, row_count=1, file_size=1,
+                ))
+                sequence_number += 1
+            entries.append(self._entry(
+                f'camera-{video}.video', sequence_number,
+                first_row_id=first_row, row_count=2,
+                file_size=video_size,
+            ))
+            sequence_number += 1
+
+        splits = DataEvolutionSplitGenerator(
+            self._Table(), target_split_size=130 * 1024 * 1024,
+            open_file_cost=0,
+        ).create_splits(entries)
+
+        self.assertEqual(5, len(splits))
+        for split in splits:
+            self.assertEqual(2, sum(
+                file.file_name.endswith('.video') for file in split.files
+            ))
+
     def test_spanning_sidecar_preserves_deletion_aware_row_count(self):
         entries = [
             self._entry(

--- a/paimon-python/pypaimon/tests/data_evolution_split_generator_test.py
+++ b/paimon-python/pypaimon/tests/data_evolution_split_generator_test.py
@@ -330,6 +330,38 @@ class SplitOrderTest(unittest.TestCase):
                 file.file_name.endswith('.video') for file in split.files
             ))
 
+    def test_oversized_spanning_sidecar_ends_at_coverage_boundary(self):
+        mb = 1024 * 1024
+        entries = [
+            self._entry(
+                f'normal-{row}.parquet', row,
+                first_row_id=row, row_count=1, file_size=1,
+            )
+            for row in range(4)
+        ]
+        entries.extend([
+            self._entry(
+                'camera-0.video', 4, first_row_id=0, row_count=2,
+                file_size=200 * mb,
+            ),
+            self._entry(
+                'camera-1.video', 5, first_row_id=2, row_count=2,
+                file_size=100 * mb,
+            ),
+        ])
+
+        splits = DataEvolutionSplitGenerator(
+            self._Table(), target_split_size=128 * mb, open_file_cost=0,
+        ).create_splits(entries)
+
+        self.assertEqual(2, len(splits))
+        self.assertEqual(
+            [['camera-0.video'], ['camera-1.video']],
+            [[file.file_name for file in split.files
+              if file.file_name.endswith('.video')]
+             for split in splits],
+        )
+
     def test_spanning_sidecar_preserves_deletion_aware_row_count(self):
         entries = [
             self._entry(

--- a/paimon-python/pypaimon/tests/data_evolution_split_generator_test.py
+++ b/paimon-python/pypaimon/tests/data_evolution_split_generator_test.py
@@ -24,6 +24,7 @@ from pypaimon.manifest.schema.manifest_entry import ManifestEntry
 from pypaimon.manifest.schema.simple_stats import SimpleStats
 from pypaimon.read.scanner.data_evolution_split_generator import DataEvolutionSplitGenerator
 from pypaimon.table.row.generic_row import GenericRow
+from pypaimon.table.source.deletion_file import DeletionFile
 from pypaimon.utils.range import Range
 
 
@@ -254,7 +255,7 @@ class SplitOrderTest(unittest.TestCase):
             file_size=1_000_000))
 
         splits = DataEvolutionSplitGenerator(
-            self._Table(), target_split_size=10_000, open_file_cost=0
+            self._Table(), target_split_size=2_000_000, open_file_cost=0
         ).create_splits(entries)
 
         self.assertEqual(1, len(splits))
@@ -262,6 +263,71 @@ class SplitOrderTest(unittest.TestCase):
         self.assertEqual(1, sum(
             file.file_name == 'camera.video' for file in splits[0].files))
         self.assertEqual(100, splits[0].merged_row_count())
+
+    def test_distinct_sidecars_remain_in_packing_weight(self):
+        video_size = 64 * 1024 * 1024
+        entries = []
+        for row in range(10):
+            entries.extend([
+                self._entry(
+                    f'normal-{row}.parquet', row * 2,
+                    first_row_id=row, row_count=1,
+                ),
+                self._entry(
+                    f'camera-{row}.video', row * 2 + 1,
+                    first_row_id=row, row_count=1,
+                    file_size=video_size,
+                ),
+            ])
+
+        splits = DataEvolutionSplitGenerator(
+            self._Table(), target_split_size=130 * 1024 * 1024,
+            open_file_cost=0,
+        ).create_splits(entries)
+
+        self.assertEqual(5, len(splits))
+        for split in splits:
+            videos = [
+                file for file in split.files
+                if file.file_name.endswith('.video')
+            ]
+            self.assertEqual(2, len(videos))
+            self.assertLessEqual(
+                sum(file.file_size for file in videos),
+                130 * 1024 * 1024,
+            )
+
+    def test_spanning_sidecar_preserves_deletion_aware_row_count(self):
+        entries = [
+            self._entry(
+                'normal-0.parquet', 0, first_row_id=0, row_count=1,
+            ),
+            self._entry(
+                'normal-1.parquet', 1, first_row_id=1, row_count=1,
+            ),
+            self._entry(
+                'camera.video', 2, first_row_id=0, row_count=2,
+            ),
+        ]
+
+        for cardinality, expected in ((1, 1), (None, None)):
+            with self.subTest(cardinality=cardinality):
+                deletion_files = {
+                    ((), 0): {
+                        'normal-0.parquet': DeletionFile(
+                            'dv', 0, 1, cardinality
+                        )
+                    }
+                }
+                splits = DataEvolutionSplitGenerator(
+                    self._Table(), target_split_size=1024,
+                    open_file_cost=0,
+                    deletion_files_map=deletion_files,
+                ).create_splits(entries)
+
+                self.assertEqual(1, len(splits))
+                self.assertIsInstance(splits[0], IndexedSplit)
+                self.assertEqual(expected, splits[0].merged_row_count())
 
     def test_filtered_anchor_keeps_spanning_sidecar_range_bounded(self):
         entries = [

--- a/paimon-python/pypaimon/tests/data_evolution_split_generator_test.py
+++ b/paimon-python/pypaimon/tests/data_evolution_split_generator_test.py
@@ -246,7 +246,7 @@ class SplitOrderTest(unittest.TestCase):
         entries = [
             self._entry(
                 f'normal-{row}.parquet', row, first_row_id=row,
-                row_count=1,
+                row_count=1, file_size=10,
             )
             for row in range(100)
         ]
@@ -255,14 +255,17 @@ class SplitOrderTest(unittest.TestCase):
             file_size=1_000_000))
 
         splits = DataEvolutionSplitGenerator(
-            self._Table(), target_split_size=2_000_000, open_file_cost=0
+            self._Table(), target_split_size=500, open_file_cost=0
         ).create_splits(entries)
 
-        self.assertEqual(1, len(splits))
-        self.assertEqual(101, len(splits[0].files))
-        self.assertEqual(1, sum(
-            file.file_name == 'camera.video' for file in splits[0].files))
-        self.assertEqual(100, splits[0].merged_row_count())
+        self.assertEqual(2, len(splits))
+        self.assertEqual(102, sum(len(split.files) for split in splits))
+        for split in splits:
+            self.assertEqual(1, sum(
+                file.file_name == 'camera.video' for file in split.files))
+        self.assertEqual(100, sum(
+            split.merged_row_count() for split in splits
+        ))
 
     def test_distinct_sidecars_remain_in_packing_weight(self):
         video_size = 64 * 1024 * 1024

--- a/paimon-python/pypaimon/tests/data_evolution_split_generator_test.py
+++ b/paimon-python/pypaimon/tests/data_evolution_split_generator_test.py
@@ -18,6 +18,7 @@
 import random
 import unittest
 
+from pypaimon.globalindex.indexed_split import IndexedSplit
 from pypaimon.manifest.schema.data_file_meta import DataFileMeta
 from pypaimon.manifest.schema.manifest_entry import ManifestEntry
 from pypaimon.manifest.schema.simple_stats import SimpleStats
@@ -142,13 +143,15 @@ class SplitOrderTest(unittest.TestCase):
     _Table.options = _Options()
 
     @staticmethod
-    def _entry(name, sequence, first_row_id=0, external_path=None):
+    def _entry(
+            name, sequence, first_row_id=0, external_path=None,
+            row_count=10, file_size=1):
         empty_row = GenericRow([], [])
         empty_stats = SimpleStats(empty_row, empty_row, [])
         file = DataFileMeta.create(
             file_name=name,
-            file_size=1,
-            row_count=10,
+            file_size=file_size,
+            row_count=row_count,
             min_key=empty_row,
             max_key=empty_row,
             key_stats=empty_stats,
@@ -237,6 +240,54 @@ class SplitOrderTest(unittest.TestCase):
                     [file.external_path for split in splits
                      for file in split.files],
                 )
+
+    def test_spanning_sidecar_keeps_anchor_ranges_packable(self):
+        entries = [
+            self._entry(
+                f'normal-{row}.parquet', row, first_row_id=row,
+                row_count=1,
+            )
+            for row in range(100)
+        ]
+        entries.append(self._entry(
+            'camera.video', 100, first_row_id=0, row_count=100,
+            file_size=1_000_000))
+
+        splits = DataEvolutionSplitGenerator(
+            self._Table(), target_split_size=10_000, open_file_cost=0
+        ).create_splits(entries)
+
+        self.assertEqual(1, len(splits))
+        self.assertEqual(101, len(splits[0].files))
+        self.assertEqual(1, sum(
+            file.file_name == 'camera.video' for file in splits[0].files))
+        self.assertEqual(100, splits[0].merged_row_count())
+
+    def test_filtered_anchor_keeps_spanning_sidecar_range_bounded(self):
+        entries = [
+            self._entry(
+                f'normal-{row}.parquet', row, first_row_id=row,
+                row_count=1,
+            )
+            for row in range(3)
+        ]
+        entries.append(self._entry(
+            'camera.video', 3, first_row_id=0, row_count=3))
+
+        class OnlyMiddleGroup:
+            @staticmethod
+            def may_match(group):
+                return any(
+                    file.file_name == 'normal-1.parquet' for file in group)
+
+        splits = DataEvolutionSplitGenerator(
+            self._Table(), target_split_size=10_000, open_file_cost=0,
+            group_stats_filter=OnlyMiddleGroup(),
+        ).create_splits(entries)
+
+        self.assertEqual(1, len(splits))
+        self.assertIsInstance(splits[0], IndexedSplit)
+        self.assertEqual([Range(1, 1)], splits[0].row_ranges())
 
 
 if __name__ == "__main__":

--- a/paimon-python/pypaimon/tests/data_evolution_split_generator_test.py
+++ b/paimon-python/pypaimon/tests/data_evolution_split_generator_test.py
@@ -27,9 +27,10 @@ from pypaimon.utils.range import Range
 
 
 class _F:
-    def __init__(self, tag: int, from_: int = None, to: int = None):
+    def __init__(self, tag: int, from_: int = None, to: int = None,
+                 file_name: str = None):
         self.tag = tag
-        self.file_name = f"f{tag}"
+        self.file_name = file_name or f"f{tag}"
         self._range = Range(from_, to) if from_ is not None else None
 
     def row_id_range(self):
@@ -91,6 +92,20 @@ class SplitByRowIdEquivalenceTest(unittest.TestCase):
         files = [_F(0, 10, 14), _F(1, 0, 4), _F(2, 5, 9)]  # unsorted input
         self.assertEqual(_shape(DataEvolutionSplitGenerator._split_by_row_id(files)),
                          [[1], [2], [0]])  # groups come out ordered by range start
+
+    def test_sidecar_attaches_only_to_intersecting_normal_ranges(self):
+        files = [
+            _F(0, 0, 9),
+            _F(1, 20, 29),
+            _F(2, 40, 49),
+            _F(3, 25, 44, "spanning.video"),
+            _F(4, 60, 69, "unanchored.video"),
+        ]
+
+        self.assertEqual(
+            _shape(DataEvolutionSplitGenerator._split_by_row_id(files)),
+            [[0], [1, 3], [2, 3], [4]],
+        )
 
     def test_matches_reference_grouping_on_random_inputs(self):
         rng = random.Random(1234)

--- a/paimon-python/pypaimon/tests/field_bunch_test.py
+++ b/paimon-python/pypaimon/tests/field_bunch_test.py
@@ -141,6 +141,19 @@ class BlobBunchTest(unittest.TestCase):
         self.assertEqual(10, bunch.row_count())
         self.assertEqual(Range(100, 109), bunch.logical_range())
 
+    def test_finish_uses_normal_range_for_spanning_blob(self):
+        bunch = BlobBunch(
+            expected_row_count=2,
+            expected_row_range=Range(0, 1),
+        )
+        bunch.add(_BlobFile("spanning.blob", 0, 4))
+
+        bunch.finish()
+
+        self.assertEqual(2, bunch.row_count())
+        self.assertEqual(Range(0, 1), bunch.logical_range())
+        self.assertFalse(bunch.sequential_read_optimize())
+
     def test_finish_rejects_range_outside_normal_file(self):
         bunch = BlobBunch(
             expected_row_count=10,

--- a/paimon-python/pypaimon/tests/file_store_commit_test.py
+++ b/paimon-python/pypaimon/tests/file_store_commit_test.py
@@ -64,6 +64,8 @@ class TestFileStoreCommitRowTracking(unittest.TestCase):
     def setUp(self):
         self.mock_table = Mock()
         self.mock_table.partition_keys = ['dt', 'region']
+        self.mock_table.partition_keys_fields = []
+        self.mock_table.total_buckets = 1
         self.mock_table.current_branch.return_value = 'main'
         self.mock_table.table_path = '/test/table/path'
         self.mock_table.file_io = Mock()
@@ -116,7 +118,7 @@ class TestFileStoreCommitRowTracking(unittest.TestCase):
     def _append_entry(cls, partition, name, row_count, write_cols=None):
         return ManifestEntry(
             kind=0,
-            partition=GenericRow(list(partition), None),
+            partition=GenericRow(list(partition), []),
             bucket=0,
             total_buckets=1,
             file=cls._data_file(name, row_count, write_cols),
@@ -140,6 +142,28 @@ class TestFileStoreCommitRowTracking(unittest.TestCase):
         self.assertEqual(16, next_row_id)
         self.assertEqual(
             [10, 12, 14, 10, 14, 10, 12],
+            [entry.file.first_row_id for entry in assigned],
+        )
+
+    def test_assigns_blob_from_its_commit_message_range(self):
+        file_store_commit = self._create_file_store_commit()
+        normal_only = self._data_file('normal-0.parquet', 1)
+        normal_with_blob = self._data_file('normal-1.parquet', 1)
+        blob = self._data_file('camera-0.video', 1, ['camera'])
+        entries, groups = file_store_commit._collect_manifest_entries_with_groups([
+            CommitMessage(partition=(), bucket=0, new_files=[normal_only]),
+            CommitMessage(
+                partition=(), bucket=0,
+                new_files=[normal_with_blob, blob],
+            ),
+        ])
+
+        assigned, next_row_id = file_store_commit._assign_row_tracking_meta(
+            10, entries, groups)
+
+        self.assertEqual(12, next_row_id)
+        self.assertEqual(
+            [10, 11, 11],
             [entry.file.first_row_id for entry in assigned],
         )
 

--- a/paimon-python/pypaimon/tests/file_store_commit_test.py
+++ b/paimon-python/pypaimon/tests/file_store_commit_test.py
@@ -94,7 +94,7 @@ class TestFileStoreCommitRowTracking(unittest.TestCase):
         )
 
     @staticmethod
-    def _data_file(name, row_count):
+    def _data_file(name, row_count, write_cols=None):
         return DataFileMeta.create(
             file_name=name,
             file_size=10,
@@ -109,16 +109,38 @@ class TestFileStoreCommitRowTracking(unittest.TestCase):
             level=0,
             extra_files=[],
             file_source=0,
+            write_cols=write_cols,
         )
 
     @classmethod
-    def _append_entry(cls, partition, name, row_count):
+    def _append_entry(cls, partition, name, row_count, write_cols=None):
         return ManifestEntry(
             kind=0,
             partition=GenericRow(list(partition), None),
             bucket=0,
             total_buckets=1,
-            file=cls._data_file(name, row_count),
+            file=cls._data_file(name, row_count, write_cols),
+        )
+
+    def test_assigns_independently_rolling_blob_fields_after_normal_files(self):
+        file_store_commit = self._create_file_store_commit()
+        entries = [
+            self._append_entry((), 'normal-0.parquet', 2),
+            self._append_entry((), 'normal-1.parquet', 2),
+            self._append_entry((), 'normal-2.parquet', 2),
+            self._append_entry((), 'camera-a-0.video', 4, ['camera_a']),
+            self._append_entry((), 'camera-a-1.video', 2, ['camera_a']),
+            self._append_entry((), 'camera-b-0.video', 2, ['camera_b']),
+            self._append_entry((), 'camera-b-1.video', 4, ['camera_b']),
+        ]
+
+        assigned, next_row_id = file_store_commit._assign_row_tracking_meta(
+            10, entries)
+
+        self.assertEqual(16, next_row_id)
+        self.assertEqual(
+            [10, 12, 14, 10, 14, 10, 12],
+            [entry.file.first_row_id for entry in assigned],
         )
 
     def test_groups_files_by_partition_before_assigning_row_ids(self):

--- a/paimon-python/pypaimon/tests/multimodal_table_test.py
+++ b/paimon-python/pypaimon/tests/multimodal_table_test.py
@@ -197,6 +197,22 @@ class MultimodalTableTest(unittest.TestCase):
         self.assertTrue(descriptors[0].uri.endswith(".video"))
         self.assertEqual(2, len({d.payload_descriptor for d in descriptors}))
 
+    def test_add_video_requires_column_when_multiple_video_fields_configured(self):
+        table = self.conn.create_table(
+            "multi_video_frames",
+            schema=_schema({
+                "episode_id": pa.int64(),
+                "camera_a": pa.large_binary(),
+                "camera_b": pa.large_binary(),
+            }),
+            options=dict(_PARQUET_OPTIONS, **{
+                "video-frame-field": "camera_a,camera_b",
+            }),
+        )
+
+        with self.assertRaisesRegex(ValueError, "video_column is required"):
+            table.add_video(None, [])
+
     def test_normal_update_preserves_video_descriptors(self):
         from pypaimon.table.row.blob import Blob
 

--- a/paimon-python/pypaimon/tests/multimodal_table_test.py
+++ b/paimon-python/pypaimon/tests/multimodal_table_test.py
@@ -984,6 +984,44 @@ class MultimodalTableTest(unittest.TestCase):
             users.scan().to_list(),
         )
 
+    def test_overwrite_keeps_blob_commit_message_range(self):
+        obs = self.conn.create_table(
+            "overwrite_blob_groups",
+            schema=_schema({
+                "id": pa.int32(),
+                "image": pa.large_binary(),
+            }),
+            options=_PARQUET_OPTIONS,
+        )
+        obs.add([{"id": 0, "image": b"old-image"}])
+        builder = obs.raw_table.new_batch_write_builder().overwrite()
+        messages = []
+
+        normal_write = builder.new_write().with_write_type(["id"])
+        blob_write = builder.new_write()
+        commit = builder.new_commit()
+        try:
+            normal_write.write_arrow(pa.table({
+                "id": pa.array([1], type=pa.int32()),
+            }))
+            messages.extend(normal_write.prepare_commit())
+            blob_write.write_arrow(pa.table({
+                "id": pa.array([2], type=pa.int32()),
+                "image": pa.array([b"image-2"], type=pa.large_binary()),
+            }))
+            messages.extend(blob_write.prepare_commit())
+            commit.commit(messages)
+        finally:
+            normal_write.close()
+            blob_write.close()
+            commit.close()
+
+        scalar, blobs = obs.scan().read_blobs("image")
+        self.assertEqual(
+            {1: None, 2: b"image-2"},
+            dict(zip(scalar["id"].to_pylist(), blobs["image"])),
+        )
+
     def test_empty_overwrite_clears_unpartitioned_table(self):
         users = self.conn.create_table(
             "users",

--- a/paimon-python/pypaimon/tests/partition_predicate_test.py
+++ b/paimon-python/pypaimon/tests/partition_predicate_test.py
@@ -55,6 +55,7 @@ def _mock_table():
     table.partition_keys = ['dt', 'region']
     table.partition_keys_fields = PARTITION_FIELDS
     table.options.options.get = Mock(return_value="__DEFAULT_PARTITION__")
+    table.options.row_tracking_enabled.return_value = False
     return table
 
 

--- a/paimon-python/pypaimon/tests/video_format_test.py
+++ b/paimon-python/pypaimon/tests/video_format_test.py
@@ -19,6 +19,7 @@ import struct
 import tempfile
 import unittest
 from pathlib import Path
+from unittest.mock import patch
 
 from pypaimon.common.delta_varint_compressor import DeltaVarintCompressor
 from pypaimon.common.options import Options
@@ -214,6 +215,52 @@ class VideoFormatTest(unittest.TestCase):
             )
         finally:
             reader.close()
+
+    def test_readers_share_cached_video_index(self):
+        target = (self.root / "cached-index.video").as_uri()
+        writer = VideoFormatWriter(self.file_io.new_output_stream(target))
+        for frame_index in range(4):
+            writer.add_element(
+                GenericRow(
+                    [self._source_frame("cached-index.mp4", b"video", frame_index)],
+                    [self.field],
+                    RowKind.INSERT,
+                )
+            )
+        writer.close()
+
+        cache = {}
+        readers = []
+        with patch.object(
+            self.file_io,
+            "new_input_stream",
+            wraps=self.file_io.new_input_stream,
+        ) as new_input_stream:
+            for row_indices in ([0, 2], [1, 3]):
+                readers.append(FormatBlobReader(
+                    file_io=self.file_io,
+                    file_path=target,
+                    read_fields=["video"],
+                    full_fields=[self.field],
+                    push_down_predicate=None,
+                    blob_as_descriptor=True,
+                    row_indices=row_indices,
+                    video_meta_cache=cache,
+                ))
+            self.assertEqual(1, new_input_stream.call_count)
+
+        try:
+            actual = []
+            for reader in readers:
+                values = reader.read_arrow_batch().column(0).to_pylist()
+                actual.append([
+                    VideoFrameDescriptor.deserialize(value).frame_index
+                    for value in values
+                ])
+            self.assertEqual([[0, 2], [1, 3]], actual)
+        finally:
+            for reader in readers:
+                reader.close()
 
     def test_rejects_non_video_frame_input(self):
         target = (self.root / "reject.video").as_uri()

--- a/paimon-python/pypaimon/tests/video_format_test.py
+++ b/paimon-python/pypaimon/tests/video_format_test.py
@@ -245,7 +245,7 @@ class VideoFormatTest(unittest.TestCase):
                     push_down_predicate=None,
                     blob_as_descriptor=True,
                     row_indices=row_indices,
-                    video_meta_cache=cache,
+                    blob_index_cache=cache,
                 ))
             self.assertEqual(1, new_input_stream.call_count)
 

--- a/paimon-python/pypaimon/tests/write/write_buffer_test.py
+++ b/paimon-python/pypaimon/tests/write/write_buffer_test.py
@@ -591,7 +591,9 @@ class CompositeFlushResumeTest(unittest.TestCase):
             self.written = []
             first_blob = next(iter(blob_writers.values()), None)
             self.total_record_count = first_blob._row_count if first_blob else 0
-            self._blob_writers_closed = False
+            self._blob_prepared_record_counts = {
+                column: 0 for column in self.blob_file_column_names
+            }
 
         def _write_normal_data_to_file(self, data: pa.Table):
             self.written.append(data)

--- a/paimon-python/pypaimon/tests/write/write_buffer_test.py
+++ b/paimon-python/pypaimon/tests/write/write_buffer_test.py
@@ -589,7 +589,9 @@ class CompositeFlushResumeTest(unittest.TestCase):
             self._committed_files_to_delete_on_abort = []
             self.file_io = _RecordingFileIO()
             self.written = []
-            self._video_group_policy = None
+            first_blob = next(iter(blob_writers.values()), None)
+            self.total_record_count = first_blob._row_count if first_blob else 0
+            self._blob_writers_closed = False
 
         def _write_normal_data_to_file(self, data: pa.Table):
             self.written.append(data)
@@ -680,7 +682,7 @@ class CompositeFlushResumeTest(unittest.TestCase):
         self.assertIsNone(writer._pending_normal_meta)
         self.assertTrue(vector.aborted)
 
-    def test_dedicated_writer_failed_blob_phase_publishes_nothing(self):
+    def test_dedicated_writer_failed_blob_phase_resumes_without_rewrite(self):
         blob = _StubSidecarWriter(3, 'blob-0', fail_times=1)
         writer = self._DedicatedHarness({'payload': blob})
         writer._normal_buffer.append(_table(0, 3))
@@ -688,8 +690,7 @@ class CompositeFlushResumeTest(unittest.TestCase):
         with self.assertRaises(IOError):
             writer._close_current_writers()
         self.assertEqual([t.num_rows for t in writer.written], [3])
-        self.assertEqual(writer.committed_files, [])
-        # Already tracked for abort, since no committed list holds it yet.
+        self.assertEqual([m.file_name for m in writer.committed_files], ['data-1'])
         self.assertEqual(
             [m.file_name for m in writer._committed_files_to_delete_on_abort],
             ['data-1'])
@@ -701,17 +702,17 @@ class CompositeFlushResumeTest(unittest.TestCase):
         self.assertEqual(blob.committed_files, [])
         self.assertIsNone(writer._pending_normal_meta)
 
-    def test_dedicated_writer_keeps_the_documented_meta_order(self):
+    def test_dedicated_writer_keeps_normal_vector_ranges_before_blobs(self):
         blob = _StubSidecarWriter(3, 'blob-0')
         vector = _StubSidecarWriter(3, 'vector-0')
         writer = self._DedicatedHarness({'payload': blob}, vector)
         writer._normal_buffer.append(_table(0, 3))
         writer._close_current_writers()
         self.assertEqual([m.file_name for m in writer.committed_files],
-                         ['data-1', 'blob-0', 'vector-0'])
+                         ['data-1', 'vector-0', 'blob-0'])
         self.assertEqual(
             [m.file_name for m in writer._committed_files_to_delete_on_abort],
-            ['data-1', 'blob-0', 'vector-0'])
+            ['data-1', 'vector-0', 'blob-0'])
 
     def test_dedicated_writer_respects_the_blob_delete_policy(self):
         # Externally managed blob files are not the writer's to delete, so they

--- a/paimon-python/pypaimon/utils/data_evolution_utils.py
+++ b/paimon-python/pypaimon/utils/data_evolution_utils.py
@@ -17,9 +17,11 @@
 
 """Utilities for data-evolution tables."""
 
-from typing import Callable, Iterable, TypeVar
+from typing import Callable, Iterable, List, TypeVar
 
 from pypaimon.manifest.schema.data_file_meta import DataFileMeta
+from pypaimon.utils.range import Range
+from pypaimon.utils.range_helper import RangeHelper
 
 T = TypeVar("T")
 
@@ -49,3 +51,47 @@ def retrieve_anchor_file(
         )
 
     return anchor
+
+
+def group_by_normal_file_range(
+    files: List[DataFileMeta],
+    range_func: Callable[[DataFileMeta], Range],
+) -> List[List[DataFileMeta]]:
+    """Attach each sidecar to every normal-file range group it intersects."""
+    normal = [
+        file for file in files
+        if (not DataFileMeta.is_blob_file(file.file_name)
+            and not DataFileMeta.is_vector_file(file.file_name))
+    ]
+    if not normal:
+        return RangeHelper(range_func).merge_overlapping_ranges(files)
+
+    normal_ids = {id(file) for file in normal}
+    groups = RangeHelper(range_func).merge_overlapping_ranges(normal)
+    group_ranges = [
+        Range(
+            min(range_func(file).from_ for file in group),
+            max(range_func(file).to for file in group),
+        )
+        for group in groups
+    ]
+
+    unanchored = []
+    for sidecar in files:
+        if id(sidecar) in normal_ids:
+            continue
+        sidecar_range = range_func(sidecar)
+        attached = False
+        for index, group_range in enumerate(group_ranges):
+            if group_range.overlaps(sidecar_range):
+                groups[index].append(sidecar)
+                attached = True
+        if not attached:
+            unanchored.append(sidecar)
+
+    groups.extend(RangeHelper(range_func).merge_overlapping_ranges(unanchored))
+    original_order = {id(file): index for index, file in enumerate(files)}
+    for group in groups:
+        group.sort(key=lambda file: original_order[id(file)])
+    groups.sort(key=lambda group: min(range_func(file).from_ for file in group))
+    return groups

--- a/paimon-python/pypaimon/utils/data_evolution_utils.py
+++ b/paimon-python/pypaimon/utils/data_evolution_utils.py
@@ -17,6 +17,7 @@
 
 """Utilities for data-evolution tables."""
 
+from bisect import bisect_left
 from typing import Callable, Iterable, List, TypeVar
 
 from pypaimon.manifest.schema.data_file_meta import DataFileMeta
@@ -75,6 +76,7 @@ def group_by_normal_file_range(
         )
         for group in groups
     ]
+    group_ends = [group_range.to for group_range in group_ranges]
 
     unanchored = []
     for sidecar in files:
@@ -82,10 +84,12 @@ def group_by_normal_file_range(
             continue
         sidecar_range = range_func(sidecar)
         attached = False
-        for index, group_range in enumerate(group_ranges):
-            if group_range.overlaps(sidecar_range):
-                groups[index].append(sidecar)
-                attached = True
+        index = bisect_left(group_ends, sidecar_range.from_)
+        while (index < len(group_ranges)
+               and group_ranges[index].from_ <= sidecar_range.to):
+            groups[index].append(sidecar)
+            attached = True
+            index += 1
         if not attached:
             unanchored.append(sidecar)
 

--- a/paimon-python/pypaimon/write/file_store_commit.py
+++ b/paimon-python/pypaimon/write/file_store_commit.py
@@ -1054,6 +1054,7 @@ class FileStoreCommit:
             self, commit_messages: List[CommitMessage]):
         commit_entries = []
         entry_groups = {}
+        collect_groups = self.table.options.row_tracking_enabled()
         for group, msg in enumerate(commit_messages):
             partition = GenericRow(list(msg.partition), self.table.partition_keys_fields)
             total_buckets = (
@@ -1070,7 +1071,8 @@ class FileStoreCommit:
                     file=file,
                 )
                 commit_entries.append(entry)
-                entry_groups[entry.identifier()] = group
+                if collect_groups:
+                    entry_groups[entry.identifier()] = group
             for file in msg.deleted_files:
                 commit_entries.append(ManifestEntry(
                     kind=1,

--- a/paimon-python/pypaimon/write/file_store_commit.py
+++ b/paimon-python/pypaimon/write/file_store_commit.py
@@ -368,6 +368,9 @@ class FileStoreCommit:
         )
 
         if not skip_overwrite:
+            _, row_tracking_groups = (
+                self._collect_manifest_entries_with_groups(commit_messages)
+            )
             index_deletes = self._overwrite_hash_index_deletes(
                 partition_filter, index_deletes
             )
@@ -382,6 +385,7 @@ class FileStoreCommit:
                 index_deletes=index_deletes,
                 index_adds=index_adds,
                 hash_index_base_snapshot=hash_index_base_snapshot,
+                row_tracking_groups=row_tracking_groups,
             )
 
     @staticmethod

--- a/paimon-python/pypaimon/write/file_store_commit.py
+++ b/paimon-python/pypaimon/write/file_store_commit.py
@@ -1244,9 +1244,23 @@ class FileStoreCommit:
         if not commit_entries:
             return commit_entries, first_row_id_start
 
-        row_id_assigned = []
         start = first_row_id_start
-        blob_start_default = first_row_id_start
+        normal_starts = {}
+        for entry in commit_entries:
+            write_cols = entry.file.write_cols
+            contains_row_id = (
+                write_cols is not None
+                and SpecialFields.ROW_ID.name in write_cols
+            )
+            if (entry.file.file_source == 0
+                    and entry.file.first_row_id is None
+                    and not contains_row_id
+                    and not DataFileMeta.is_blob_file(entry.file.file_name)
+                    and not DataFileMeta.is_vector_file(entry.file.file_name)):
+                normal_starts[id(entry)] = start
+                start += entry.file.row_count
+
+        row_id_assigned = []
         blob_starts = {}
         vector_store_start = first_row_id_start
 
@@ -1267,7 +1281,7 @@ class FileStoreCommit:
 
                 if DataFileMeta.is_blob_file(entry.file.file_name):
                     blob_field_name = entry.file.write_cols[0]
-                    blob_start = blob_starts.get(blob_field_name, blob_start_default)
+                    blob_start = blob_starts.get(blob_field_name, first_row_id_start)
                     if blob_start >= start:
                         raise RuntimeError(
                             f"This is a bug, blobStart {blob_start} should be less than "
@@ -1286,10 +1300,8 @@ class FileStoreCommit:
                     vector_store_start += row_count
 
                 else:
-                    row_id_assigned.append(entry.assign_first_row_id(start))
-                    blob_start_default = start
-                    blob_starts.clear()
-                    start += row_count
+                    row_id_assigned.append(
+                        entry.assign_first_row_id(normal_starts[id(entry)]))
             else:
                 row_id_assigned.append(entry)
 

--- a/paimon-python/pypaimon/write/file_store_commit.py
+++ b/paimon-python/pypaimon/write/file_store_commit.py
@@ -266,7 +266,9 @@ class FileStoreCommit:
             self.table.identifier,
             len(commit_messages),
         )
-        commit_entries = self._collect_manifest_entries(commit_messages)
+        commit_entries, row_tracking_groups = (
+            self._collect_manifest_entries_with_groups(commit_messages)
+        )
         changelog_entries = self._collect_changelog_entries(commit_messages)
 
         logger.info("Finished collecting changes, including: %d entries, %d changelog entries",
@@ -331,7 +333,8 @@ class FileStoreCommit:
                          allow_rollback=allow_rollback,
                          index_deletes=index_deletes,
                          index_adds=index_adds,
-                         hash_index_base_snapshot=hash_index_base_snapshot)
+                         hash_index_base_snapshot=hash_index_base_snapshot,
+                         row_tracking_groups=row_tracking_groups)
 
     def overwrite(self, overwrite_partition, commit_messages: List[CommitMessage], commit_identifier: int):
         """Commit the given commit messages in overwrite mode."""
@@ -484,7 +487,7 @@ class FileStoreCommit:
     def _try_commit(self, commit_kind, commit_identifier, commit_entries_plan,
                     detect_conflicts=False, allow_rollback=False, index_deletes=None,
                     index_adds=None, changelog_entries=None,
-                    hash_index_base_snapshot=None):
+                    hash_index_base_snapshot=None, row_tracking_groups=None):
 
         retry_count = 0
         retry_result = None
@@ -518,6 +521,7 @@ class FileStoreCommit:
                 index_adds=index_adds,
                 hash_index_base_snapshot=hash_index_base_snapshot,
                 commit_result_may_be_uncertain=commit_result_may_be_uncertain,
+                row_tracking_groups=row_tracking_groups,
             )
 
             if isinstance(result, RewriteResult):
@@ -596,7 +600,8 @@ class FileStoreCommit:
                          index_deletes=None,
                          index_adds=None,
                          hash_index_base_snapshot=None,
-                         commit_result_may_be_uncertain: bool = False) -> CommitResult:
+                         commit_result_may_be_uncertain: bool = False,
+                         row_tracking_groups=None) -> CommitResult:
         start_millis = int(time.time() * 1000)
         if self._is_duplicate_commit(
                 retry_result, latest_snapshot, commit_identifier, commit_kind):
@@ -697,7 +702,7 @@ class FileStoreCommit:
                     commit_entries)
             first_row_id_start = self._get_next_row_id_start(latest_snapshot)
             commit_entries, next_row_id = self._assign_row_tracking_meta(
-                first_row_id_start, commit_entries)
+                first_row_id_start, commit_entries, row_tracking_groups)
 
         changelog_manifest_list_name = None
         changelog_manifest_list_size = None
@@ -1039,8 +1044,13 @@ class FileStoreCommit:
         return changelog_entries
 
     def _collect_manifest_entries(self, commit_messages: List[CommitMessage]) -> List[ManifestEntry]:
+        return self._collect_manifest_entries_with_groups(commit_messages)[0]
+
+    def _collect_manifest_entries_with_groups(
+            self, commit_messages: List[CommitMessage]):
         commit_entries = []
-        for msg in commit_messages:
+        entry_groups = {}
+        for group, msg in enumerate(commit_messages):
             partition = GenericRow(list(msg.partition), self.table.partition_keys_fields)
             total_buckets = (
                 msg.total_buckets
@@ -1048,13 +1058,15 @@ class FileStoreCommit:
                 else self.table.total_buckets
             )
             for file in msg.new_files:
-                commit_entries.append(ManifestEntry(
+                entry = ManifestEntry(
                     kind=0,
                     partition=partition,
                     bucket=msg.bucket,
                     total_buckets=total_buckets,
                     file=file,
-                ))
+                )
+                commit_entries.append(entry)
+                entry_groups[entry.identifier()] = group
             for file in msg.deleted_files:
                 commit_entries.append(ManifestEntry(
                     kind=1,
@@ -1063,7 +1075,7 @@ class FileStoreCommit:
                     total_buckets=total_buckets,
                     file=file,
                 ))
-        return commit_entries
+        return commit_entries, entry_groups
 
     def _clean_up_reuse_tmp_manifests(
             self,
@@ -1236,7 +1248,9 @@ class FileStoreCommit:
             for entry in entries
         ]
 
-    def _assign_row_tracking_meta(self, first_row_id_start: int, commit_entries: List[ManifestEntry]):
+    def _assign_row_tracking_meta(
+            self, first_row_id_start: int,
+            commit_entries: List[ManifestEntry], entry_groups=None):
         """Assign row tracking metadata (first_row_id) to new files.
 
         Aligned with Java RowTrackingCommitUtils.assignRowTrackingMeta.
@@ -1244,6 +1258,29 @@ class FileStoreCommit:
         if not commit_entries:
             return commit_entries, first_row_id_start
 
+        entry_groups = entry_groups or {}
+        grouped_entries = {}
+        default_group = object()
+        for entry in commit_entries:
+            if not entry_groups:
+                group = default_group
+            elif entry.identifier() in entry_groups:
+                group = ('message', entry_groups[entry.identifier()])
+            else:
+                group = ('entry', id(entry))
+            grouped_entries.setdefault(group, []).append(entry)
+
+        assigned_by_entry = {}
+        start = first_row_id_start
+        for entries in grouped_entries.values():
+            start = self._assign_row_tracking_group(
+                start, entries, assigned_by_entry)
+
+        return [assigned_by_entry[id(entry)] for entry in commit_entries], start
+
+    @staticmethod
+    def _assign_row_tracking_group(
+            first_row_id_start, commit_entries, assigned_by_entry):
         start = first_row_id_start
         normal_starts = {}
         for entry in commit_entries:
@@ -1260,7 +1297,6 @@ class FileStoreCommit:
                 normal_starts[id(entry)] = start
                 start += entry.file.row_count
 
-        row_id_assigned = []
         blob_starts = {}
         vector_store_start = first_row_id_start
 
@@ -1287,7 +1323,8 @@ class FileStoreCommit:
                             f"This is a bug, blobStart {blob_start} should be less than "
                             f"start {start} when assigning a blob entry file."
                         )
-                    row_id_assigned.append(entry.assign_first_row_id(blob_start))
+                    assigned_by_entry[id(entry)] = entry.assign_first_row_id(
+                        blob_start)
                     blob_starts[blob_field_name] = blob_start + row_count
 
                 elif DataFileMeta.is_vector_file(entry.file.file_name):
@@ -1296,13 +1333,14 @@ class FileStoreCommit:
                             f"This is a bug, vectorStoreStart {vector_store_start} should be "
                             f"less than start {start} when assigning a vector-store entry file."
                         )
-                    row_id_assigned.append(entry.assign_first_row_id(vector_store_start))
+                    assigned_by_entry[id(entry)] = entry.assign_first_row_id(
+                        vector_store_start)
                     vector_store_start += row_count
 
                 else:
-                    row_id_assigned.append(
-                        entry.assign_first_row_id(normal_starts[id(entry)]))
+                    assigned_by_entry[id(entry)] = entry.assign_first_row_id(
+                        normal_starts[id(entry)])
             else:
-                row_id_assigned.append(entry)
+                assigned_by_entry[id(entry)] = entry
 
-        return row_id_assigned, start
+        return start

--- a/paimon-python/pypaimon/write/table_update_by_row_id.py
+++ b/paimon-python/pypaimon/write/table_update_by_row_id.py
@@ -793,7 +793,7 @@ class TableUpdateByRowId:
                     0,
                     column_name,
                     self.table.options,
-                    video=column_name == self.table.options.video_frame_field(),
+                    video=column_name in self.table.options.video_frame_fields(),
                 )
                 blob_writers.append(blob_writer)
                 arrow_type = original_data.schema.field(column_name).type

--- a/paimon-python/pypaimon/write/writer/dedicated_format_writer.py
+++ b/paimon-python/pypaimon/write/writer/dedicated_format_writer.py
@@ -138,7 +138,9 @@ class DedicatedFormatWriter(DataWriter):
         # State management for blob writer
         self.record_count = 0
         self.total_record_count = 0
-        self._blob_writers_closed = False
+        self._blob_prepared_record_counts = {
+            column: 0 for column in self.blob_file_column_names
+        }
         self.closed = False
 
         # Normal columns are buffered separately from the blob and vector
@@ -519,8 +521,6 @@ class DedicatedFormatWriter(DataWriter):
     def _close_current_writers(self):
         """Close normal/vector writers, then finalize independently rolling blobs."""
         self._close_normal_and_vector_writers()
-        if self._blob_writers_closed:
-            return
 
         blob_metas = []
         deletable_blob_metas = []
@@ -528,10 +528,14 @@ class DedicatedFormatWriter(DataWriter):
             blob_writer = self.blob_writers[blob_column]
             writer_metas = blob_writer.prepare_commit()
             blob_row_count = sum(meta.row_count for meta in writer_metas)
-            if blob_row_count != self.total_record_count:
+            expected_row_count = (
+                self.total_record_count
+                - self._blob_prepared_record_counts[blob_column]
+            )
+            if blob_row_count != expected_row_count:
                 raise RuntimeError(
                     f"This is a bug: blob field {blob_column} contains "
-                    f"{blob_row_count} rows, expected {self.total_record_count}."
+                    f"{blob_row_count} rows, expected {expected_row_count}."
                 )
             blob_metas.extend(writer_metas)
             if blob_writer.delete_file_upon_abort():
@@ -541,7 +545,7 @@ class DedicatedFormatWriter(DataWriter):
         self._committed_files_to_delete_on_abort.extend(deletable_blob_metas)
         for blob_column in self.blob_file_column_names:
             self.blob_writers[blob_column].committed_files.clear()
-        self._blob_writers_closed = True
+            self._blob_prepared_record_counts[blob_column] = self.total_record_count
 
         if blob_metas:
             logger.info("Closed %d blob files", len(blob_metas))

--- a/paimon-python/pypaimon/write/writer/dedicated_format_writer.py
+++ b/paimon-python/pypaimon/write/writer/dedicated_format_writer.py
@@ -34,7 +34,6 @@ from pypaimon.schema.data_types import (
 from pypaimon.table.row.blob import (
     Blob,
     BlobConsumer,
-    video_payload_descriptor,
 )
 from pypaimon.table.row.generic_row import GenericRow
 from pypaimon.write.row_utils import (
@@ -43,7 +42,6 @@ from pypaimon.write.row_utils import (
     row_values_to_arrow_table,
 )
 from pypaimon.write.writer.data_writer import DataWriter
-from pypaimon.write.writer.video_group import VideoGroupRollingPolicy
 from pypaimon.write.writer.write_buffer import WriteBuffer
 
 logger = logging.getLogger(__name__)
@@ -59,8 +57,8 @@ class DedicatedFormatWriter(DataWriter):
 
     This mirrors Java's DedicatedFormatRollingFileWriter.
 
-    Metadata order in committed_files:
-        [normal_meta, blob_meta1, …, vector_meta1, …]
+    Normal/vector files roll together. Blob files roll independently and are
+    appended to committed_files when the writer is finalized.
     """
 
     # Constant for checking rolling condition periodically
@@ -76,7 +74,7 @@ class DedicatedFormatWriter(DataWriter):
         self.blob_column_names = self._get_blob_columns_from_schema()
         self.blob_descriptor_fields = CoreOptions.blob_descriptor_fields(self.options)
         self.blob_view_fields = CoreOptions.blob_view_fields(self.options)
-        self.video_frame_column = CoreOptions.video_frame_field(self.options)
+        self.video_frame_fields = CoreOptions.video_frame_fields(self.options)
         self.blob_inline_fields = self.blob_descriptor_fields.union(self.blob_view_fields)
 
         unknown_descriptor_fields = self.blob_descriptor_fields.difference(
@@ -131,8 +129,6 @@ class DedicatedFormatWriter(DataWriter):
             self.normal_column_names = [
                 col for col in all_column_names if col not in dedicated_set
             ]
-        if self.video_frame_column not in self.blob_file_column_names:
-            self.video_frame_column = None
         normal_name_set = set(self.normal_column_names)
         self.normal_columns = [
             field for field in self.table.table_schema.fields if field.name in normal_name_set
@@ -141,12 +137,9 @@ class DedicatedFormatWriter(DataWriter):
 
         # State management for blob writer
         self.record_count = 0
+        self.total_record_count = 0
+        self._blob_writers_closed = False
         self.closed = False
-        self._video_group_policy = (
-            VideoGroupRollingPolicy()
-            if self.video_frame_column is not None
-            else None
-        )
 
         # Normal columns are buffered separately from the blob and vector
         # columns, which their own writers own.
@@ -169,7 +162,7 @@ class DedicatedFormatWriter(DataWriter):
                 blob_column=blob_column,
                 options=options,
                 blob_consumer=blob_consumer,
-                video=blob_column == self.video_frame_column,
+                video=blob_column in self.video_frame_fields,
             )
 
         # Initialize vector writer when vector.file.format is configured.
@@ -224,34 +217,50 @@ class DedicatedFormatWriter(DataWriter):
         # writer, or the unfinished flush would lose its chance to be retried.
         self._require_finished_flush()
         try:
-            if self.video_frame_column is not None:
-                self._write_video_batches(data)
+            self._validate_inline_stored_fields_input(data)
+            for blob_column in self.blob_file_column_names:
+                blob_data = self._project_columns(data, [blob_column])
+                if blob_data.num_rows > 0:
+                    self.blob_writers[blob_column].write(blob_data)
+            self.total_record_count += data.num_rows
+
+            if not self.normal_column_names and self.vector_writer is None:
                 return
 
-            self._write_bounded_batches(data)
+            offset = 0
+            # Slice at normal/vector boundaries. Blob writers receive the same
+            # rows but roll independently from their physical payload groups.
+            while offset < data.num_rows:
+                capacity = self.target_file_row_num - self.pending_row_count
+                if capacity <= 0:
+                    self._close_normal_and_vector_writers()
+                    capacity = self.target_file_row_num
+                length = min(capacity, data.num_rows - offset)
+                self._write_normal_vector_batch(data.slice(offset, length))
+                offset += length
 
         except Exception as e:
             logger.error("Exception occurs when writing data. Cleaning up.", exc_info=e)
             self.abort()
             raise e
 
-    def _write_batch(self, data: pa.RecordBatch):
+    def _write_normal_vector_batch(self, data: pa.RecordBatch):
         if data.num_rows == 0:
             return
 
-        # Split data into normal, blob, and vector parts
-        normal_data, blob_data_map, vector_data = self._split_data(data)
-        self._validate_inline_stored_fields_input(data)
+        normal_data = (
+            self._project_columns(data, self.normal_column_names)
+            if self.normal_column_names else None
+        )
+        vector_data = (
+            self._project_columns(data, self.vector_write_columns)
+            if self.vector_write_columns else None
+        )
 
         # Process and accumulate normal data (may be None for partial writes)
         processed_normal = self._process_normal_data(normal_data)
         if processed_normal is not None:
             self._normal_buffer.append(processed_normal)
-
-        # Write blob-file columns to dedicated blob writers.
-        for blob_column, blob_data in blob_data_map.items():
-            if blob_data is not None and blob_data.num_rows > 0:
-                self.blob_writers[blob_column].write(blob_data)
 
         # Write vector columns to dedicated vector writer.
         if self.vector_writer is not None and vector_data is not None and vector_data.num_rows > 0:
@@ -261,7 +270,7 @@ class DedicatedFormatWriter(DataWriter):
 
         # Check if normal data rolling is needed
         if self._should_roll_normal():
-            self._roll_or_defer_for_video_group()
+            self._close_normal_and_vector_writers()
 
     def write_row(self, row):
         self._require_finished_flush()
@@ -274,13 +283,6 @@ class DedicatedFormatWriter(DataWriter):
                 + list(self.vector_write_columns)
             )
             require_columns(values_by_name, required_columns, "write_row")
-
-            if self.video_frame_column is not None:
-                next_group = video_payload_descriptor(
-                    values_by_name[self.video_frame_column]
-                )
-                self._roll_before_video_group(next_group)
-                self._video_group_policy.record(next_group)
 
             if self.normal_column_names:
                 normal_values = dict(values_by_name)
@@ -312,8 +314,9 @@ class DedicatedFormatWriter(DataWriter):
                 self.vector_writer.write(vector_data)
 
             self.record_count += 1
+            self.total_record_count += 1
             if self._should_roll_normal():
-                self._roll_or_defer_for_video_group()
+                self._close_normal_and_vector_writers()
 
         except Exception as e:
             logger.error("Exception occurs when writing row. Cleaning up.", exc_info=e)
@@ -497,60 +500,6 @@ class DedicatedFormatWriter(DataWriter):
         # Check if normal data exceeds target size
         return self._normal_buffer.nbytes > self.target_file_size
 
-    def _roll_or_defer_for_video_group(self):
-        if self._video_group_policy is not None and self._video_group_policy.defer_roll():
-            return
-        self._close_current_writers()
-
-    def _roll_before_video_group(self, next_group):
-        if (
-            self._video_group_policy is not None
-            and self._video_group_policy.should_roll_before(next_group)
-        ):
-            self._close_current_writers()
-
-    def _write_video_batches(self, data: pa.RecordBatch):
-        for batch, group in self._video_group_runs(data):
-            self._roll_before_video_group(group)
-            self._video_group_policy.record(group)
-            if group is None:
-                self._write_bounded_batches(batch)
-            else:
-                self._write_batch(batch)
-
-    def _write_bounded_batches(self, data: pa.RecordBatch):
-        offset = 0
-        # _write_batch keeps normal/blob/vector pending rows in lockstep
-        # and closes all writers when the common row limit is reached.
-        while offset < data.num_rows:
-            capacity = self.target_file_row_num - self.pending_row_count
-            if capacity <= 0:
-                self._close_current_writers()
-                capacity = self.target_file_row_num
-            length = min(capacity, data.num_rows - offset)
-            self._write_batch(data.slice(offset, length))
-            offset += length
-
-    def _video_group_runs(self, data: pa.RecordBatch):
-        column_index = data.schema.get_field_index(self.video_frame_column)
-        if column_index < 0:
-            raise KeyError(
-                f"Column '{self.video_frame_column}' was not found in the record batch."
-            )
-        if data.num_rows == 0:
-            return
-
-        column = data.column(column_index)
-        start = 0
-        current_group = video_payload_descriptor(column[0])
-        for index in range(1, data.num_rows):
-            next_group = video_payload_descriptor(column[index])
-            if next_group != current_group:
-                yield data.slice(start, index - start), current_group
-                start = index
-                current_group = next_group
-        yield data.slice(start, data.num_rows - start), current_group
-
     @property
     def pending_row_count(self) -> int:
         # Overrides the base property, which reads a buffer this writer never
@@ -568,14 +517,37 @@ class DedicatedFormatWriter(DataWriter):
         return 0
 
     def _close_current_writers(self):
-        """Close normal, blob, and vector writers; add metadata in order: normal, blob, vector."""
-        # A flush spans the normal file and every blob/vector sidecar, and the
-        # sidecar writers drain their own buffers as they go, so their half cannot
-        # be replayed from scratch. Two rules make a retry resume rather than
-        # restart: the normal rows stay buffered until their file lands, and once
-        # it has landed the file is remembered instead of the rows. Nothing
-        # reaches ``committed_files`` until every phase has succeeded, so a retry
-        # never finds a half-published flush.
+        """Close normal/vector writers, then finalize independently rolling blobs."""
+        self._close_normal_and_vector_writers()
+        if self._blob_writers_closed:
+            return
+
+        blob_metas = []
+        deletable_blob_metas = []
+        for blob_column in self.blob_file_column_names:
+            blob_writer = self.blob_writers[blob_column]
+            writer_metas = blob_writer.prepare_commit()
+            blob_row_count = sum(meta.row_count for meta in writer_metas)
+            if blob_row_count != self.total_record_count:
+                raise RuntimeError(
+                    f"This is a bug: blob field {blob_column} contains "
+                    f"{blob_row_count} rows, expected {self.total_record_count}."
+                )
+            blob_metas.extend(writer_metas)
+            if blob_writer.delete_file_upon_abort():
+                deletable_blob_metas.extend(writer_metas)
+
+        self.committed_files.extend(blob_metas)
+        self._committed_files_to_delete_on_abort.extend(deletable_blob_metas)
+        for blob_column in self.blob_file_column_names:
+            self.blob_writers[blob_column].committed_files.clear()
+        self._blob_writers_closed = True
+
+        if blob_metas:
+            logger.info("Closed %d blob files", len(blob_metas))
+
+    def _close_normal_and_vector_writers(self):
+        """Close one normal/vector row range without closing independently rolling blobs."""
         normal_meta = self._pending_normal_meta
         if normal_meta is None:
             normal_data = self._normal_buffer.materialize()
@@ -587,47 +559,30 @@ class DedicatedFormatWriter(DataWriter):
                 self._committed_files_to_delete_on_abort.append(normal_meta)
             self._normal_buffer.reset()
 
-        blob_metas = []
-        deletable_blob_metas = []
-        for blob_column in self.blob_file_column_names:
-            blob_writer = self.blob_writers[blob_column]
-            writer_metas = blob_writer.prepare_commit()
-            if normal_meta is not None:
-                self._validate_consistency(normal_meta, writer_metas, blob_column)
-            blob_metas.extend(writer_metas)
-            if blob_writer.delete_file_upon_abort():
-                deletable_blob_metas.extend(writer_metas)
-
         vector_metas = []
         if self.vector_writer is not None:
             vector_metas = self.vector_writer.prepare_commit()
             if vector_metas and normal_meta is not None:
                 self._validate_consistency(normal_meta, vector_metas, 'vector')
 
-        # Every phase landed; publish in order: normal, blob, vector.
+        # Every phase landed; publish the normal range and its vector files.
         if normal_meta is not None:
             self.committed_files.append(normal_meta)
-        self.committed_files.extend(blob_metas)
         self.committed_files.extend(vector_metas)
-        self._committed_files_to_delete_on_abort.extend(deletable_blob_metas)
         self._committed_files_to_delete_on_abort.extend(vector_metas)
         # The sub-writers' metas are cleared only now: before the flush completes,
         # a retry has to be able to harvest the same ones again, and an abort has
         # to find them so each sub-writer can apply its own delete policy.
-        for blob_column in self.blob_file_column_names:
-            self.blob_writers[blob_column].committed_files.clear()
         if self.vector_writer is not None:
             self.vector_writer.committed_files.clear()
 
         self._pending_normal_meta = None
         self.record_count = 0
-        if self._video_group_policy is not None:
-            self._video_group_policy.reset()
 
-        if normal_meta is not None or blob_metas or vector_metas:
+        if normal_meta is not None or vector_metas:
             normal_name = normal_meta.file_name if normal_meta is not None else '<none>'
             logger.info(f"Closed writers - normal: {normal_name}, "
-                        f"{len(blob_metas)} blob metas, {len(vector_metas)} vector metas")
+                        f"{len(vector_metas)} vector metas")
 
     def _write_normal_data_to_file(self, data: pa.Table) -> Optional[DataFileMeta]:
         if data.num_rows == 0:


### PR DESCRIPTION
## What

- Allow `video-frame-field` to configure multiple scalar BLOB fields.
- Roll each `.video` field independently, so different camera boundaries do not split or duplicate encoded videos.
- Align independently rolled sidecars with normal-file row ranges in Java and Python read/commit paths.

## Tests

- Java: two video fields with different boundaries, schema validation, split generation, and row-range reads.
- Python: independent video rolling, commit row IDs, retry safety, and multimodal column selection.
- Local checks: Java compile/Spotless, 5 targeted Java tests, 86 targeted Python tests, Flake8, `py_compile`, and `git diff --check`.