### PR TITLE
[common] Keep the selected variant schema when its evidence is gone

### DIFF
--- a/paimon-common/src/main/java/org/apache/paimon/data/variant/InferVariantShreddingSchema.java
+++ b/paimon-common/src/main/java/org/apache/paimon/data/variant/InferVariantShreddingSchema.java
@@ -691,6 +691,12 @@ public class InferVariantShreddingSchema {
                                     ((ArrayType) selected).getElementType(), maxFields);
             return new ArrayType(element);
         }
+        if (selected instanceof VariantType) {
+            // The caller has already spent this node's entry unit, and a VARIANT has no typed child
+            // to spend another on - the evidence-driven walk also returns VARIANT after the entry
+            // debit alone.
+            return selected;
+        }
         maxFields.remaining--;
         return selected;
     }

--- a/paimon-common/src/main/java/org/apache/paimon/data/variant/InferVariantShreddingSchema.java
+++ b/paimon-common/src/main/java/org/apache/paimon/data/variant/InferVariantShreddingSchema.java
@@ -574,7 +574,11 @@ public class InferVariantShreddingSchema {
             if (current != null && !(current instanceof VariantType)) {
                 combined = current;
             } else if (previousSelected != null) {
-                combined = previousSelected;
+                // This node has no evidence in the current file. A previously selected schema is
+                // not
+                // evidence - its fields carry no counts - so it cannot be run through admission and
+                // retention again; carry it forward unchanged.
+                return previousSelected;
             } else {
                 return DataTypes.VARIANT();
             }

--- a/paimon-common/src/main/java/org/apache/paimon/data/variant/InferVariantShreddingSchema.java
+++ b/paimon-common/src/main/java/org/apache/paimon/data/variant/InferVariantShreddingSchema.java
@@ -574,11 +574,11 @@ public class InferVariantShreddingSchema {
             if (current != null && !(current instanceof VariantType)) {
                 combined = current;
             } else if (previousSelected != null) {
-                // This node has no evidence in the current file. A previously selected schema is
-                // not
-                // evidence - its fields carry no counts - so it cannot be run through admission and
-                // retention again; carry it forward unchanged.
-                return previousSelected;
+                // This node has no evidence in the current file. A previously selected schema
+                // is not evidence - its fields carry no counts - so it cannot be run through
+                // admission and retention again; carry it forward as it is, debiting the shared
+                // width budget for what it holds.
+                return retainSelectedSchema(previousSelected, maxFields);
             } else {
                 return DataTypes.VARIANT();
             }
@@ -656,6 +656,37 @@ public class InferVariantShreddingSchema {
 
         maxFields.remaining--;
         return selectScalarType(combined, current, previousSelected);
+    }
+
+    /**
+     * Carries a previously selected schema forward for a node the current file has no evidence for.
+     * The selection is already final, so nothing is re-thresholded, but its nodes still consume the
+     * shared width budget and are dropped once it runs out, on the same terms as the
+     * evidence-driven walk above: one unit per node, VARIANT once the budget is gone.
+     */
+    private DataType retainSelectedSchema(DataType selected, MaxFields maxFields) {
+        if (selected instanceof RowType) {
+            List<DataField> fields = new ArrayList<>();
+            for (DataField field : ((RowType) selected).getFields()) {
+                maxFields.remaining--;
+                if (maxFields.remaining <= 0) {
+                    break;
+                }
+                DataType retained = retainSelectedSchema(field.type(), maxFields);
+                fields.add(new DataField(fields.size(), field.name(), retained));
+            }
+            return fields.isEmpty() ? DataTypes.VARIANT() : new RowType(fields);
+        }
+        if (selected instanceof ArrayType) {
+            maxFields.remaining--;
+            if (maxFields.remaining <= 0) {
+                return DataTypes.VARIANT();
+            }
+            return new ArrayType(
+                    retainSelectedSchema(((ArrayType) selected).getElementType(), maxFields));
+        }
+        maxFields.remaining--;
+        return selected;
     }
 
     private DataType selectScalarType(

--- a/paimon-common/src/main/java/org/apache/paimon/data/variant/InferVariantShreddingSchema.java
+++ b/paimon-common/src/main/java/org/apache/paimon/data/variant/InferVariantShreddingSchema.java
@@ -661,29 +661,35 @@ public class InferVariantShreddingSchema {
     /**
      * Carries a previously selected schema forward for a node the current file has no evidence for.
      * The selection is already final, so nothing is re-thresholded, but its nodes still consume the
-     * shared width budget and are dropped once it runs out, on the same terms as the
-     * evidence-driven walk above: one unit per node, VARIANT once the budget is gone.
+     * shared width budget. The entry unit for this node has already been spent by the caller, so
+     * this mirrors what finalizeAdaptiveSchema does from that point on: a child is entered only
+     * while budget remains, entering it spends one unit, and a child that exhausts the budget
+     * becomes VARIANT while its field or array container is still kept.
      */
     private DataType retainSelectedSchema(DataType selected, MaxFields maxFields) {
         if (selected instanceof RowType) {
             List<DataField> fields = new ArrayList<>();
             for (DataField field : ((RowType) selected).getFields()) {
-                maxFields.remaining--;
                 if (maxFields.remaining <= 0) {
                     break;
                 }
-                DataType retained = retainSelectedSchema(field.type(), maxFields);
+                maxFields.remaining--;
+                DataType retained =
+                        maxFields.remaining <= 0
+                                ? DataTypes.VARIANT()
+                                : retainSelectedSchema(field.type(), maxFields);
                 fields.add(new DataField(fields.size(), field.name(), retained));
             }
             return fields.isEmpty() ? DataTypes.VARIANT() : new RowType(fields);
         }
         if (selected instanceof ArrayType) {
             maxFields.remaining--;
-            if (maxFields.remaining <= 0) {
-                return DataTypes.VARIANT();
-            }
-            return new ArrayType(
-                    retainSelectedSchema(((ArrayType) selected).getElementType(), maxFields));
+            DataType element =
+                    maxFields.remaining <= 0
+                            ? DataTypes.VARIANT()
+                            : retainSelectedSchema(
+                                    ((ArrayType) selected).getElementType(), maxFields);
+            return new ArrayType(element);
         }
         maxFields.remaining--;
         return selected;

--- a/paimon-common/src/test/java/org/apache/paimon/data/variant/InferVariantShreddingSchemaTest.java
+++ b/paimon-common/src/test/java/org/apache/paimon/data/variant/InferVariantShreddingSchemaTest.java
@@ -397,6 +397,40 @@ public class InferVariantShreddingSchemaTest {
                 .doesNotContain("`r` ROW<`value` BYTES, `typed_value`");
     }
 
+    /**
+     * At the last budget unit the evidence-driven walk still keeps the field and downgrades its
+     * child to VARIANT. Retaining a schema has to do the same rather than drop the field, or the
+     * whole retained node collapses.
+     */
+    @Test
+    void testRetainedSchemaKeepsItsFieldsAtTheLastBudgetUnit() {
+        RowType schema =
+                RowType.of(
+                        new DataType[] {DataTypes.VARIANT(), DataTypes.VARIANT()},
+                        new String[] {"a", "b"});
+        VariantShreddingInferenceSession session =
+                new VariantShreddingInferenceSession(
+                        new InferVariantShreddingSchema(schema, 7, 50, 0.1), 256, 0.1, 0.05);
+
+        session.inferSchema(
+                Collections.singletonList(
+                        GenericRow.of(GenericVariant.fromJson("1"), GenericVariant.fromJson("5"))));
+        session.commitPendingInference();
+        session.inferSchema(
+                Collections.singletonList(
+                        GenericRow.of(
+                                GenericVariant.fromJson("1"),
+                                GenericVariant.fromJson("{\"q\":1}"))));
+        session.commitPendingInference();
+
+        RowType afterAbsence =
+                session.inferSchema(
+                        Collections.singletonList(
+                                GenericRow.of(GenericVariant.fromJson("{\"x\":1,\"y\":1}"), null)));
+
+        assertThat(afterAbsence.getField("b").type().toString()).contains("`q`");
+    }
+
     @Test
     void testInferSchemaWithDeepNesting() {
         // Schema: row<v: variant>

--- a/paimon-common/src/test/java/org/apache/paimon/data/variant/InferVariantShreddingSchemaTest.java
+++ b/paimon-common/src/test/java/org/apache/paimon/data/variant/InferVariantShreddingSchemaTest.java
@@ -356,6 +356,47 @@ public class InferVariantShreddingSchemaTest {
                                         new String[] {"k", "p"})));
     }
 
+    /**
+     * maxSchemaWidth is one budget shared by every variant column. A schema carried forward for a
+     * node with no evidence still occupies it, so a later column must not get to spend what the
+     * carried-forward schema is holding.
+     */
+    @Test
+    void testRetainedSchemaStillConsumesTheSharedWidthBudget() {
+        RowType schema =
+                RowType.of(
+                        new DataType[] {DataTypes.VARIANT(), DataTypes.VARIANT()},
+                        new String[] {"a", "b"});
+        VariantShreddingInferenceSession session =
+                new VariantShreddingInferenceSession(
+                        new InferVariantShreddingSchema(schema, 8, 50, 0.1), 256, 0.1, 0.05);
+
+        session.inferSchema(
+                Collections.singletonList(
+                        GenericRow.of(
+                                GenericVariant.fromJson("{\"p\":5}"),
+                                GenericVariant.fromJson("{\"q\":1}"))));
+        session.commitPendingInference();
+        session.inferSchema(
+                Collections.singletonList(
+                        GenericRow.of(
+                                GenericVariant.fromJson("{\"p\":{\"x\":1}}"),
+                                GenericVariant.fromJson("{\"q\":1}"))));
+        session.commitPendingInference();
+
+        RowType afterAbsence =
+                session.inferSchema(
+                        Collections.singletonList(
+                                GenericRow.of(
+                                        GenericVariant.fromJson("{}"),
+                                        GenericVariant.fromJson("{\"q\":1,\"r\":1}"))));
+
+        // "a" keeps ROW<x BIGINT> under "p", and the budget it holds leaves "r" untyped in "b".
+        assertThat(afterAbsence.getField("b").type().toString())
+                .contains("`q` ROW<`value` BYTES, `typed_value` BIGINT>")
+                .doesNotContain("`r` ROW<`value` BYTES, `typed_value`");
+    }
+
     @Test
     void testInferSchemaWithDeepNesting() {
         // Schema: row<v: variant>

--- a/paimon-common/src/test/java/org/apache/paimon/data/variant/InferVariantShreddingSchemaTest.java
+++ b/paimon-common/src/test/java/org/apache/paimon/data/variant/InferVariantShreddingSchemaTest.java
@@ -31,6 +31,7 @@ import java.math.BigDecimal;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -313,6 +314,46 @@ public class InferVariantShreddingSchemaTest {
                                 RowType.of(
                                         new DataType[] {DataTypes.BIGINT()},
                                         new String[] {"historical"})));
+    }
+
+    /**
+     * A node can drift from scalar to object, which degrades its combined evidence to VARIANT while
+     * the selected schema for it is a ROW, and then be absent from the next file. With no evidence
+     * to fall back on, the selected schema is the only thing left - but it is not evidence: its
+     * fields carry no counts, so it cannot be run through admission and retention a second time.
+     */
+    @Test
+    void testAdaptiveInferenceKeepsSelectedRowWhenEvidenceDegradedAndNodeIsAbsent() {
+        RowType schema = RowType.of(new DataType[] {DataTypes.VARIANT()}, new String[] {"v"});
+        VariantShreddingInferenceSession session =
+                new VariantShreddingInferenceSession(
+                        new InferVariantShreddingSchema(schema, 300, 50, 0.1), 256, 0.1, 0.05);
+
+        session.inferSchema(
+                Collections.singletonList(
+                        GenericRow.of(GenericVariant.fromJson("{\"k\":1,\"p\":5}"))));
+        session.commitPendingInference();
+        session.inferSchema(
+                Collections.singletonList(
+                        GenericRow.of(GenericVariant.fromJson("{\"k\":1,\"p\":{\"x\":1}}"))));
+        session.commitPendingInference();
+
+        RowType afterAbsence =
+                session.inferSchema(
+                        Collections.singletonList(
+                                GenericRow.of(GenericVariant.fromJson("{\"k\":1}"))));
+
+        assertThat(afterAbsence.getField("v").type())
+                .isEqualTo(
+                        variantShreddingSchema(
+                                RowType.of(
+                                        new DataType[] {
+                                            DataTypes.BIGINT(),
+                                            RowType.of(
+                                                    new DataType[] {DataTypes.BIGINT()},
+                                                    new String[] {"x"})
+                                        },
+                                        new String[] {"k", "p"})));
     }
 
     @Test

--- a/paimon-common/src/test/java/org/apache/paimon/data/variant/InferVariantShreddingSchemaTest.java
+++ b/paimon-common/src/test/java/org/apache/paimon/data/variant/InferVariantShreddingSchemaTest.java
@@ -431,6 +431,34 @@ public class InferVariantShreddingSchemaTest {
         assertThat(afterAbsence.getField("b").type().toString()).contains("`q`");
     }
 
+    /**
+     * A retained VARIANT leaf costs the entry unit the caller already spent and nothing more - it
+     * has no typed child to spend a second on. Charging it twice takes width away from the columns
+     * that follow.
+     */
+    @Test
+    void testRetainedVariantLeafIsNotChargedTwice() {
+        RowType schema =
+                RowType.of(
+                        new DataType[] {DataTypes.VARIANT(), DataTypes.VARIANT()},
+                        new String[] {"a", "b"});
+        VariantShreddingInferenceSession session =
+                new VariantShreddingInferenceSession(
+                        new InferVariantShreddingSchema(schema, 3, 50, 0.1), 256, 0.1, 0.05);
+
+        session.inferSchema(
+                Collections.singletonList(GenericRow.of(null, GenericVariant.fromJson("5"))));
+        session.commitPendingInference();
+
+        RowType afterAbsence =
+                session.inferSchema(
+                        Collections.singletonList(
+                                GenericRow.of(null, GenericVariant.fromJson("6"))));
+
+        assertThat(afterAbsence.getField("b").type())
+                .isEqualTo(variantShreddingSchema(DataTypes.BIGINT()));
+    }
+
     @Test
     void testInferSchemaWithDeepNesting() {
         // Schema: row<v: variant>


### PR DESCRIPTION
### Purpose

Adaptive variant shredding inference throws and fails the write when a node's evidence is gone but its selected schema is still a `ROW`.

`finalizeAdaptiveSchema` substitutes the previously *selected* schema when the current file has no evidence for a node:

```java
if (combined == null || combined instanceof VariantType) {
    if (current != null && !(current instanceof VariantType)) {
        combined = current;
    } else if (previousSelected != null) {
        combined = previousSelected;          // InferVariantShreddingSchema:576-577
    } else {
        return DataTypes.VARIANT();
    }
}
```

Execution then falls into the `RowType` branch, which reads that substitute as if it were evidence:

```java
double ratio = rootValueCount == 0 ? 0 : getFieldCount(field) / rootValueCount;   // :592
```

Selected schemas carry no per-field counts — `finalizeSimpleSchema` clears them, and the adaptive `RowType` branch rebuilds fields with the description-free three-argument `DataField` constructor — so `getFieldCount` throws:

```
java.lang.IllegalStateException: Field 'x' is missing count in description. This should not happen during schema inference.
  at InferVariantShreddingSchema.getFieldCount(InferVariantShreddingSchema.java:394)
  at InferVariantShreddingSchema.finalizeAdaptiveSchema(InferVariantShreddingSchema.java:592)
  at InferVariantShreddingSchema.finalizeAdaptiveSchema(InferVariantShreddingSchema.java:615)
  at InferVariantShreddingSchema.inferAdaptive(InferVariantShreddingSchema.java:134)
  at VariantShreddingInferenceSession.inferSchema(VariantShreddingInferenceSession.java:74)
```

Getting there needs three things in one rolling writer with `variant.inferShreddingSchema=true` and `variant.shredding.inferenceMode=adaptive`: a node drifts across a type family, which degrades its combined evidence to `VARIANT` while the schema selected for it is a `ROW`; and it is then absent from the next file, so there is no current evidence either. Two files cannot do it — when a node is absent, `combineEvidence` falls back to the previous file's *evidence*, which still carries counts — so it takes three.

The exception comes out of `InferShreddingWritePlanWriter` uncaught, so the file fails to write at all.

Three files of a `ROW<v VARIANT>` table, at the default options, are enough:

| file | rows | result |
|---|---|---|
| 1 | `{"k":1,"p":5}` | plans, `p` selected as `BIGINT` |
| 2 | `{"k":1,"p":{"x":1}}` | plans, `p` selected as `ROW<x BIGINT>`, combined evidence for `p` degrades to `VARIANT` |
| 3 | `{"k":1}` | **throws** |

A root-level variant of the same shape — `42`, then `{"a":1}`, then SQL `NULL` — fails the same way with `Field 'a'`.

### Summary and Changelog

Return `previousSelected` instead of assigning it to `combined`. It is already a finalized selection: it has been through admission, retention and the field budget once, and with no evidence for this file there is nothing to re-threshold it against. Carrying it forward unchanged is also what the retention path does for a node whose evidence is still a `RowType`.

### Tests

`InferVariantShreddingSchemaTest#testAdaptiveInferenceKeepsSelectedRowWhenEvidenceDegradedAndNodeIsAbsent` drives the three files above and asserts `p` keeps `ROW<x BIGINT>`. On `master` it errors with the `IllegalStateException` above, and the other 24 cases in the class are unaffected either way.

Four negative controls, run against a build of this ref, confirm the trigger is that specific combination rather than absence alone — no drift and `p` merely disappears; drift but `p` still present in file 3; object all the way, which is the shape every existing adaptive test uses; and root scalar to scalar to NULL. All four pass before and after.

The reason no existing test catches this: the four adaptive cases in `InferVariantShreddingSchemaTest` and `InferVariantShreddingWriteTest` all keep the root variant an object across every file, so combined evidence stays a `RowType` and line 577 is never reached with a `RowType` in `previousSelected`. `testAdaptiveInferenceWidensScalarSelectedFromPriorEvidence` comes closest — its `second` column has no current evidence in round 2 — but its combined evidence there is the previous file's evidence, which still carries counts.

`mvn test -pl paimon-common -Dtest='org.apache.paimon.data.variant.**'` — 52 tests, and `-pl paimon-format -Dtest=InferVariantShreddingWriteTest` — 18 tests, all passing. `spotless:check` and `checkstyle:check` clean.

### Tests API and Compatibility

No API, format or configuration change. Only the path that currently throws behaves differently; every schema that infers successfully today infers the same way.
