### PR TITLE
[core] Rename FM index identifier to fm

### DIFF
--- a/docs/docs/flink/procedures.md
+++ b/docs/docs/flink/procedures.md
@@ -1085,7 +1085,7 @@ All available procedures are listed below.
          To create a global index on a table for accelerating queries. Arguments:
             <li>table(required): the target table identifier.</li>
             <li>index_column(required): the column name to build index on.</li>
-            <li>index_type(required): the type of global index, supported types include 'btree', 'bitmap', 'fmindex', 'ivf-flat', 'ivf-pq', 'ivf-sq', 'ivf-rq', 'diskann', and 'full-text'.</li>
+            <li>index_type(required): the type of global index, supported types include 'btree', 'bitmap', 'fm', 'ivf-flat', 'ivf-pq', 'ivf-sq', 'ivf-rq', 'diskann', and 'full-text'.</li>
             <li>partitions(optional): partition filter for selective index creation.</li>
             <li>options(optional): additional dynamic options for index creation.</li>
       </td>
@@ -1105,7 +1105,7 @@ All available procedures are listed below.
          CALL sys.create_global_index(<br/>
             `table` => 'default.T',<br/>
             `index_column` => 'content',<br/>
-            `index_type` => 'fmindex')<br/><br/>
+            `index_type` => 'fm')<br/><br/>
          -- Create index for specific partitions<br/>
          CALL sys.create_global_index(<br/>
             `table` => 'default.T',<br/>

--- a/docs/docs/multimodal-table/global-index/fm.mdx
+++ b/docs/docs/multimodal-table/global-index/fm.mdx
@@ -43,7 +43,7 @@ Create the index on a Data Evolution table with row tracking enabled:
 CALL sys.create_global_index(
     table => 'db.documents',
     index_column => 'content',
-    index_type => 'fmindex',
+    index_type => 'fm',
     options => 'fm-index.partition-row-count=100000'
 );
 ```
@@ -54,7 +54,7 @@ Drop it with the same index type:
 CALL sys.drop_global_index(
     table => 'db.documents',
     index_column => 'content',
-    index_type => 'fmindex'
+    index_type => 'fm'
 );
 ```
 

--- a/docs/docs/spark/procedures.md
+++ b/docs/docs/spark/procedures.md
@@ -560,14 +560,14 @@ This section introduce all available spark procedures about paimon.
          To create global index files for a given column. The table must have <code>row-tracking.enabled=true</code>. Arguments:
             <li>table: the target table identifier. Cannot be empty.</li>
             <li>index_column: the name of the column to index. Cannot be empty.</li>
-            <li>index_type: type of the index to build, e.g. 'btree', 'bitmap', or 'fmindex'. Cannot be empty.</li>
+            <li>index_type: type of the index to build, e.g. 'btree', 'bitmap', or 'fm'. Cannot be empty.</li>
             <li>partitions: partition filter to limit the partitions on which to build the index. The comma (",") represents "AND", the semicolon (";") represents "OR". Left empty for all partitions.</li>
             <li>options: additional dynamic options of the table. It prioritizes higher than original `tableProp` and lower than `procedureArg`.</li>
       </td>
       <td>
          CALL sys.create_global_index(table => 'default.T', index_column => 'name', index_type => 'btree')<br/><br/>
          CALL sys.create_global_index(table => 'default.T', index_column => 'tag', index_type => 'bitmap', options => 'sorted-index.records-per-range=1000000')<br/><br/>
-         CALL sys.create_global_index(table => 'default.T', index_column => 'content', index_type => 'fmindex')<br/><br/>
+         CALL sys.create_global_index(table => 'default.T', index_column => 'content', index_type => 'fm')<br/><br/>
          CALL sys.create_global_index(table => 'default.T', index_column => 'name', index_type => 'btree', partitions => 'pt=p1;pt=p2')<br/><br/>
          CALL sys.create_global_index(table => 'default.T', index_column => 'content', index_type => 'full-text', options => 'full-text.tokenizer=ngram,full-text.ngram.min-gram=2,full-text.ngram.max-gram=2')<br/><br/>
          CALL sys.create_global_index(table => 'default.T', index_column => 'content', index_type => 'full-text', options => 'full-text.tokenizer=jieba')<br/><br/>

--- a/paimon-common/src/main/java/org/apache/paimon/globalindex/fmindex/FMGlobalIndexWriter.java
+++ b/paimon-common/src/main/java/org/apache/paimon/globalindex/fmindex/FMGlobalIndexWriter.java
@@ -290,7 +290,7 @@ public class FMGlobalIndexWriter implements GlobalIndexSingleColumnWriter, Close
         if (output != null) {
             return;
         }
-        fileName = fileWriter.newFileName("fmindex");
+        fileName = fileWriter.newFileName("fm");
         stream = fileWriter.newOutputStream(fileName);
         output = new DataOutputStream(stream);
     }

