### PR TITLE
[common] Fix partition getter indexing in InternalRowPartitionComputer

### DIFF
--- a/paimon-common/src/main/java/org/apache/paimon/utils/InternalRowPartitionComputer.java
+++ b/paimon-common/src/main/java/org/apache/paimon/utils/InternalRowPartitionComputer.java
@@ -59,11 +59,13 @@ public class InternalRowPartitionComputer {
         List<String> columnList = rowType.getFieldNames();
         this.partitionFieldGetters = new FieldGetter[partitionColumns.length];
         this.partitionCastExecutors = new CastExecutor[partitionColumns.length];
-        for (String partitionColumn : partitionColumns) {
-            int i = columnList.indexOf(partitionColumn);
+        for (int j = 0; j < partitionColumns.length; j++) {
+            // The getter must be stored at the partition-column position, while the type
+            // comes from the column's position in the full row schema.
+            int i = columnList.indexOf(partitionColumns[j]);
             DataType type = rowType.getTypeAt(i);
-            partitionFieldGetters[i] = createNullCheckingFieldGetter(type, i);
-            partitionCastExecutors[i] = CastExecutors.resolve(type, VarCharType.STRING_TYPE);
+            partitionFieldGetters[j] = createNullCheckingFieldGetter(type, i);
+            partitionCastExecutors[j] = CastExecutors.resolve(type, VarCharType.STRING_TYPE);
         }
     }
 

--- a/paimon-common/src/test/java/org/apache/paimon/utils/InternalRowPartitionComputerTest.java
+++ b/paimon-common/src/test/java/org/apache/paimon/utils/InternalRowPartitionComputerTest.java
@@ -21,12 +21,14 @@ package org.apache.paimon.utils;
 import org.apache.paimon.data.BinaryRow;
 import org.apache.paimon.data.BinaryRowWriter;
 import org.apache.paimon.data.BinaryString;
+import org.apache.paimon.types.DataType;
 import org.apache.paimon.types.DataTypes;
 import org.apache.paimon.types.RowType;
 
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.entry;
 
 /** Test for {@link InternalRowPartitionComputer}. */
 public class InternalRowPartitionComputerTest {
@@ -53,5 +55,57 @@ public class InternalRowPartitionComputerTest {
         writer.writeInt(1, 10);
         assertThat(InternalRowPartitionComputer.partToSimpleString(rowType, binaryRow, "-", 30))
                 .isEqualTo("null-10");
+    }
+
+    @Test
+    public void testPartitionColumnNotAtRowPrefix() {
+        RowType rowType =
+                RowType.of(
+                        new DataType[] {
+                            DataTypes.INT(),
+                            DataTypes.STRING(),
+                            DataTypes.STRING(),
+                            DataTypes.STRING()
+                        },
+                        new String[] {"id", "dt", "region", "extra"});
+        InternalRowPartitionComputer computer =
+                new InternalRowPartitionComputer(
+                        "__DEFAULT_PARTITION__", rowType, new String[] {"region", "dt"}, false);
+
+        BinaryRow binaryRow = new BinaryRow(4);
+        BinaryRowWriter writer = new BinaryRowWriter(binaryRow);
+        writer.writeInt(0, 1);
+        writer.writeString(1, BinaryString.fromString("20240731"));
+        writer.writeString(2, BinaryString.fromString("hangzhou"));
+        writer.writeString(3, BinaryString.fromString("ignored"));
+        writer.complete();
+
+        // "region" sits at row position 2, which is out of range for an array sized by the
+        // number of partition columns.
+        assertThat(computer.generatePartValues(binaryRow))
+                .containsExactly(entry("region", "hangzhou"), entry("dt", "20240731"));
+    }
+
+    @Test
+    public void testPartitionColumnsReorderedWithinRowPrefix() {
+        RowType rowType =
+                RowType.of(
+                        new DataType[] {DataTypes.INT(), DataTypes.STRING(), DataTypes.STRING()},
+                        new String[] {"id", "dt", "region"});
+        InternalRowPartitionComputer computer =
+                new InternalRowPartitionComputer(
+                        "__DEFAULT_PARTITION__", rowType, new String[] {"dt", "id"}, false);
+
+        BinaryRow binaryRow = new BinaryRow(3);
+        BinaryRowWriter writer = new BinaryRowWriter(binaryRow);
+        writer.writeInt(0, 1);
+        writer.writeString(1, BinaryString.fromString("20240731"));
+        writer.writeString(2, BinaryString.fromString("hangzhou"));
+        writer.complete();
+
+        // Both row positions are in range here, so indexing by row position did not throw: it
+        // paired each column name with the other column's getter and cast executor.
+        assertThat(computer.generatePartValues(binaryRow))
+                .containsExactly(entry("dt", "20240731"), entry("id", "1"));
     }
 }


### PR DESCRIPTION
### Purpose

close #9512

`InternalRowPartitionComputer`'s constructor sized `partitionFieldGetters` and `partitionCastExecutors` by the number of partition columns, then stored into them at the partition column's position in the full row schema. `generatePartValues` reads all three of `partitionFieldGetters[i]`, `partitionCastExecutors[i]` and `partitionColumns[i]` with one loop variable over the partition columns, so the array bound and the index expression have to agree, and they only agree when the partition columns are a prefix of the row type in row order.

Each getter is now stored at its partition-column position, while the type and the field position it reads still come from the row schema.

Nothing in the constructor's signature requires the partition columns to be a row prefix, but every current caller passes a row type already projected to the partition columns in `partitionKeys` order (`TableSchema.logicalPartitionType()`, `store().partitionType()`, `rowType().project(partitionKeys())`, `TypeUtils.project(rowType, partitionKeys)`). `indexOf` therefore always returns the loop position, old and new code produce identical arrays at every call site, and the bug is latent rather than something a deployment hits today. It fires as soon as a caller hands over the full row type: either `ArrayIndexOutOfBoundsException`, or, when the row positions happen to be in range, a partition spec in which every column name carries another column's value with no error raised.

### Tests

Two cases in `InternalRowPartitionComputerTest`, one per failure mode.

- `testPartitionColumnNotAtRowPrefix`: row type `id, dt, region, extra` with partition columns `{region, dt}`. `region` sits at row position 2, out of range for a two-element array. Fails on the old code with `ArrayIndexOutOfBoundsException: 2`.
- `testPartitionColumnsReorderedWithinRowPrefix`: row type `id INT, dt STRING, region STRING` with partition columns `{dt, id}`. Both row positions are in range, so the old code does not throw; it returns `{dt=1, id=20240731}` instead of `{dt=20240731, id=1}`. Mixed types make the crossed values visible rather than symmetric.

Both assert with `containsExactly(entry(...), entry(...))`, which pins the iteration order of the returned `LinkedHashMap` as well as the pairing, since partition paths and partition specs consume that order.

Verified red before the change (`ArrayIndexOutOfBoundsException: 2` and crossed values respectively), and the pre-existing `testPartitionToString` stays green.

`mvn -pl paimon-common test` on JDK 8: 12467 tests, 0 failures, 0 errors. checkstyle, spotless, enforcer and rat run clean.
