### PR TITLE
[spark] Support timestamp_ntz and variant in generic row access

### DIFF
--- a/paimon-spark/paimon-spark-4.0/src/main/scala/org/apache/spark/sql/paimon/shims/Spark4Shim.scala
+++ b/paimon-spark/paimon-spark-4.0/src/main/scala/org/apache/spark/sql/paimon/shims/Spark4Shim.scala
@@ -375,6 +375,9 @@ class Spark4Shim extends SparkShim {
     new GenericVariant(v.getValue, v.getMetadata)
   }
 
+  override def toSparkVariant(variant: Variant): Object =
+    new VariantVal(variant.value(), variant.metadata())
+
   override def isSparkVariantType(dataType: org.apache.spark.sql.types.DataType): Boolean =
     dataType.isInstanceOf[VariantType]
 

--- a/paimon-spark/paimon-spark-4.0/src/test/scala/org/apache/paimon/spark/data/SparkInternalRowVariantTest.scala
+++ b/paimon-spark/paimon-spark-4.0/src/test/scala/org/apache/paimon/spark/data/SparkInternalRowVariantTest.scala
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.spark.data
+
+import org.apache.paimon.data.GenericRow
+import org.apache.paimon.data.variant.GenericVariant
+import org.apache.paimon.types.{RowType, VariantType}
+
+import org.apache.spark.SparkFunSuite
+import org.apache.spark.sql.types.DataTypes
+import org.apache.spark.unsafe.types.VariantVal
+
+class SparkInternalRowVariantTest extends SparkFunSuite {
+
+  test("get variant with generic data type access") {
+    val variant = GenericVariant.fromJson("""{"id":1}""")
+    val rowType = RowType.of(new VariantType())
+    val row = SparkInternalRow.create(rowType).replace(GenericRow.of(variant))
+
+    val actual = row.get(0, DataTypes.VariantType).asInstanceOf[VariantVal]
+
+    assert(actual.getValue.sameElements(variant.value()))
+    assert(actual.getMetadata.sameElements(variant.metadata()))
+  }
+}

--- a/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/AbstractSparkInternalRow.java
+++ b/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/AbstractSparkInternalRow.java
@@ -47,6 +47,7 @@ import org.apache.spark.sql.types.NullType;
 import org.apache.spark.sql.types.ShortType;
 import org.apache.spark.sql.types.StringType;
 import org.apache.spark.sql.types.StructType;
+import org.apache.spark.sql.types.TimestampNTZType;
 import org.apache.spark.sql.types.TimestampType;
 import org.apache.spark.sql.types.UserDefinedType;
 import org.apache.spark.sql.types.VarcharType;
