### PR TITLE
[docs] Fix misleading DROP COLUMN doc for hive catalog

### DIFF
--- a/docs/docs/flink/sql-alter.md
+++ b/docs/docs/flink/sql-alter.md
@@ -110,10 +110,16 @@ To drop a column in a row type, see [Changing Column Type](#changing-column-type
 
 :::
 
-In hive catalog, you need to ensure:
+:::warning
 
-1. disable `hive.metastore.disallow.incompatible.col.type.changes` in your hive server
-2. or set `hadoop.hive.metastore.disallow.incompatible.col.type.changes=false` in your paimon catalog.
+When using a `hive` catalog, this operation requires `hive.metastore.disallow.incompatible.col.type.changes=false`
+to be set on the **Hive Metastore server** (in its `hive-site.xml`, then restart HMS). Setting this key on the
+Paimon catalog (`WITH (...)`) or via a Flink SQL `SET` only configures the *client-side* `HiveConf`; the value is
+**not** propagated to the remote Hive Metastore service over Thrift, so setting it on the client has no effect.
+
+See [HIVE-17832](https://issues.apache.org/jira/browse/HIVE-17832) for the historical discussion.
+
+:::
 
 Otherwise this operation may fail, throws an exception like `The following columns have types incompatible with the
 existing columns in their respective positions`.

--- a/docs/docs/flink/sql-ddl.md
+++ b/docs/docs/flink/sql-ddl.md
@@ -108,7 +108,7 @@ You can define any default table options with the prefix `table-default.` for ta
 
 Also, you can create [FlinkGenericCatalog](./quick-start).
 
-> When using hive catalog to change incompatible column types through alter table, you need to configure `hive.metastore.disallow.incompatible.col.type.changes=false`. see [HIVE-17832](https://issues.apache.org/jira/browse/HIVE-17832).
+> When using hive catalog to change incompatible column types through alter table, you need to configure `hive.metastore.disallow.incompatible.col.type.changes=false` on the **Hive Metastore server** (in its `hive-site.xml`, then restart HMS). Setting this on the Paimon catalog or via Flink SQL `SET` only configures the client-side HiveConf and is not propagated to the remote HMS over Thrift. See [HIVE-17832](https://issues.apache.org/jira/browse/HIVE-17832).
 
 > If you are using Hive3, please disable Hive ACID:
 >

--- a/docs/docs/spark/sql-alter.md
+++ b/docs/docs/spark/sql-alter.md
@@ -174,10 +174,17 @@ The following SQL drops a nested column `f2` from a struct type, which is the va
 ALTER TABLE my_table DROP COLUMN v.value.f2;
 ```
 
-In hive catalog, you need to ensure:
+:::warning
 
-1. disable `hive.metastore.disallow.incompatible.col.type.changes` in your hive server
-2. or `spark-sql --conf spark.hadoop.hive.metastore.disallow.incompatible.col.type.changes=false` in your spark.
+When using a `hive` catalog, this operation requires `hive.metastore.disallow.incompatible.col.type.changes=false`
+to be set on the **Hive Metastore server** (in its `hive-site.xml`, then restart HMS). Setting this key via
+`--conf spark.hadoop.hive.metastore.disallow.incompatible.col.type.changes=false` only configures the *client-side*
+`HiveConf`; the value is **not** propagated to the remote Hive Metastore service over Thrift, so setting it on
+the client has no effect.
+
+See [HIVE-17832](https://issues.apache.org/jira/browse/HIVE-17832) for the historical discussion.
+
+:::
 
 Otherwise this operation may fail, throws an exception like `The following columns have types incompatible with the
 existing columns in their respective positions`.


### PR DESCRIPTION
### Purpose

The current docs for `ALTER TABLE ... DROP (col)` against a `hive` catalog
tell users they can work around the
`The following columns have types incompatible with the existing columns in
their respective positions` error by either:

1. disabling `hive.metastore.disallow.incompatible.col.type.changes` on the hive server (correct), or
2. setting `hadoop.hive.metastore.disallow.incompatible.col.type.changes=false` on the Paimon catalog / via Flink SQL `SET` / via   `spark-sql --conf spark.hadoop.hive.metastore.disallow.incompatible.col.type.changes=false` (incorrect for a remote HMS).

Option 2 does not work against a real (remote) Hive Metastore. The compatibility check lives in the Hive Metastore **server**, in `HiveAlterHandler#alterTable` (hive-metastore):

```java
if (HiveConf.getBoolVar(hiveConf,
        HiveConf.ConfVars.METASTORE_DISALLOW_INCOMPATIBLE_COL_TYPE_CHANGES, false)
        && !oldt.getTableType().equals(TableType.VIRTUAL_VIEW.toString())) {
    MetaStoreUtils.throwExceptionIfIncompatibleColTypeChange(...);
}
```
The hiveConf here is the server-side HiveConf (loaded from hive-site.xml), and the alter is invoked over Thrift via client.alter_table_with_environmentContext(...) from HiveAlterTableUtils#alterTableWithEnv. The Thrift RPC does not carry the client's HiveConf to the server, so any client-side setting (including SET hadoop.hive.metastore.disallow.incompatible.col.type.changes=false in Flink SQL, the equivalent WITH (...) catalog option, or spark-sql --conf spark.hadoop.hive.metastore.disallow.incompatible.col.type.changes=false) has no effect. The check runs with the server's own value of hive.metastore.disallow.incompatible.col.type.changes, whose default in HiveConf is true.

That's why users following the documented workaround still hit the error. Paimon's own unit test for this scenario passes only because it uses an embedded HMSHandler in the same JVM, where the client HiveConf and the server HiveConf happen to be the same object.

This PR drops option 2 and rewrites the note in
docs/docs/flink/sql-alter.md and docs/docs/spark/sql-alter.md
(plus the related tip in docs/docs/flink/sql-ddl.md) so the only recommended path is to sethive.metastore.disallow.incompatible.col.type.changes=false on the Hive Metastore server (hive-site.xml, then restart HMS).

Refs: [HIVE-17832](https://issues.apache.org/jira/browse/HIVE-17832).
Refs: [Iceberg#hive-catalog](https://iceberg.apache.org/docs/latest/flink-ddl/#hive-catalog).

### Tests
Manual: re-rendered the three updated doc pages; the new :::warning block reads as the only supported way to opt out of the compatibility check, and the misleading "or set ... in your paimon catalog" bullet is removed.
No code / no test changes; this is a docs-only fix.