### PR TITLE
[spark] Skip time-travel self-merge test on Spark 3.2

### DIFF
--- a/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/sql/RowTrackingTestBase.scala
+++ b/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/sql/RowTrackingTestBase.scala
@@ -1226,6 +1226,8 @@ abstract class RowTrackingTestBase extends PaimonSparkTestBase with AdaptiveSpar
   }
 
   test("Data Evolution: self-merge falls back for time-travel source") {
+    assume(gteqSpark3_3)
+
     withTable("target") {
       sql("""
             |CREATE TABLE target (id INT, b INT, dt STRING)


### PR DESCRIPTION
### Purpose

The time-travel self-merge test uses relation time-travel syntax (`VERSION AS OF`) that Spark 3.2 cannot parse. Spark added this SQL syntax in 3.3, so the new shared test currently fails the Spark 3.2 CI matrix before exercising Paimon behavior.

Guard the test with the existing `gteqSpark3_3` capability helper. The assumption runs before table creation, and Spark 3.3+ continues to execute the full test.

### Tests

- Spark 3.2 / Scala 2.12 `RowTrackingTest`: 47 passed, 2 canceled, 0 failed.
- Spark 3.2 / Scala 2.13 `RowTrackingTest`: 47 passed, 2 canceled, 0 failed.
- Spark 3.3 / Scala 2.12 `RowTrackingTest`: 49 passed, 0 canceled, 0 failed; the guarded time-travel test executed.