### PR TITLE
[flink] Fix schema inference for multi partition Kafka topics

### DIFF
--- a/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/action/cdc/kafka/KafkaActionUtils.java
+++ b/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/action/cdc/kafka/KafkaActionUtils.java
@@ -46,8 +46,6 @@ import org.apache.kafka.common.serialization.ByteArrayDeserializer;
 
 import java.time.Duration;
 import java.util.Arrays;
-import java.util.Collection;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
@@ -278,10 +276,10 @@ public class KafkaActionUtils {
                                     + "'topic' and 'bootstrap.servers' config.",
                             topic));
         }
-        int firstPartition =
-                partitionInfos.stream().map(PartitionInfo::partition).sorted().findFirst().get();
-        Collection<TopicPartition> topicPartitions =
-                Collections.singletonList(new TopicPartition(topic, firstPartition));
+        List<TopicPartition> topicPartitions =
+                partitionInfos.stream()
+                        .map(partition -> new TopicPartition(topic, partition.partition()))
+                        .collect(Collectors.toList());
         consumer.assign(topicPartitions);
         consumer.seekToBeginning(topicPartitions);
 

--- a/paimon-flink/paimon-flink-cdc/src/test/java/org/apache/paimon/flink/action/cdc/kafka/KafkaActionITCaseBase.java
+++ b/paimon-flink/paimon-flink-cdc/src/test/java/org/apache/paimon/flink/action/cdc/kafka/KafkaActionITCaseBase.java
@@ -249,6 +249,19 @@ public abstract class KafkaActionITCaseBase extends CdcActionITCaseBase {
                 .forEach(r -> send(topic, r, wait));
     }
 
+    protected void writeRecordsToKafka(
+            String topic, int partition, String resourceDirFormat, Object... args)
+            throws Exception {
+        URL url =
+                KafkaActionITCaseBase.class
+                        .getClassLoader()
+                        .getResource(String.format(resourceDirFormat, args));
+        assert url != null;
+        Files.readAllLines(Paths.get(url.toURI())).stream()
+                .filter(this::isRecordLine)
+                .forEach(r -> send(topic, partition, r));
+    }
+
     protected boolean isRecordLine(String line) {
         try {
             objectMapper.readTree(line);
@@ -266,6 +279,14 @@ public abstract class KafkaActionITCaseBase extends CdcActionITCaseBase {
             } catch (InterruptedException | ExecutionException e) {
                 throw new RuntimeException(e);
             }
+        }
+    }
+
+    private void send(String topic, int partition, String record) {
+        try {
+            kafkaProducer.send(new ProducerRecord<>(topic, partition, null, record)).get();
+        } catch (InterruptedException | ExecutionException e) {
+            throw new RuntimeException(e);
         }
     }
 

--- a/paimon-flink/paimon-flink-cdc/src/test/java/org/apache/paimon/flink/action/cdc/kafka/KafkaSchemaITCase.java
+++ b/paimon-flink/paimon-flink-cdc/src/test/java/org/apache/paimon/flink/action/cdc/kafka/KafkaSchemaITCase.java
@@ -69,6 +69,31 @@ public class KafkaSchemaITCase extends KafkaActionITCaseBase {
 
     @Test
     @Timeout(60)
+    public void testKafkaSchemaFromNonFirstPartition() throws Exception {
+        final String topic = "test_kafka_schema_from_non_first_partition";
+        createTestTopic(topic, 2, 1);
+        writeRecordsToKafka(topic, 1, "kafka/canal/table/schemaevolution/canal-data-1.txt");
+
+        Configuration kafkaConfig = Configuration.fromMap(getBasicKafkaConfig());
+        kafkaConfig.setString(VALUE_FORMAT.key(), "canal-json");
+        kafkaConfig.setString(TOPIC.key(), topic);
+
+        Schema kafkaSchema =
+                MessageQueueSchemaUtils.getSchema(
+                        getKafkaEarliestConsumer(
+                                kafkaConfig, new KafkaDebeziumJsonDeserializationSchema()),
+                        getDataFormat(kafkaConfig),
+                        TypeMapping.defaultMapping());
+
+        assertThat(kafkaSchema.fields())
+                .containsExactly(
+                        new DataField(0, "pt", DataTypes.INT()),
+                        new DataField(1, "_id", DataTypes.INT().notNull()),
+                        new DataField(2, "v1", DataTypes.VARCHAR(10)));
+    }
+
+    @Test
+    @Timeout(60)
     public void testTableOptionsChange() throws Exception {
         final String topic = "test_table_options_change";
         createTestTopic(topic, 1, 1);


### PR DESCRIPTION
### Purpose
 - Kafka table sync fails table creation when 1st partition has no cdc records, even when other partitions have records.
 - Schema discovery reads only the 1st partition and fails with SchemaRetrievalException.
-  Read records from all topic partitions so the schema is inferred from the first valid CDC record.

### Tests
 - UT