### PR TITLE
[python] Reject overlapping row-id update batches

### DIFF
--- a/paimon-python/pypaimon/tests/table_update_test.py
+++ b/paimon-python/pypaimon/tests/table_update_test.py
@@ -53,6 +53,8 @@ def test_batch_row_id_update_batches_reuse_file_index():
         updater.commit_messages = []
 
         def update_columns(batch, columns):
+            updater._last_updated_first_row_ids = {
+                batch['_ROW_ID'][0].as_py()}
             updater.commit_messages.append((batch, columns))
             return updater.commit_messages
 
@@ -1606,6 +1608,28 @@ class _StreamModeMixin(StreamModeMixin):
 class TableUpdateBatchTest(_BatchModeMixin, _TableUpdateTestBase, unittest.TestCase):
     """All shared update tests under batch (``BatchWriteBuilder``) semantics."""
 
+    def test_update_batches_reject_same_file_and_abort_staged_files(self):
+        table = self._create_seeded_table()
+        before_files = self._list_table_files(table)
+        update = (
+            self._make_write_builder(table)
+            .new_update()
+            .with_update_type(['age'])
+        )
+
+        with self.assertRaisesRegex(
+                ValueError, "overlapping first_row_ids.*0"):
+            update.update_by_arrow_batches_with_row_id(iter([
+                pa.Table.from_pydict({'_ROW_ID': [0], 'age': [26]}),
+                pa.Table.from_pydict({'_ROW_ID': [1], 'age': [31]}),
+            ]))
+
+        self.assertEqual(before_files, self._list_table_files(table))
+        self.assertEqual(
+            [25, 30, 35, 40, 45],
+            self._read_all(table)['age'].to_pylist(),
+        )
+
     def test_callable_output_preserves_large_offset_chunks(self):
         from pypaimon.write.table_update import TableUpdate
         from pypaimon.write.table_update_by_row_id import TableUpdateByRowId
@@ -1635,7 +1659,10 @@ class TableUpdateBatchTest(_BatchModeMixin, _TableUpdateTestBase, unittest.TestC
         )
         with mock.patch.object(
                 updater, '_calculate_first_row_id',
-                side_effect=lambda data: data) as calculate:
+                side_effect=lambda data: data.append_column(
+                    TableUpdateByRowId.FIRST_ROW_ID_COLUMN,
+                    pa.array([0, 0], type=pa.int64()),
+                )) as calculate:
             with mock.patch.object(updater, '_write_by_first_row_id'):
                 updater.update_columns(updates, ['payload'])
 

--- a/paimon-python/pypaimon/tests/table_update_test.py
+++ b/paimon-python/pypaimon/tests/table_update_test.py
@@ -32,6 +32,7 @@ from pypaimon.tests.data_evolution_test_helpers import (
     StreamModeMixin,
 )
 from pypaimon.write.table_update import BatchTableUpdate
+from pypaimon.write.table_update_by_row_id import TableUpdateByRowId
 
 
 # ======================================================================
@@ -53,8 +54,6 @@ def test_batch_row_id_update_batches_reuse_file_index():
         updater.commit_messages = []
 
         def update_columns(batch, columns):
-            updater._last_updated_first_row_ids = {
-                batch['_ROW_ID'][0].as_py()}
             updater.commit_messages.append((batch, columns))
             return updater.commit_messages
 
@@ -71,6 +70,30 @@ def test_batch_row_id_update_batches_reuse_file_index():
         (batches[0], ["value"]),
         (batches[1], ["value"]),
     ]
+
+
+def test_batch_row_id_update_detects_overlap_before_write():
+    updater = TableUpdateByRowId.__new__(TableUpdateByRowId)
+    updater.table = mock.Mock(field_names=['age'])
+    updater.commit_messages = []
+    updater._updated_first_row_ids_by_column = {}
+
+    def route(data):
+        return data.append_column(
+            TableUpdateByRowId.FIRST_ROW_ID_COLUMN,
+            pa.array([0], type=pa.int64()),
+        )
+
+    with mock.patch.object(
+            updater, '_calculate_first_row_id', side_effect=route):
+        with mock.patch.object(updater, '_write_by_first_row_id') as write:
+            updater.update_columns(
+                pa.table({'_ROW_ID': [0], 'age': [26]}), ['age'])
+            with pytest.raises(ValueError, match='overlapping first_row_ids'):
+                updater.update_columns(
+                    pa.table({'_ROW_ID': [1], 'age': [31]}), ['age'])
+
+    assert write.call_count == 1
 
 
 class _TableUpdateTestBase(DataEvolutionTestBase):