@@ -236,7 +237,7 @@ public abstract class AbstractSparkInternalRow extends SparkInternalRow {
         if (dataType instanceof DateType) {
             return getInt(ordinal);
         }
-        if (dataType instanceof TimestampType) {
+        if (dataType instanceof TimestampType || dataType instanceof TimestampNTZType) {
             return getLong(ordinal);
         }
         if (dataType instanceof CalendarIntervalType) {
@@ -256,6 +257,9 @@ public abstract class AbstractSparkInternalRow extends SparkInternalRow {
         }
         if (dataType instanceof UserDefinedType) {
             return get(ordinal, ((UserDefinedType<?>) dataType).sqlType());
+        }
+        if (SparkShimLoader.shim().isSparkVariantType(dataType)) {
+            return SparkShimLoader.shim().toSparkVariant(row.getVariant(ordinal));
         }
         if (SparkShimLoader.shim().isSparkGeometryType(dataType)) {
             org.apache.paimon.types.GeometryType geometryType =

--- a/paimon-spark/paimon-spark-common/src/main/scala/org/apache/spark/sql/paimon/shims/SparkShim.scala
+++ b/paimon-spark/paimon-spark-common/src/main/scala/org/apache/spark/sql/paimon/shims/SparkShim.scala
@@ -265,6 +265,8 @@ trait SparkShim {
 
   def toPaimonVariant(array: ArrayData, pos: Int): Variant
 
+  def toSparkVariant(variant: Variant): Object
+
   def isSparkVariantType(dataType: org.apache.spark.sql.types.DataType): Boolean
 
   def SparkVariantType(): org.apache.spark.sql.types.DataType

--- a/paimon-spark/paimon-spark-ut/src/test/java/org/apache/paimon/spark/SparkInternalRowTest.java
+++ b/paimon-spark/paimon-spark-ut/src/test/java/org/apache/paimon/spark/SparkInternalRowTest.java
@@ -30,6 +30,7 @@ import org.apache.paimon.data.Timestamp;
 import org.apache.paimon.fs.local.LocalFileIO;
 import org.apache.paimon.spark.data.SparkInternalRow;
 import org.apache.paimon.types.DataTypes;
+import org.apache.paimon.types.RowType;
 import org.apache.paimon.utils.DateTimeUtils;
 import org.apache.paimon.utils.UriReaderFactory;
 
@@ -176,6 +177,17 @@ public class SparkInternalRowTest {
                                         false))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessage("Spark MAP<X, BLOB> does not support null keys.");
+    }
+
+    @Test
+    public void testGetTimestampNtz() {
+        Timestamp timestamp =
+                Timestamp.fromLocalDateTime(LocalDateTime.parse("2026-08-31T10:15:30.123456"));
+        RowType rowType = RowType.of(DataTypes.TIMESTAMP());
+        SparkInternalRow row = SparkInternalRow.create(rowType).replace(GenericRow.of(timestamp));
+
+        assertThat(row.get(0, SparkTypeUtils.fromPaimonType(DataTypes.TIMESTAMP())))
+                .isEqualTo(timestamp.toMicros());
     }
 
     private String sparkRowToString(org.apache.spark.sql.Row row) {

--- a/paimon-spark/paimon-spark3-common/src/main/scala/org/apache/spark/sql/paimon/shims/Spark3Shim.scala
+++ b/paimon-spark/paimon-spark3-common/src/main/scala/org/apache/spark/sql/paimon/shims/Spark3Shim.scala
@@ -349,6 +349,9 @@ class Spark3Shim extends SparkShim {
 
   override def toPaimonVariant(o: Object): Variant = throw new UnsupportedOperationException()
 
+  override def toSparkVariant(variant: Variant): Object =
+    throw new UnsupportedOperationException("Variant requires Spark 4.0 or later")
+
   override def isSparkVariantType(dataType: org.apache.spark.sql.types.DataType): Boolean = false
 
   override def SparkVariantType(): org.apache.spark.sql.types.DataType =

--- a/paimon-spark/paimon-spark4-common/src/main/scala/org/apache/spark/sql/paimon/shims/Spark4Shim.scala
+++ b/paimon-spark/paimon-spark4-common/src/main/scala/org/apache/spark/sql/paimon/shims/Spark4Shim.scala
@@ -353,6 +353,9 @@ class Spark4Shim extends SparkShim {
     new GenericVariant(v.getValue, v.getMetadata)
   }
 
+  override def toSparkVariant(variant: Variant): Object =
+    new VariantVal(variant.value(), variant.metadata())
+
   override def isSparkVariantType(dataType: org.apache.spark.sql.types.DataType): Boolean =
     dataType.isInstanceOf[VariantType]
 


### PR DESCRIPTION
### Purpose

The known user-visible failure is in **lateral vector search**: when a matched Paimon row contains a timestamp column, the result projection reads it through generic `InternalRow.get(ordinal, dataType)` access. Paimon `TIMESTAMP` maps to Spark `TimestampNTZType`, but `AbstractSparkInternalRow.get` only recognized `TimestampType`, causing `UnsupportedOperationException: Unsupported data type timestamp_ntz`.

While auditing the generic row-access mappings, Spark 4 `VariantType` was also found to fall through to the unsupported-type branch even though Paimon already provides dedicated variant access. This is an independent completeness fix and is not part of the known vector-search impact.

### Changes

- Handle `TimestampNTZType` as Spark's internal microsecond `long` representation.
- Handle Spark 4 `VariantType` through a shimmed Paimon-to-Spark variant conversion.
- Add regression tests for timestamp-NTZ and Spark 4 variant generic row access.

### Tests

- `SparkInternalRowTest#testGetTimestampNtz` passed with Spark 3.5.
- `SparkInternalRowVariantTest` passed with Spark 4.0.
- `mvn spotless:apply`
