### PR TITLE
[spark] Fix analyze failure for timestamp ntz columns

### DIFF
--- a/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/commands/PaimonAnalyzeTableColumnCommand.scala
+++ b/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/commands/PaimonAnalyzeTableColumnCommand.scala
@@ -31,7 +31,7 @@ import org.apache.spark.sql.catalyst.plans.logical.ColumnStat
 import org.apache.spark.sql.catalyst.util.DateTimeUtils
 import org.apache.spark.sql.connector.catalog.{Identifier, TableCatalog}
 import org.apache.spark.sql.execution.datasources.v2.DataSourceV2Relation
-import org.apache.spark.sql.types.{DataType, Decimal, DecimalType, TimestampType}
+import org.apache.spark.sql.types.{DataType, Decimal, DecimalType, TimestampNTZType, TimestampType}
 
 import java.util
 
@@ -162,6 +162,8 @@ case class PaimonAnalyzeTableColumnCommand(
       case _: TimestampType =>
         val l = o.asInstanceOf[Long]
         org.apache.paimon.data.Timestamp.fromSQLTimestamp(DateTimeUtils.toJavaTimestamp(l))
+      case _: TimestampNTZType =>
+        org.apache.paimon.data.Timestamp.fromMicros(o.asInstanceOf[Long])
       case _ => o
     }
   }

--- a/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/sql/AnalyzeTableTestBase.scala
+++ b/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/sql/AnalyzeTableTestBase.scala
@@ -326,6 +326,31 @@ abstract class AnalyzeTableTestBase extends PaimonSparkTestBase {
       colStats.get("varchar_col"))
   }
 
+  test("Paimon analyze: timestamp ntz column") {
+    assume(gteqSpark3_4)
+
+    spark.sql("CREATE TABLE T (ts TIMESTAMP_NTZ) USING PAIMON")
+    spark.sql(s"""INSERT INTO T VALUES
+                 |(TIMESTAMP_NTZ '2020-01-01 00:00:00.123456'),
+                 |(TIMESTAMP_NTZ '2020-01-02 00:00:00.654321')
+                 |""".stripMargin)
+
+    spark.sql("ANALYZE TABLE T COMPUTE STATISTICS FOR COLUMNS ts")
+
+    val colStats = loadTable("T").statistics().get().colStats()
+    Assertions.assertEquals(
+      ColStats.newColStats(
+        0,
+        2,
+        DateTimeUtils.parseTimestampData("2020-01-01 00:00:00.123456", 6),
+        DateTimeUtils.parseTimestampData("2020-01-02 00:00:00.654321", 6),
+        0,
+        8,
+        8),
+      colStats.get("ts")
+    )
+  }
+
   test("Paimon analyze: analyze unsupported cols") {
     spark.sql(
       s"""


### PR DESCRIPTION
### Purpose
 - Analyzing a table with timestamp ntz columns causes ClassCastException.
 - Spark reports timestamp ntz statistics as microsecond long values, but converter attempts to serialize them directly as timestamps.
 - Convert the statistics to Paimon timestamps before persisting them.

### Tests
 - UT