### PR TITLE
[format] Prevent text tables from accepting unsupported schemas

### DIFF
--- a/paimon-format/src/main/java/org/apache/paimon/format/text/TextFileFormat.java
+++ b/paimon-format/src/main/java/org/apache/paimon/format/text/TextFileFormat.java
@@ -66,7 +66,7 @@ public class TextFileFormat extends FileFormat {
     @Override
     public void validateDataFields(RowType rowType) {
         if (rowType.getFieldCount() != 1
-                && !rowType.getFieldTypes().get(0).equals(DataTypes.STRING())) {
+                || !rowType.getFieldTypes().get(0).equals(DataTypes.STRING())) {
             throw new IllegalArgumentException("Text format only supports a single string column");
         }
     }

--- a/paimon-format/src/test/java/org/apache/paimon/format/text/TextFileFormatTest.java
+++ b/paimon-format/src/test/java/org/apache/paimon/format/text/TextFileFormatTest.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.format.text;
+
+import org.apache.paimon.format.FileFormatFactory.FormatContext;
+import org.apache.paimon.options.Options;
+import org.apache.paimon.types.DataTypes;
+import org.apache.paimon.types.RowType;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/** Tests for {@link TextFileFormat}. */
+class TextFileFormatTest {
+
+    private final TextFileFormat format =
+            new TextFileFormat(new FormatContext(new Options(), 1024, 1024));
+
+    @Test
+    void testValidateDataFields() {
+        assertThatCode(() -> format.validateDataFields(RowType.of(DataTypes.STRING())))
+                .doesNotThrowAnyException();
+
+        assertInvalidSchema(RowType.of(DataTypes.STRING(), DataTypes.INT()));
+        assertInvalidSchema(RowType.of(DataTypes.INT()));
+        assertInvalidSchema(RowType.of());
+    }
+
+    private void assertInvalidSchema(RowType rowType) {
+        assertThatThrownBy(() -> format.validateDataFields(rowType))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Text format only supports a single string column");
+    }
+}


### PR DESCRIPTION
### Purpose
 - Text format supports exactly one string column.
 - Schema validation accepts multiple columns when the first column is a string, causing writes to serialize only the first column and discard the remaining values.
 - Reject every text table schema that is not exactly one string column.

### Tests
 - UT