### PR TITLE
[spark] Fix flaky row tracking concurrent compaction test

### DIFF
--- a/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/sql/RowTrackingTestBase.scala
+++ b/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/sql/RowTrackingTestBase.scala
@@ -117,15 +117,19 @@ abstract class RowTrackingTestBase extends PaimonSparkTestBase with AdaptiveSpar
       }
 
       val compact = Future {
-        for (_ <- 1 to 10) {
-          while (!canBeCompacted) {
+        var hasCompacted = false
+        while (!mergeInto.isCompleted || canBeCompacted) {
+          if (canBeCompacted) {
+            sql("CALL sys.compact(table => 't')")
+            val snapshot = t.latestSnapshot().get()
+            assert(snapshot.totalRecordCount > 0)
+            assert(snapshot.totalRecordCount < 12)
+            hasCompacted = true
+          } else {
             Thread.sleep(1)
           }
-          sql("CALL sys.compact(table => 't')")
-          val snapshot = t.latestSnapshot().get()
-          assert(snapshot.totalRecordCount > 0)
-          assert(snapshot.totalRecordCount < 12)
         }
+        assert(hasCompacted)
       }
 
       Await.result(mergeInto, 60.seconds)


### PR DESCRIPTION
### Purpose

Fix the flaky Data Evolution: concurrent merge and compact test observed in https://github.com/apache/paimon/actions/runs/33253723275/job/99103720771.

The compaction future previously required ten separate compactable states. A compaction can consume files produced by multiple merge iterations, so after the merge future completed there might be no additional compactable state and the compaction future would wait until the test timed out.

Run compaction while the merge is active or compactable files remain, and retain the assertion that at least one compaction occurred.

### Tests

- Spark 3.3 / Scala 2.13 targeted test passed.
- The targeted test passed three consecutive runs after the final change.
- Scala compilation, Checkstyle, and Spotless passed for the shared Spark test module.