### PR TITLE
[test-util] Set accessible on @Parameters provider and @Parameter field

### DIFF
--- a/paimon-test-utils/src/main/java/org/apache/paimon/testutils/junit/parameterized/ParameterizedTestExtension.java
+++ b/paimon-test-utils/src/main/java/org/apache/paimon/testutils/junit/parameterized/ParameterizedTestExtension.java
@@ -83,6 +83,7 @@ public class ParameterizedTestExtension implements TestTemplateInvocationContext
         // Get parameter values
         final Object parameterValues;
         try {
+            parameterProvider.setAccessible(true);
             parameterValues = parameterProvider.invoke(null);
             context.getStore(NAMESPACE).put(PARAMETERS_STORE_KEY, parameterValues);
         } catch (Exception e) {
@@ -155,6 +156,7 @@ public class ParameterizedTestExtension implements TestTemplateInvocationContext
             @Override
             public void beforeEach(ExtensionContext context) throws Exception {
                 for (int i = 0; i < parameterValues.length; i++) {
+                    getParameterField(i, context).setAccessible(true);
                     getParameterField(i, context)
                             .set(context.getRequiredTestInstance(), parameterValues[i]);
                 }

--- a/paimon-test-utils/src/test/java/org/apache/paimon/testutils/junit/parameterized/ParameterizedTestExtensionTest.java
+++ b/paimon-test-utils/src/test/java/org/apache/paimon/testutils/junit/parameterized/ParameterizedTestExtensionTest.java
@@ -1,0 +1,73 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.testutils.junit.parameterized;
+
+import org.junit.jupiter.api.TestTemplate;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests that {@link ParameterizedTestExtension} can reach the {@link Parameters} provider and the
+ * {@link Parameter} fields even when Java access control denies the extension access to them.
+ *
+ * <p>Both nested classes below are picked up by surefire on their own, because the unit test
+ * pattern {@code **}{@code /*Test.*} also matches nested class files.
+ */
+class ParameterizedTestExtensionTest {
+
+    private static final List<String> VALUES = Arrays.asList("a", "b");
+
+    /** The {@code @Parameters} provider is not accessible to the extension. */
+    @ExtendWith(ParameterizedTestExtension.class)
+    static class InaccessibleParameterProviderTest {
+
+        @Parameter public String value;
+
+        @Parameters(name = "value = {0}")
+        private static List<String> parameters() {
+            return VALUES;
+        }
+
+        @TestTemplate
+        void injectsValueFromInaccessibleProvider() {
+            assertThat(VALUES).contains(value);
+        }
+    }
+
+    /** The {@code @Parameter} field is not accessible to the extension. */
+    @ExtendWith(ParameterizedTestExtension.class)
+    static class InaccessibleParameterFieldTest {
+
+        @Parameter private String value;
+
+        @Parameters(name = "value = {0}")
+        public static List<String> parameters() {
+            return VALUES;
+        }
+
+        @TestTemplate
+        void injectsValueIntoInaccessibleField() {
+            assertThat(VALUES).contains(value);
+        }
+    }
+}


### PR DESCRIPTION

### Purpose

fix #9509

- `ParameterizedTestExtension` invokes the `@Parameters` provider and writes `@Parameter` fields reflectively without `setAccessible(true)`, so a test class the extension cannot access fails with `IllegalAccessException` even when the provider is `public static`.
- A package-private test class is enough to trigger it: all 20 usage sites here are `public class`, while about a quarter of the repo's `*Test`/`*ITCase` classes are package-private.
- Adds the two `setAccessible(true)` calls upstream `flink-test-utils-junit`, the origin of this file, added in FLINK-32058 and FLINK-32942. No existing test changes behavior.

### Tests

- Added `ParameterizedTestExtensionTest` with two fixtures: an inaccessible `@Parameters` provider and an inaccessible `@Parameter` field.
- Reverting the two lines makes them fail with 3 errors (1 provider + 2 field invocations); with the fix all 4 pass.
- `mvn -pl paimon-test-utils -DfailIfNoTests=false clean install` on JDK 11: green, checkstyle and spotless included.


