### PR TITLE
[pvfs] Set working directory to the catalog root in PaimonVirtualFileSystem

### DIFF
--- a/paimon-vfs/paimon-vfs-hadoop/src/main/java/org/apache/paimon/vfs/hadoop/PaimonVirtualFileSystem.java
+++ b/paimon-vfs/paimon-vfs-hadoop/src/main/java/org/apache/paimon/vfs/hadoop/PaimonVirtualFileSystem.java
@@ -67,11 +67,13 @@ public class PaimonVirtualFileSystem extends FileSystem {
         this.conf = conf;
         super.initialize(uri, conf);
 
-        this.workingDirectory = new Path(uri);
         if (uri.getAuthority() == null || uri.getAuthority().isEmpty()) {
             throw new IllegalArgumentException("URI authority is empty: " + uri);
         }
         this.uri = URI.create(uri.getScheme() + "://" + uri.getAuthority() + "/");
+        // Hadoop passes the full user URI here, path component included, so the working
+        // directory must be derived from the normalized catalog root.
+        this.workingDirectory = new Path(this.uri);
 
         initVFSOperations();
     }

--- a/paimon-vfs/paimon-vfs-hadoop/src/test/java/org/apache/paimon/vfs/hadoop/VirtualFileSystemTest.java
+++ b/paimon-vfs/paimon-vfs-hadoop/src/test/java/org/apache/paimon/vfs/hadoop/VirtualFileSystemTest.java
@@ -474,6 +474,30 @@ public abstract class VirtualFileSystemTest {
     }
 
     @Test
+    public void testWorkingDirectoryIsCatalogRoot() throws Exception {
+        String databaseName = "test_db";
+        String tableName = "object_table";
+        createObjectTable(databaseName, tableName);
+
+        // Hadoop hands initialize() the full user URI, path component included
+        Path filePath = new Path(vfsRoot, databaseName + "/" + tableName + "/a.csv");
+        try (FileSystem fs = new PaimonVirtualFileSystem()) {
+            fs.initialize(filePath.toUri(), vfs.getConf());
+            assertThat(fs.getWorkingDirectory()).isEqualTo(vfsRoot);
+
+            // A relative path resolves against the catalog root, so it lands in the table it
+            // names rather than in the table that happened to open this file system
+            String relative = databaseName + "/" + tableName + "2/b.csv";
+            FSDataOutputStream out = fs.create(new Path(relative));
+            out.write("hello".getBytes());
+            out.close();
+
+            assertThat(fs.exists(new Path(vfsRoot, relative))).isTrue();
+            assertThat(fs.exists(filePath)).isFalse();
+        }
+    }
+
+    @Test
     public void testTrash() throws Exception {
         String databaseName = "test_db";
         String tableName = "object_table";


### PR DESCRIPTION

### Purpose

fix #9506

- Behavior change, up front: a single-segment relative path such as `x.csv` succeeds today and throws `IOException` after this change. That success writes into a table the user never named, and which table is non-deterministic — the Hadoop FileSystem cache key is scheme+authority+ugi.
- `initialize()` took `workingDirectory` from the raw URI Hadoop passes in while normalizing `this.uri` to `scheme://authority/`. Reorder so it derives from the normalized catalog root. The self-contradiction dates to #5916.
- Reached by the documented usage in `docs/docs/concepts/rest/pvfs.md` lines 61-62.

### Tests

- Added `VirtualFileSystemTest#testWorkingDirectoryIsCatalogRoot`, inherited by both subclasses: the working directory equals the catalog root, and a relative-path `create` lands in the table it names.
- `mvn -pl paimon-vfs/paimon-vfs-hadoop clean install` — 29 tests pass. No existing test initializes with a path component (`MockRestVirtualFileSystemTest` L119, `MockRestNoCacheVirtualFileSystemTest` L47), so the 27 pre-existing tests stay green.
