### PR TITLE
[rest] Make RESTTokenFileIO cache maximum size configurable

### DIFF
--- a/paimon-common/src/main/java/org/apache/paimon/rest/RESTTokenFileIO.java
+++ b/paimon-common/src/main/java/org/apache/paimon/rest/RESTTokenFileIO.java
@@ -55,6 +55,7 @@ import static org.apache.paimon.options.CatalogOptions.FILE_IO_ALLOW_CACHE;
 import static org.apache.paimon.rest.RESTApi.TOKEN_EXPIRATION_SAFE_TIME_MILLIS;
 import static org.apache.paimon.rest.RESTCatalogOptions.DLF_OSS_ENDPOINT;
 import static org.apache.paimon.rest.RESTCatalogOptions.IO_CACHE_ENABLED;
+import static org.apache.paimon.utils.Preconditions.checkArgument;
 
 /** A {@link FileIO} to support getting token from REST Server. */
 public class RESTTokenFileIO implements FileIO {
@@ -84,6 +85,7 @@ public class RESTTokenFileIO implements FileIO {
 
     /** Sets the maximum number of cached FileIO instances. */
     public static void setFileIOCacheMaximumSize(long maximumSize) {
+        checkArgument(maximumSize > 0, "Maximum cache size must be positive.");
         FILE_IO_CACHE
                 .policy()
                 .eviction()

--- a/paimon-common/src/main/java/org/apache/paimon/rest/RESTTokenFileIO.java
+++ b/paimon-common/src/main/java/org/apache/paimon/rest/RESTTokenFileIO.java
@@ -82,6 +82,23 @@ public class RESTTokenFileIO implements FileIO {
 
     private static final Logger LOG = LoggerFactory.getLogger(RESTTokenFileIO.class);
 
+    /** Sets the maximum number of cached FileIO instances. */
+    public static void setFileIOCacheMaximumSize(long maximumSize) {
+        FILE_IO_CACHE
+                .policy()
+                .eviction()
+                .orElseThrow(IllegalStateException::new)
+                .setMaximum(maximumSize);
+    }
+
+    static long fileIOCacheMaximumSize() {
+        return FILE_IO_CACHE
+                .policy()
+                .eviction()
+                .orElseThrow(IllegalStateException::new)
+                .getMaximum();
+    }
+
     private final CatalogContext catalogContext;
     private final Identifier identifier;
     private final Path path;

--- a/paimon-common/src/test/java/org/apache/paimon/rest/RESTTokenFileIOTest.java
+++ b/paimon-common/src/test/java/org/apache/paimon/rest/RESTTokenFileIOTest.java
@@ -48,6 +48,19 @@ import static org.mockito.Mockito.when;
 class RESTTokenFileIOTest {
 
     @Test
+    void testSetFileIOCacheMaximumSize() {
+        long originalMaximumSize = RESTTokenFileIO.fileIOCacheMaximumSize();
+        try {
+            RESTTokenFileIO.setFileIOCacheMaximumSize(0);
+            assertThat(RESTTokenFileIO.fileIOCacheMaximumSize()).isZero();
+            assertThatThrownBy(() -> RESTTokenFileIO.setFileIOCacheMaximumSize(-1))
+                    .isInstanceOf(IllegalArgumentException.class);
+        } finally {
+            RESTTokenFileIO.setFileIOCacheMaximumSize(originalMaximumSize);
+        }
+    }
+
+    @Test
     void testCreateBlobPresignedUrlRequiresBoundRootAndDelegates() throws IOException {
         Path tableRoot = new Path("oss://bucket/table");
         BlobDescriptor descriptor =

--- a/paimon-common/src/test/java/org/apache/paimon/rest/RESTTokenFileIOTest.java
+++ b/paimon-common/src/test/java/org/apache/paimon/rest/RESTTokenFileIOTest.java
@@ -51,10 +51,11 @@ class RESTTokenFileIOTest {
     void testSetFileIOCacheMaximumSize() {
         long originalMaximumSize = RESTTokenFileIO.fileIOCacheMaximumSize();
         try {
-            RESTTokenFileIO.setFileIOCacheMaximumSize(0);
-            assertThat(RESTTokenFileIO.fileIOCacheMaximumSize()).isZero();
-            assertThatThrownBy(() -> RESTTokenFileIO.setFileIOCacheMaximumSize(-1))
-                    .isInstanceOf(IllegalArgumentException.class);
+            RESTTokenFileIO.setFileIOCacheMaximumSize(2000);
+            assertThat(RESTTokenFileIO.fileIOCacheMaximumSize()).isEqualTo(2000);
+            assertThatThrownBy(() -> RESTTokenFileIO.setFileIOCacheMaximumSize(0))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessage("Maximum cache size must be positive.");
         } finally {
             RESTTokenFileIO.setFileIOCacheMaximumSize(originalMaximumSize);
         }


### PR DESCRIPTION
### Purpose

`RESTTokenFileIO` uses a cache with a fixed maximum size of 1000. When the cache reaches this limit, a `FileIO` that is still in use may be evicted and closed prematurely.

This PR adds `RESTTokenFileIO#setFileIOCacheMaximumSize(long)`, allowing applications to configure the cache size during initialization according to their workloads.

To keep this change focused, this PR does not introduce reference counting or change the `FileIO` lifecycle management.

### Tests

Added a unit test to verify that the maximum cache size can be updated.