--- a/paimon-common/src/main/java/org/apache/paimon/globalindex/fmindex/FMGlobalIndexerFactory.java
+++ b/paimon-common/src/main/java/org/apache/paimon/globalindex/fmindex/FMGlobalIndexerFactory.java
@@ -29,7 +29,7 @@ import static org.apache.paimon.utils.Preconditions.checkArgument;
 /** Factory for the exact partitioned FM contains index. */
 public class FMGlobalIndexerFactory implements GlobalIndexerFactory {
 
-    public static final String IDENTIFIER = "fmindex";
+    public static final String IDENTIFIER = "fm";
 
     @Override
     public String identifier() {

--- a/paimon-common/src/test/java/org/apache/paimon/globalindex/fmindex/FMGlobalIndexTest.java
+++ b/paimon-common/src/test/java/org/apache/paimon/globalindex/fmindex/FMGlobalIndexTest.java
@@ -295,7 +295,7 @@ public class FMGlobalIndexTest {
         try (GlobalIndexReader reader = createReader(Collections.emptyList(), 0)) {
             assertRows(reader.visitContains(fieldRef, str("")).join());
         }
-        assertThat(GlobalIndexer.create("fmindex", dataField, new Options()))
+        assertThat(GlobalIndexer.create("fm", dataField, new Options()))
                 .isInstanceOf(FMGlobalIndexer.class);
 
         List<GlobalIndexIOMeta> shifted = writeData(Collections.singletonList(str("value")), 1);

--- a/paimon-core/src/test/java/org/apache/paimon/index/pk/PrimaryKeyIndexDefinitionsTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/index/pk/PrimaryKeyIndexDefinitionsTest.java
@@ -110,7 +110,7 @@ class PrimaryKeyIndexDefinitionsTest {
                 PrimaryKeyIndexDefinitions.create(schema(options)).definitions().get(0);
 
         assertThat(definition.column()).isEqualTo("name");
-        assertThat(definition.indexType()).isEqualTo("fmindex");
+        assertThat(definition.indexType()).isEqualTo("fm");
         assertThat(definition.family()).isEqualTo(PrimaryKeyIndexDefinition.Family.FM);
         assertThat(definition.options().get("fm-index.sa-sample-rate")).isEqualTo("16");
         assertThat(definition.options().get("fm-index.partition-row-count")).isEqualTo("2");

--- a/paimon-core/src/test/java/org/apache/paimon/index/pksorted/PkSequentialIndexBuilderTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/index/pksorted/PkSequentialIndexBuilderTest.java
@@ -88,7 +88,7 @@ class PkSequentialIndexBuilderTest {
                         },
                         capturingFile,
                         field(),
-                        "fmindex",
+                        "fm",
                         new Options())
                 .build(Arrays.asList(sourceB, sourceA));
 
@@ -116,7 +116,7 @@ class PkSequentialIndexBuilderTest {
                         ignored -> reader,
                         new PkSortedIndexFile(LocalFileIO.create(), pathFactory()),
                         field(),
-                        "fmindex",
+                        "fm",
                         new Options());
 
         assertThatThrownBy(() -> builder.build(Collections.singletonList(dataFile("data-file", 2))))
@@ -134,7 +134,7 @@ class PkSequentialIndexBuilderTest {
                                 },
                         new PkSortedIndexFile(LocalFileIO.create(), pathFactory()),
                         field(),
-                        "fmindex",
+                        "fm",
                         new Options());
 
         assertThatThrownBy(() -> builder.build(Collections.singletonList(dataFile("data-file", 1))))

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/globalindex/SortedIndexTopoBuilderTest.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/globalindex/SortedIndexTopoBuilderTest.java
@@ -63,7 +63,7 @@ public class SortedIndexTopoBuilderTest {
         assertThat(SortedIndexTopoBuilder.supports("bitmap")).isTrue();
         assertThat(SortedIndexTopoBuilder.supports("btree")).isTrue();
         assertThat(SortedIndexTopoBuilder.supports("multivalue")).isTrue();
-        assertThat(SortedIndexTopoBuilder.supports("fmindex")).isFalse();
+        assertThat(SortedIndexTopoBuilder.supports("fm")).isFalse();
         assertThat(SortedIndexTopoBuilder.supports("inverted")).isFalse();
     }
 

--- a/paimon-spark/paimon-spark-common/src/test/java/org/apache/paimon/spark/globalindex/DefaultGlobalIndexTopoBuilderTest.java
+++ b/paimon-spark/paimon-spark-common/src/test/java/org/apache/paimon/spark/globalindex/DefaultGlobalIndexTopoBuilderTest.java
@@ -43,7 +43,7 @@ public class DefaultGlobalIndexTopoBuilderTest {
 
     @Test
     void testFMIndexUsesDefaultTopologyBuilder() {
-        assertThat(GlobalIndexTopologyBuilderUtils.createTopoBuilder("fmindex"))
+        assertThat(GlobalIndexTopologyBuilderUtils.createTopoBuilder("fm"))
                 .isInstanceOf(DefaultGlobalIndexTopoBuilder.class);
     }
 

--- a/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/procedure/FMGlobalIndexProcedureTest.scala
+++ b/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/procedure/FMGlobalIndexProcedureTest.scala
@@ -53,7 +53,7 @@ class FMGlobalIndexProcedureTest extends PaimonSparkTestBase with StreamTest {
       val output = spark
         .sql(
           "CALL sys.create_global_index(" +
-            "table => 'test.T', index_column => 'content', index_type => 'fmindex', " +
+            "table => 'test.T', index_column => 'content', index_type => 'fm', " +
             "options => 'fm-index.partition-row-count=2')")
         .collect()
         .head
@@ -65,7 +65,7 @@ class FMGlobalIndexProcedureTest extends PaimonSparkTestBase with StreamTest {
         .scanEntries()
         .asScala
         .map(_.indexFile())
-        .filter(_.indexType() == "fmindex")
+        .filter(_.indexType() == "fm")
       assert(entries.nonEmpty)
       assert(entries.map(_.rowCount()).sum == 7L)
 
@@ -111,7 +111,7 @@ class FMGlobalIndexProcedureTest extends PaimonSparkTestBase with StreamTest {
       val output = spark
         .sql(
           "CALL sys.create_global_index(" +
-            "table => 'test.T', index_column => 'content', index_type => 'fmindex', " +
+            "table => 'test.T', index_column => 'content', index_type => 'fm', " +
             "options => 'fm-index.partition-row-count=2')")
         .collect()
         .head
@@ -123,7 +123,7 @@ class FMGlobalIndexProcedureTest extends PaimonSparkTestBase with StreamTest {
         .scanEntries()
         .asScala
         .map(_.indexFile())
-        .filter(_.indexType() == "fmindex")
+        .filter(_.indexType() == "fm")
       assert(entries.nonEmpty)
       // The index retains the stable physical row-id range, including rows hidden by DVs.
       assert(entries.map(_.rowCount()).sum == 7L)

--- a/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/sql/PrimaryKeySortedIndexTest.scala
+++ b/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/sql/PrimaryKeySortedIndexTest.scala
@@ -62,7 +62,7 @@ class PrimaryKeySortedIndexTest extends PaimonSparkTestBase {
       val sourceIndexes = loadTable("t").store.newIndexFileHandler.scanEntries.asScala
         .map(_.indexFile)
         .filter(meta => meta.globalIndexMeta != null && meta.globalIndexMeta.sourceMeta != null)
-      assert(sourceIndexes.map(_.indexType).toSet == Set("fmindex"))
+      assert(sourceIndexes.map(_.indexType).toSet == Set("fm"))
       assert(sourceIndexes.size == 1)
 
       val predicateBuilder = new PredicateBuilder(loadTable("t").rowType())


### PR DESCRIPTION
### Purpose

Rename the external FM index identifier from `fmindex` to `fm` before release. This aligns it with `pk-fm` options and existing index identifiers such as `btree` and `bitmap`. Keep FM-index implementation names and option prefixes unchanged.

### Tests

- `mvn -pl paimon-common -Pfast-build -DwildcardSuites=none -Dtest=FMGlobalIndexTest#testEmptyShardServiceLoadingAndFileCoverageValidation test`
- `mvn -pl paimon-core -am -Pfast-build -DfailIfNoTests=false -DwildcardSuites=none -Dtest=PrimaryKeyIndexDefinitionsTest#testCreatesFMDefinitionAndResolvesOptions test`
- `git diff --check`