### PR TITLE
[Bug] Fix Flink Dedicated Streaming Compact Job stuck when checkpointed snapshot expired

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/table/source/DataTableStreamScan.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/source/DataTableStreamScan.java
@@ -315,6 +315,19 @@ public class DataTableStreamScan extends AbstractDataTableScan implements Stream
 
     @Override
     public void restore(@Nullable Long nextSnapshotId) {
+        if (nextSnapshotId != null) {
+            Long earliestSnapshotId = snapshotManager.earliestSnapshotId();
+            if (earliestSnapshotId != null && earliestSnapshotId > nextSnapshotId) {
+                LOG.warn(
+                        "The restored snapshot with id {} has expired. "
+                                + "The earliest snapshot is {}. "
+                                + "Falling back to starting scanner.",
+                        nextSnapshotId,
+                        earliestSnapshotId);
+                this.nextSnapshotId = null;
+                return;
+            }
+        }
         this.nextSnapshotId = nextSnapshotId;
     }
 


### PR DESCRIPTION
Fixes #9533: When Flink Dedicated Streaming Compact Job restores from a checkpoint whose snapshot has been expired, the job gets stuck in a loop because nextPlan() keeps returning SnapshotNotExistPlan without incrementing nextSnapshotId.

### Fix

In restore(), when nextSnapshotId is less than earliestSnapshotId (snapshot expired), set nextSnapshotId to null so plan() falls back to tryFirstPlan() which uses ContinuousCompactorStartingScanner to find the latest compact snapshot.