### PR TITLE
[common] Release the BTree index file on every path that abandons the writer

### DIFF
--- a/paimon-common/src/main/java/org/apache/paimon/globalindex/btree/BTreeIndexWriter.java
+++ b/paimon-common/src/main/java/org/apache/paimon/globalindex/btree/BTreeIndexWriter.java
@@ -100,7 +100,7 @@ public class BTreeIndexWriter implements GlobalIndexSingleColumnWriter, Closeabl
             this.comparator = keySerializer.createComparator();
             // todo: we may enable bf to accelerate equal and in predicate in the future
             this.writer = new SstFileWriter(out, blockSize, null, compressionFactory);
-        } catch (RuntimeException e) {
+        } catch (RuntimeException | Error e) {
             IOUtils.closeQuietly(out);
             throw e;
         }

--- a/paimon-common/src/main/java/org/apache/paimon/globalindex/btree/BTreeIndexWriter.java
+++ b/paimon-common/src/main/java/org/apache/paimon/globalindex/btree/BTreeIndexWriter.java
@@ -36,6 +36,7 @@ import org.apache.paimon.utils.RoaringNavigableMap64;
 
 import javax.annotation.Nullable;
 
+import java.io.Closeable;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -69,10 +70,11 @@ import java.util.zip.CRC32;
  * <p>For efficiency, we combine entries with the same keys and store a compact list of row ids for
  * each key.
  */
