### PR TITLE
[spark] Show format table partition statistics

### DIFF
--- a/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/PaimonPartitionManagement.scala
+++ b/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/PaimonPartitionManagement.scala
@@ -165,6 +165,30 @@ trait PaimonPartitionManagement extends SupportsAtomicPartitionManagement with L
         } else {
           Map.empty[String, String].asJava
         }
+      case formatTable: FormatTable =>
+        val partitionManager = formatTable.partitionManager()
+        if (partitionManager == null) {
+          Map.empty[String, String].asJava
+        } else {
+          val partitionSpec =
+            toPaimonPartition(ident, formatTable.partitionKeys().asScala.toSeq)
+          val partitions = partitionManager.listPartitionsByNames(Seq(partitionSpec).asJava)
+          if (!partitions.isEmpty) {
+            val partition = partitions.get(0)
+            Map(
+              PartitionStatistics.FIELD_RECORD_COUNT -> partition.recordCount().toString,
+              PartitionStatistics.FIELD_FILE_SIZE_IN_BYTES -> partition
+                .fileSizeInBytes()
+                .toString,
+              PartitionStatistics.FIELD_FILE_COUNT -> partition.fileCount().toString,
+              PartitionStatistics.FIELD_LAST_FILE_CREATION_TIME -> partition
+                .lastFileCreationTime()
+                .toString
+            ).asJava
+          } else {
+            Map.empty[String, String].asJava
+          }
+        }
       case _ =>
         Map.empty[String, String].asJava
     }

--- a/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/sql/CatalogManagedPartitionAnalyzeTest.scala
+++ b/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/sql/CatalogManagedPartitionAnalyzeTest.scala
@@ -338,6 +338,55 @@ class CatalogManagedPartitionAnalyzeTest extends PaimonSparkTestWithRestCatalogB
     }
   }
 
+  test("SHOW TABLE EXTENDED displays catalog-managed Format Table partition statistics") {
+    val tableName = "analyze_show_partition_statistics"
+    withTable(tableName) {
+      sql(s"""CREATE TABLE $tableName (id INT, payload STRING, dt STRING, hour STRING)
+             |USING PARQUET
+             |PARTITIONED BY (dt, hour)
+             |TBLPROPERTIES (
+             |  'format-table.implementation' = 'paimon',
+             |  'metastore.partitioned-table' = 'true')
+             |""".stripMargin)
+      sql(s"""INSERT INTO ${qualified(tableName)} VALUES
+             |(1, 'a', '20260101', '00'), (2, 'b', '20260101', '00')
+             |""".stripMargin)
+      sql(
+        s"ANALYZE TABLE ${qualified(tableName)} " +
+          s"PARTITION (dt = '20260101', hour = '00') COMPUTE STATISTICS").collect()
+
+      val information =
+        sql(
+          s"SHOW TABLE EXTENDED IN paimon.$dbName0 LIKE '$tableName' " +
+            s"PARTITION (dt = '20260101', hour = '00')")
+          .select("information")
+          .collect()
+          .head
+          .getString(0)
+
+      assert(information.contains(s"${PartitionStatistics.FIELD_RECORD_COUNT}=2"), information)
+      val statistics = statisticsOf(tableName, "20260101", "00")
+      assert(statistics.fileCount() > 0L, statistics.toString)
+      assert(statistics.fileSizeInBytes() > 0L, statistics.toString)
+      assert(statistics.lastFileCreationTime() > 0L, statistics.toString)
+      assert(
+        information.contains(s"${PartitionStatistics.FIELD_FILE_COUNT}=${statistics.fileCount()}"),
+        information)
+      assert(
+        information.contains(
+          s"${PartitionStatistics.FIELD_FILE_SIZE_IN_BYTES}=${statistics.fileSizeInBytes()}"),
+        information)
+      assert(
+        information.contains(
+          s"${PartitionStatistics.FIELD_LAST_FILE_CREATION_TIME}=" +
+            s"${statistics.lastFileCreationTime()}"),
+        information)
+      assert(
+        information.matches("(?s).*Partition Statistics: 2 rows, [1-9]\\d* bytes.*"),
+        information)
+    }
+  }
+
   test("a full ANALYZE clamps non-positive statistics parallelism") {
     Seq("zero" -> 0, "negative" -> -1).foreach {
       case (label, parallelism) =>


### PR DESCRIPTION
### Purpose

`ANALYZE TABLE ... PARTITION` stores statistics for catalog-managed Format Table partitions, but `SHOW TABLE EXTENDED ... PARTITION` did not expose them because partition metadata loading only handled native Paimon tables.

Load the exact Format Table partition from its partition manager and return the same four statistics fields used for native Paimon partitions. Format Tables without catalog-managed partitions keep the previous empty-metadata behavior.

### Tests

- Added `CatalogManagedPartitionAnalyzeTest` coverage for `SHOW TABLE EXTENDED` after `ANALYZE`, including exact record count, file count, file size, and last file creation time.
- Passed 42 Spark 3.5.5 partition-management and statistics tests.
- Passed Spotless checks for the changed Spark modules.
- Passed the full 75-module `clean install -DskipTests -Pspark3,flink1` reactor build.
