### PR TITLE
[common] Reject non-struct inner fields in variant shredding schema

### DIFF
--- a/paimon-common/src/main/java/org/apache/paimon/data/variant/PaimonShreddingUtils.java
+++ b/paimon-common/src/main/java/org/apache/paimon/data/variant/PaimonShreddingUtils.java
@@ -346,19 +346,17 @@ public class PaimonShreddingUtils {
                     typedIdx = i;
                     switch (field.type().getTypeRoot()) {
                         case ROW:
-                            if (!(dataType instanceof RowType)) {
-                                throw invalidVariantShreddingSchema(rowType);
-                            }
                             RowType r = (RowType) dataType;
                             List<DataField> rFields = r.getFields();
-                            // The struct must not be empty or contain duplicate field names.
-                            if (fields.isEmpty()
-                                    || fields.stream().distinct().count() != fields.size()) {
-                                throw invalidVariantShreddingSchema(rowType);
-                            }
+                            // Every field of an object's typed_value is itself a
+                            // value/typed_value struct. An empty struct shreds nothing and
+                            // stays legal.
                             objectSchema = new VariantSchema.ObjectField[rFields.size()];
                             for (int index = 0; index < rFields.size(); index++) {
                                 DataField f = rFields.get(index);
+                                if (!(f.type() instanceof RowType)) {
+                                    throw invalidVariantShreddingSchema(rowType);
+                                }
                                 objectSchema[index] =
                                         new VariantSchema.ObjectField(
                                                 f.name(),

--- a/paimon-common/src/test/java/org/apache/paimon/data/variant/PaimonShreddingUtilsTest.java
+++ b/paimon-common/src/test/java/org/apache/paimon/data/variant/PaimonShreddingUtilsTest.java
@@ -65,6 +65,30 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 public class PaimonShreddingUtilsTest {
 
     @Test
+    void testBuildVariantSchemaAcceptsEmptyInnerStruct() {
+        // An empty typed_value struct shreds no field, and stays a legal schema.
+        RowType physicalType = variantShreddingSchema(RowType.of(new DataType[0], new String[0]));
+        assertThat(buildVariantSchema(physicalType).objectSchema).isEmpty();
+    }
+
+    @Test
+    void testBuildVariantSchemaRejectsNonStructInnerField() {
+        RowType physicalType =
+                RowType.of(
+                        new DataType[] {
+                            DataTypes.BYTES(),
+                            DataTypes.BYTES(),
+                            RowType.of(new DataType[] {DataTypes.INT()}, new String[] {"x"})
+                        },
+                        new String[] {"metadata", "value", "typed_value"});
+        // Everything except the inner field's type is valid here, and the message is what
+        // separates the two outcomes: before, the cast below raised a bare ClassCastException.
+        assertThatThrownBy(() -> buildVariantSchema(physicalType))
+                .isInstanceOf(RuntimeException.class)
+                .hasMessageContaining("Invalid variant shredding schema");
+    }
+
+    @Test
     void testAssembleColumnarShreddedVariant() {
         RowType shreddedType = RowType.of(new DataType[] {DataTypes.INT()}, new String[] {"a"});
         RowType physicalType = variantShreddingSchema(shreddedType);


### PR DESCRIPTION
### Purpose

close #9517

In a variant shredding schema, every field of an object's `typed_value` is itself a group of `value` / `typed_value`. `buildVariantSchema` cast each inner field to `RowType` without checking it, so a physical schema whose inner field is a scalar died on a bare `ClassCastException` naming two class names, instead of the `Invalid variant shredding schema: <rowType>` error the method raises for every other malformed shape. That path now checks the type and raises the same error as the rest.

Two checks in the same branch are removed because they cannot fire:

- `if (!(dataType instanceof RowType))` sits inside `case ROW:` of a switch on `field.type().getTypeRoot()`, and `RowType` is the only type in paimon-api with `DataTypeRoot.ROW`.
- `if (fields.isEmpty() || fields.stream().distinct().count() != fields.size())` tests the *outer* field list, not the inner struct it appears to guard. Emptiness is already rejected at the top of the method; duplicates cannot exist because `RowType`'s constructor calls `validateFields`, which throws on duplicate field names. Duplicate `typed_value` / `value` / `metadata` are caught by the `typedIdx != -1` style checks, and any other outer name falls into the throwing `default:` of the name switch.

An empty inner struct stays legal, exactly as before: the removed check never guarded the inner list, so nothing changes there. It yields a zero-length `objectSchema`, which is what `ShreddingUtils` and `VariantShreddingWriter` already consume by looping on `.length`.

### Tests

Both cases live in `PaimonShreddingUtilsTest`.

- `testBuildVariantSchemaRejectsNonStructInnerField` builds a schema that is valid except for a scalar inner field and asserts the message is the invalid-schema one. Verified red before the change, where it fails with `ClassCastException: org.apache.paimon.types.IntType cannot be cast to org.apache.paimon.types.RowType`. The message is what separates the two outcomes, since `ClassCastException` is itself a `RuntimeException`.
- `testBuildVariantSchemaAcceptsEmptyInnerStruct` pins that an empty `typed_value` struct produces a zero-length `objectSchema` rather than null, which is the shape the two consumers above depend on. This one passes before the change as well; it is there to hold that behavior still.

`mvn -pl paimon-common test` on JDK 8: 12467 tests, 0 failures, 0 errors. checkstyle, spotless, enforcer and rat run clean.
