### PR TITLE
[common] Make BinaryRow.anyNull respect the row offset

### DIFF
--- a/paimon-common/src/main/java/org/apache/paimon/data/BinaryRow.java
+++ b/paimon-common/src/main/java/org/apache/paimon/data/BinaryRow.java
@@ -376,11 +376,11 @@ public final class BinaryRow extends BinarySection implements InternalRow, DataS
     /** The bit is 1 when the field is null. Default is 0. */
     public boolean anyNull() {
         // Skip the header.
-        if ((segments[0].getLong(0) & FIRST_BYTE_ZERO) != 0) {
+        if ((segments[0].getLong(offset) & FIRST_BYTE_ZERO) != 0) {
             return true;
         }
         for (int i = 8; i < nullBitsSizeInBytes; i += 8) {
-            if (segments[0].getLong(i) != 0) {
+            if (segments[0].getLong(offset + i) != 0) {
                 return true;
             }
         }

--- a/paimon-common/src/test/java/org/apache/paimon/data/BinaryRowTest.java
+++ b/paimon-common/src/test/java/org/apache/paimon/data/BinaryRowTest.java
@@ -325,6 +325,86 @@ public class BinaryRowTest {
     }
 
     @Test
+    public void testAnyNullWithNonZeroOffset() {
+        BinaryRow rowWithNull = new BinaryRow(1);
+        BinaryRowWriter writer = new BinaryRowWriter(rowWithNull);
+        writer.setNullAt(0);
+        writer.complete();
+
+        BinaryRow rowWithoutNull = new BinaryRow(1);
+        writer = new BinaryRowWriter(rowWithoutNull);
+        writer.writeInt(0, 42);
+        writer.complete();
+
+        // A four-byte pad in front, as BinaryRowSerializer leaves when it points a row at the
+        // bytes following a length prefix, so the row offset is not a multiple of eight either.
+        // The leading row is an INSERT row with no nulls, so a read that starts at zero finds
+        // only zero bytes and reports no null.
+        int pad = 4;
+        MemorySegment segment = concat(pad, rowWithoutNull, rowWithNull);
+        int notNullLength = rowWithoutNull.getSizeInBytes();
+
+        BinaryRow atOffset = new BinaryRow(1);
+        atOffset.pointTo(segment, pad + notNullLength, rowWithNull.getSizeInBytes());
+        assertThat(atOffset.isNullAt(0)).isTrue();
+        assertThat(atOffset.anyNull()).isTrue();
+
+        BinaryRow leading = new BinaryRow(1);
+        leading.pointTo(segment, pad, notNullLength);
+        assertThat(leading.anyNull()).isFalse();
+    }
+
+    @Test
+    public void testAnyNullHighFieldWithNonZeroOffset() {
+        // 60 fields push the null-bit set past the first 8-byte word, so the loop in anyNull()
+        // has to honor the offset as well as the header read above it does.
+        int arity = 60;
+        int nullField = 59;
+        BinaryRow rowWithNull = new BinaryRow(arity);
+        BinaryRowWriter writer = new BinaryRowWriter(rowWithNull);
+        writer.setNullAt(nullField);
+        writer.complete();
+
+        BinaryRow rowWithoutNull = new BinaryRow(arity);
+        writer = new BinaryRowWriter(rowWithoutNull);
+        for (int i = 0; i < arity; i++) {
+            writer.writeInt(i, i);
+        }
+        writer.complete();
+
+        MemorySegment segment = concat(0, rowWithoutNull, rowWithNull);
+        int notNullLength = rowWithoutNull.getSizeInBytes();
+
+        BinaryRow atOffset = new BinaryRow(arity);
+        atOffset.pointTo(segment, notNullLength, rowWithNull.getSizeInBytes());
+        assertThat(atOffset.isNullAt(nullField)).isTrue();
+        assertThat(atOffset.anyNull()).isTrue();
+
+        BinaryRow leading = new BinaryRow(arity);
+        leading.pointTo(segment, 0, notNullLength);
+        assertThat(leading.anyNull()).isFalse();
+    }
+
+    /**
+     * Lays the rows out back to back in one segment behind {@code pad} bytes. The row without nulls
+     * goes first, so a read that ignores the row offset lands on it and reports no null.
+     */
+    private static MemorySegment concat(int pad, BinaryRow... rows) {
+        int size = pad;
+        for (BinaryRow row : rows) {
+            size += row.getSizeInBytes();
+        }
+        byte[] bytes = new byte[size];
+        int position = pad;
+        for (BinaryRow row : rows) {
+            byte[] rowBytes = row.toBytes();
+            System.arraycopy(rowBytes, 0, bytes, position, rowBytes.length);
+            position += rowBytes.length;
+        }
+        return MemorySegment.wrap(bytes);
+    }
+
+    @Test
     public void testSingleSegmentBinaryRowHashCode() {
         final Random rnd = new Random(System.currentTimeMillis());
         // test hash stabilization


### PR DESCRIPTION
### Purpose

close #9524

`BinaryRow.anyNull()` read the header word and the null-bit words from `segments[0]` at absolute positions 0 and `i`, while every other accessor in the class reads through the row's `offset`: `isNullAt` goes through `bitGet(segments[0], offset, ...)`, the field getters through `getFieldOffset(pos)`, and `getRowKind()` reads `segments[0].get(offset)`. A row pointed at a non-zero offset therefore answered from whatever bytes sat at the start of the segment, so `anyNull()` and `isNullAt()` could disagree about the same row. Both reads now add the offset.

The four in-repo callers, in `FieldNestedUpdateAgg` and `FieldNestedPartialUpdateAgg`, each pass a row from `keyProjection.apply(row).copy()`, and `BinaryRow.copy()` re-points the copy at offset 0, so no current code path is affected. Non-zero offsets do occur: `BinaryRowSerializer.pointTo` gives a row the position after a length prefix when `mapFromPages` walks a page, so the first row in a page sits at offset 4.

`anyNull(int[] fields)` needed no change; it goes through `isNullAt`. `BinaryArray.anyNull()` already reads from `offset + 4`, so this was the last member of that family reading at an absolute index.

### Tests

Two cases next to the existing `anyNullTest` in `BinaryRowTest`, one per code path in the method, both laying two rows into one segment with a shared `concat` helper and pointing the second one at a non-zero offset.

- `testAnyNullWithNonZeroOffset`: arity 1, so only the header read runs. The row starts at offset 20, four bytes of padding plus a 16-byte row, so the offset is not a multiple of eight either, which is the alignment `BinaryRowSerializer` actually produces.
- `testAnyNullHighFieldWithNonZeroOffset`: arity 60 with the null at field 59, which puts the null bit in the second 8-byte word, so the loop is what has to honor the offset. It also asserts `isNullAt(59)` first, so a failure cannot be blamed on the fixture.

In both cases the row without nulls goes first, so a read that ignores the offset lands on it and reports no null. Both fail against the pre-fix code.

`mvn -pl paimon-common test` on JDK 8: 12467 tests, 0 failures, 0 errors. checkstyle, spotless, enforcer and rat run clean.