@@ -1630,6 +1653,28 @@ class TableUpdateBatchTest(_BatchModeMixin, _TableUpdateTestBase, unittest.TestC
             self._read_all(table)['age'].to_pylist(),
         )
 
+    def test_update_batches_allow_same_file_for_different_columns(self):
+        table = self._create_seeded_table()
+        builder = self._make_write_builder(table)
+        messages = (
+            builder.new_update()
+            .update_by_arrow_batches_with_row_id(iter([
+                pa.Table.from_pydict({'_ROW_ID': [0], 'age': [26]}),
+                pa.Table.from_pydict({'_ROW_ID': [1], 'city': ['Seattle']}),
+            ]))
+        )
+
+        commit = builder.new_commit()
+        commit.commit(messages)
+        commit.close()
+
+        rows = self._read_all(table)
+        self.assertEqual([26, 30, 35, 40, 45], rows['age'].to_pylist())
+        self.assertEqual(
+            ['NYC', 'Seattle', 'Chicago', 'Houston', 'Phoenix'],
+            rows['city'].to_pylist(),
+        )
+
     def test_callable_output_preserves_large_offset_chunks(self):
         from pypaimon.write.table_update import TableUpdate
         from pypaimon.write.table_update_by_row_id import TableUpdateByRowId
@@ -1653,6 +1698,7 @@ class TableUpdateBatchTest(_BatchModeMixin, _TableUpdateTestBase, unittest.TestC
         updater = TableUpdateByRowId.__new__(TableUpdateByRowId)
         updater.table = mock.Mock(field_names=['payload'])
         updater.commit_messages = []
+        updater._updated_first_row_ids_by_column = {}
         updates = pa.Table.from_arrays(
             [pa.array([1, 0], type=pa.int64()), result],
             names=['_ROW_ID', 'payload'],

--- a/paimon-python/pypaimon/write/table_update.py
+++ b/paimon-python/pypaimon/write/table_update.py
@@ -170,6 +170,7 @@ class TableUpdate:
             self, tables: Iterable[pa.Table], commit_identifier: int
     ) -> List[CommitMessage]:
         updater = None
+        updated_first_row_ids = set()
         try:
             for table in tables:
                 cols = self.update_cols if self.update_cols is not None else [
@@ -180,6 +181,15 @@ class TableUpdate:
                     updater = TableUpdateByRowId(
                         self.table, self.commit_user, commit_identifier)
                 updater.update_columns(table, cols)
+                overlapping_first_row_ids = updated_first_row_ids.intersection(
+                    updater._last_updated_first_row_ids)
+                if overlapping_first_row_ids:
+                    raise ValueError(
+                        "Input batches contain overlapping first_row_ids: "
+                        f"{sorted(overlapping_first_row_ids)}"
+                    )
+                updated_first_row_ids.update(
+                    updater._last_updated_first_row_ids)
             return [] if updater is None else updater.commit_messages
         except Exception:
             if updater is not None:
@@ -647,7 +657,11 @@ class BatchTableUpdate(TableUpdate):
     def update_by_arrow_batches_with_row_id(
             self, tables: Iterable[pa.Table]
     ) -> List[CommitMessage]:
-        """Apply row-id updates from batches using one target-file index."""
+        """Apply row-id updates from batches using one target-file index.
+
+        Batches must target disjoint ``first_row_id`` file groups. Overlap is
+        rejected and all files staged by earlier batches are aborted.
+        """
         return self._update_by_arrow_batches_with_row_id(
             tables, BATCH_COMMIT_IDENTIFIER)
 

--- a/paimon-python/pypaimon/write/table_update.py
+++ b/paimon-python/pypaimon/write/table_update.py
@@ -170,7 +170,6 @@ class TableUpdate:
             self, tables: Iterable[pa.Table], commit_identifier: int
     ) -> List[CommitMessage]:
         updater = None
-        updated_first_row_ids = set()
         try:
             for table in tables:
                 cols = self.update_cols if self.update_cols is not None else [
@@ -181,15 +180,6 @@ class TableUpdate:
                     updater = TableUpdateByRowId(
                         self.table, self.commit_user, commit_identifier)
                 updater.update_columns(table, cols)
-                overlapping_first_row_ids = updated_first_row_ids.intersection(
-                    updater._last_updated_first_row_ids)
-                if overlapping_first_row_ids:
-                    raise ValueError(
-                        "Input batches contain overlapping first_row_ids: "
-                        f"{sorted(overlapping_first_row_ids)}"
-                    )
-                updated_first_row_ids.update(
-                    updater._last_updated_first_row_ids)
             return [] if updater is None else updater.commit_messages
         except Exception:
             if updater is not None:
@@ -659,8 +649,9 @@ class BatchTableUpdate(TableUpdate):
     ) -> List[CommitMessage]:
         """Apply row-id updates from batches using one target-file index.
 
-        Batches must target disjoint ``first_row_id`` file groups. Overlap is
-        rejected and all files staged by earlier batches are aborted.
+        For each updated column, batches must target disjoint ``first_row_id``
+        file groups. Conflicting overlap is rejected and all files staged by
+        earlier batches are aborted.
         """
         return self._update_by_arrow_batches_with_row_id(
             tables, BATCH_COMMIT_IDENTIFIER)

--- a/paimon-python/pypaimon/write/table_update_by_row_id.py
+++ b/paimon-python/pypaimon/write/table_update_by_row_id.py
@@ -99,7 +99,7 @@ class TableUpdateByRowId:
         self.valid_row_id_ranges = info.valid_row_id_ranges
 
         self.commit_messages: List[CommitMessage] = []
-        self._last_updated_first_row_ids: Set[int] = set()
+        self._updated_first_row_ids_by_column: Dict[str, Set[int]] = {}
 
     def _snapshot_files_info(self) -> _FilesInfo:
         """Return the already loaded snapshot file index for broadcast."""
@@ -220,10 +220,24 @@ class TableUpdateByRowId:
                 raise ValueError(f"Column {col_name} not found in table schema")
 
         data_with_first_row_id = self._calculate_first_row_id(data)
-        self._last_updated_first_row_ids = set(
+        first_row_ids = set(
             data_with_first_row_id[self.FIRST_ROW_ID_COLUMN].to_pylist()
         )
+        overlapping = {}
+        for col_name in column_names:
+            ids = first_row_ids.intersection(
+                self._updated_first_row_ids_by_column.get(col_name, set()))
+            if ids:
+                overlapping[col_name] = sorted(ids)
+        if overlapping:
+            raise ValueError(
+                "Input batches contain overlapping first_row_ids by column: "
+                f"{overlapping}"
+            )
         self._write_by_first_row_id(data_with_first_row_id, column_names)
+        for col_name in column_names:
+            self._updated_first_row_ids_by_column.setdefault(
+                col_name, set()).update(first_row_ids)
 
         return self.commit_messages
 

--- a/paimon-python/pypaimon/write/table_update_by_row_id.py
+++ b/paimon-python/pypaimon/write/table_update_by_row_id.py
@@ -99,6 +99,7 @@ class TableUpdateByRowId:
         self.valid_row_id_ranges = info.valid_row_id_ranges
 
         self.commit_messages: List[CommitMessage] = []
+        self._last_updated_first_row_ids: Set[int] = set()
 
     def _snapshot_files_info(self) -> _FilesInfo:
         """Return the already loaded snapshot file index for broadcast."""
@@ -219,6 +220,9 @@ class TableUpdateByRowId:
                 raise ValueError(f"Column {col_name} not found in table schema")
 
         data_with_first_row_id = self._calculate_first_row_id(data)
+        self._last_updated_first_row_ids = set(
+            data_with_first_row_id[self.FIRST_ROW_ID_COLUMN].to_pylist()
+        )
         self._write_by_first_row_id(data_with_first_row_id, column_names)
 
         return self.commit_messages


### PR DESCRIPTION
### Purpose

Prevent local `BatchTableUpdate.update_by_arrow_batches_with_row_id` calls from silently producing conflicting rewrites when multiple input batches target the same data file.

The update now tracks each batch's `first_row_id` file groups, rejects overlap, and aborts files staged by earlier batches. This change is intentionally limited to the local table-update path; distributed Ray updates already coalesce rows by target file.

### Tests

- `python3.13 -m pytest -q pypaimon/tests/table_update_test.py pypaimon/tests/table_update_by_row_id_chunked_test.py`
- flake8 on the three changed files with `dev/cfg.ini`
- `python3.13 -m py_compile` on the three changed files