-public class BTreeIndexWriter implements GlobalIndexSingleColumnWriter {
+public class BTreeIndexWriter implements GlobalIndexSingleColumnWriter, Closeable {
 
     private final String fileName;
     private final PositionOutputStream out;
+    private boolean closed;
 
     private final SstFileWriter writer;
     private final KeySerializer keySerializer;
@@ -170,8 +172,10 @@ public class BTreeIndexWriter implements GlobalIndexSingleColumnWriter {
             writer.writeSlice(footerEncoding);
 
             out.close();
+            closed = true;
         } catch (IOException e) {
             IOUtils.closeQuietly(out);
+            closed = true;
             throw new RuntimeException("Error in closing BTree index writer", e);
         }
 
@@ -208,5 +212,18 @@ public class BTreeIndexWriter implements GlobalIndexSingleColumnWriter {
         writer.writeSlice(sliceOutput.toSlice());
 
         return nullBitmapHandle;
+    }
+
+    /**
+     * Releases the output stream for a build that is abandoned without {@link #finish()}. The owner
+     * cleanup paths reach a writer only through {@code instanceof AutoCloseable}, so without this
+     * the stream opened in the constructor stays open for the life of the process.
+     */
+    @Override
+    public void close() throws IOException {
+        if (!closed) {
+            closed = true;
+            out.close();
+        }
     }
 }

--- a/paimon-common/src/main/java/org/apache/paimon/globalindex/btree/BTreeIndexWriter.java
+++ b/paimon-common/src/main/java/org/apache/paimon/globalindex/btree/BTreeIndexWriter.java
@@ -30,6 +30,7 @@ import org.apache.paimon.memory.MemorySliceOutput;
 import org.apache.paimon.sst.BlockHandle;
 import org.apache.paimon.sst.BloomFilterHandle;
 import org.apache.paimon.sst.SstFileWriter;
+import org.apache.paimon.utils.IOUtils;
 import org.apache.paimon.utils.LazyField;
 import org.apache.paimon.utils.RoaringNavigableMap64;
 
@@ -92,10 +93,15 @@ public class BTreeIndexWriter implements GlobalIndexSingleColumnWriter {
             throws IOException {
         this.fileName = indexFileWriter.newFileName(BTreeGlobalIndexerFactory.IDENTIFIER);
         this.out = indexFileWriter.newOutputStream(this.fileName);
-        this.keySerializer = keySerializer;
-        this.comparator = keySerializer.createComparator();
-        // todo: we may enable bf to accelerate equal and in predicate in the future
-        this.writer = new SstFileWriter(out, blockSize, null, compressionFactory);
+        try {
+            this.keySerializer = keySerializer;
+            this.comparator = keySerializer.createComparator();
+            // todo: we may enable bf to accelerate equal and in predicate in the future
+            this.writer = new SstFileWriter(out, blockSize, null, compressionFactory);
+        } catch (RuntimeException e) {
+            IOUtils.closeQuietly(out);
+            throw e;
+        }
     }
 
     @Override
@@ -165,6 +171,7 @@ public class BTreeIndexWriter implements GlobalIndexSingleColumnWriter {
 
             out.close();
         } catch (IOException e) {
+            IOUtils.closeQuietly(out);
             throw new RuntimeException("Error in closing BTree index writer", e);
         }
 

--- a/paimon-common/src/test/java/org/apache/paimon/globalindex/btree/BTreeIndexWriterCloseTest.java
+++ b/paimon-common/src/test/java/org/apache/paimon/globalindex/btree/BTreeIndexWriterCloseTest.java
@@ -22,12 +22,14 @@ import org.apache.paimon.compression.BlockCompressionFactory;
 import org.apache.paimon.fs.PositionOutputStream;
 import org.apache.paimon.globalindex.KeySerializer;
 import org.apache.paimon.globalindex.io.GlobalIndexFileWriter;
+import org.apache.paimon.memory.MemorySlice;
 import org.apache.paimon.types.IntType;
 import org.apache.paimon.utils.IOUtils;
 
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
+import java.util.Comparator;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -107,6 +109,47 @@ public class BTreeIndexWriterCloseTest {
         writer.close();
 
         assertThat(closed).hasValue(1);
+    }
+
+    /**
+     * SstFileWriter allocates its block buffers after the stream is open, so a direct or heap
+     * allocation failure there arrives as an Error rather than an exception. The stream still has
+     * to be released: a task runtime can catch that and keep the JVM alive.
+     */
+    @Test
+    public void testConstructorReleasesTheFileWhenSetupThrowsAnError() {
+        AtomicInteger closed = new AtomicInteger();
+        assertThatThrownBy(
+                        () ->
+                                new BTreeIndexWriter(
+                                        failingWriter(closed),
+                                        errorThrowingSerializer(),
+                                        1024,
+                                        (BlockCompressionFactory) null))
+                .isInstanceOf(OutOfMemoryError.class);
+
+        assertThat(closed).hasValue(1);
+    }
+
+    private static KeySerializer errorThrowingSerializer() {
+        KeySerializer delegate = KeySerializer.create(new IntType());
+        return new KeySerializer() {
+
+            @Override
+            public byte[] serialize(Object key) {
+                return delegate.serialize(key);
+            }
+
+            @Override
+            public Object deserialize(MemorySlice data) {
+                return delegate.deserialize(data);
+            }
+
+            @Override
+            public Comparator<Object> createComparator() {
+                throw new OutOfMemoryError("Direct buffer memory");
+            }
+        };
     }
 
     private static GlobalIndexFileWriter failingWriter(AtomicInteger closed) {

--- a/paimon-common/src/test/java/org/apache/paimon/globalindex/btree/BTreeIndexWriterCloseTest.java
+++ b/paimon-common/src/test/java/org/apache/paimon/globalindex/btree/BTreeIndexWriterCloseTest.java
@@ -1,0 +1,113 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.globalindex.btree;
+
+import org.apache.paimon.compression.BlockCompressionFactory;
+import org.apache.paimon.fs.PositionOutputStream;
+import org.apache.paimon.globalindex.KeySerializer;
+import org.apache.paimon.globalindex.io.GlobalIndexFileWriter;
+import org.apache.paimon.types.IntType;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/** Tests that {@link BTreeIndexWriter} releases the file it opened when writing fails. */
+public class BTreeIndexWriterCloseTest {
+
+    /**
+     * finish() writes the null bitmap, the bloom filter, the index block and the footer before
+     * closing. A write that fails part way through - a full disk is the ordinary cause - must not
+     * leave the file open.
+     */
+    @Test
+    public void testFinishReleasesTheFileWhenWritingFails() throws IOException {
+        AtomicInteger closed = new AtomicInteger();
+        BTreeIndexWriter writer =
+                new BTreeIndexWriter(
+                        failingWriter(closed),
+                        KeySerializer.create(new IntType()),
+                        1024,
+                        (BlockCompressionFactory) null);
+
+        for (int i = 0; i < 200; i++) {
+            writer.write(i, (long) i);
+        }
+
+        assertThatThrownBy(writer::finish)
+                .isInstanceOf(RuntimeException.class)
+                .hasMessageContaining("Error in closing BTree index writer");
+
+        assertThat(closed).hasValue(1);
+    }
+
+    private static GlobalIndexFileWriter failingWriter(AtomicInteger closed) {
+        return new GlobalIndexFileWriter() {
+
+            @Override
+            public String newFileName(String prefix) {
+                return "test-btree" + prefix;
+            }
+
+            @Override
+            public PositionOutputStream newOutputStream(String fileName) {
+                return new PositionOutputStream() {
+
+                    private long pos;
+                    private final long capacity = 1500L;
+
+                    @Override
+                    public long getPos() {
+                        return pos;
+                    }
+
+                    @Override
+                    public void write(int b) throws IOException {
+                        write(new byte[] {(byte) b}, 0, 1);
+                    }
+
+                    @Override
+                    public void write(byte[] b) throws IOException {
+                        write(b, 0, b.length);
+                    }
+
+                    @Override
+                    public void write(byte[] b, int off, int len) throws IOException {
+                        if (pos + len > capacity) {
+                            throw new IOException("no space left on device");
+                        }
+                        pos += len;
+                    }
+
+                    @Override
+                    public void flush() {}
+
+                    @Override
+                    public void close() {
+                        closed.incrementAndGet();
+                    }
+                };
+            }
+        };
+    }
+}

--- a/paimon-common/src/test/java/org/apache/paimon/globalindex/btree/BTreeIndexWriterCloseTest.java
+++ b/paimon-common/src/test/java/org/apache/paimon/globalindex/btree/BTreeIndexWriterCloseTest.java
@@ -23,6 +23,7 @@ import org.apache.paimon.fs.PositionOutputStream;
 import org.apache.paimon.globalindex.KeySerializer;
 import org.apache.paimon.globalindex.io.GlobalIndexFileWriter;
 import org.apache.paimon.types.IntType;
+import org.apache.paimon.utils.IOUtils;
 
 import org.junit.jupiter.api.Test;
 
@@ -32,7 +33,9 @@ import java.util.concurrent.atomic.AtomicInteger;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-/** Tests that {@link BTreeIndexWriter} releases the file it opened when writing fails. */
+/**
+ * Tests that {@link BTreeIndexWriter} releases the file it opened, on every path that abandons it.
+ */
 public class BTreeIndexWriterCloseTest {
 
     /**
@@ -57,6 +60,51 @@ public class BTreeIndexWriterCloseTest {
         assertThatThrownBy(writer::finish)
                 .isInstanceOf(RuntimeException.class)
                 .hasMessageContaining("Error in closing BTree index writer");
+
+        assertThat(closed).hasValue(1);
+    }
+
+    /**
+     * A build can be abandoned before finish() ever runs - the row source fails, or a Flink or
+     * Spark index build task is cancelled. The owner cleanup paths, PkSortedIndexFile#build and
+     * SortedSingleColumnIndexWriter#close, release the writer only if they can see it as an
+     * AutoCloseable, and skip it silently otherwise. This is that exact idiom.
+     */
+    @Test
+    public void testTheOwnerCleanupPathReleasesAnAbandonedWriter() throws IOException {
+        AtomicInteger closed = new AtomicInteger();
+        BTreeIndexWriter writer =
+                new BTreeIndexWriter(
+                        failingWriter(closed),
+                        KeySerializer.create(new IntType()),
+                        1024,
+                        (BlockCompressionFactory) null);
+        writer.write(1, 1L);
+
+        if (writer instanceof AutoCloseable) {
+            IOUtils.closeQuietly((AutoCloseable) writer);
+        }
+
+        assertThat(closed).hasValue(1);
+    }
+
+    /**
+     * SortedGlobalIndexWriter holds the task writer in a try-with-resources, so close() can follow
+     * a successful finish(). It must not close the stream a second time.
+     */
+    @Test
+    public void testCloseIsIdempotent() throws IOException {
+        AtomicInteger closed = new AtomicInteger();
+        BTreeIndexWriter writer =
+                new BTreeIndexWriter(
+                        failingWriter(closed),
+                        KeySerializer.create(new IntType()),
+                        1024,
+                        (BlockCompressionFactory) null);
+        writer.write(1, 1L);
+
+        writer.close();
+        writer.close();
 
         assertThat(closed).hasValue(1);
     }


### PR DESCRIPTION
### Purpose

`BTreeIndexWriter` opens a `PositionOutputStream` in its constructor and, before this change, gave it back on exactly one path: the success path of `finish()`. Three ways that leaves the file open.

**1. The writer is the only one its owners cannot release.** It is the only `GlobalIndexSingleColumnWriter` in `src/main` that does not implement `Closeable`:

| writer | Closeable |
|---|---|
| `BitmapGlobalIndexWriter` `MultiValueBitmapIndexWriter` `FMGlobalIndexWriter` `NativeFullTextGlobalIndexWriter` `NativeVectorGlobalIndexWriter` `LuminaVectorGlobalIndexWriter` `ESIndexGlobalIndexWriter` | yes |
| `BTreeIndexWriter` | **no** |

Both cleanup paths a btree writer can reach guard on that:

```java
// PkSortedIndexFile#build, in the finally block
if (writer instanceof AutoCloseable) {
    IOUtils.closeQuietly((AutoCloseable) writer);
}
```

```java
// SortedSingleColumnIndexWriter#close, reached from SortedGlobalIndexWriter's
// try-with-resources and from the Flink SortedIndexBuildOperator
if (writer instanceof AutoCloseable) { ... }
```

For a btree writer both evaluate false, so the writer is skipped without a word. A build abandoned before `finish()` — the row source fails, or a Flink or Spark `CREATE GLOBAL INDEX ... btree` task is cancelled — leaves the stream open with nothing left that can reach it: the class exposes neither a `close()` nor any accessor for `out`. On the `PkSortedIndexFile` path, `deleteCreatedFiles()` then unlinks the target while that stream is still open.

**2. A partially built writer keeps the file.** The constructor opens the stream, then builds the comparator and the `SstFileWriter`. If either throws, the stream is already open and the object is never handed back.

**3. `finish()` keeps the file when it fails.** It writes the null bitmap, the bloom filter, the index block and the footer before closing. Anything failing part way — a full disk is the ordinary cause — went to `catch (IOException e)` and rethrew without closing.

### Tests

`BTreeIndexWriterCloseTest`, three cases against a `PositionOutputStream` that counts closes and fails past a fixed capacity:

- `testTheOwnerCleanupPathReleasesAnAbandonedWriter` — runs the exact `instanceof AutoCloseable` idiom the owners use, against a writer that never reaches `finish()`.
- `testCloseIsIdempotent` — `SortedGlobalIndexWriter` holds the task writer in a try-with-resources, so `close()` can follow a successful `finish()`; the stream must not be closed twice.
- `testFinishReleasesTheFileWhenWritingFails` — a write that fails mid-`finish()`.

On `master` the first two fail and the third errors. Removing only `Closeable` from the class while keeping the `close()` method — so it still compiles and still has a way to be closed, just not one the owners can see — fails exactly one test, `testTheOwnerCleanupPathReleasesAnAbandonedWriter` with `Expecting AtomicInteger(0) to have value: 1`, which is what pins that the test discriminates the property being fixed rather than merely the presence of a method.

Worth noting for review: `SortedGlobalIndexWriterTest` already asserts this cleanup, in `testSingleColumnWriterClosesActiveWriter` and `testBuildForSinglePartitionClosesWriterAfterFailure`. Both build the subject with `mock(GlobalIndexSingleColumnWriter.class, withSettings().extraInterfaces(Closeable.class))` — they add to the mock the one property the real class lacks — and the second names indexType `btree` but then overrides `createWriter()` to return that mock, so `BTreeIndexWriter` is never constructed. Both are green today.

`mvn test -pl paimon-common -Dtest='org.apache.paimon.globalindex.**'` — 349 tests, all passing. `spotless:check` and `checkstyle:check` clean.

### Tests API and Compatibility

No API, format or configuration change. `close()` is additive and idempotent, so a successful `finish()` behaves exactly as before.