### PR TITLE
[spark] Clamp Format Table ANALYZE parallelism

### DIFF
--- a/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/commands/PaimonAnalyzeFormatTablePartitionsCommand.scala
+++ b/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/commands/PaimonAnalyzeFormatTablePartitionsCommand.scala
@@ -105,8 +105,9 @@ case class PaimonAnalyzeFormatTablePartitionsCommand(
       sparkSession: SparkSession,
       partitions: List[JMap[String, String]],
       parallelism: Int): JList[PartitionStatistics] = {
-    val tasks = math.min(parallelism, partitions.size)
-    val perTask = math.max(1, parallelism / tasks)
+    val effectiveParallelism = math.max(1, parallelism)
+    val tasks = math.min(effectiveParallelism, partitions.size)
+    val perTask = math.max(1, effectiveParallelism / tasks)
     // The table, not this command: a Spark table cannot be shipped to an executor.
     val table = v2Table.table
     val measured = sparkSession.sparkContext

--- a/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/sql/CatalogManagedPartitionAnalyzeTest.scala
+++ b/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/sql/CatalogManagedPartitionAnalyzeTest.scala
@@ -338,6 +338,40 @@ class CatalogManagedPartitionAnalyzeTest extends PaimonSparkTestWithRestCatalogB
     }
   }
 
+  test("a full ANALYZE clamps non-positive statistics parallelism") {
+    Seq("zero" -> 0, "negative" -> -1).foreach {
+      case (label, parallelism) =>
+        val tableName = s"analyze_${label}_parallelism"
+        withTable(tableName) {
+          sql(s"""CREATE TABLE $tableName (id INT, payload STRING, dt STRING, hour STRING)
+                 |USING PARQUET
+                 |PARTITIONED BY (dt, hour)
+                 |TBLPROPERTIES (
+                 |  'format-table.implementation' = 'paimon',
+                 |  'metastore.partitioned-table' = 'true')
+                 |""".stripMargin)
+          sql(s"""INSERT INTO ${qualified(tableName)}
+                 |VALUES (1, 'a', '20260101', '00'), (2, 'b', '20260101', '00')
+                 |""".stripMargin)
+          copyPartitionFiles(tableName, "20260101", "20260102")
+          repair(tableName)
+          assert(
+            !PartitionStatistics.isKnown(statisticsOf(tableName, "20260102", "00").recordCount()))
+
+          withSparkSQLConf(
+            "spark.paimon.format-table.statistics.parallelism" -> parallelism.toString) {
+            sql(
+              s"ANALYZE TABLE ${qualified(tableName)} PARTITION (dt = '20260102') " +
+                s"COMPUTE STATISTICS").collect()
+          }
+
+          val scanned = statisticsOf(tableName, "20260102", "00")
+          // The exact row count confirms that ANALYZE completed the Parquet footer scan.
+          assert(scanned.recordCount() == 2L, scanned.toString)
+        }
+    }
+  }
+
   test("catalog partition row counts feed scan statistics after partition pruning") {
     val tableName = "analyze_scan_statistics"
     withTable(tableName) {


### PR DESCRIPTION
### Purpose

`format-table.statistics.parallelism` can be set to zero or a negative value through Spark configuration. The NOSCAN collector already clamps it to at least one, but full ANALYZE used the raw value to derive Spark task count. Zero caused division by zero and a negative value produced an invalid partition count before any footer was read.

This change applies the same lower bound before deriving executor tasks and per-task file concurrency.

### Tests

- `CatalogManagedPartitionAnalyzeTest` with Spark 3: 23/23
- `CatalogManagedPartitionAnalyzeTest` with Spark 4: 23/23
- Mutation check: a zero-only guard fails the new negative-value arm
- Spotless check for the affected Spark modules