### PR TITLE
[common] Grow from one byte in MemorySliceOutput when the segment is empty

### DIFF
--- a/paimon-common/src/main/java/org/apache/paimon/memory/MemorySliceOutput.java
+++ b/paimon-common/src/main/java/org/apache/paimon/memory/MemorySliceOutput.java
@@ -103,7 +103,8 @@ public class MemorySliceOutput {
             return;
         }
 
-        int newCapacity = segment.size();
+        // Doubling never leaves zero, so an empty segment has to grow from one byte.
+        int newCapacity = Math.max(segment.size(), 1);
         int minNewCapacity = segment.size() + minWritableBytes;
         while (newCapacity < minNewCapacity) {
             newCapacity <<= 1;

--- a/paimon-common/src/test/java/org/apache/paimon/memory/MemorySliceOutputTest.java
+++ b/paimon-common/src/test/java/org/apache/paimon/memory/MemorySliceOutputTest.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.memory;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Test for {@link MemorySliceOutput}. */
+public class MemorySliceOutputTest {
+
+    @Test
+    public void testWriteAfterZeroInitialCapacity() throws InterruptedException {
+        MemorySliceOutput out = new MemorySliceOutput(0);
+        AtomicReference<Throwable> failure = new AtomicReference<>();
+
+        // Growth doubled from the segment size, which never leaves zero, so the first write
+        // spun on the CPU. JUnit's @Timeout in its default same-thread mode only reports after
+        // the method returns, so the write runs on a daemon thread and the test asserts that it
+        // finished; the daemon flag keeps a regression from holding the surefire fork open.
+        Thread writer =
+                new Thread(
+                        () -> {
+                            try {
+                                out.writeByte(5);
+                                out.writeBytes(new byte[] {1, 2, 3}, 0, 3);
+                            } catch (Throwable t) {
+                                failure.set(t);
+                            }
+                        });
+        writer.setDaemon(true);
+        writer.start();
+        writer.join(10_000);
+
+        assertThat(writer.isAlive()).as("write did not terminate").isFalse();
+        assertThat(failure.get()).isNull();
+        assertThat(out.size()).isEqualTo(4);
+        assertThat(out.toSlice().readByte(0)).isEqualTo((byte) 5);
+        assertThat(out.toSlice().readByte(3)).isEqualTo((byte) 3);
+    }
+}


### PR DESCRIPTION
### Purpose

close #9522

`MemorySliceOutput.ensureSize` grows the buffer by doubling from the current segment size, and doubling never leaves zero, so a `MemorySliceOutput` created with capacity 0 spun on the CPU inside the growth loop on its first write and never returned. It looks like a hang rather than a bug: a live thread inside `ensureSize`, no exception and no progress. The doubling now starts from one byte, and positive capacities take exactly the path they did before.

Every construction site in the repository passes a positive size, the smallest being 2 in the global-index key serializer, so no current Paimon code path reaches this. The class is public in paimon-common and takes its capacity from the caller.

Two older problems in the same loop are left alone: `newCapacity <<= 1` overflows above 2^30 and walks through negative back into 0, and `segment.size() + minWritableBytes` can overflow so that the loop is skipped and `ensureSize` returns as though it had grown. Both need `long` arithmetic and a clamp against a maximum array size, which turns a hang into a thrown exception for very large requests. That is a separate decision from this one, and it is recorded in #9522.

### Tests

`MemorySliceOutputTest` is new; the class had no test before.

`testWriteAfterZeroInitialCapacity` writes a byte and then three bytes into an output created with capacity 0, and asserts the buffer holds `5 1 2 3`. The write runs on a separate daemon thread joined for ten seconds, and the test asserts the thread finished: JUnit's `@Timeout` in its default same-thread mode only reports after the method returns, so it cannot fail a CPU-bound loop. The thread captures any `Throwable` into an `AtomicReference` that is asserted null before the content assertions, so a future failure inside the write is reported as itself rather than as a wrong buffer length. The daemon flag matters for the same reason the test exists: on a real regression the spinning thread must not outlive the test and hold a core in the surefire fork.

Verified red before the change: the join times out and the test fails with `[write did not terminate]` after 10.06 seconds.

`mvn -pl paimon-common test` on JDK 8: 12466 tests, 0 failures, 0 errors. checkstyle, spotless, enforcer and rat run clean.
