### PR TITLE
[common] Fix double position advance in DataOutputSerializer.writeBytes

### DIFF
--- a/paimon-common/src/main/java/org/apache/paimon/io/DataOutputSerializer.java
+++ b/paimon-common/src/main/java/org/apache/paimon/io/DataOutputSerializer.java
@@ -153,7 +153,6 @@ public class DataOutputSerializer implements DataOutputView, MemorySegmentWritab
         for (int i = 0; i < sLen; i++) {
             writeByte(s.charAt(i));
         }
-        this.position += sLen;
     }
 
     @Override

--- a/paimon-common/src/test/java/org/apache/paimon/io/DataOutputSerializerTest.java
+++ b/paimon-common/src/test/java/org/apache/paimon/io/DataOutputSerializerTest.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.io;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Test for {@link DataOutputSerializer}. */
+public class DataOutputSerializerTest {
+
+    @Test
+    public void testWriteBytesAdvancesPositionOnce() throws IOException {
+        DataOutputSerializer out = new DataOutputSerializer(16);
+        out.writeBytes("abc");
+
+        assertThat(out.length()).isEqualTo(3);
+        assertThat(out.getCopyOfBuffer()).containsExactly('a', 'b', 'c');
+    }
+
+    @Test
+    public void testWriteBytesLeavesTheNextWriteInPlace() throws IOException {
+        DataOutputSerializer out = new DataOutputSerializer(16);
+        out.writeBytes("abc");
+        out.writeInt(42);
+
+        // "abc" and then 42 as a big-endian int, with no gap of untouched bytes in between.
+        assertThat(out.getCopyOfBuffer()).containsExactly('a', 'b', 'c', 0, 0, 0, 42);
+    }
+
+    @Test
+    public void testWriteBytesAcrossAResize() throws IOException {
+        DataOutputSerializer out = new DataOutputSerializer(2);
+        out.writeBytes("abcdef");
+
+        assertThat(out.getCopyOfBuffer()).containsExactly('a', 'b', 'c', 'd', 'e', 'f');
+    }
+}


### PR DESCRIPTION
### Purpose

close #9519

`DataOutputSerializer.writeBytes(String)` wrote each byte through `writeByte`, which goes to `write(int)` and does `this.buffer[this.position++] = ...`, and then advanced the position by the string length a second time. After the call `length()` reported twice the bytes written, and the next write landed past a gap of untouched buffer, so the serialized output was longer than the data and carried whatever the array happened to hold. Removing the extra advance is the whole change.

The sibling `writeChars(String)` has the same shape, a `resize` followed by a loop of `writeChar`, and never had that line, which is the form this method should have had.

I audited every position update in the class while checking this: `write(byte[], int, int)`, `write(MemorySegment, int, int)`, `writeChar`, `writeShort`, `writeInt`, `writeLong`, `writeUTF`, `skipBytesToWrite` and `write(DataInputView, int)` each advance by exactly the bytes they wrote. `writeBytes` was the only one that did not.

Nothing in the repository calls this overload, so no Paimon code path changes behavior. It is part of the `java.io.DataOutput` contract that `DataOutputView` exposes, so the defect was visible to callers outside the repository.

### Tests

`DataOutputSerializerTest` is new; the class had no test before. All three assert on `getCopyOfBuffer()`, which is cut at `length()`, so each one pins the length and the content together.

- `testWriteBytesAdvancesPositionOnce`: `writeBytes("abc")` leaves exactly `a b c`.
- `testWriteBytesLeavesTheNextWriteInPlace`: `writeBytes("abc")` then `writeInt(42)` leaves `a b c 0 0 0 42`, which is the assertion that catches a gap rather than just a wrong length.
- `testWriteBytesAcrossAResize`: starts from a two-byte buffer and writes six bytes, so the growth path runs during the call.

All three fail against the pre-fix code.

`mvn -pl paimon-common test` on JDK 8: 12467 tests, 0 failures, 0 errors. checkstyle, spotless, enforcer and rat run clean.
