### PR TITLE
[docs] Fix stale paimon-vindex version in vector index documentation

### DIFF
--- a/docs/docs/multimodal-table/global-index/vector.mdx
+++ b/docs/docs/multimodal-table/global-index/vector.mdx
@@ -123,7 +123,7 @@ added_files = table.create_global_index(
 print(added_files)
 ```
 
-PyPaimon vector index build supports the paimon-vindex 0.3.0 identifiers `ivf-flat`, `ivf-pq`,
+PyPaimon vector index build supports the paimon-vindex 0.4.0 identifiers `ivf-flat`, `ivf-pq`,
 `ivf-sq`, `ivf-rq`, and `diskann`. Install `paimon-vindex==0.4.0` or `pypaimon[vindex]` before
 building or querying paimon-vindex indexes from Python.
 


### PR DESCRIPTION

### Purpose


- In `docs/docs/multimodal-table/global-index/vector.mdx`, line 126 names the paimon-vindex `0.3.0` identifiers while line 127 of the same sentence says to install `paimon-vindex==0.4.0`.
- #9341 (`193723d19`, "[paimon-vector] Upgrade paimon-vector-index to 0.4.0") updated the install pin on line 127 but missed line 126.
- 0.4.0 is what the build resolves: `paimon-vector/pom.xml` sets `paimon-vector-index-java.version` to `0.4.0`, and `paimon-python/setup.py` pins `paimon-vindex==0.4.0`.
- Scope: line 126 only. The 0.2.x -> 0.3.0 upgrade warning at L56-58 is a historical note and is left unchanged. The listed identifiers match the module factory constants and are untouched.

### Tests

- Documentation-only wording change with no behavior change, so it carries no tests and no Maven build gate applies.
- Only a version number inside prose changes; the inline code backticks and line wrapping are unchanged, so the mdx rendering is unaffected.


