### PR TITLE
[api][core][spark] Support custom partition locations

### DIFF
--- a/docs/docs/concepts/rest/rest-api.md
+++ b/docs/docs/concepts/rest/rest-api.md
@@ -25,6 +25,11 @@ under the License.
 The OpenAPI 3.1 document below defines the language-neutral wire contract for REST Catalog
 servers and clients. It can also be used to generate or validate SDK models in other languages.
 
+Partition options use the existing `POST .../partitions` request. `partitionOptions` follows the
+order of `partitionSpecs`; use `{}` when a partition has no options. Custom locations use the
+`path` option. Before registering custom locations, ensure that the REST server supports partition
+options and all readers support custom locations.
+
 <body>
     <iframe src="/docs/master/rest-catalog-open-api.yaml" width="100%" height="800px" />
 </body>

--- a/docs/docs/flink/sql-ddl.md
+++ b/docs/docs/flink/sql-ddl.md
@@ -49,6 +49,9 @@ and a table whose catalog holds no partitions reads as empty. Flink has no SQL c
 them: use Spark's `MSCK REPAIR TABLE` or the catalog's partition API. Flink writes on a current
 version do register the partitions they produce.
 
+Flink SQL cannot set a custom partition `LOCATION`. Upgrade Flink readers before registering custom
+locations through the catalog API.
+
 In a REST catalog, asking for catalog-managed partitions on a table that cannot have them — an
 external table, or `format-table.implementation = engine` — fails. In any other catalog the option
 keeps the meaning it has always had on a Format Table — none — and partitions come from the

--- a/docs/docs/spark/sql-ddl.md
+++ b/docs/docs/spark/sql-ddl.md
@@ -213,6 +213,8 @@ partitions and Spark supports the standard partition DDL:
 
 ```sql
 ALTER TABLE my_table ADD PARTITION (dt='2025-01-01');
+ALTER TABLE my_table ADD PARTITION (dt='2024-12-31')
+    LOCATION 'oss://archive-bucket/events/dt=2024-12-31';
 ALTER TABLE my_table DROP PARTITION (dt='2025-01-01');
 MSCK REPAIR TABLE my_table;
 SHOW PARTITIONS my_table;
@@ -225,6 +227,10 @@ On a Format Table whose partitions are discovered from the filesystem, `ADD PART
 `ADD PARTITION` creates the partition directory and registers the partition; querying a newly
 added partition before any data is written returns no rows. `DROP PARTITION` unregisters the
 partition and deletes its directory.
+
+`ADD PARTITION ... LOCATION` registers a custom absolute URI without moving data and requires a
+compatible REST catalog. Paimon can read the partition but does not write, delete, or analyze its
+data. `DROP PARTITION` only unregisters it, and `MSCK REPAIR TABLE` leaves it unchanged.
 
 A partition value that is empty or all whitespace is rejected by `ADD PARTITION`, `DROP PARTITION`
 and `TRUNCATE PARTITION`. Such a value is written to the partition named by

--- a/docs/scripts/validate-rest-openapi.js
+++ b/docs/scripts/validate-rest-openapi.js
@@ -237,6 +237,48 @@ function validateCatalogOpenApi() {
     'dropTable',
   ].forEach(contract.requireOperation);
 
+  const createOperation = contract.requireOperation('createPartitions');
+  const createRequestRef =
+    createOperation.requestBody.content['application/json'].schema.$ref;
+  contract.checkSpec(
+    createRequestRef === '#/components/schemas/CreatePartitionsRequest',
+    'createPartitions must use CreatePartitionsRequest',
+  );
+  contract.checkSpec(
+    !contract.operations.has('createPartitionsWithOptions'),
+    'partition options must use the existing createPartitions operation',
+  );
+  const createResponseRef =
+    createOperation.responses['200'].content['application/json'].schema.$ref;
+  contract.checkSpec(
+    createResponseRef === '#/components/schemas/CreatePartitionsResponse',
+    'createPartitions must use CreatePartitionsResponse',
+  );
+  contract.checkSpec(
+    createOperation.responses['400'] && createOperation.responses['501'],
+    'createPartitions must declare invalid and unsupported option responses',
+  );
+  const createRequestProperties = contract.requireProperties('CreatePartitionsRequest', [
+    'partitionSpecs',
+    'partitionOptions',
+  ]);
+  const requestOptions = createRequestProperties.partitionOptions;
+  contract.checkSpec(
+    Array.isArray(requestOptions.type) &&
+      requestOptions.type.includes('array') &&
+      requestOptions.type.includes('null') &&
+      requestOptions.items.type === 'object' &&
+      requestOptions.items.additionalProperties.type === 'string',
+    'CreatePartitionsRequest.partitionOptions must be a nullable array of string maps',
+  );
+  contract.checkSpec(
+    requestOptions.description.includes('partitionSpecs') &&
+      requestOptions.description.toLowerCase().includes('position') &&
+      requestOptions.description.toLowerCase().includes('same length') &&
+      requestOptions.description.toLowerCase().includes('empty object'),
+    'CreatePartitionsRequest.partitionOptions must document positional alignment and empty options',
+  );
+  contract.requireProperties('Partition', ['options']);
   contract.requireProperties('ConfigResponse', ['defaults', 'overrides']);
   contract.requireProperties('CreateDatabaseRequest', ['name', 'options']);
   contract.requireProperties('AlterDatabaseRequest', ['removals', 'updates']);

--- a/docs/static/rest-catalog-open-api.yaml
+++ b/docs/static/rest-catalog-open-api.yaml
@@ -984,6 +984,9 @@ paths:
       tags:
         - partition
       summary: Create partitions
+      description: >
+        Creates partitions with optional position-aligned options. The server validates and stores
+        the partitions, options, and statistics atomically.
       operationId: createPartitions
       parameters:
         - name: prefix
@@ -1014,6 +1017,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/CreatePartitionsResponse'
+        "400":
+          $ref: '#/components/responses/BadRequestErrorResponse'
         "401":
           $ref: '#/components/responses/UnauthorizedErrorResponse'
         "404":
@@ -1022,6 +1027,12 @@ paths:
           $ref: '#/components/responses/ResourceAlreadyExistErrorResponse'
         "500":
           $ref: '#/components/responses/ServerErrorResponse'
+        "501":
+          description: The catalog provider does not support partition options
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
   /v1/{prefix}/databases/{database}/tables/{table}/partitions/drop:
     post:
       tags:
@@ -2497,6 +2508,13 @@ components:
         replaceStatistics:
           description: Whether partitionStatistics replace the stored values rather than add to them; required whenever partitionStatistics is present, and absent otherwise. Replacing overwrites recordCount, fileSizeInBytes, fileCount and lastFileCreationTime; adding sums the three counts and keeps the later lastFileCreationTime, since two timestamps do not add. A field reported as unknown leaves the stored one alone either way, and totalBuckets is never combined. A client that reports only the files it just wrote adds; one that reports a whole partition, such as an overwrite or a directory rescan, replaces.
           type: [ boolean, "null" ]
+        partitionOptions:
+          description: Optional options aligned with partitionSpecs by position. The list must have the same length as partitionSpecs; use an empty object when a partition has no options. A custom location is stored under the path key.
+          type: [ array, "null" ]
+          items:
+            type: object
+            additionalProperties:
+              type: string
     CreatePartitionsResponse:
       type: object
       required:

--- a/paimon-api/src/main/java/org/apache/paimon/rest/RESTApi.java
+++ b/paimon-api/src/main/java/org/apache/paimon/rest/RESTApi.java
@@ -996,6 +996,7 @@ public class RESTApi {
      *     PartitionStatistics#spec()} rather than by position, or null to report none
      * @param replaceStatistics whether the report replaces the stored values rather than adding to
      *     them; ignored when {@code statistics} is null, and not sent at all in that case
+     * @param partitionOptions options aligned with {@code partitions} by position, or null
      * @return the partitions the server created and the ones it already held
      */
     public CreatePartitionsResponse createPartitions(
@@ -1003,13 +1004,15 @@ public class RESTApi {
             List<Map<String, String>> partitions,
             boolean ignoreIfExists,
             @Nullable List<PartitionStatistics> statistics,
-            boolean replaceStatistics) {
+            boolean replaceStatistics,
+            @Nullable List<Map<String, String>> partitionOptions) {
         CreatePartitionsRequest request =
                 new CreatePartitionsRequest(
                         partitions,
                         ignoreIfExists,
                         statistics,
-                        statistics == null ? null : replaceStatistics);
+                        statistics == null ? null : replaceStatistics,
+                        partitionOptions);
         return client.post(
                 resourcePaths.partitions(identifier.getDatabaseName(), identifier.getObjectName()),
                 request,

--- a/paimon-api/src/main/java/org/apache/paimon/rest/requests/CreatePartitionsRequest.java
+++ b/paimon-api/src/main/java/org/apache/paimon/rest/requests/CreatePartitionsRequest.java
@@ -33,6 +33,8 @@ import javax.annotation.Nullable;
 import java.util.List;
 import java.util.Map;
 
+import static org.apache.paimon.utils.Preconditions.checkArgument;
+
 /**
  * Request for creating partitions.
  *
@@ -47,6 +49,7 @@ public class CreatePartitionsRequest implements RESTRequest {
     private static final String FIELD_IGNORE_IF_EXISTS = "ignoreIfExists";
     private static final String FIELD_PARTITION_STATISTICS = "partitionStatistics";
     private static final String FIELD_REPLACE_STATISTICS = "replaceStatistics";
+    private static final String FIELD_PARTITION_OPTIONS = "partitionOptions";
 
     @JsonProperty(FIELD_PARTITION_SPECS)
     private final List<Map<String, String>> partitionSpecs;
@@ -64,13 +67,26 @@ public class CreatePartitionsRequest implements RESTRequest {
     @Nullable
     private final Boolean replaceStatistics;
 
+    @JsonProperty(FIELD_PARTITION_OPTIONS)
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    @Nullable
+    private final List<Map<String, String>> partitionOptions;
+
     public CreatePartitionsRequest(List<Map<String, String>> partitionSpecs) {
         this(partitionSpecs, true);
     }
 
     public CreatePartitionsRequest(
             List<Map<String, String>> partitionSpecs, @Nullable Boolean ignoreIfExists) {
-        this(partitionSpecs, ignoreIfExists, null, null);
+        this(partitionSpecs, ignoreIfExists, null, null, null);
+    }
+
+    public CreatePartitionsRequest(
+            List<Map<String, String>> partitionSpecs,
+            @Nullable Boolean ignoreIfExists,
+            @Nullable List<PartitionStatistics> partitionStatistics,
+            @Nullable Boolean replaceStatistics) {
+        this(partitionSpecs, ignoreIfExists, partitionStatistics, replaceStatistics, null);
     }
 
     @JsonCreator
@@ -79,11 +95,30 @@ public class CreatePartitionsRequest implements RESTRequest {
             @JsonProperty(FIELD_IGNORE_IF_EXISTS) @Nullable Boolean ignoreIfExists,
             @JsonProperty(FIELD_PARTITION_STATISTICS) @Nullable
                     List<PartitionStatistics> partitionStatistics,
-            @JsonProperty(FIELD_REPLACE_STATISTICS) @Nullable Boolean replaceStatistics) {
+            @JsonProperty(FIELD_REPLACE_STATISTICS) @Nullable Boolean replaceStatistics,
+            @JsonProperty(FIELD_PARTITION_OPTIONS) @Nullable
+                    List<Map<String, String>> partitionOptions) {
+        checkArgument(
+                partitionOptions == null
+                        || (partitionSpecs != null
+                                && partitionOptions.size() == partitionSpecs.size()),
+                "partitionOptions must be null or have the same size as partitionSpecs.");
+        checkArgument(
+                partitionOptions == null || !partitionOptions.contains(null),
+                "partitionOptions must not contain null maps.");
+        checkArgument(
+                partitionOptions == null
+                        || partitionOptions.stream()
+                                .flatMap(options -> options.entrySet().stream())
+                                .noneMatch(
+                                        entry ->
+                                                entry.getKey() == null || entry.getValue() == null),
+                "partitionOptions must not contain null keys or values.");
         this.partitionSpecs = partitionSpecs;
         this.ignoreIfExists = ignoreIfExists == null || ignoreIfExists;
         this.partitionStatistics = partitionStatistics;
         this.replaceStatistics = replaceStatistics;
+        this.partitionOptions = partitionOptions;
     }
 
     @JsonGetter(FIELD_PARTITION_SPECS)
@@ -111,6 +146,13 @@ public class CreatePartitionsRequest implements RESTRequest {
     @Nullable
     public Boolean replaceStatistics() {
         return replaceStatistics;
+    }
+
+    /** Options aligned with partition specs; a null list omits the field. */
+    @JsonGetter(FIELD_PARTITION_OPTIONS)
+    @Nullable
+    public List<Map<String, String>> getPartitionOptions() {
+        return partitionOptions;
     }
 
     /**

--- a/paimon-core/src/main/java/org/apache/paimon/catalog/CachingCatalog.java
+++ b/paimon-core/src/main/java/org/apache/paimon/catalog/CachingCatalog.java
@@ -350,10 +350,16 @@ public class CachingCatalog extends DelegateCatalog {
             List<Map<String, String>> partitions,
             boolean ignoreIfExists,
             @Nullable List<PartitionStatistics> statistics,
-            boolean replaceStatistics)
+            boolean replaceStatistics,
+            @Nullable List<Map<String, String>> partitionOptions)
             throws TableNotExistException {
         wrapped.createPartitions(
-                identifier, partitions, ignoreIfExists, statistics, replaceStatistics);
+                identifier,
+                partitions,
+                ignoreIfExists,
+                statistics,
+                replaceStatistics,
+                partitionOptions);
         if (partitionCache != null) {
             partitionCache.invalidate(identifier);
         }

--- a/paimon-core/src/main/java/org/apache/paimon/catalog/Catalog.java
+++ b/paimon-core/src/main/java/org/apache/paimon/catalog/Catalog.java
@@ -1072,35 +1072,29 @@ public interface Catalog extends AutoCloseable {
             throws TableNotExistException {}
 
     /**
-     * Create partitions of the specify table, with explicit existence semantics and optionally
-     * reporting statistics for them in the same call.
-     *
-     * <p>The statistics are matched to {@code partitions} by {@link PartitionStatistics#spec()}, so
-     * they may cover only some of them, and {@code replaceStatistics} says whether they replace
-     * what the catalog already holds or add to it. What decides whether they survive is whether a
-     * catalog overrides this method: one that does not registers the partitions exactly as {@link
-     * #createPartitions(Identifier, List)} does and drops the report, however much of it the
-     * catalog could have stored, and for a catalog that keeps no partitions at all that means it
-     * does nothing.
-     *
-     * @param identifier path of the table to create partitions
-     * @param partitions partitions to be created
-     * @param ignoreIfExists if false, fail when any partition already exists and apply none of the
-     *     batch; if true, behave like {@link #createPartitions(Identifier, List)}
-     * @param statistics statistics to report, or null to report none
-     * @param replaceStatistics whether the report replaces the stored values rather than adding to
-     *     them; ignored when {@code statistics} is null
-     * @throws TableNotExistException if the table does not exist
-     * @throws UnsupportedOperationException if {@code ignoreIfExists} is false and the catalog does
-     *     not implement strict creation, which is what the default here does
+     * Create partitions atomically unless existing entries are ignored, with optional statistics
+     * and position-aligned options.
      */
     default void createPartitions(
             Identifier identifier,
             List<Map<String, String>> partitions,
             boolean ignoreIfExists,
             @Nullable List<PartitionStatistics> statistics,
-            boolean replaceStatistics)
+            boolean replaceStatistics,
+            @Nullable List<Map<String, String>> partitionOptions)
             throws TableNotExistException {
+        if (partitionOptions != null) {
+            if (partitionOptions.size() != partitions.size() || partitionOptions.contains(null)) {
+                throw new IllegalArgumentException(
+                        "Partition options must contain one non-null map per partition.");
+            }
+            if (partitionOptions.stream().anyMatch(options -> !options.isEmpty())) {
+                throw new UnsupportedOperationException(
+                        String.format(
+                                "Catalog %s does not support partition options.",
+                                getClass().getName()));
+            }
+        }
         if (!ignoreIfExists) {
             throw new UnsupportedOperationException(
                     String.format(

--- a/paimon-core/src/main/java/org/apache/paimon/catalog/DelegateCatalog.java
+++ b/paimon-core/src/main/java/org/apache/paimon/catalog/DelegateCatalog.java
@@ -331,10 +331,16 @@ public abstract class DelegateCatalog implements Catalog {
             List<Map<String, String>> partitions,
             boolean ignoreIfExists,
             @Nullable List<PartitionStatistics> statistics,
-            boolean replaceStatistics)
+            boolean replaceStatistics,
+            @Nullable List<Map<String, String>> partitionOptions)
             throws TableNotExistException {
         wrapped.createPartitions(
-                identifier, partitions, ignoreIfExists, statistics, replaceStatistics);
+                identifier,
+                partitions,
+                ignoreIfExists,
+                statistics,
+                replaceStatistics,
+                partitionOptions);
     }
 
     @Override

--- a/paimon-core/src/main/java/org/apache/paimon/rest/RESTCatalog.java
+++ b/paimon-core/src/main/java/org/apache/paimon/rest/RESTCatalog.java
@@ -67,6 +67,7 @@ import org.apache.paimon.table.FormatTable;
 import org.apache.paimon.table.Instant;
 import org.apache.paimon.table.Table;
 import org.apache.paimon.table.TableSnapshot;
+import org.apache.paimon.table.format.FormatTablePartitionPathResolver;
 import org.apache.paimon.table.sink.BatchTableCommit;
 import org.apache.paimon.table.system.SystemTableLoader;
 import org.apache.paimon.utils.JsonSerdeUtil;
@@ -84,6 +85,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -760,7 +762,7 @@ public class RESTCatalog implements Catalog {
     @Override
     public void createPartitions(Identifier identifier, List<Map<String, String>> partitions)
             throws TableNotExistException {
-        createPartitions(identifier, partitions, true, null, false);
+        createPartitions(identifier, partitions, true, null, false, null);
     }
 
     @Override
@@ -769,11 +771,19 @@ public class RESTCatalog implements Catalog {
             List<Map<String, String>> partitions,
             boolean ignoreIfExists,
             @Nullable List<PartitionStatistics> statistics,
-            boolean replaceStatistics)
+            boolean replaceStatistics,
+            @Nullable List<Map<String, String>> partitionOptions)
             throws TableNotExistException {
+        List<Map<String, String>> canonicalOptions =
+                canonicalizePartitionOptions(identifier, partitions, partitionOptions);
         try {
             api.createPartitions(
-                    identifier, partitions, ignoreIfExists, statistics, replaceStatistics);
+                    identifier,
+                    partitions,
+                    ignoreIfExists,
+                    statistics,
+                    replaceStatistics,
+                    canonicalOptions);
         } catch (NoSuchResourceException e) {
             throw new TableNotExistException(identifier);
         } catch (ForbiddenException e) {
@@ -786,7 +796,78 @@ public class RESTCatalog implements Catalog {
                             identifier, e.getMessage()));
         } catch (BadRequestException e) {
             throw new IllegalArgumentException(e.getMessage());
+        } catch (NotImplementedException e) {
+            if (canonicalOptions == null) {
+                throw e;
+            }
+            throw new UnsupportedOperationException(
+                    String.format(
+                            "REST Catalog server does not support partition options for table %s.",
+                            identifier.getFullName()),
+                    e);
         }
+    }
+
+    @Nullable
+    private List<Map<String, String>> canonicalizePartitionOptions(
+            Identifier identifier,
+            List<Map<String, String>> partitions,
+            @Nullable List<Map<String, String>> requested) {
+        if (requested == null) {
+            return null;
+        }
+        if (requested.size() != partitions.size()) {
+            throw new IllegalArgumentException(
+                    String.format(
+                            "Partition options for table %s must align with all %d partition specs, but found %d.",
+                            identifier.getFullName(), partitions.size(), requested.size()));
+        }
+        Set<Map<String, String>> uniquePartitions = new HashSet<>();
+        List<Map<String, String>> canonical = new ArrayList<>(requested.size());
+        boolean hasOptions = false;
+        for (int i = 0; i < requested.size(); i++) {
+            Map<String, String> partition = partitions.get(i);
+            if (partition == null || !uniquePartitions.add(partition)) {
+                throw new IllegalArgumentException(
+                        "Partition specs must be non-null and unique when partition options are provided.");
+            }
+            Map<String, String> options = requested.get(i);
+            if (options == null) {
+                throw new IllegalArgumentException("Partition options must not contain null maps.");
+            }
+            if (options.entrySet().stream()
+                    .anyMatch(entry -> entry.getKey() == null || entry.getValue() == null)) {
+                throw new IllegalArgumentException(
+                        "Partition options must not contain null keys or values.");
+            }
+            Map<String, String> copied = new HashMap<>(options);
+            String location = copied.get(PATH.key());
+            if (location != null) {
+                try {
+                    copied.put(
+                            PATH.key(),
+                            FormatTablePartitionPathResolver.canonicalizeCustomLocation(
+                                            location, context)
+                                    .toString());
+                } catch (IllegalArgumentException e) {
+                    throw invalidPartitionLocation(identifier, partition, e);
+                }
+            }
+            hasOptions |= !copied.isEmpty();
+            canonical.add(copied);
+        }
+        return hasOptions ? canonical : null;
+    }
+
+    private static IllegalArgumentException invalidPartitionLocation(
+            Identifier identifier,
+            @Nullable Map<String, String> partition,
+            IllegalArgumentException cause) {
+        String message =
+                String.format(
+                        "Invalid custom partition location for partition %s of table %s.",
+                        partition, identifier.getFullName());
+        return new IllegalArgumentException(message, cause);
     }
 
     @Override

--- a/paimon-core/src/main/java/org/apache/paimon/table/format/CatalogFormatTablePartitionManager.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/format/CatalogFormatTablePartitionManager.java
@@ -172,7 +172,7 @@ class CatalogFormatTablePartitionManager implements FormatTablePartitionManager 
                         // Rejecting the whole batch when any partition exists is only meaningful
                         // if the batch stays one request, so a strict create is never split.
                         catalog.createPartitions(
-                                identifier, partitions, false, statistics, replaceStatistics);
+                                identifier, partitions, false, statistics, replaceStatistics, null);
                         return null;
                     }
                     // isRetrySafe() bounds the transport retry only: a caller-level rerun of a
@@ -184,7 +184,8 @@ class CatalogFormatTablePartitionManager implements FormatTablePartitionManager 
                                 batch,
                                 true,
                                 statisticsOf(batch, statisticsBySpec),
-                                replaceStatistics);
+                                replaceStatistics,
+                                null);
                     }
                     return null;
                 },

--- a/paimon-core/src/main/java/org/apache/paimon/table/format/CatalogFormatTablePartitionManager.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/format/CatalogFormatTablePartitionManager.java
@@ -159,8 +159,9 @@ class CatalogFormatTablePartitionManager implements FormatTablePartitionManager 
             List<Map<String, String>> partitions,
             boolean ignoreIfExists,
             @Nullable List<PartitionStatistics> statistics,
-            boolean replaceStatistics) {
-        // Validated before the empty check: returning early would swallow a malformed report.
+            boolean replaceStatistics,
+            @Nullable List<Map<String, String>> partitionOptions) {
+        validatePartitionOptions(partitionOptions, partitions);
         Map<Map<String, String>, PartitionStatistics> statisticsBySpec =
                 validateAndIndexStatistics(statistics, partitions);
         if (partitions.isEmpty()) {
@@ -172,24 +173,59 @@ class CatalogFormatTablePartitionManager implements FormatTablePartitionManager 
                         // Rejecting the whole batch when any partition exists is only meaningful
                         // if the batch stays one request, so a strict create is never split.
                         catalog.createPartitions(
-                                identifier, partitions, false, statistics, replaceStatistics, null);
+                                identifier,
+                                partitions,
+                                false,
+                                statistics,
+                                replaceStatistics,
+                                partitionOptions);
                         return null;
                     }
                     // isRetrySafe() bounds the transport retry only: a caller-level rerun of a
                     // multi-batch ADD still double counts the batches that already landed.
+                    int offset = 0;
                     for (List<Map<String, String>> batch : batches(partitions)) {
                         // A partition and its statistics travel in the same request.
+                        int end = offset + batch.size();
                         catalog.createPartitions(
                                 identifier,
                                 batch,
                                 true,
                                 statisticsOf(batch, statisticsBySpec),
                                 replaceStatistics,
-                                null);
+                                partitionOptions == null
+                                        ? null
+                                        : partitionOptions.subList(offset, end));
+                        offset = end;
                     }
                     return null;
                 },
                 "create partitions");
+    }
+
+    private void validatePartitionOptions(
+            @Nullable List<Map<String, String>> partitionOptions,
+            List<Map<String, String>> partitions) {
+        if (partitionOptions == null) {
+            return;
+        }
+        checkArgument(
+                partitionOptions.size() == partitions.size(),
+                "Partition options for table %s must align with all %s partition specs.",
+                identifier.getFullName(),
+                partitions.size());
+        Set<Map<String, String>> uniqueSpecs = capacityFor(partitions.size());
+        for (int i = 0; i < partitionOptions.size(); i++) {
+            Map<String, String> options = partitionOptions.get(i);
+            checkArgument(options != null, "Partition options must not contain null maps.");
+            checkArgument(
+                    options.entrySet().stream()
+                            .noneMatch(entry -> entry.getKey() == null || entry.getValue() == null),
+                    "Partition options must not contain null keys or values.");
+            checkArgument(
+                    partitions.get(i) != null && uniqueSpecs.add(partitions.get(i)),
+                    "Partition specs must be non-null and unique when partition options are provided.");
+        }
     }
 
     /**

--- a/paimon-core/src/main/java/org/apache/paimon/table/format/CatalogSplitEnumerator.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/format/CatalogSplitEnumerator.java
@@ -20,7 +20,6 @@ package org.apache.paimon.table.format;
 
 import org.apache.paimon.CoreOptions;
 import org.apache.paimon.data.BinaryRow;
-import org.apache.paimon.fs.FileIO;
 import org.apache.paimon.fs.FileStatus;
 import org.apache.paimon.fs.Path;
 import org.apache.paimon.manifest.PartitionEntry;
@@ -89,7 +88,8 @@ final class CatalogSplitEnumerator extends SplitEnumerator {
     @Override
     List<Split> enumeratePartitions(@Nullable PartitionPredicate partitionFilter)
             throws IOException {
-        return enumeratePartitions(findCatalogPartitions(partitionFilter), partitionFilter);
+        CatalogPartitionListing listing = findCatalogPartitions(partitionFilter);
+        return enumeratePartitions(filterPartitions(listing.partitionPaths, partitionFilter));
     }
 
     @Override
@@ -97,34 +97,43 @@ final class CatalogSplitEnumerator extends SplitEnumerator {
         if (table.partitionKeys().isEmpty()) {
             return super.plan(partitionFilter);
         }
-        List<Partition> partitions = findCatalogPartitions(partitionFilter);
-        List<PartitionEntry> entries = toPartitionEntries(partitions, partitionFilter);
-        return new ScanPlan(enumeratePartitions(partitions, partitionFilter), rowCount(entries));
+        CatalogPartitionListing listing = findCatalogPartitions(partitionFilter);
+        List<Pair<LinkedHashMap<String, String>, Path>> selected =
+                filterPartitions(listing.partitionPaths, partitionFilter);
+        List<PartitionEntry> entries = toPartitionEntries(listing.partitions, partitionFilter);
+        return new ScanPlan(enumeratePartitions(selected), rowCount(entries));
     }
 
     private List<Split> enumeratePartitions(
-            List<Partition> catalogPartitions, @Nullable PartitionPredicate partitionFilter)
-            throws IOException {
-        List<Pair<LinkedHashMap<String, String>, Path>> partitions =
-                toSpecsAndPaths(
-                        catalogPartitions, coreOptions.formatTablePartitionOnlyValueInPath());
+            List<Pair<LinkedHashMap<String, String>, Path>> partitions) throws IOException {
         List<Split> splits = new ArrayList<>();
         if (partitions.isEmpty()) {
             return splits;
         }
 
-        FileIO fileIO = table.fileIO();
-        // Establish the filesystem on the caller thread so listing workers reuse it under the
-        // caller's security context instead of creating it lazily under a shared worker.
-        fileIO.exists(new Path(table.location()));
+        FormatTableFileIOResolver fileIOResolver = new FormatTableFileIOResolver(table);
+        boolean tableFileIOPrepared = false;
+        for (Pair<LinkedHashMap<String, String>, Path> partition : partitions) {
+            boolean useCatalogContextFileIO =
+                    fileIOResolver.useCatalogContextFileIO(partition.getValue());
+            if (useCatalogContextFileIO) {
+                fileIOResolver.prepare(partition.getValue(), true);
+            } else if (!tableFileIOPrepared) {
+                fileIOResolver.prepare(partition.getValue(), false);
+                tableFileIOPrepared = true;
+            }
+        }
         Function<Pair<LinkedHashMap<String, String>, Path>, List<Split>> lister =
                 pair -> {
                     BinaryRow partitionRow = toPartitionRow(pair.getKey());
-                    if (partitionFilter != null && !partitionFilter.test(partitionRow)) {
-                        return Collections.emptyList();
-                    }
                     try {
-                        return createSplits(fileIO, pair.getValue(), partitionRow);
+                        boolean useCatalogContextFileIO =
+                                fileIOResolver.useCatalogContextFileIO(pair.getValue());
+                        return createSplits(
+                                fileIOResolver.fileIO(useCatalogContextFileIO),
+                                pair.getValue(),
+                                partitionRow,
+                                useCatalogContextFileIO);
                     } catch (FileNotFoundException e) {
                         warnMissingPartition(pair.getKey(), pair.getValue());
                         return Collections.emptyList();
@@ -146,12 +155,12 @@ final class CatalogSplitEnumerator extends SplitEnumerator {
     @Override
     List<Pair<LinkedHashMap<String, String>, Path>> findPartitions(
             @Nullable PartitionPredicate partitionFilter) {
-        return toSpecsAndPaths(
-                findCatalogPartitions(partitionFilter),
-                coreOptions.formatTablePartitionOnlyValueInPath());
+        CatalogPartitionListing listing = findCatalogPartitions(partitionFilter);
+        return filterPartitions(listing.partitionPaths, partitionFilter);
     }
 
-    private List<Partition> findCatalogPartitions(@Nullable PartitionPredicate partitionFilter) {
+    private CatalogPartitionListing findCatalogPartitions(
+            @Nullable PartitionPredicate partitionFilter) {
         Optional<Predicate> extracted = FormatTableScan.extractPartitionPredicate(partitionFilter);
         Map<String, String> prefix = leadingEqualityPrefix(extracted);
         Predicate catalogFilter = extracted.orElse(null);
@@ -159,7 +168,9 @@ final class CatalogSplitEnumerator extends SplitEnumerator {
         if (partitions.isEmpty() && prefix.isEmpty() && catalogFilter == null) {
             warnIfFilesystemPartitionsExist();
         }
-        return partitions;
+        List<Pair<LinkedHashMap<String, String>, Path>> partitionPaths =
+                toSpecsAndPaths(partitions, coreOptions.formatTablePartitionOnlyValueInPath());
+        return new CatalogPartitionListing(partitions, partitionPaths);
     }
 
     @Override
@@ -169,7 +180,36 @@ final class CatalogSplitEnumerator extends SplitEnumerator {
 
     @Override
     List<PartitionEntry> listPartitionEntries(@Nullable PartitionPredicate partitionFilter) {
-        return toPartitionEntries(findCatalogPartitions(partitionFilter), partitionFilter);
+        return toPartitionEntries(
+                findCatalogPartitions(partitionFilter).partitions, partitionFilter);
+    }
+
+    private static final class CatalogPartitionListing {
+
+        private final List<Partition> partitions;
+        private final List<Pair<LinkedHashMap<String, String>, Path>> partitionPaths;
+
+        private CatalogPartitionListing(
+                List<Partition> partitions,
+                List<Pair<LinkedHashMap<String, String>, Path>> partitionPaths) {
+            this.partitions = partitions;
+            this.partitionPaths = partitionPaths;
+        }
+    }
+
+    private List<Pair<LinkedHashMap<String, String>, Path>> filterPartitions(
+            List<Pair<LinkedHashMap<String, String>, Path>> partitions,
+            @Nullable PartitionPredicate partitionFilter) {
+        if (partitionFilter == null) {
+            return partitions;
+        }
+        List<Pair<LinkedHashMap<String, String>, Path>> selected = new ArrayList<>();
+        for (Pair<LinkedHashMap<String, String>, Path> partition : partitions) {
+            if (partitionFilter.test(toPartitionRow(partition.getKey()))) {
+                selected.add(partition);
+            }
+        }
+        return selected;
     }
 
     private List<PartitionEntry> toPartitionEntries(
@@ -219,16 +259,45 @@ final class CatalogSplitEnumerator extends SplitEnumerator {
 
     private List<Pair<LinkedHashMap<String, String>, Path>> toSpecsAndPaths(
             List<Partition> partitions, boolean onlyValueInPath) {
+        if (partitions.stream()
+                .noneMatch(
+                        partition ->
+                                FormatTablePartitionPathResolver.customLocation(partition)
+                                        != null)) {
+            return toDefaultSpecsAndPaths(partitions, onlyValueInPath);
+        }
         List<Pair<LinkedHashMap<String, String>, Path>> result = new ArrayList<>(partitions.size());
         Path tablePath = new Path(table.location());
-        // A duplicate catalog entry must not duplicate all records in that partition.
-        Set<String> seenPartitionPaths = new HashSet<>(partitions.size());
+        FormatTablePartitionPathResolver pathResolver =
+                new FormatTablePartitionPathResolver(
+                        tablePath, table.fullName(), onlyValueInPath, table.catalogContext());
         for (Partition partition : partitions) {
             LinkedHashMap<String, String> spec = normalizeSpec(partition.spec(), onlyValueInPath);
-            String partitionPath =
-                    PartitionPathUtils.generatePartitionPathUtil(spec, onlyValueInPath);
-            if (seenPartitionPaths.add(partitionPath)) {
-                result.add(Pair.of(spec, new Path(tablePath, partitionPath)));
+            Path partitionPath =
+                    pathResolver.resolve(
+                            spec, FormatTablePartitionPathResolver.customLocation(partition));
+            if (pathResolver.validateAndRecord(spec, partitionPath)) {
+                result.add(Pair.of(spec, partitionPath));
+            }
+        }
+        return result;
+    }
+
+    private List<Pair<LinkedHashMap<String, String>, Path>> toDefaultSpecsAndPaths(
+            List<Partition> partitions, boolean onlyValueInPath) {
+        List<Pair<LinkedHashMap<String, String>, Path>> result = new ArrayList<>(partitions.size());
+        Set<Map<String, String>> seen = new HashSet<>(partitions.size());
+        Path tablePath = new Path(table.location());
+        for (Partition partition : partitions) {
+            LinkedHashMap<String, String> spec = normalizeSpec(partition.spec(), onlyValueInPath);
+            if (seen.add(spec)) {
+                result.add(
+                        Pair.of(
+                                spec,
+                                new Path(
+                                        tablePath,
+                                        PartitionPathUtils.generatePartitionPathUtil(
+                                                spec, onlyValueInPath))));
             }
         }
         return result;

--- a/paimon-core/src/main/java/org/apache/paimon/table/format/FormatDataSplit.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/format/FormatDataSplit.java
@@ -39,10 +39,17 @@ public class FormatDataSplit implements Split {
 
     private final List<FileMeta> files;
     @Nullable private final BinaryRow partition;
+    private final boolean useCatalogContextFileIO;
 
     public FormatDataSplit(List<FileMeta> files, @Nullable BinaryRow partition) {
+        this(files, partition, false);
+    }
+
+    public FormatDataSplit(
+            List<FileMeta> files, @Nullable BinaryRow partition, boolean useCatalogContextFileIO) {
         this.files = files;
         this.partition = partition;
+        this.useCatalogContextFileIO = useCatalogContextFileIO;
     }
 
     public List<FileMeta> files() {
@@ -52,6 +59,14 @@ public class FormatDataSplit implements Split {
     @Nullable
     public BinaryRow partition() {
         return partition;
+    }
+
+    /**
+     * Whether readers must resolve this split through the client {@code CatalogContext} instead of
+     * the FileIO bound to the table root.
+     */
+    public boolean useCatalogContextFileIO() {
+        return useCatalogContextFileIO;
     }
 
     /** Total bytes to read for this split, i.e. the sum of {@link FileMeta#readSize()}. */
@@ -83,12 +98,14 @@ public class FormatDataSplit implements Split {
             return false;
         }
         FormatDataSplit that = (FormatDataSplit) o;
-        return Objects.equals(files, that.files) && Objects.equals(partition, that.partition);
+        return useCatalogContextFileIO == that.useCatalogContextFileIO
+                && Objects.equals(files, that.files)
+                && Objects.equals(partition, that.partition);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(files, partition);
+        return Objects.hash(files, partition, useCatalogContextFileIO);
     }
 
     /**

--- a/paimon-core/src/main/java/org/apache/paimon/table/format/FormatReadBuilder.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/format/FormatReadBuilder.java
@@ -25,6 +25,7 @@ import org.apache.paimon.data.InternalRow;
 import org.apache.paimon.format.FileFormatDiscover;
 import org.apache.paimon.format.FormatReaderContext;
 import org.apache.paimon.format.FormatReaderFactory;
+import org.apache.paimon.fs.FileIO;
 import org.apache.paimon.io.DataFileRecordReader;
 import org.apache.paimon.mergetree.compact.ConcatRecordReader;
 import org.apache.paimon.options.CatalogOptions;
@@ -78,6 +79,7 @@ public class FormatReadBuilder implements ReadBuilder {
     @Nullable private Predicate filter;
     @Nullable private PartitionPredicate partitionFilter;
     @Nullable private Integer limit;
+    @Nullable private transient FormatTableFileIOResolver fileIOResolver;
 
     public FormatReadBuilder(FormatTable table) {
         this.table = table;
@@ -204,11 +206,13 @@ public class FormatReadBuilder implements ReadBuilder {
                         table.partitionKeys(), readType().getFields(), table.partitionType());
 
         BinaryRow partition = dataSplit.partition();
+        FileIO fileIO = fileIOResolver().fileIO(dataSplit.useCatalogContextFileIO());
         List<ReaderSupplier<InternalRow>> suppliers = new ArrayList<>();
         for (FormatDataSplit.FileMeta file : dataSplit.files()) {
             suppliers.add(
                     () ->
                             createFileReader(
+                                    fileIO,
                                     file,
                                     partition,
                                     readerFactory,
@@ -219,6 +223,7 @@ public class FormatReadBuilder implements ReadBuilder {
     }
 
     private RecordReader<InternalRow> createFileReader(
+            FileIO fileIO,
             FormatDataSplit.FileMeta file,
             @Nullable BinaryRow partition,
             FormatReaderFactory readerFactory,
@@ -227,7 +232,7 @@ public class FormatReadBuilder implements ReadBuilder {
             throws IOException {
         FormatReaderContext formatReaderContext =
                 new FormatReaderContext(
-                        table.fileIO(), file.filePath(), file.fileSize(), null, readBatchSizer);
+                        fileIO, file.filePath(), file.fileSize(), null, readBatchSizer);
         try {
             FileRecordReader<InternalRow> reader;
             Long length = file.length();
@@ -269,6 +274,13 @@ public class FormatReadBuilder implements ReadBuilder {
                 rowType.getFieldNames().stream()
                         .filter(name -> !partitionKeys.contains(name))
                         .collect(Collectors.toList()));
+    }
+
+    private synchronized FormatTableFileIOResolver fileIOResolver() {
+        if (fileIOResolver == null) {
+            fileIOResolver = new FormatTableFileIOResolver(table);
+        }
+        return fileIOResolver;
     }
 
     // ===================== Unsupported ===============================

--- a/paimon-core/src/main/java/org/apache/paimon/table/format/FormatTableCommit.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/format/FormatTableCommit.java
@@ -63,12 +63,14 @@ import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Consumer;
 import java.util.function.Function;
+import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
 import static org.apache.paimon.table.format.FormatBatchWriteBuilder.validateStaticPartition;
@@ -94,6 +96,7 @@ public class FormatTableCommit implements BatchTableCommit {
     protected boolean overwrite = false;
     private Catalog hiveCatalog;
     private Identifier tableIdentifier;
+    private final CatalogContext catalogContext;
     @Nullable private final FormatTablePartitionManager partitionManager;
     private final boolean dynamicPartitionOverwrite;
     private final int cleanupThreadNum;
@@ -165,6 +168,7 @@ public class FormatTableCommit implements BatchTableCommit {
         this.overwrite = overwrite;
         this.partitionKeys = partitionKeys;
         this.tableIdentifier = tableIdentifier;
+        this.catalogContext = catalogContext;
         this.partitionManager = partitionManager;
         this.dynamicPartitionOverwrite = dynamicPartitionOverwrite;
         this.cleanupThreadNum = cleanupThreadNum;
@@ -202,6 +206,8 @@ public class FormatTableCommit implements BatchTableCommit {
                                     + commitMessage.getClass().getName());
                 }
             }
+
+            List<Partition> validatedPartitions = rejectWritesToCustomLocationPartitions(messages);
 
             Set<Map<String, String>> partitionSpecs = new HashSet<>();
             Set<Path> clearedPartitionPaths = new HashSet<>();
@@ -243,7 +249,10 @@ public class FormatTableCommit implements BatchTableCommit {
                     // is everything the table holds rather than the files this commit happens to
                     // write: a statement whose query returns nothing still empties the table.
                     clearedPartitionPaths.addAll(
-                            deletePreviousDataFiles(tableDataDirectories(), 0, cleanupThreadNum));
+                            deletePreviousDataFiles(
+                                    tableDataDirectories(validatedPartitions),
+                                    0,
+                                    cleanupThreadNum));
                 }
             }
             if (overwrite) {
@@ -388,6 +397,136 @@ public class FormatTableCommit implements BatchTableCommit {
         }
     }
 
+    /** Rejects writes whose files would belong to a catalog partition outside the table root. */
+    private List<Partition> rejectWritesToCustomLocationPartitions(
+            List<TwoPhaseCommitMessage> messages) {
+        if (partitionManager == null || partitionKeys == null || partitionKeys.isEmpty()) {
+            return Collections.emptyList();
+        }
+
+        try {
+            return rejectWritesToCustomLocationPartitionsBeforeMutation(messages);
+        } catch (RuntimeException failure) {
+            // Nothing has been published yet. Abort should clean staging only: the target may be
+            // a pre-existing file in a directory owned by another partition.
+            markPublishedTargetsToPreserveOnAbort(messages);
+            throw failure;
+        }
+    }
+
+    private List<Partition> rejectWritesToCustomLocationPartitionsBeforeMutation(
+            List<TwoPhaseCommitMessage> messages) {
+        Predicate<Partition> affectsPartition;
+        boolean hasStaticPrefixWithoutFiles = false;
+        if (overwrite && staticPartitions != null && !staticPartitions.isEmpty()) {
+            LinkedHashMap<String, String> staticSpec = orderedPartitionPrefix(staticPartitions);
+            if (staticSpec.size() == partitionKeys.size()) {
+                affectsPartition = partition -> partition.spec().equals(staticPartitions);
+            } else {
+                affectsPartition =
+                        partition -> partitionSpecMatchesPrefix(partition.spec(), staticSpec);
+            }
+        } else if (overwrite && !replacesOnlyWrittenPartitions()) {
+            affectsPartition = ignored -> true;
+        } else {
+            Set<Map<String, String>> affectedSpecs = new LinkedHashSet<>();
+            for (TwoPhaseCommitMessage message : messages) {
+                Path targetPath = message.getCommitter().targetPath();
+                if (targetPath == null) {
+                    // Preserve the established failure order for a malformed committer. The
+                    // publish or registration path will report its own contract violation.
+                    continue;
+                }
+                affectedSpecs.add(
+                        extractPartitionSpecFromPath(targetPath.getParent(), partitionKeys));
+            }
+            if (!overwrite && staticPartitions != null && !staticPartitions.isEmpty()) {
+                LinkedHashMap<String, String> staticSpec = orderedPartitionPrefix(staticPartitions);
+                if (staticSpec.size() == partitionKeys.size()) {
+                    if (affectedSpecs.isEmpty()) {
+                        affectedSpecs.add(staticPartitions);
+                    }
+                } else {
+                    hasStaticPrefixWithoutFiles = affectedSpecs.isEmpty();
+                }
+            }
+            if (affectedSpecs.isEmpty() && !hasStaticPrefixWithoutFiles) {
+                return Collections.emptyList();
+            }
+            affectsPartition =
+                    affectedSpecs.isEmpty()
+                            ? ignored -> false
+                            : partition -> affectedSpecs.contains(partition.spec());
+        }
+
+        List<Partition> registry = loadPartitionRegistry();
+        List<Partition> affectedPartitions =
+                registry.stream().filter(affectsPartition).collect(Collectors.toList());
+        for (Partition partition : affectedPartitions) {
+            if (FormatTablePartitionPathResolver.customLocation(partition) != null) {
+                throw unsupportedCustomLocation(overwrite ? "Overwriting" : "Writing", partition);
+            }
+        }
+        return registry;
+    }
+
+    private LinkedHashMap<String, String> orderedPartitionPrefix(
+            Map<String, String> partitionSpec) {
+        if (partitionSpec.size() > partitionKeys.size()) {
+            throw new IllegalArgumentException(
+                    String.format(
+                            "Partition spec %s is not a leading prefix of partition keys %s.",
+                            partitionSpec, partitionKeys));
+        }
+        LinkedHashMap<String, String> orderedSpec = new LinkedHashMap<>();
+        for (int i = 0; i < partitionSpec.size(); i++) {
+            String key = partitionKeys.get(i);
+            if (!partitionSpec.containsKey(key)) {
+                throw new IllegalArgumentException(
+                        String.format(
+                                "Partition spec %s is not a leading prefix of partition keys %s.",
+                                partitionSpec, partitionKeys));
+            }
+            orderedSpec.put(key, partitionSpec.get(key));
+        }
+        return orderedSpec;
+    }
+
+    /** Validates every registered path before using it for a write or truncate decision. */
+    private List<Partition> loadPartitionRegistry() {
+        List<Partition> partitions = partitionManager.listPartitions(Collections.emptyMap(), null);
+        FormatTablePartitionRegistryValidator.validatePartitionLocations(
+                partitions,
+                partitionKeys,
+                new Path(location),
+                tableIdentifier.getFullName(),
+                formatTablePartitionOnlyValueInPath,
+                catalogContext);
+        return partitions;
+    }
+
+    private static boolean partitionSpecMatchesPrefix(
+            Map<String, String> partitionSpec, Map<String, String> prefix) {
+        for (Map.Entry<String, String> entry : prefix.entrySet()) {
+            if (!partitionSpec.containsKey(entry.getKey())
+                    || !Objects.equals(entry.getValue(), partitionSpec.get(entry.getKey()))) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private UnsupportedOperationException unsupportedCustomLocation(
+            String operation, Partition partition) {
+        return new UnsupportedOperationException(
+                String.format(
+                        "%s catalog-managed Format Table partition %s with custom location "
+                                + "'%s' is not supported.",
+                        operation,
+                        partition.spec(),
+                        FormatTablePartitionPathResolver.customLocation(partition)));
+    }
+
     private List<Void> publishMessage(TwoPhaseCommitMessage message) {
         try {
             message.getCommitter().commit(fileIO);
@@ -436,7 +575,8 @@ public class FormatTableCommit implements BatchTableCommit {
                 new ArrayList<>(specs),
                 true,
                 new ArrayList<>(statisticsByPartition.values()),
-                replaceStatistics);
+                replaceStatistics,
+                null);
     }
 
     /** What one commit wrote into a partition, with one more of its files folded in. */
@@ -674,17 +814,17 @@ public class FormatTableCommit implements BatchTableCommit {
      * has not registered, or one whose name does not parse into the partition keys - and replacing
      * what the table holds leaves it alone, the way {@link #truncateTable()} does.
      */
-    private List<Path> tableDataDirectories() {
+    private List<Path> tableDataDirectories(List<Partition> validatedPartitions) {
         if (partitionKeys == null || partitionKeys.isEmpty()) {
             return Collections.singletonList(new Path(location));
         }
         List<Path> directories = new ArrayList<>();
         if (partitionManager != null) {
-            for (Map<String, String> spec : registeredPartitions(Collections.emptyMap())) {
+            for (Partition partition : validatedPartitions) {
                 directories.add(
                         buildPartitionPath(
                                 location,
-                                spec,
+                                partition.spec(),
                                 formatTablePartitionOnlyValueInPath,
                                 partitionKeys));
             }
@@ -1070,7 +1210,13 @@ public class FormatTableCommit implements BatchTableCommit {
         // Emptying the table is emptying every partition it has, and which those are is answered
         // by whatever the table reads its partitions from.
         if (partitionManager != null) {
-            truncate(registeredPartitions(Collections.emptyMap()));
+            List<Partition> partitions = loadPartitionRegistry();
+            for (Partition partition : partitions) {
+                if (FormatTablePartitionPathResolver.customLocation(partition) != null) {
+                    throw unsupportedCustomLocation("Truncating", partition);
+                }
+            }
+            truncate(partitions.stream().map(Partition::spec).collect(Collectors.toList()));
             return;
         }
         // Filesystem partition discovery: the partition directories the scan reads are the table.
@@ -1091,45 +1237,47 @@ public class FormatTableCommit implements BatchTableCommit {
 
     @Override
     public void truncatePartitions(List<Map<String, String>> partitionSpecs) {
-        if (partitionManager == null) {
-            truncate(partitionSpecs);
+        if (partitionSpecs.isEmpty()) {
             return;
         }
-        // Complete specs are asked for in one request; only a prefix has to be listed on its own.
-        List<Map<String, String>> complete = new ArrayList<>();
+        List<Map<String, String>> normalizedSpecs = new ArrayList<>(partitionSpecs.size());
         for (Map<String, String> partitionSpec : partitionSpecs) {
-            if (partitionSpec.size() == partitionKeys.size()) {
-                complete.add(partitionSpec);
+            normalizedSpecs.add(orderedPartitionPrefix(partitionSpec));
+        }
+        if (partitionManager == null) {
+            truncate(normalizedSpecs);
+            return;
+        }
+        List<Partition> registry = loadPartitionRegistry();
+        Map<Map<String, String>, Partition> partitions =
+                selectRequestedPartitions(registry, normalizedSpecs);
+        for (Partition partition : partitions.values()) {
+            if (FormatTablePartitionPathResolver.customLocation(partition) != null) {
+                throw unsupportedCustomLocation("Truncating", partition);
             }
         }
-        Set<Map<String, String>> registered =
-                complete.isEmpty()
-                        ? Collections.emptySet()
-                        : partitionManager.listPartitionsByNames(complete).stream()
-                                .map(Partition::spec)
-                                .collect(Collectors.toSet());
-        List<Map<String, String>> partitions = new ArrayList<>();
-        for (Map<String, String> partitionSpec : partitionSpecs) {
-            if (partitionSpec.size() == partitionKeys.size()) {
-                if (registered.contains(partitionSpec)) {
-                    partitions.add(partitionSpec);
-                }
-            } else {
-                partitions.addAll(registeredPartitions(partitionSpec));
-            }
-        }
-        truncate(partitions);
+        truncate(partitions.values().stream().map(Partition::spec).collect(Collectors.toList()));
     }
 
-    /**
-     * The registered partitions named by {@code prefix}, which names only the leading partition
-     * keys, or none of them. The catalog says which partitions a catalog-managed table has, so
-     * truncating neither empties nor registers a directory still waiting for MSCK REPAIR TABLE.
-     */
-    private List<Map<String, String>> registeredPartitions(Map<String, String> prefix) {
-        return partitionManager.listPartitions(prefix, null).stream()
-                .map(Partition::spec)
-                .collect(Collectors.toList());
+    private Map<Map<String, String>, Partition> selectRequestedPartitions(
+            List<Partition> registry, List<Map<String, String>> partitionSpecs) {
+        Map<Map<String, String>, Partition> selected = new LinkedHashMap<>();
+        Set<Map<String, String>> requestedPrefixes = new HashSet<>(partitionSpecs);
+        for (Partition partition : registry) {
+            if (requestedPrefixes.contains(Collections.emptyMap())) {
+                selected.putIfAbsent(partition.spec(), partition);
+                continue;
+            }
+            LinkedHashMap<String, String> registeredPrefix = new LinkedHashMap<>();
+            for (String partitionKey : partitionKeys) {
+                registeredPrefix.put(partitionKey, partition.spec().get(partitionKey));
+                if (requestedPrefixes.contains(registeredPrefix)) {
+                    selected.putIfAbsent(partition.spec(), partition);
+                    break;
+                }
+            }
+        }
+        return selected;
     }
 
     private void truncate(List<Map<String, String>> partitionSpecs) {

--- a/paimon-core/src/main/java/org/apache/paimon/table/format/FormatTableFileIOResolver.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/format/FormatTableFileIOResolver.java
@@ -1,0 +1,87 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.table.format;
+
+import org.apache.paimon.catalog.CatalogContext;
+import org.apache.paimon.fs.FileIO;
+import org.apache.paimon.fs.Path;
+import org.apache.paimon.fs.ResolvingFileIO;
+import org.apache.paimon.table.FormatTable;
+
+import javax.annotation.Nullable;
+
+import java.io.IOException;
+
+/**
+ * Uses the table FileIO under the table root and the catalog-context FileIO outside it. The choice
+ * comes from the registered partition path, not a listed file URI.
+ */
+final class FormatTableFileIOResolver {
+
+    private final Path tableRoot;
+    private final FileIO tableFileIO;
+    @Nullable private final CatalogContext catalogContext;
+    @Nullable private transient volatile ResolvingFileIO catalogContextFileIO;
+
+    FormatTableFileIOResolver(FormatTable table) {
+        this.tableRoot = new Path(table.location());
+        this.tableFileIO = table.fileIO();
+        this.catalogContext = table.catalogContext();
+    }
+
+    boolean useCatalogContextFileIO(Path partitionPath) {
+        return !FormatTablePartitionPathResolver.isWithin(partitionPath, tableRoot, catalogContext);
+    }
+
+    /**
+     * Resolves an external filesystem on the caller thread before parallel listing starts. The
+     * underlying resolver caches the result by scheme and authority.
+     */
+    void prepare(Path path, boolean useCatalogContextFileIO) throws IOException {
+        if (useCatalogContextFileIO) {
+            catalogContextFileIO().fileIO(path);
+        } else {
+            tableFileIO.exists(tableRoot);
+        }
+    }
+
+    FileIO fileIO(boolean useCatalogContextFileIO) {
+        return useCatalogContextFileIO ? catalogContextFileIO() : tableFileIO;
+    }
+
+    private ResolvingFileIO catalogContextFileIO() {
+        ResolvingFileIO result = catalogContextFileIO;
+        if (result != null) {
+            return result;
+        }
+        synchronized (this) {
+            result = catalogContextFileIO;
+            if (result == null) {
+                if (catalogContext == null) {
+                    throw new IllegalStateException(
+                            "A CatalogContext is required to access a Format Table partition outside the table root.");
+                }
+                result = new ResolvingFileIO();
+                result.configure(catalogContext);
+                catalogContextFileIO = result;
+            }
+            return result;
+        }
+    }
+}

--- a/paimon-core/src/main/java/org/apache/paimon/table/format/FormatTablePartitionManager.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/format/FormatTablePartitionManager.java
@@ -66,7 +66,7 @@ public interface FormatTablePartitionManager extends Serializable {
      * whole batch is rejected when any partition already exists, so such a request is never split.
      */
     default void createPartitions(List<Map<String, String>> partitions, boolean ignoreIfExists) {
-        createPartitions(partitions, ignoreIfExists, null, false);
+        createPartitions(partitions, ignoreIfExists, null, false, null);
     }
 
     /**
@@ -78,7 +78,7 @@ public interface FormatTablePartitionManager extends Serializable {
      * holds or add to it, and is ignored when {@code statistics} is null. A field reported as
      * unknown says nothing about itself and leaves the stored one as it was, so a measurement that
      * could not take a number does not erase the last one that could. Reporting never unregisters a
-     * partition.
+     * partition. {@code partitionOptions}, when present, align with {@code partitions} by position.
      *
      * <p>This is the method an implementation provides, so that none can report nothing by
      * accident: a decorator that forwards only the two-argument form would otherwise drop every
@@ -88,7 +88,8 @@ public interface FormatTablePartitionManager extends Serializable {
             List<Map<String, String>> partitions,
             boolean ignoreIfExists,
             @Nullable List<PartitionStatistics> statistics,
-            boolean replaceStatistics);
+            boolean replaceStatistics,
+            @Nullable List<Map<String, String>> partitionOptions);
 
     /** Unregister partitions. Metadata only; missing partitions are ignored. */
     void dropPartitions(List<Map<String, String>> partitions);

--- a/paimon-core/src/main/java/org/apache/paimon/table/format/FormatTablePartitionPathResolver.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/format/FormatTablePartitionPathResolver.java
@@ -1,0 +1,507 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.table.format;
+
+import org.apache.paimon.CoreOptions;
+import org.apache.paimon.catalog.CatalogContext;
+import org.apache.paimon.fs.Path;
+import org.apache.paimon.partition.Partition;
+import org.apache.paimon.utils.PartitionPathUtils;
+
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.net.NetUtils;
+
+import javax.annotation.Nullable;
+
+import java.io.ByteArrayOutputStream;
+import java.net.URI;
+import java.nio.ByteBuffer;
+import java.nio.charset.CharacterCodingException;
+import java.nio.charset.CodingErrorAction;
+import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Objects;
+
+/** Resolves and validates catalog-managed Format Table partition locations. */
+public final class FormatTablePartitionPathResolver {
+
+    private final Path tablePath;
+    private final String tableName;
+    private final boolean onlyValueInPath;
+    @Nullable private final CatalogContext catalogContext;
+    private final Map<Map<String, String>, String> pathsBySpec = new LinkedHashMap<>();
+    private final Map<String, OwnershipNode> ownershipRoots = new HashMap<>();
+
+    FormatTablePartitionPathResolver(Path tablePath, String tableName, boolean onlyValueInPath) {
+        this(tablePath, tableName, onlyValueInPath, null);
+    }
+
+    FormatTablePartitionPathResolver(
+            Path tablePath,
+            String tableName,
+            boolean onlyValueInPath,
+            @Nullable CatalogContext catalogContext) {
+        this.tablePath = tablePath;
+        this.tableName = tableName;
+        this.onlyValueInPath = onlyValueInPath;
+        this.catalogContext = catalogContext;
+    }
+
+    @Nullable
+    static String customLocation(Partition partition) {
+        Map<String, String> options = partition.options();
+        if (options == null || !options.containsKey(CoreOptions.PATH.key())) {
+            return null;
+        }
+        String location = options.get(CoreOptions.PATH.key());
+        if (location == null) {
+            throw new IllegalStateException("Partition path option must not be null.");
+        }
+        return location;
+    }
+
+    Path resolve(LinkedHashMap<String, String> spec, @Nullable String customLocation) {
+        Path defaultPath =
+                new Path(
+                        tablePath,
+                        PartitionPathUtils.generatePartitionPathUtil(spec, onlyValueInPath));
+        if (customLocation == null) {
+            return defaultPath;
+        }
+
+        try {
+            return resolveCustomLocation(
+                    tablePath, spec, onlyValueInPath, customLocation, catalogContext);
+        } catch (IllegalArgumentException e) {
+            throw invalidLocation(spec, e);
+        }
+    }
+
+    /** Resolves a custom location using the catalog's Hadoop filesystem identity. */
+    public static Path resolveCustomLocation(
+            Path tablePath,
+            LinkedHashMap<String, String> spec,
+            boolean onlyValueInPath,
+            String customLocation,
+            @Nullable CatalogContext catalogContext) {
+        PartitionPathUtils.validatePartitionSpecForPath(spec, onlyValueInPath);
+        Path customPath = canonicalizeCustomLocation(customLocation, catalogContext);
+        if (usesViewFileSystem(tablePath) || usesViewFileSystem(customPath)) {
+            throw new IllegalArgumentException(
+                    "Custom ViewFS partition locations require mount-table identity resolution.");
+        }
+        if (overlaps(customPath, tablePath, catalogContext)) {
+            throw new IllegalArgumentException("Custom partition location overlaps table data.");
+        }
+        return customPath;
+    }
+
+    /**
+     * Records a resolved path. Returns false for a repeated identical spec and path; callers skip
+     * that entry so duplicate catalog rows do not produce duplicate data.
+     */
+    boolean validateAndRecord(LinkedHashMap<String, String> spec, Path path) {
+        ResolvedPath resolved = ResolvedPath.of(path, catalogContext);
+        String previousForSpec = pathsBySpec.get(spec);
+        if (previousForSpec != null) {
+            if (previousForSpec.equals(path.toString())) {
+                return false;
+            }
+            throw overlappingLocations();
+        }
+
+        if (overlapsOwnedPath(resolved)) {
+            throw overlappingLocations();
+        }
+        pathsBySpec.put(new LinkedHashMap<>(spec), path.toString());
+        return true;
+    }
+
+    private boolean overlapsOwnedPath(ResolvedPath path) {
+        OwnershipNode node =
+                ownershipRoots.computeIfAbsent(path.fileSystem, ignored -> new OwnershipNode());
+        String[] segments = path.pathSegments();
+        for (String segment : segments) {
+            // A terminal node reached before the candidate ends is an existing ancestor.
+            if (node.owned) {
+                return true;
+            }
+            node = node.children.computeIfAbsent(segment, ignored -> new OwnershipNode());
+        }
+        // A terminal final node is equality. Children below it make the candidate an ancestor.
+        if (node.owned || !node.children.isEmpty()) {
+            return true;
+        }
+        node.owned = true;
+        return false;
+    }
+
+    /** Canonicalizes a custom location using the catalog's Hadoop configuration when present. */
+    public static Path canonicalizeCustomLocation(
+            String location, @Nullable CatalogContext catalogContext) {
+        try {
+            validateDecodedLocation(location);
+            String decoded = decodePercentOnce(location);
+            if (decoded.contains("%")) {
+                throw new IllegalArgumentException("Invalid custom partition location.");
+            }
+            validateDecodedLocation(decoded);
+
+            Path path = new Path(decoded);
+            URI uri = path.toUri();
+            String scheme = uri.getScheme();
+            String authority = uri.getAuthority();
+            String uriPath = uri.getPath();
+            if (scheme == null
+                    || scheme.isEmpty()
+                    || (uri.getUserInfo() != null && !isAbfsAuthority(uri))
+                    || uriPath == null
+                    || !uriPath.startsWith(Path.SEPARATOR)
+                    || uriPath.equals(Path.SEPARATOR)) {
+                throw new IllegalArgumentException("Invalid custom partition location.");
+            }
+
+            scheme = scheme.toLowerCase(Locale.ROOT);
+            if ((scheme.equals("file") && authority != null && !authority.isEmpty())
+                    || (!scheme.equals("file")
+                            && !scheme.equals("hdfs")
+                            && (authority == null || authority.isEmpty()))) {
+                throw new IllegalArgumentException("Invalid custom partition location.");
+            }
+            authority =
+                    authority == null || authority.isEmpty()
+                            ? null
+                            : authority.toLowerCase(Locale.ROOT);
+            Path canonical = new Path(scheme, authority, uriPath);
+            return scheme.equals("hdfs")
+                    ? canonicalizeHdfsPath(canonical, catalogContext)
+                    : canonical;
+        } catch (IllegalArgumentException e) {
+            throw e;
+        } catch (RuntimeException e) {
+            throw new IllegalArgumentException("Invalid custom partition location.", e);
+        }
+    }
+
+    private static boolean isAbfsAuthority(URI uri) {
+        String scheme = uri.getScheme();
+        String userInfo = uri.getUserInfo();
+        return scheme != null
+                && (scheme.equalsIgnoreCase("abfs") || scheme.equalsIgnoreCase("abfss"))
+                && userInfo != null
+                && !userInfo.isEmpty()
+                && userInfo.indexOf(':') < 0
+                && uri.getHost() != null;
+    }
+
+    private static boolean usesViewFileSystem(Path path) {
+        String scheme = path.toUri().getScheme();
+        return scheme != null && scheme.equalsIgnoreCase("viewfs");
+    }
+
+    private static Path canonicalizeHdfsPath(Path path, @Nullable CatalogContext catalogContext) {
+        URI canonicalUri = canonicalHdfsUri(path.toUri(), catalogContext);
+        if (canonicalUri.getAuthority() == null) {
+            throw new IllegalArgumentException(
+                    "Authorityless HDFS location requires an HDFS default filesystem.");
+        }
+        return new Path("hdfs", canonicalUri.getAuthority(), path.toUri().getPath());
+    }
+
+    private static URI canonicalHdfsUri(URI uri, @Nullable CatalogContext catalogContext) {
+        URI resolved = uri;
+        if (resolved.getAuthority() == null && catalogContext != null) {
+            URI defaultUri = FileSystem.getDefaultUri(catalogContext.hadoopConf());
+            if ("hdfs".equalsIgnoreCase(defaultUri.getScheme())
+                    && defaultUri.getAuthority() != null) {
+                resolved = defaultUri;
+            }
+        }
+        if (resolved.getAuthority() == null) {
+            return resolved;
+        }
+        String logicalNameservice = logicalHdfsNameservice(resolved, catalogContext);
+        if (logicalNameservice != null) {
+            return new Path("hdfs", logicalNameservice, "/").toUri();
+        }
+        URI physical = NetUtils.getCanonicalUri(resolved, 8020);
+        return new Path("hdfs", physical.getAuthority().toLowerCase(Locale.ROOT), Path.SEPARATOR)
+                .toUri();
+    }
+
+    @Nullable
+    private static String logicalHdfsNameservice(URI uri, @Nullable CatalogContext catalogContext) {
+        if (catalogContext == null || uri.getHost() == null) {
+            return null;
+        }
+        String nameservices = catalogContext.hadoopConf().get("dfs.nameservices", "");
+        String requestedAuthority = canonicalHdfsAuthority(uri);
+        String match = null;
+        for (String name : nameservices.split(",")) {
+            String nameservice = name.trim();
+            if (nameservice.isEmpty()) {
+                continue;
+            }
+            boolean matches =
+                    nameservice.equalsIgnoreCase(uri.getHost())
+                            || matchesConfiguredHdfsAddress(
+                                    requestedAuthority,
+                                    catalogContext
+                                            .hadoopConf()
+                                            .get("dfs.namenode.rpc-address." + nameservice));
+            String namenodes =
+                    catalogContext.hadoopConf().get("dfs.ha.namenodes." + nameservice, "");
+            for (String node : namenodes.split(",")) {
+                String nodeId = node.trim();
+                if (nodeId.isEmpty()) {
+                    continue;
+                }
+                String address =
+                        catalogContext
+                                .hadoopConf()
+                                .get("dfs.namenode.rpc-address." + nameservice + "." + nodeId);
+                if (address == null || address.trim().isEmpty()) {
+                    continue;
+                }
+                if (matchesConfiguredHdfsAddress(requestedAuthority, address)) {
+                    matches = true;
+                }
+            }
+            if (matches) {
+                if (match != null && !match.equals(nameservice)) {
+                    throw new IllegalArgumentException(
+                            "HDFS authority belongs to multiple logical nameservices.");
+                }
+                match = nameservice;
+            }
+        }
+        return match;
+    }
+
+    private static boolean matchesConfiguredHdfsAddress(
+            String requestedAuthority, @Nullable String address) {
+        if (address == null || address.trim().isEmpty()) {
+            return false;
+        }
+        URI member = URI.create("hdfs://" + address.trim());
+        return requestedAuthority.equals(canonicalHdfsAuthority(member));
+    }
+
+    private static String canonicalHdfsAuthority(URI uri) {
+        return NetUtils.getCanonicalUri(uri, 8020).getAuthority().toLowerCase(Locale.ROOT);
+    }
+
+    private static void validateDecodedLocation(String location) {
+        if (location == null
+                || location.isEmpty()
+                || isBoundaryWhitespace(location)
+                || location.contains("?")
+                || location.contains("#")
+                || location.contains("\\")) {
+            throw new IllegalArgumentException("Invalid custom partition location.");
+        }
+
+        for (int offset = 0; offset < location.length(); ) {
+            int codePoint = location.codePointAt(offset);
+            if (Character.isISOControl(codePoint)) {
+                throw new IllegalArgumentException("Invalid custom partition location.");
+            }
+            offset += Character.charCount(codePoint);
+        }
+
+        for (String segment : location.split(Path.SEPARATOR, -1)) {
+            if (segment.equals(Path.CUR_DIR) || segment.equals("..")) {
+                throw new IllegalArgumentException("Invalid custom partition location.");
+            }
+        }
+    }
+
+    private static boolean isBoundaryWhitespace(String value) {
+        int first = value.codePointAt(0);
+        int last = value.codePointBefore(value.length());
+        return isWhitespace(first) || isWhitespace(last);
+    }
+
+    private static boolean isWhitespace(int codePoint) {
+        return Character.isWhitespace(codePoint) || Character.isSpaceChar(codePoint);
+    }
+
+    private static String decodePercentOnce(String value) {
+        StringBuilder decoded = new StringBuilder(value.length());
+        for (int offset = 0; offset < value.length(); ) {
+            char current = value.charAt(offset);
+            if (current != '%') {
+                decoded.append(current);
+                offset++;
+                continue;
+            }
+
+            ByteArrayOutputStream bytes = new ByteArrayOutputStream();
+            while (offset < value.length() && value.charAt(offset) == '%') {
+                if (offset + 2 >= value.length()) {
+                    throw new IllegalArgumentException("Invalid percent encoding in location.");
+                }
+                int high = Character.digit(value.charAt(offset + 1), 16);
+                int low = Character.digit(value.charAt(offset + 2), 16);
+                if (high < 0 || low < 0) {
+                    throw new IllegalArgumentException("Invalid percent encoding in location.");
+                }
+                bytes.write((high << 4) + low);
+                offset += 3;
+            }
+            try {
+                decoded.append(
+                        StandardCharsets.UTF_8
+                                .newDecoder()
+                                .onMalformedInput(CodingErrorAction.REPORT)
+                                .onUnmappableCharacter(CodingErrorAction.REPORT)
+                                .decode(ByteBuffer.wrap(bytes.toByteArray())));
+            } catch (CharacterCodingException e) {
+                throw new IllegalArgumentException("Invalid percent encoding in location.", e);
+            }
+        }
+        return decoded.toString();
+    }
+
+    static boolean isWithin(Path candidate, Path root) {
+        return isWithin(candidate, root, null);
+    }
+
+    static boolean isWithin(Path candidate, Path root, @Nullable CatalogContext catalogContext) {
+        ResolvedPath candidatePath = ResolvedPath.of(candidate, catalogContext);
+        ResolvedPath rootPath = ResolvedPath.of(root, catalogContext);
+        return rootPath.equals(candidatePath) || rootPath.isAncestorOf(candidatePath);
+    }
+
+    private static boolean overlaps(
+            Path left, Path right, @Nullable CatalogContext catalogContext) {
+        ResolvedPath resolvedLeft = ResolvedPath.of(left, catalogContext);
+        ResolvedPath resolvedRight = ResolvedPath.of(right, catalogContext);
+        return resolvedLeft.equals(resolvedRight)
+                || resolvedLeft.isAncestorOf(resolvedRight)
+                || resolvedRight.isAncestorOf(resolvedLeft);
+    }
+
+    private IllegalStateException invalidLocation(
+            Map<String, String> spec, IllegalArgumentException cause) {
+        return new IllegalStateException(
+                String.format(
+                        "Catalog returned an invalid custom location for partition %s of Format Table %s.",
+                        spec, tableName),
+                cause);
+    }
+
+    private IllegalStateException overlappingLocations() {
+        return new IllegalStateException(
+                String.format(
+                        "Catalog returned overlapping locations for different partitions of Format Table %s.",
+                        tableName));
+    }
+
+    /**
+     * One trie is maintained per filesystem. Visiting each path segment once is sufficient:
+     * ancestors are terminal nodes on the route, equality is the terminal node at the route's end,
+     * and descendants are children below that node.
+     */
+    private static final class OwnershipNode {
+
+        private final Map<String, OwnershipNode> children = new HashMap<>();
+        private boolean owned;
+    }
+
+    private static final class ResolvedPath {
+
+        private final String fileSystem;
+        private final String path;
+
+        private ResolvedPath(String fileSystem, String path) {
+            this.fileSystem = fileSystem;
+            this.path = path;
+        }
+
+        private static ResolvedPath of(Path path, @Nullable CatalogContext catalogContext) {
+            URI uri = path.toUri().normalize();
+            String scheme = canonicalFileSystemScheme(uri.getScheme());
+            URI fileSystemUri = scheme.equals("hdfs") ? canonicalHdfsUri(uri, catalogContext) : uri;
+            String authority = fileSystemUri.getAuthority();
+            authority = authority == null ? "" : authority.toLowerCase(Locale.ROOT);
+            String normalizedPath = trimTrailingSeparators(uri.getPath());
+            return new ResolvedPath(scheme + "://" + authority, normalizedPath);
+        }
+
+        private static String canonicalFileSystemScheme(@Nullable String scheme) {
+            // An absolute path without a scheme and file:/ name the same local filesystem.
+            if (scheme == null) {
+                return "file";
+            }
+            String normalized = scheme.toLowerCase(Locale.ROOT);
+            // These aliases address the same storage namespaces with different clients or
+            // transport settings and therefore cannot establish separate ownership boundaries.
+            if (normalized.equals("abfss")) {
+                return "abfs";
+            }
+            if (normalized.equals("s3a") || normalized.equals("s3n")) {
+                return "s3";
+            }
+            return normalized;
+        }
+
+        private boolean isAncestorOf(ResolvedPath other) {
+            if (!fileSystem.equals(other.fileSystem) || path.equals(other.path)) {
+                return false;
+            }
+            if (path.equals(Path.SEPARATOR)) {
+                return other.path.startsWith(Path.SEPARATOR);
+            }
+            return other.path.startsWith(path + Path.SEPARATOR);
+        }
+
+        private String[] pathSegments() {
+            return path.substring(1).split(Path.SEPARATOR, -1);
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
+            ResolvedPath that = (ResolvedPath) o;
+            return fileSystem.equals(that.fileSystem) && path.equals(that.path);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(fileSystem, path);
+        }
+
+        private static String trimTrailingSeparators(String path) {
+            int end = path.length();
+            while (end > 1 && path.charAt(end - 1) == Path.SEPARATOR_CHAR) {
+                end--;
+            }
+            return path.substring(0, end);
+        }
+    }
+}

--- a/paimon-core/src/main/java/org/apache/paimon/table/format/FormatTablePartitionRegistryValidator.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/format/FormatTablePartitionRegistryValidator.java
@@ -1,0 +1,67 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.table.format;
+
+import org.apache.paimon.catalog.CatalogContext;
+import org.apache.paimon.fs.Path;
+import org.apache.paimon.partition.Partition;
+
+import javax.annotation.Nullable;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+/** Rejects incomplete specs and partition locations that resolve to the same or nested paths. */
+public final class FormatTablePartitionRegistryValidator {
+
+    private FormatTablePartitionRegistryValidator() {}
+
+    public static void validatePartitionLocations(
+            List<Partition> partitions,
+            List<String> partitionKeys,
+            Path tablePath,
+            String tableName,
+            boolean onlyValueInPath,
+            @Nullable CatalogContext catalogContext) {
+        FormatTablePartitionPathResolver resolver =
+                new FormatTablePartitionPathResolver(
+                        tablePath, tableName, onlyValueInPath, catalogContext);
+        for (Partition partition : partitions) {
+            Map<String, String> spec = partition.spec();
+            if (spec == null
+                    || spec.size() != partitionKeys.size()
+                    || !spec.keySet().containsAll(partitionKeys)) {
+                throw new IllegalStateException(
+                        String.format(
+                                "Catalog returned incomplete partition spec %s for Format Table %s.",
+                                spec, tableName));
+            }
+            LinkedHashMap<String, String> orderedSpec = new LinkedHashMap<>();
+            for (String partitionKey : partitionKeys) {
+                orderedSpec.put(partitionKey, spec.get(partitionKey));
+            }
+            Path resolved =
+                    resolver.resolve(
+                            orderedSpec,
+                            FormatTablePartitionPathResolver.customLocation(partition));
+            resolver.validateAndRecord(orderedSpec, resolved);
+        }
+    }
+}

--- a/paimon-core/src/main/java/org/apache/paimon/table/format/SplitEnumerator.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/format/SplitEnumerator.java
@@ -145,6 +145,15 @@ abstract class SplitEnumerator {
 
     List<Split> createSplits(FileIO fileIO, Path path, @Nullable BinaryRow partition)
             throws IOException {
+        return createSplits(fileIO, path, partition, false);
+    }
+
+    List<Split> createSplits(
+            FileIO fileIO,
+            Path path,
+            @Nullable BinaryRow partition,
+            boolean useCatalogContextFileIO)
+            throws IOException {
         List<FormatDataSplit.FileMeta> segments = new ArrayList<>();
         // The listed directory is a single partition, or the table itself when unpartitioned.
         List<FileStatus> files = FormatTableScan.listDataFiles(fileIO, path);
@@ -159,7 +168,7 @@ abstract class SplitEnumerator {
                         segments,
                         file -> Math.max(file.readSize(), openFileCost),
                         targetSplitSize)) {
-            splits.add(new FormatDataSplit(bin, partition));
+            splits.add(new FormatDataSplit(bin, partition, useCatalogContextFileIO));
         }
         return splits;
     }

--- a/paimon-core/src/test/java/org/apache/paimon/catalog/CachingCatalogTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/catalog/CachingCatalogTest.java
@@ -364,7 +364,7 @@ class CachingCatalogTest extends CatalogTestBase {
         when(wrapped.listPartitions(identifier)).thenReturn(emptyList(), singletonList(created));
 
         assertThat(catalog.listPartitions(identifier)).isEmpty();
-        catalog.createPartitions(identifier, singletonList(spec), false, null, false);
+        catalog.createPartitions(identifier, singletonList(spec), false, null, false, null);
 
         assertThat(catalog.listPartitions(identifier)).containsExactly(created);
     }
@@ -383,12 +383,37 @@ class CachingCatalogTest extends CatalogTestBase {
         when(wrapped.listPartitions(identifier)).thenReturn(emptyList(), singletonList(created));
 
         assertThat(catalog.listPartitions(identifier)).isEmpty();
-        catalog.createPartitions(identifier, singletonList(spec), true, statistics, false);
+        catalog.createPartitions(identifier, singletonList(spec), true, statistics, false, null);
 
         // Dropping the forward would leave the statistics unreported and nothing else would say so.
         Mockito.verify(wrapped)
-                .createPartitions(identifier, singletonList(spec), true, statistics, false);
+                .createPartitions(identifier, singletonList(spec), true, statistics, false, null);
         // A report changes what a partition holds, so the cached listing is stale after it.
+        assertThat(catalog.listPartitions(identifier)).containsExactly(created);
+    }
+
+    @Test
+    public void testCreatePartitionsWithOptionsForwardsAndInvalidatesPartitionCache()
+            throws Exception {
+        Catalog wrapped = Mockito.mock(Catalog.class);
+        TestableCachingCatalog catalog =
+                new TestableCachingCatalog(wrapped, EXPIRATION_TTL, ticker);
+        Identifier identifier = new Identifier("db", "tbl");
+        Map<String, String> spec = singletonMap("dt", "20260717");
+        Map<String, String> options = new HashMap<>();
+        options.put(CoreOptions.PATH.key(), "file:/archive/dt=20260717");
+        options.put("owner", "data-platform");
+        List<Map<String, String>> partitionOptions = singletonList(options);
+        Partition created = new Partition(spec, 0, 0, 0, 0, -1, false);
+        when(wrapped.listPartitions(identifier)).thenReturn(emptyList(), singletonList(created));
+
+        assertThat(catalog.listPartitions(identifier)).isEmpty();
+        catalog.createPartitions(
+                identifier, singletonList(spec), true, null, false, partitionOptions);
+
+        Mockito.verify(wrapped)
+                .createPartitions(
+                        identifier, singletonList(spec), true, null, false, partitionOptions);
         assertThat(catalog.listPartitions(identifier)).containsExactly(created);
     }
 

--- a/paimon-core/src/test/java/org/apache/paimon/catalog/DelegateCatalogTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/catalog/DelegateCatalogTest.java
@@ -18,12 +18,14 @@
 
 package org.apache.paimon.catalog;
 
+import org.apache.paimon.CoreOptions;
 import org.apache.paimon.partition.PartitionStatistics;
 
 import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -53,9 +55,9 @@ class DelegateCatalogTest {
                 Collections.singletonList(
                         new PartitionStatistics(specs.get(0), 3L, 300L, 1L, 1000L, -1));
 
-        delegating.createPartitions(IDENTIFIER, specs, true, statistics, false);
+        delegating.createPartitions(IDENTIFIER, specs, true, statistics, false, null);
 
-        verify(wrapped).createPartitions(IDENTIFIER, specs, true, statistics, false);
+        verify(wrapped).createPartitions(IDENTIFIER, specs, true, statistics, false, null);
         // Falling through to the two-argument call is how the statistics would go missing.
         verify(wrapped, never()).createPartitions(any(), anyList());
     }
@@ -67,9 +69,26 @@ class DelegateCatalogTest {
         List<Map<String, String>> specs =
                 Collections.singletonList(Collections.singletonMap("dt", "20260728"));
 
-        delegating.createPartitions(IDENTIFIER, specs, false, null, false);
+        delegating.createPartitions(IDENTIFIER, specs, false, null, false, null);
 
-        verify(wrapped).createPartitions(IDENTIFIER, specs, false, null, false);
+        verify(wrapped).createPartitions(IDENTIFIER, specs, false, null, false, null);
+    }
+
+    @Test
+    void testCreatePartitionsCarriesOptionsToTheWrappedCatalog() throws Exception {
+        Catalog wrapped = mock(Catalog.class);
+        Catalog delegating = new TestDelegateCatalog(wrapped);
+        Map<String, String> spec = Collections.singletonMap("dt", "20260728");
+        List<Map<String, String>> specs = Collections.singletonList(spec);
+        Map<String, String> options = new HashMap<>();
+        options.put(CoreOptions.PATH.key(), "file:/archive/dt=20260728");
+        options.put("owner", "data-platform");
+        List<Map<String, String>> partitionOptions = Collections.singletonList(options);
+
+        delegating.createPartitions(IDENTIFIER, specs, true, null, false, partitionOptions);
+
+        verify(wrapped).createPartitions(IDENTIFIER, specs, true, null, false, partitionOptions);
+        verify(wrapped, never()).createPartitions(IDENTIFIER, specs, true, null, false, null);
     }
 
     /** {@link DelegateCatalog} forwards every operation; these tests never rebuild one. */

--- a/paimon-core/src/test/java/org/apache/paimon/rest/MockRESTCatalogTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/rest/MockRESTCatalogTest.java
@@ -892,7 +892,8 @@ class MockRESTCatalogTest extends RESTCatalogTest {
                 specs,
                 true,
                 Collections.singletonList(new PartitionStatistics(spec, 4L, 400L, 2L, 500L, -1)),
-                false);
+                false,
+                null);
         assertStatistics(identifier, 7L, 700L, 3L, 1000L);
 
         // A field reported as unknown leaves the stored one alone rather than zeroing it.

--- a/paimon-core/src/test/java/org/apache/paimon/rest/MockRESTCatalogTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/rest/MockRESTCatalogTest.java
@@ -51,9 +51,11 @@ import org.apache.paimon.rest.auth.DLFToken;
 import org.apache.paimon.rest.auth.DLFTokenLoader;
 import org.apache.paimon.rest.auth.DLFTokenLoaderFactory;
 import org.apache.paimon.rest.auth.RESTAuthParameter;
+import org.apache.paimon.rest.exceptions.AlreadyExistsException;
 import org.apache.paimon.rest.exceptions.BadRequestException;
 import org.apache.paimon.rest.exceptions.NotAuthorizedException;
 import org.apache.paimon.rest.exceptions.NotImplementedException;
+import org.apache.paimon.rest.requests.CreatePartitionsRequest;
 import org.apache.paimon.rest.responses.ConfigResponse;
 import org.apache.paimon.schema.Schema;
 import org.apache.paimon.schema.SchemaChange;
@@ -78,12 +80,19 @@ import java.io.IOException;
 import java.net.URI;
 import java.nio.file.Files;
 import java.nio.file.Paths;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
 
 import static org.apache.paimon.catalog.Catalog.SYSTEM_DATABASE_NAME;
 import static org.apache.paimon.catalog.Catalog.TABLE_DEFAULT_OPTION_PREFIX;
@@ -92,6 +101,7 @@ import static org.apache.paimon.rest.RESTApi.READ_VIA_HEADER;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.tuple;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
@@ -487,6 +497,347 @@ class MockRESTCatalogTest extends RESTCatalogTest {
     }
 
     @Test
+    void testCustomPartitionLocationUsesExistingRouteAndStoresCanonicalLocation() throws Exception {
+        Identifier identifier = createFormatTableWithCatalogManagedPartitions();
+        Map<String, String> spec = Collections.singletonMap("dt", "20260717");
+        String requested = "OSS://ARCHIVE-BUCKET//history///%64t%3D20260717/";
+        String canonical = "oss://archive-bucket/history/dt=20260717";
+        Map<String, String> options = new HashMap<>();
+        options.put(CoreOptions.PATH.key(), requested);
+        options.put("owner", "data-platform");
+        String partitionsResource =
+                ResourcePaths.forCatalogProperties(restCatalog.api().options())
+                        .partitions(identifier.getDatabaseName(), identifier.getObjectName());
+        restCatalogServer.clearReceivedHeaders();
+
+        restCatalog.createPartitions(
+                identifier,
+                Collections.singletonList(spec),
+                true,
+                null,
+                false,
+                Collections.singletonList(options));
+
+        assertThat(restCatalogServer.getReceivedHeaders(partitionsResource)).hasSize(1);
+        assertThat(onlyPartition(identifier).options())
+                .containsExactlyInAnyOrderEntriesOf(
+                        ImmutableMap.of(
+                                CoreOptions.PATH.key(), canonical, "owner", "data-platform"));
+    }
+
+    @Test
+    void testRenamePreservesCustomPartitionLocation() throws Exception {
+        Identifier source = createFormatTableWithCatalogManagedPartitions();
+        Identifier destination =
+                Identifier.create(source.getDatabaseName(), "renamed_managed_partition_table");
+        Map<String, String> spec = Collections.singletonMap("dt", "20260717");
+        String location = "file:/archive/dt=20260717";
+        restCatalog.createPartitions(
+                source,
+                Collections.singletonList(spec),
+                true,
+                null,
+                false,
+                partitionOptions(location));
+
+        restCatalog.renameTable(source, destination, false);
+
+        assertThat(restCatalog.listPartitions(destination))
+                .singleElement()
+                .satisfies(
+                        partition -> {
+                            assertThat(partition.spec()).isEqualTo(spec);
+                            assertThat(customLocation(partition)).isEqualTo(location);
+                        });
+    }
+
+    @Test
+    void testInvalidCustomPartitionLocationFailsBeforePost() throws Exception {
+        Identifier identifier = createFormatTableWithCatalogManagedPartitions();
+        Map<String, String> spec = Collections.singletonMap("dt", "20260717");
+        String partitionsResource =
+                ResourcePaths.forCatalogProperties(restCatalog.api().options())
+                        .partitions(identifier.getDatabaseName(), identifier.getObjectName());
+        restCatalogServer.clearReceivedHeaders();
+
+        assertThatThrownBy(
+                        () ->
+                                restCatalog.createPartitions(
+                                        identifier,
+                                        Collections.singletonList(spec),
+                                        true,
+                                        null,
+                                        false,
+                                        partitionOptions(
+                                                "oss://archive-bucket/history/%2e%2e/secret")))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("Invalid custom partition location");
+
+        assertThat(restCatalogServer.getReceivedHeaders(partitionsResource)).isEmpty();
+    }
+
+    @Test
+    void testAlignedCustomPartitionLocationsRejectInvalidRequestsBeforeMutation() throws Exception {
+        Identifier identifier = createFormatTableWithCatalogManagedPartitions();
+        Map<String, String> first = Collections.singletonMap("dt", "20260717");
+        Map<String, String> second = Collections.singletonMap("dt", "20260718");
+        String resource =
+                ResourcePaths.forCatalogProperties(restCatalog.api().options())
+                        .partitions(identifier.getDatabaseName(), identifier.getObjectName());
+        HttpClient client = new HttpClient(restCatalogServer.getUrl());
+
+        assertThatThrownBy(
+                        () ->
+                                client.post(
+                                        resource,
+                                        new RawCreatePartitionsRequest(
+                                                Arrays.asList(first, second),
+                                                partitionOptions("file:/archive/dt=20260717")),
+                                        restCatalog.api().authFunction()))
+                .isInstanceOf(BadRequestException.class)
+                .hasMessageContaining("same size as partitionSpecs");
+        assertThatThrownBy(
+                        () ->
+                                client.post(
+                                        resource,
+                                        new CreatePartitionsRequest(
+                                                Collections.singletonList(first),
+                                                true,
+                                                null,
+                                                null,
+                                                partitionOptions("  ")),
+                                        restCatalog.api().authFunction()))
+                .isInstanceOf(BadRequestException.class)
+                .hasMessageContaining("Invalid custom partition location");
+        assertThatThrownBy(
+                        () ->
+                                client.post(
+                                        resource,
+                                        new CreatePartitionsRequest(
+                                                Arrays.asList(first, first),
+                                                true,
+                                                null,
+                                                null,
+                                                partitionOptions(
+                                                        "file:/archive/one", "file:/archive/two")),
+                                        restCatalog.api().authFunction()))
+                .isInstanceOf(BadRequestException.class)
+                .hasMessageContaining("must not contain duplicates");
+        assertThat(restCatalog.listPartitions(identifier)).isEmpty();
+    }
+
+    @Test
+    void testPartitionOptionsRejectNullValuesBeforeMutation() throws Exception {
+        Identifier identifier = createFormatTableWithCatalogManagedPartitions();
+        Map<String, String> spec = Collections.singletonMap("dt", "20260717");
+        Map<String, String> options = new HashMap<>();
+        options.put("owner", null);
+        String resource =
+                ResourcePaths.forCatalogProperties(restCatalog.api().options())
+                        .partitions(identifier.getDatabaseName(), identifier.getObjectName());
+        HttpClient client = new HttpClient(restCatalogServer.getUrl());
+
+        assertThatThrownBy(
+                        () ->
+                                client.post(
+                                        resource,
+                                        new RawCreatePartitionsRequest(
+                                                Collections.singletonList(spec),
+                                                Collections.singletonList(options)),
+                                        restCatalog.api().authFunction()))
+                .isInstanceOf(BadRequestException.class)
+                .hasMessageContaining("null keys or values");
+        assertThat(restCatalog.listPartitions(identifier)).isEmpty();
+    }
+
+    @Test
+    void testCustomPartitionLocationOwnershipConflictsAreRejectedAtomically() throws Exception {
+        Identifier identifier = createFormatTableWithCatalogManagedPartitions();
+        Map<String, String> first = Collections.singletonMap("dt", "20260717");
+        Map<String, String> second = Collections.singletonMap("dt", "20260718");
+        List<List<String>> conflicts =
+                Arrays.asList(
+                        Arrays.asList("file:/archive/shared", "file:/archive/shared"),
+                        Arrays.asList("file:/archive/root", "file:/archive/root/nested"),
+                        Arrays.asList("file:/archive/root/nested", "file:/archive/root"));
+
+        for (List<String> locations : conflicts) {
+            for (boolean ignoreIfExists : Arrays.asList(true, false)) {
+                assertThatThrownBy(
+                                () ->
+                                        restCatalog.createPartitions(
+                                                identifier,
+                                                Arrays.asList(first, second),
+                                                ignoreIfExists,
+                                                null,
+                                                false,
+                                                partitionOptions(locations.toArray(new String[0]))))
+                        .isInstanceOf(IllegalArgumentException.class);
+                assertThat(restCatalog.listPartitions(identifier)).isEmpty();
+            }
+        }
+    }
+
+    @Test
+    void testExistingPartitionRejectsADifferentCustomLocationWithoutMutation() throws Exception {
+        Identifier identifier = createFormatTableWithCatalogManagedPartitions();
+        Map<String, String> spec = Collections.singletonMap("dt", "20260717");
+        String originalLocation = "file:/archive/original";
+        restCatalog.createPartitions(
+                identifier,
+                Collections.singletonList(spec),
+                true,
+                null,
+                false,
+                partitionOptions(originalLocation));
+
+        assertThatThrownBy(
+                        () ->
+                                restCatalog
+                                        .api()
+                                        .createPartitions(
+                                                identifier,
+                                                Collections.singletonList(spec),
+                                                true,
+                                                null,
+                                                false,
+                                                partitionOptions("file:/archive/different")))
+                .isInstanceOf(AlreadyExistsException.class)
+                .hasMessageContaining("different location");
+
+        assertThat(restCatalog.listPartitions(identifier))
+                .extracting(Partition::spec, MockRESTCatalogTest::customLocation)
+                .containsExactly(tuple(spec, originalLocation));
+    }
+
+    @Test
+    void testConcurrentCustomLocationCreatesValidateAndCommitSerially() throws Exception {
+        Identifier identifier = createFormatTableWithCatalogManagedPartitions();
+        Map<String, String> firstSpec = Collections.singletonMap("dt", "20260717");
+        Map<String, String> secondSpec = Collections.singletonMap("dt", "20260718");
+        String sharedLocation = "file:/archive/shared";
+        CountDownLatch start = new CountDownLatch(1);
+        ExecutorService executor = Executors.newFixedThreadPool(2);
+
+        try {
+            Future<?> first =
+                    executor.submit(
+                            () -> {
+                                start.await();
+                                restCatalog.createPartitions(
+                                        identifier,
+                                        Collections.singletonList(firstSpec),
+                                        true,
+                                        null,
+                                        false,
+                                        partitionOptions(sharedLocation));
+                                return null;
+                            });
+            Future<?> second =
+                    executor.submit(
+                            () -> {
+                                start.await();
+                                restCatalog.createPartitions(
+                                        identifier,
+                                        Collections.singletonList(secondSpec),
+                                        true,
+                                        null,
+                                        false,
+                                        partitionOptions(sharedLocation));
+                                return null;
+                            });
+
+            start.countDown();
+            int failures = 0;
+            for (Future<?> future : Arrays.asList(first, second)) {
+                try {
+                    future.get(10, TimeUnit.SECONDS);
+                } catch (ExecutionException e) {
+                    assertThat(e).hasCauseInstanceOf(IllegalArgumentException.class);
+                    failures++;
+                }
+            }
+            assertThat(failures).isEqualTo(1);
+            List<Partition> stored = restCatalog.listPartitions(identifier);
+            assertThat(stored).hasSize(1);
+            assertThat(customLocation(stored.get(0))).isEqualTo(sharedLocation);
+        } finally {
+            start.countDown();
+            executor.shutdownNow();
+        }
+    }
+
+    @Test
+    void testUnsupportedCustomPartitionLocationCreateFailsWithoutMutation() throws Exception {
+        Identifier identifier = createFormatTableWithCatalogManagedPartitions();
+        Map<String, String> spec = Collections.singletonMap("dt", "20260717");
+        String resource =
+                ResourcePaths.forCatalogProperties(restCatalog.api().options())
+                        .partitions(identifier.getDatabaseName(), identifier.getObjectName());
+        restCatalogServer.setPartitionOptionsCreateSupported(false);
+        restCatalogServer.clearReceivedHeaders();
+
+        assertThatThrownBy(
+                        () ->
+                                restCatalog.createPartitions(
+                                        identifier,
+                                        Collections.singletonList(spec),
+                                        true,
+                                        null,
+                                        false,
+                                        partitionOptions("file:/archive/dt=20260717")))
+                .isInstanceOf(UnsupportedOperationException.class)
+                .hasMessageContaining("does not support partition options");
+
+        assertThat(restCatalogServer.getReceivedHeaders(resource)).hasSize(1);
+        assertThat(restCatalog.listPartitions(identifier)).isEmpty();
+    }
+
+    @Test
+    void testEmptyPartitionOptionsDoNotRequireProviderSupport() throws Exception {
+        Identifier identifier = createFormatTableWithCatalogManagedPartitions();
+        Map<String, String> spec = Collections.singletonMap("dt", "20260717");
+        restCatalogServer.setPartitionOptionsCreateSupported(false);
+
+        restCatalog.createPartitions(
+                identifier,
+                Collections.singletonList(spec),
+                true,
+                null,
+                false,
+                Collections.singletonList(Collections.emptyMap()));
+
+        assertThat(onlyPartition(identifier).spec()).isEqualTo(spec);
+        assertThat(onlyPartition(identifier).options()).isNull();
+    }
+
+    @Test
+    void testServerCanonicalizesCustomAndDerivedLocations() throws Exception {
+        Identifier identifier = createFormatTableWithCatalogManagedPartitions();
+        Map<String, String> first = Collections.singletonMap("dt", "20260717");
+        Map<String, String> second = Collections.singletonMap("dt", "20260718");
+        String resource =
+                ResourcePaths.forCatalogProperties(restCatalog.api().options())
+                        .partitions(identifier.getDatabaseName(), identifier.getObjectName());
+        HttpClient client = new HttpClient(restCatalogServer.getUrl());
+
+        client.post(
+                resource,
+                new CreatePartitionsRequest(
+                        Arrays.asList(first, second),
+                        true,
+                        null,
+                        null,
+                        partitionOptions("FILE:///archive//%64t%3D20260717/", null)),
+                restCatalog.api().authFunction());
+
+        assertThat(restCatalog.listPartitions(identifier))
+                .extracting(Partition::spec, MockRESTCatalogTest::customLocation)
+                .containsExactlyInAnyOrder(
+                        tuple(first, "file:/archive/dt=20260717"), tuple(second, null));
+    }
+
+    @Test
     void testPartitionManagerSurvivesSerialization() throws Exception {
         Identifier identifier = createFormatTableWithCatalogManagedPartitions();
         FormatTable table = (FormatTable) restCatalog.getTable(identifier);
@@ -507,12 +858,17 @@ class MockRESTCatalogTest extends RESTCatalogTest {
         Identifier identifier = createFormatTableWithCatalogManagedPartitions();
         Map<String, String> spec = Collections.singletonMap("dt", "20260717");
         List<Map<String, String>> specs = Collections.singletonList(spec);
+        String location = "file:/archive/dt=20260717";
+        Map<String, String> options = new HashMap<>();
+        options.put(CoreOptions.PATH.key(), location);
+        options.put("owner", "data-platform");
         FormatTablePartitionManager partitionManager =
                 ((FormatTable) restCatalog.getTable(identifier)).partitionManager();
         assertThat(partitionManager).isNotNull();
 
         // A registration on its own measures nothing, so everything starts out unknown.
-        restCatalog.createPartitions(identifier, specs);
+        restCatalog.createPartitions(
+                identifier, specs, true, null, false, Collections.singletonList(options));
         Partition registered = onlyPartition(identifier);
         assertThat(PartitionStatistics.isKnown(registered.recordCount())).isFalse();
         assertThat(PartitionStatistics.isKnown(registered.fileCount())).isFalse();
@@ -526,7 +882,8 @@ class MockRESTCatalogTest extends RESTCatalogTest {
                         true,
                         Collections.singletonList(
                                 new PartitionStatistics(spec, 3L, 300L, 1L, 1000L, -1)),
-                        false);
+                        false,
+                        null);
         assertStatistics(identifier, 3L, 300L, 1L, 1000L);
 
         // ADD again, through the partition manager a writer commits with: the counts accumulate
@@ -551,7 +908,8 @@ class MockRESTCatalogTest extends RESTCatalogTest {
                                 PartitionStatistics.UNKNOWN,
                                 PartitionStatistics.UNKNOWN,
                                 -1)),
-                false);
+                false,
+                null);
         assertStatistics(identifier, 7L, 800L, 3L, 1000L);
 
         // SET is the whole partition now: every reported field is replaced, including a creation
@@ -564,7 +922,8 @@ class MockRESTCatalogTest extends RESTCatalogTest {
                         true,
                         Collections.singletonList(
                                 new PartitionStatistics(spec, 5L, 500L, 1L, 700L, -1)),
-                        true);
+                        true,
+                        null);
         assertStatistics(identifier, 5L, 500L, 1L, 700L);
 
         // Unknown is skipped under SET too: it reports nothing about that field, not a zero.
@@ -580,11 +939,13 @@ class MockRESTCatalogTest extends RESTCatalogTest {
                                 PartitionStatistics.UNKNOWN,
                                 PartitionStatistics.UNKNOWN,
                                 -1)),
-                true);
+                true,
+                null);
         assertStatistics(identifier, 5L, 900L, 1L, 700L);
 
         // Reporting never registers or unregisters anything.
         assertThat(restCatalog.listPartitions(identifier)).hasSize(1);
+        assertThat(onlyPartition(identifier).options()).isEqualTo(options);
     }
 
     @Test
@@ -606,7 +967,8 @@ class MockRESTCatalogTest extends RESTCatalogTest {
                                 3L,
                                 1000L,
                                 -1)),
-                false);
+                false,
+                null);
 
         assertThat(restCatalog.listPartitions(identifier))
                 .extracting(Partition::spec)
@@ -628,7 +990,8 @@ class MockRESTCatalogTest extends RESTCatalogTest {
                 Arrays.asList(
                         new PartitionStatistics(stored, 3L, 300L, 1L, 1000L, -1),
                         new PartitionStatistics(absent, 9L, 900L, 3L, 2000L, -1)),
-                false);
+                false,
+                null);
 
         // Applying the half that matched would count it twice on the next report.
         Partition partition = onlyPartition(identifier);
@@ -642,6 +1005,21 @@ class MockRESTCatalogTest extends RESTCatalogTest {
         List<Partition> partitions = restCatalog.listPartitions(identifier);
         assertThat(partitions).hasSize(1);
         return partitions.get(0);
+    }
+
+    private static List<Map<String, String>> partitionOptions(String... locations) {
+        List<Map<String, String>> options = new ArrayList<>(locations.length);
+        for (String location : locations) {
+            options.add(
+                    location == null
+                            ? Collections.emptyMap()
+                            : Collections.singletonMap(CoreOptions.PATH.key(), location));
+        }
+        return options;
+    }
+
+    private static String customLocation(Partition partition) {
+        return partition.options() == null ? null : partition.options().get(CoreOptions.PATH.key());
     }
 
     private void assertStatistics(
@@ -1050,6 +1428,34 @@ class MockRESTCatalogTest extends RESTCatalogTest {
             options.set(entry.getKey(), entry.getValue());
         }
         return new RESTCatalog(CatalogContext.create(options));
+    }
+
+    private static class RawCreatePartitionsRequest implements RESTRequest {
+
+        private final List<Map<String, String>> partitionSpecs;
+        private final List<Map<String, String>> partitionOptions;
+
+        private RawCreatePartitionsRequest(
+                List<Map<String, String>> partitionSpecs,
+                List<Map<String, String>> partitionOptions) {
+            this.partitionSpecs = partitionSpecs;
+            this.partitionOptions = partitionOptions;
+        }
+
+        @JsonGetter("partitionSpecs")
+        public List<Map<String, String>> getPartitionSpecs() {
+            return partitionSpecs;
+        }
+
+        @JsonGetter("partitionOptions")
+        public List<Map<String, String>> getPartitionOptions() {
+            return partitionOptions;
+        }
+
+        @JsonGetter("ignoreIfExists")
+        public boolean ignoreIfExists() {
+            return true;
+        }
     }
 
     private static class InvalidColumnGrantRequest implements RESTRequest {

--- a/paimon-core/src/test/java/org/apache/paimon/rest/RESTApiJsonTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/rest/RESTApiJsonTest.java
@@ -59,13 +59,16 @@ import org.apache.paimon.shade.jackson2.com.fasterxml.jackson.core.JsonProcessin
 
 import org.junit.Test;
 
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /** Test for {@link RESTApi} json. */
@@ -335,6 +338,67 @@ public class RESTApiJsonTest {
         assertFalse(explicitRequestJson.contains("replaceStatistics"));
         assertNull(defaultRequest.getPartitionStatistics());
         assertNull(defaultRequest.replaceStatistics());
+    }
+
+    @Test
+    public void createPartitionsRequestPreservesOptionsTest() throws Exception {
+        String json =
+                "{\"partitionSpecs\":[{\"dt\":\"20260901\"},{\"dt\":\"20260902\"}],"
+                        + "\"partitionOptions\":[{},"
+                        + "{\"path\":\"oss://archive-bucket/table/dt=20260902\","
+                        + "\"owner\":\"data-platform\"}]}";
+
+        CreatePartitionsRequest request = RESTApi.fromJson(json, CreatePartitionsRequest.class);
+        Map<?, ?> serialized = RESTApi.fromJson(RESTApi.toJson(request), Map.class);
+        Map<String, String> customOptions = new HashMap<>();
+        customOptions.put("path", "oss://archive-bucket/table/dt=20260902");
+        customOptions.put("owner", "data-platform");
+
+        assertEquals(
+                Arrays.asList(Collections.emptyMap(), customOptions),
+                serialized.get("partitionOptions"));
+    }
+
+    @Test
+    public void createPartitionsRequestRejectsNullOptionMapsTest() {
+        List<Map<String, String>> specs =
+                Arrays.asList(
+                        Collections.singletonMap("dt", "20260901"),
+                        Collections.singletonMap("dt", "20260902"));
+
+        assertThrows(
+                IllegalArgumentException.class,
+                () ->
+                        new CreatePartitionsRequest(
+                                specs,
+                                true,
+                                null,
+                                null,
+                                Arrays.asList(null, Collections.emptyMap())));
+
+        Map<String, String> nullValue = new HashMap<>();
+        nullValue.put("owner", null);
+        assertThrows(
+                IllegalArgumentException.class,
+                () ->
+                        new CreatePartitionsRequest(
+                                specs,
+                                true,
+                                null,
+                                null,
+                                Arrays.asList(Collections.emptyMap(), nullValue)));
+
+        Map<String, String> nullKey = new HashMap<>();
+        nullKey.put(null, "value");
+        assertThrows(
+                IllegalArgumentException.class,
+                () ->
+                        new CreatePartitionsRequest(
+                                specs,
+                                true,
+                                null,
+                                null,
+                                Arrays.asList(Collections.emptyMap(), nullKey)));
     }
 
     @Test

--- a/paimon-core/src/test/java/org/apache/paimon/rest/RESTCatalogPartitionSupport.java
+++ b/paimon-core/src/test/java/org/apache/paimon/rest/RESTCatalogPartitionSupport.java
@@ -1,0 +1,189 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.rest;
+
+import org.apache.paimon.CoreOptions;
+import org.apache.paimon.catalog.CatalogContext;
+import org.apache.paimon.catalog.TableMetadata;
+import org.apache.paimon.fs.Path;
+import org.apache.paimon.partition.Partition;
+import org.apache.paimon.partition.PartitionStatistics;
+import org.apache.paimon.partition.PartitionUtils;
+import org.apache.paimon.rest.requests.CreatePartitionsRequest;
+import org.apache.paimon.rest.responses.ErrorResponse;
+import org.apache.paimon.table.format.FormatTablePartitionPathResolver;
+import org.apache.paimon.table.format.FormatTablePartitionRegistryValidator;
+import org.apache.paimon.utils.StringUtils;
+
+import javax.annotation.Nullable;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+
+import static org.apache.paimon.CoreOptions.PATH;
+
+/** Helpers for validating partition options in the mock REST catalog. */
+final class RESTCatalogPartitionSupport {
+
+    private RESTCatalogPartitionSupport() {}
+
+    @Nullable
+    static List<Map<String, String>> canonicalizeRequestedOptions(
+            CreatePartitionsRequest request,
+            CatalogContext catalogContext,
+            boolean optionCreateSupported) {
+        List<Map<String, String>> options = request.getPartitionOptions();
+        if (options == null) {
+            return null;
+        }
+        List<Map<String, String>> specs = request.getPartitionSpecs();
+        if (specs == null || options.size() != specs.size()) {
+            throw new IllegalArgumentException(
+                    "partitionOptions must contain exactly one entry for every partition spec.");
+        }
+        Set<Map<String, String>> uniqueSpecs = new HashSet<>();
+        boolean hasOptions = false;
+        for (int i = 0; i < options.size(); i++) {
+            if (specs.get(i) == null || !uniqueSpecs.add(specs.get(i))) {
+                throw new IllegalArgumentException(
+                        "partitionSpecs must not contain duplicates when partitionOptions is present.");
+            }
+            Map<String, String> partitionOptions = options.get(i);
+            if (partitionOptions == null) {
+                throw new IllegalArgumentException("partitionOptions must not contain null maps.");
+            }
+            if (partitionOptions.entrySet().stream()
+                    .anyMatch(entry -> entry.getKey() == null || entry.getValue() == null)) {
+                throw new IllegalArgumentException(
+                        "partitionOptions must not contain null keys or values.");
+            }
+            hasOptions |= !partitionOptions.isEmpty();
+        }
+        if (!hasOptions) {
+            return null;
+        }
+        if (!optionCreateSupported) {
+            throw new UnsupportedOperationException(
+                    "This REST provider does not support partition options.");
+        }
+        List<Map<String, String>> canonical = new ArrayList<>(options.size());
+        for (int i = 0; i < options.size(); i++) {
+            Map<String, String> partitionOptions = options.get(i);
+            Map<String, String> copied = new HashMap<>(partitionOptions);
+            String location = copied.get(PATH.key());
+            if (location != null) {
+                copied.put(
+                        PATH.key(),
+                        FormatTablePartitionPathResolver.canonicalizeCustomLocation(
+                                        location, catalogContext)
+                                .toString());
+            }
+            canonical.add(copied);
+        }
+        return canonical;
+    }
+
+    static Optional<Map<String, String>> conflictingLocation(
+            List<Partition> stored,
+            List<Map<String, String>> requestedSpecs,
+            @Nullable List<Map<String, String>> requestedOptions) {
+        if (requestedOptions == null) {
+            return Optional.empty();
+        }
+        Map<Map<String, String>, Partition> storedBySpec = new HashMap<>();
+        for (Partition partition : stored) {
+            storedBySpec.put(partition.spec(), partition);
+        }
+        for (int i = 0; i < requestedSpecs.size(); i++) {
+            Map<String, String> spec = requestedSpecs.get(i);
+            Partition existing = storedBySpec.get(spec);
+            String requestedLocation = requestedOptions.get(i).get(PATH.key());
+            if (existing != null
+                    && requestedLocation != null
+                    && !Objects.equals(customLocation(existing), requestedLocation)) {
+                return Optional.of(spec);
+            }
+        }
+        return Optional.empty();
+    }
+
+    static ErrorResponse conflictingLocationError(Map<String, String> spec) {
+        String partitionName = PartitionUtils.buildPartitionName(spec);
+        return new ErrorResponse(
+                ErrorResponse.RESOURCE_TYPE_PARTITION,
+                partitionName,
+                String.format(
+                        "Partition %s already exists at a different location.", partitionName),
+                409);
+    }
+
+    static Partition newPartition(Map<String, String> spec, @Nullable Map<String, String> options) {
+        return new Partition(
+                spec,
+                PartitionStatistics.UNKNOWN,
+                PartitionStatistics.UNKNOWN,
+                PartitionStatistics.UNKNOWN,
+                PartitionStatistics.UNKNOWN,
+                PartitionStatistics.UNKNOWN_TOTAL_BUCKETS,
+                false,
+                null,
+                null,
+                null,
+                null,
+                options);
+    }
+
+    static void validateFormatTablePartitionLocations(
+            List<Partition> partitions,
+            TableMetadata metadata,
+            String tableName,
+            CatalogContext catalogContext) {
+        if (partitions.stream().noneMatch(partition -> customLocation(partition) != null)) {
+            return;
+        }
+        String tablePath = metadata.schema().options().get(PATH.key());
+        if (StringUtils.isBlank(tablePath)) {
+            throw new IllegalStateException(
+                    String.format("Format Table %s has no authoritative path.", tableName));
+        }
+        try {
+            FormatTablePartitionRegistryValidator.validatePartitionLocations(
+                    partitions,
+                    metadata.schema().partitionKeys(),
+                    new Path(tablePath),
+                    tableName,
+                    new CoreOptions(metadata.schema().options())
+                            .formatTablePartitionOnlyValueInPath(),
+                    catalogContext);
+        } catch (IllegalStateException e) {
+            throw new IllegalArgumentException(e.getMessage(), e);
+        }
+    }
+
+    @Nullable
+    private static String customLocation(Partition partition) {
+        return partition.options() == null ? null : partition.options().get(PATH.key());
+    }
+}

--- a/paimon-core/src/test/java/org/apache/paimon/rest/RESTCatalogServer.java
+++ b/paimon-core/src/test/java/org/apache/paimon/rest/RESTCatalogServer.java
@@ -177,6 +177,7 @@ import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.function.Supplier;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
@@ -252,7 +253,7 @@ public class RESTCatalogServer {
     private final Queue<ListPartitionsResponse> scriptedListPartitionsByFilterResponses =
             new ConcurrentLinkedQueue<>();
 
-    private final Map<String, List<Partition>> tablePartitionsStore = new HashMap<>();
+    private final Map<String, List<Partition>> tablePartitionsStore = new ConcurrentHashMap<>();
     private final Map<String, View> viewStore = new ConcurrentHashMap<>();
     private final Map<String, TableSnapshot> tableLatestSnapshotStore = new HashMap<>();
     private final Map<String, TableSnapshot> tableWithSnapshotId2SnapshotStore = new HashMap<>();
@@ -268,10 +269,12 @@ public class RESTCatalogServer {
 
     private final ResourcePaths resourcePaths;
 
-    private final List<Map<String, String>> receivedHeaders = new ArrayList<>();
-    private final Map<String, List<Map<String, String>>> receivedHeadersByPath = new HashMap<>();
+    private final List<Map<String, String>> receivedHeaders = new CopyOnWriteArrayList<>();
+    private final Map<String, List<Map<String, String>>> receivedHeadersByPath =
+            new ConcurrentHashMap<>();
 
     private volatile boolean partitionListingSupported = true;
+    private volatile boolean partitionOptionsCreateSupported = true;
 
     public RESTCatalogServer(
             String dataPath, AuthProvider authProvider, ConfigResponse config, String warehouse) {
@@ -338,6 +341,10 @@ public class RESTCatalogServer {
 
     public void setPartitionListingSupported(boolean partitionListingSupported) {
         this.partitionListingSupported = partitionListingSupported;
+    }
+
+    public void setPartitionOptionsCreateSupported(boolean partitionOptionsCreateSupported) {
+        this.partitionOptionsCreateSupported = partitionOptionsCreateSupported;
     }
 
     public void clearReceivedListPartitionsByFilterRequests() {
@@ -433,7 +440,7 @@ public class RESTCatalogServer {
                     String[] paths = request.getPath().split("\\?");
                     String resourcePath = paths[0];
                     receivedHeadersByPath
-                            .computeIfAbsent(resourcePath, ignored -> new ArrayList<>())
+                            .computeIfAbsent(resourcePath, ignored -> new CopyOnWriteArrayList<>())
                             .add(new HashMap<>(headers));
                     Map<String, String> parameters =
                             paths.length == 2 ? getParameters(paths[1]) : Collections.emptyMap();
@@ -635,8 +642,19 @@ public class RESTCatalogServer {
                                         || isListPartitionsByFilter)) {
                             return mockResponse(new ErrorResponse(null, null, "", 501), 501);
                         } else if (isDropPartitions) {
-                            return dropPartitionsHandle(restAuthParameter.data(), identifier);
+                            synchronized (tableLifecycleLocks.lock(identifier.getFullName())) {
+                                return dropPartitionsHandle(restAuthParameter.data(), identifier);
+                            }
                         } else if (isPartitions) {
+                            if ("POST".equals(restAuthParameter.method())) {
+                                synchronized (tableLifecycleLocks.lock(identifier.getFullName())) {
+                                    return partitionsApiHandle(
+                                            restAuthParameter.method(),
+                                            restAuthParameter.data(),
+                                            parameters,
+                                            identifier);
+                                }
+                            }
                             return partitionsApiHandle(
                                     restAuthParameter.method(),
                                     restAuthParameter.data(),
@@ -682,7 +700,9 @@ public class RESTCatalogServer {
                         } else if (isTableAuth) {
                             return authTable(identifier, restAuthParameter.data());
                         } else if (isCommitSnapshot) {
-                            return commitTableHandle(identifier, restAuthParameter.data());
+                            synchronized (tableLifecycleLocks.lock(identifier.getFullName())) {
+                                return commitTableHandle(identifier, restAuthParameter.data());
+                            }
                         } else if (isRollbackTable) {
                             RollbackTableRequest requestBody =
                                     parseRequest(data, RollbackTableRequest.class);
@@ -2152,6 +2172,7 @@ public class RESTCatalogServer {
                                             current.isExternal());
                             tableMetadataStore.remove(fromTable.getFullName(), current);
                             tableMetadataStore.put(toTable.getFullName(), renamedMetadata);
+                            renamePartitionState(fromTable, toTable);
                             permissionStore.renameTable(fromTable, toTable);
                         }
                     }
@@ -2159,6 +2180,16 @@ public class RESTCatalogServer {
             }
         }
         return new MockResponse().setResponseCode(200);
+    }
+
+    private void renamePartitionState(Identifier source, Identifier destination) {
+        String sourceName = source.getFullName();
+        String destinationName = destination.getFullName();
+        tablePartitionsStore.remove(destinationName);
+        List<Partition> partitions = tablePartitionsStore.remove(sourceName);
+        if (partitions != null) {
+            tablePartitionsStore.put(destinationName, partitions);
+        }
     }
 
     private MockResponse partitionsApiHandle(
@@ -2185,9 +2216,18 @@ public class RESTCatalogServer {
                 return generateFinalListPartitionsResponse(parameters, partitions);
             case "POST":
                 CreatePartitionsRequest request = parseRequest(data, CreatePartitionsRequest.class);
+                List<Map<String, String>> requestedOptions =
+                        RESTCatalogPartitionSupport.canonicalizeRequestedOptions(
+                                request, catalogContext, partitionOptionsCreateSupported);
+                String tableName = tableIdentifier.getFullName();
+                TableMetadata tableMetadata = tableMetadataStore.get(tableName);
+                if (tableMetadata == null) {
+                    throw new Catalog.TableNotExistException(tableIdentifier);
+                }
                 List<Partition> storedPartitions =
-                        tablePartitionsStore.computeIfAbsent(
-                                tableIdentifier.getFullName(), ignored -> new ArrayList<>());
+                        new ArrayList<>(
+                                tablePartitionsStore.getOrDefault(
+                                        tableName, Collections.emptyList()));
                 Set<Map<String, String>> existingSpecs =
                         storedPartitions.stream().map(Partition::spec).collect(Collectors.toSet());
                 if (!request.ignoreIfExists()) {
@@ -2209,30 +2249,42 @@ public class RESTCatalogServer {
                         return mockResponse(response, 409);
                     }
                 }
+                Optional<Map<String, String>> conflictingLocation =
+                        RESTCatalogPartitionSupport.conflictingLocation(
+                                storedPartitions, request.getPartitionSpecs(), requestedOptions);
+                if (conflictingLocation.isPresent()) {
+                    return mockResponse(
+                            RESTCatalogPartitionSupport.conflictingLocationError(
+                                    conflictingLocation.get()),
+                            409);
+                }
                 List<Map<String, String>> created = new ArrayList<>();
                 List<Map<String, String>> existed = new ArrayList<>();
-                for (Map<String, String> spec : request.getPartitionSpecs()) {
+                for (int i = 0; i < request.getPartitionSpecs().size(); i++) {
+                    Map<String, String> spec = request.getPartitionSpecs().get(i);
                     if (existingSpecs.add(spec)) {
                         // A registration measures nothing, so a new partition starts unknown.
+                        Map<String, String> options =
+                                requestedOptions == null ? null : requestedOptions.get(i);
                         storedPartitions.add(
-                                new Partition(
-                                        spec,
-                                        PartitionStatistics.UNKNOWN,
-                                        PartitionStatistics.UNKNOWN,
-                                        PartitionStatistics.UNKNOWN,
-                                        PartitionStatistics.UNKNOWN,
-                                        PartitionStatistics.UNKNOWN_TOTAL_BUCKETS,
-                                        false));
+                                RESTCatalogPartitionSupport.newPartition(spec, options));
                         created.add(spec);
                     } else {
                         existed.add(spec);
                     }
                 }
+                if (isFormatTable(tableMetadata.schema().toSchema())) {
+                    RESTCatalogPartitionSupport.validateFormatTablePartitionLocations(
+                            storedPartitions, tableMetadata, tableName, catalogContext);
+                }
                 applyPartitionStatistics(
                         storedPartitions,
                         request.getPartitionStatistics(),
                         request.replaceStatistics());
-                return mockResponse(new CreatePartitionsResponse(created, existed), 200);
+                MockResponse response =
+                        mockResponse(new CreatePartitionsResponse(created, existed), 200);
+                tablePartitionsStore.put(tableName, storedPartitions);
+                return response;
             default:
                 return new MockResponse().setResponseCode(404);
         }
@@ -2282,7 +2334,12 @@ public class RESTCatalogServer {
                                     update.lastFileCreationTime(),
                                     accumulate),
                             stored.totalBuckets(),
-                            stored.done()));
+                            stored.done(),
+                            null,
+                            null,
+                            null,
+                            null,
+                            stored.options()));
         }
     }
 

--- a/paimon-core/src/test/java/org/apache/paimon/rest/RESTCatalogTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/rest/RESTCatalogTest.java
@@ -1579,7 +1579,9 @@ public abstract class RESTCatalogTest extends CatalogTestBase {
         List<Map<String, String>> partitionSpecs =
                 Arrays.asList(singletonMap("dt", "20260714"), singletonMap("dt", "20260715"));
         CreatePartitionsResponse response =
-                restCatalog.api().createPartitions(identifier, partitionSpecs, true, null, false);
+                restCatalog
+                        .api()
+                        .createPartitions(identifier, partitionSpecs, true, null, false, null);
 
         assertThat(response.getCreated()).containsExactlyInAnyOrderElementsOf(partitionSpecs);
         assertThat(response.getExisted()).isEmpty();
@@ -1594,7 +1596,12 @@ public abstract class RESTCatalogTest extends CatalogTestBase {
                                 restCatalog
                                         .api()
                                         .createPartitions(
-                                                identifier, conflictingSpecs, false, null, false))
+                                                identifier,
+                                                conflictingSpecs,
+                                                false,
+                                                null,
+                                                false,
+                                                null))
                 .isInstanceOf(AlreadyExistsException.class)
                 .hasMessageContaining("dt=20260714");
 

--- a/paimon-core/src/test/java/org/apache/paimon/table/format/CatalogFormatTablePartitionManagerTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/table/format/CatalogFormatTablePartitionManagerTest.java
@@ -476,7 +476,8 @@ class CatalogFormatTablePartitionManagerTest {
                         specCaptor.capture(),
                         eq(true),
                         statisticsCaptor.capture(),
-                        eq(false));
+                        eq(false),
+                        isNull());
         List<List<Map<String, String>>> requestedSpecs = specCaptor.getAllValues();
         List<List<PartitionStatistics>> requestedStatistics = statisticsCaptor.getAllValues();
         assertThat(requestedSpecs).extracting(List::size).containsExactly(1000, 1000, 500);
@@ -508,7 +509,12 @@ class CatalogFormatTablePartitionManagerTest {
                 ArgumentCaptor.forClass(List.class);
         verify(catalog, times(3))
                 .createPartitions(
-                        eq(IDENTIFIER), anyList(), eq(true), statisticsCaptor.capture(), eq(false));
+                        eq(IDENTIFIER),
+                        anyList(),
+                        eq(true),
+                        statisticsCaptor.capture(),
+                        eq(false),
+                        isNull());
         List<List<PartitionStatistics>> requestedStatistics = statisticsCaptor.getAllValues();
         assertThat(requestedStatistics.get(0)).containsExactlyElementsOf(statistics);
         // Null would mean "this client does not report", which is the call that predates
@@ -526,7 +532,7 @@ class CatalogFormatTablePartitionManagerTest {
 
         partitionManager(catalog).createPartitions(specs, false, statistics, true);
 
-        verify(catalog).createPartitions(IDENTIFIER, specs, false, statistics, true);
+        verify(catalog).createPartitions(IDENTIFIER, specs, false, statistics, true, null);
     }
 
     @Test
@@ -708,7 +714,7 @@ class CatalogFormatTablePartitionManagerTest {
         RuntimeException failure = new IllegalStateException("catalog unavailable");
         doThrow(failure)
                 .when(catalog)
-                .createPartitions(any(), anyList(), anyBoolean(), any(), anyBoolean());
+                .createPartitions(any(), anyList(), anyBoolean(), any(), anyBoolean(), isNull());
         FormatTablePartitionManager partitionManager = partitionManager(catalog);
 
         Throwable thrown = catchThrowable(() -> partitionManager.createPartitions(specs(1), true));
@@ -751,7 +757,12 @@ class CatalogFormatTablePartitionManagerTest {
         ArgumentCaptor<List<Map<String, String>>> captor = ArgumentCaptor.forClass(List.class);
         verify(catalog, times(expectedRequests))
                 .createPartitions(
-                        eq(IDENTIFIER), captor.capture(), eq(ignoreIfExists), isNull(), eq(false));
+                        eq(IDENTIFIER),
+                        captor.capture(),
+                        eq(ignoreIfExists),
+                        isNull(),
+                        eq(false),
+                        isNull());
         return captor.getAllValues();
     }
 

--- a/paimon-core/src/test/java/org/apache/paimon/table/format/CatalogFormatTablePartitionManagerTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/table/format/CatalogFormatTablePartitionManagerTest.java
@@ -395,6 +395,58 @@ class CatalogFormatTablePartitionManagerTest {
     }
 
     @Test
+    void testPartitionOptionsStayAlignedAcrossBatches() throws Exception {
+        Catalog catalog = mock(Catalog.class);
+        List<Map<String, String>> specs = specs(2500);
+        List<Map<String, String>> options = new ArrayList<>(specs.size());
+        for (int i = 0; i < specs.size(); i++) {
+            options.add(Collections.singletonMap("marker", Integer.toString(i)));
+        }
+
+        partitionManager(catalog).createPartitions(specs, true, null, false, options);
+
+        @SuppressWarnings("unchecked")
+        ArgumentCaptor<List<Map<String, String>>> specCaptor = ArgumentCaptor.forClass(List.class);
+        @SuppressWarnings("unchecked")
+        ArgumentCaptor<List<Map<String, String>>> optionCaptor =
+                ArgumentCaptor.forClass(List.class);
+        verify(catalog, times(3))
+                .createPartitions(
+                        eq(IDENTIFIER),
+                        specCaptor.capture(),
+                        eq(true),
+                        isNull(),
+                        eq(false),
+                        optionCaptor.capture());
+        assertThat(specCaptor.getAllValues())
+                .extracting(List::size)
+                .containsExactly(1000, 1000, 500);
+        assertThat(optionCaptor.getAllValues())
+                .extracting(List::size)
+                .containsExactly(1000, 1000, 500);
+        assertThat(flatten(specCaptor.getAllValues())).isEqualTo(specs);
+        assertThat(flatten(optionCaptor.getAllValues())).isEqualTo(options);
+    }
+
+    @Test
+    void testMisalignedPartitionOptionsAreRejectedBeforeCatalogAccess() {
+        Catalog catalog = mock(Catalog.class);
+
+        assertThatThrownBy(
+                        () ->
+                                partitionManager(catalog)
+                                        .createPartitions(
+                                                specs(2),
+                                                true,
+                                                null,
+                                                false,
+                                                Collections.singletonList(Collections.emptyMap())))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("must align");
+        verifyNoInteractions(catalog);
+    }
+
+    @Test
     void testDropIsSplitIntoRequests() throws Exception {
         Catalog catalog = mock(Catalog.class);
         List<Map<String, String>> specs = specs(2500);
@@ -463,7 +515,7 @@ class CatalogFormatTablePartitionManagerTest {
                         statistics(specs.get(1000), 3L),
                         statistics(specs.get(2499), 4L));
 
-        partitionManager(catalog).createPartitions(specs, true, statistics, false);
+        partitionManager(catalog).createPartitions(specs, true, statistics, false, null);
 
         @SuppressWarnings("unchecked")
         ArgumentCaptor<List<Map<String, String>>> specCaptor = ArgumentCaptor.forClass(List.class);
@@ -502,7 +554,7 @@ class CatalogFormatTablePartitionManagerTest {
         List<PartitionStatistics> statistics =
                 Arrays.asList(statistics(specs.get(0), 1L), statistics(specs.get(999), 2L));
 
-        partitionManager(catalog).createPartitions(specs, true, statistics, false);
+        partitionManager(catalog).createPartitions(specs, true, statistics, false, null);
 
         @SuppressWarnings("unchecked")
         ArgumentCaptor<List<PartitionStatistics>> statisticsCaptor =
@@ -530,7 +582,7 @@ class CatalogFormatTablePartitionManagerTest {
         List<PartitionStatistics> statistics =
                 Arrays.asList(statistics(specs.get(0), 1L), statistics(specs.get(2499), 2L));
 
-        partitionManager(catalog).createPartitions(specs, false, statistics, true);
+        partitionManager(catalog).createPartitions(specs, false, statistics, true, null);
 
         verify(catalog).createPartitions(IDENTIFIER, specs, false, statistics, true, null);
     }
@@ -544,7 +596,10 @@ class CatalogFormatTablePartitionManagerTest {
         List<PartitionStatistics> statistics =
                 Collections.singletonList(statistics(spec("2025", "02"), 7L));
 
-        assertThatThrownBy(() -> partitionManager.createPartitions(specs, true, statistics, false))
+        assertThatThrownBy(
+                        () ->
+                                partitionManager.createPartitions(
+                                        specs, true, statistics, false, null))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessageContaining("does not register")
                 .hasMessageContaining("month=02")
@@ -565,7 +620,7 @@ class CatalogFormatTablePartitionManagerTest {
         assertThatThrownBy(
                         () ->
                                 partitionManager.createPartitions(
-                                        Collections.emptyList(), true, statistics, false))
+                                        Collections.emptyList(), true, statistics, false, null))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessageContaining("does not register")
                 .hasMessageContaining("catalog_partition_db.catalog_partition_table");
@@ -580,7 +635,8 @@ class CatalogFormatTablePartitionManagerTest {
         Catalog catalog = mock(Catalog.class);
 
         partitionManager(catalog)
-                .createPartitions(Collections.emptyList(), true, Collections.emptyList(), false);
+                .createPartitions(
+                        Collections.emptyList(), true, Collections.emptyList(), false, null);
 
         verifyNoInteractions(catalog);
     }
@@ -594,7 +650,10 @@ class CatalogFormatTablePartitionManagerTest {
                 Arrays.asList(repeated, spec("2025", "02"), spec("2025", "01"));
         List<PartitionStatistics> statistics = Collections.singletonList(statistics(repeated, 7L));
 
-        assertThatThrownBy(() -> partitionManager.createPartitions(specs, true, statistics, false))
+        assertThatThrownBy(
+                        () ->
+                                partitionManager.createPartitions(
+                                        specs, true, statistics, false, null))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessageContaining("registered twice")
                 .hasMessageContaining("month=01")
@@ -614,7 +673,11 @@ class CatalogFormatTablePartitionManagerTest {
         assertThatThrownBy(
                         () ->
                                 partitionManager.createPartitions(
-                                        Collections.singletonList(spec), true, statistics, false))
+                                        Collections.singletonList(spec),
+                                        true,
+                                        statistics,
+                                        false,
+                                        null))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessageContaining("reported twice")
                 .hasMessageContaining("month=01")

--- a/paimon-core/src/test/java/org/apache/paimon/table/format/CatalogManagedPartitionScanTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/table/format/CatalogManagedPartitionScanTest.java
@@ -20,14 +20,18 @@ package org.apache.paimon.table.format;
 
 import org.apache.paimon.PagedList;
 import org.apache.paimon.catalog.Catalog;
+import org.apache.paimon.catalog.CatalogContext;
 import org.apache.paimon.catalog.Identifier;
 import org.apache.paimon.data.BinaryString;
 import org.apache.paimon.data.GenericRow;
+import org.apache.paimon.data.serializer.InternalRowSerializer;
+import org.apache.paimon.fs.FileIOLoader;
 import org.apache.paimon.fs.FileStatus;
 import org.apache.paimon.fs.Path;
 import org.apache.paimon.fs.PositionOutputStream;
 import org.apache.paimon.fs.local.LocalFileIO;
 import org.apache.paimon.manifest.PartitionEntry;
+import org.apache.paimon.options.Options;
 import org.apache.paimon.partition.Partition;
 import org.apache.paimon.partition.PartitionPredicate;
 import org.apache.paimon.partition.PartitionStatistics;
@@ -64,12 +68,14 @@ import java.util.stream.Collectors;
 
 import static org.apache.paimon.CoreOptions.FORMAT_TABLE_PARTITION_ONLY_VALUE_IN_PATH;
 import static org.apache.paimon.CoreOptions.FORMAT_TABLE_SCAN_LIST_PARALLELISM;
+import static org.apache.paimon.CoreOptions.PATH;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -84,8 +90,7 @@ class CatalogManagedPartitionScanTest {
     @Test
     void testLeadingPatternResidualFilterAndUnregisteredDirectory() throws Exception {
         Catalog catalog = mock(Catalog.class);
-        // The residual predicate beyond the prefix goes to the filter endpoint; the filter is a
-        // hint, so returning a superset here is legal and the plan still filters per partition.
+        // The filter endpoint may return a superset, so the scan still checks every candidate.
         when(catalog.listPartitionsByFilterPaged(
                         eq(IDENTIFIER),
                         any(Predicate.class),
@@ -124,6 +129,7 @@ class CatalogManagedPartitionScanTest {
                         eq("year=2025/%"));
         assertThat(pushedFilter.getValue().test(GenericRow.of(2025, 11))).isTrue();
         assertThat(pushedFilter.getValue().test(GenericRow.of(2025, 10))).isFalse();
+        verify(catalog, never()).listPartitionsPaged(any(), any(), any(), any());
     }
 
     @Test
@@ -158,20 +164,76 @@ class CatalogManagedPartitionScanTest {
     }
 
     @Test
-    void testListPartitionEntriesUsesCatalogVisibility() throws Exception {
+    void testUnextractablePartitionFilterDoesNotReloadFullRegistry() throws Exception {
+        TrackingLocalFileIO fileIO = new TrackingLocalFileIO();
+        Path tablePath = new Path(tempDir.toUri());
+        Path novemberFile = writeDataFile(fileIO, tablePath, "year=2025/month=11");
+        FormatTable table =
+                createTable(
+                        fileIO,
+                        tablePath,
+                        recordingCatalog(
+                                Arrays.asList(partition("2025", "10"), partition("2025", "11"))),
+                        false);
+        PartitionPredicate filter =
+                PartitionPredicate.fromMultiple(
+                        table.partitionType(),
+                        Collections.singletonList(
+                                new InternalRowSerializer(table.partitionType())
+                                        .toBinaryRow(GenericRow.of(2025, 11))));
+
+        List<Path> plannedFiles =
+                plannedFiles(new FormatTableScan(table, filter, null).plan().splits());
+
+        assertThat(plannedFiles).containsExactly(novemberFile);
+        assertThat(requestedPrefixes).containsExactly(Collections.emptyMap());
+        assertThat(requestedFilters).containsExactly((Predicate) null);
+    }
+
+    @Test
+    void testFindPartitionsPushesFilterAndAppliesItLocally() {
+        LocalFileIO fileIO = LocalFileIO.create();
+        Path tablePath = new Path(tempDir.toUri());
+        FormatTable table =
+                createTable(
+                        fileIO,
+                        tablePath,
+                        recordingCatalog(
+                                Arrays.asList(partition("2025", "10"), partition("2025", "11"))),
+                        false);
+        Predicate predicate = new PredicateBuilder(table.partitionType()).equal(1, 11);
+        PartitionPredicate filter =
+                PartitionPredicate.fromPredicate(table.partitionType(), predicate);
+
+        assertThat(new FormatTableScan(table, filter, null).findPartitions())
+                .extracting(partition -> partition.getKey().get("month"))
+                .containsExactly("11");
+        assertThat(requestedPrefixes).containsExactly(Collections.emptyMap());
+        assertThat(requestedFilters).hasSize(1);
+        assertThat(requestedFilters.get(0)).isNotNull();
+    }
+
+    @Test
+    void testListPartitionEntriesPushesFilterAndAppliesItLocally() throws Exception {
         Catalog catalog = mock(Catalog.class);
-        Partition catalogPartition =
+        Partition october = new Partition(partition("2025", "10").spec(), 7L, 8L, 1L, 9L, 2, false);
+        Partition november =
                 new Partition(partition("2025", "11").spec(), 11L, 22L, 3L, 44L, 5, false);
-        when(catalog.listPartitionsPaged(eq(IDENTIFIER), eq(1000), isNull(), isNull()))
-                .thenReturn(new PagedList<>(Collections.singletonList(catalogPartition), null));
+        when(catalog.listPartitionsByFilterPaged(
+                        eq(IDENTIFIER), any(Predicate.class), eq(1000), isNull(), isNull()))
+                .thenReturn(new PagedList<>(Arrays.asList(october, november), null));
         TrackingLocalFileIO fileIO = new TrackingLocalFileIO();
         Path tablePath = new Path(tempDir.toUri());
         writeDataFile(fileIO, tablePath, "year=2025/month=11");
         writeDataFile(fileIO, tablePath, "year=2025/month=12");
         FormatTable table = createTable(fileIO, tablePath, partitionManager(catalog), false);
 
+        Predicate predicate = new PredicateBuilder(table.partitionType()).equal(1, 11);
+        PartitionPredicate filter =
+                PartitionPredicate.fromPredicate(table.partitionType(), predicate);
+
         List<PartitionEntry> entries =
-                new FormatTableScan(table, null, null).listPartitionEntries();
+                new FormatTableScan(table, filter, null).listPartitionEntries();
 
         assertThat(entries)
                 .extracting(
@@ -183,6 +245,10 @@ class CatalogManagedPartitionScanTest {
         assertThat(entries.get(0).lastFileCreationTime()).isEqualTo(44L);
         assertThat(entries.get(0).totalBuckets()).isEqualTo(5);
         assertThat(fileIO.listedPaths).isEmpty();
+        verify(catalog)
+                .listPartitionsByFilterPaged(
+                        eq(IDENTIFIER), any(Predicate.class), eq(1000), isNull(), any());
+        verify(catalog, never()).listPartitionsPaged(any(), any(), any(), any());
     }
 
     @Test
@@ -303,6 +369,8 @@ class CatalogManagedPartitionScanTest {
         // '_' has no special meaning in the prefix contract; it must not widen the match.
         assertThat(plannedFiles).isEmpty();
         assertThat(requestedPrefixes).containsExactly(Collections.singletonMap("year", "a_b"));
+        assertThat(requestedFilters).hasSize(1);
+        assertThat(requestedFilters.get(0)).isNotNull();
     }
 
     @Test
@@ -339,6 +407,142 @@ class CatalogManagedPartitionScanTest {
                 plannedFiles(new FormatTableScan(table, null, null).plan().splits());
 
         assertThat(plannedFiles).containsExactly(dataFile);
+    }
+
+    @Test
+    void testUnrelatedPartitionOptionUsesDefaultLocation() throws Exception {
+        LocalFileIO fileIO = LocalFileIO.create();
+        Path tablePath = new Path(tempDir.toUri());
+        Path dataFile = writeDataFile(fileIO, tablePath, "year=2025/month=11");
+        Catalog catalog = mock(Catalog.class);
+        Partition partition =
+                partitionWithOptions(
+                        "2025", "11", Collections.singletonMap("owner", "data-platform"));
+        when(catalog.listPartitionsPaged(eq(IDENTIFIER), eq(1000), isNull(), isNull()))
+                .thenReturn(new PagedList<>(Collections.singletonList(partition), null));
+        FormatTable table = createTable(fileIO, tablePath, partitionManager(catalog), false);
+
+        assertThat(plannedFiles(new FormatTableScan(table, null, null).plan().splits()))
+                .containsExactly(dataFile);
+    }
+
+    @Test
+    void testDifferentPartitionsCannotShareACustomLocation() throws Exception {
+        Path externalPath = new Path(tempDir.resolve("external").toUri());
+        Catalog catalog = mock(Catalog.class);
+        when(catalog.listPartitionsPaged(eq(IDENTIFIER), eq(1000), isNull(), isNull()))
+                .thenReturn(
+                        new PagedList<>(
+                                Arrays.asList(
+                                        partition("2025", "10", externalPath.toString()),
+                                        partition("2025", "11", externalPath.toString())),
+                                null));
+        LocalFileIO fileIO = LocalFileIO.create();
+        writeDataFile(fileIO, externalPath, "files");
+        Path tablePath = new Path(tempDir.resolve("table").toUri());
+        FormatTable table = createTable(fileIO, tablePath, partitionManager(catalog), false);
+
+        assertThatThrownBy(() -> new FormatTableScan(table, null, null).plan().splits())
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("overlapping locations")
+                .hasMessageContaining(IDENTIFIER.getFullName());
+    }
+
+    @Test
+    void testFilteredListingReadsSelectedCustomLocation() throws Exception {
+        LocalFileIO clientFileIO = LocalFileIO.create();
+        Path externalPath = new Path(tempDir.resolve("external").toUri());
+        Path selectedFile = writeDataFile(clientFileIO, externalPath, "files");
+        Path tablePath = new Path(tempDir.resolve("table").toUri());
+        TableRootOnlyLocalFileIO tableFileIO = new TableRootOnlyLocalFileIO(tablePath);
+        Catalog catalog = mock(Catalog.class);
+        when(catalog.listPartitionsByFilterPaged(
+                        eq(IDENTIFIER), any(Predicate.class), eq(1000), isNull(), isNull()))
+                .thenReturn(
+                        new PagedList<>(
+                                Arrays.asList(
+                                        partition("2025", "10"),
+                                        partition("2025", "11", externalPath.toString())),
+                                null));
+        FileIOLoader clientLoader =
+                new FileIOLoader() {
+                    @Override
+                    public String getScheme() {
+                        return "file";
+                    }
+
+                    @Override
+                    public LocalFileIO load(Path path) {
+                        return clientFileIO;
+                    }
+                };
+        FormatTable table =
+                createTable(
+                        tableFileIO,
+                        tablePath,
+                        partitionManager(catalog),
+                        false,
+                        CatalogContext.create(new Options(), clientLoader, null));
+        Predicate predicate = new PredicateBuilder(table.partitionType()).equal(1, 11);
+        PartitionPredicate filter =
+                PartitionPredicate.fromPredicate(table.partitionType(), predicate);
+
+        List<Split> splits = new FormatTableScan(table, filter, null).plan().splits();
+
+        assertThat(plannedFiles(splits)).containsExactly(selectedFile);
+        assertThat(splits)
+                .allSatisfy(
+                        split ->
+                                assertThat(((FormatDataSplit) split).useCatalogContextFileIO())
+                                        .isTrue());
+        assertThat(tableFileIO.listedPaths).isEmpty();
+        verify(catalog)
+                .listPartitionsByFilterPaged(
+                        eq(IDENTIFIER), any(Predicate.class), eq(1000), isNull(), isNull());
+        verify(catalog, never()).listPartitionsPaged(any(), any(), any(), any());
+    }
+
+    @Test
+    void testCustomLocationOutsideTableUsesCatalogContextFileIOForPlanning() throws Exception {
+        LocalFileIO clientFileIO = LocalFileIO.create();
+        Path externalPath = new Path(tempDir.resolve("external").toUri());
+        Path dataFile = writeDataFile(clientFileIO, externalPath, "files");
+        Catalog catalog = mock(Catalog.class);
+        when(catalog.listPartitionsPaged(eq(IDENTIFIER), eq(1000), isNull(), isNull()))
+                .thenReturn(
+                        new PagedList<>(
+                                Collections.singletonList(
+                                        partition("2025", "11", externalPath.toString())),
+                                null));
+        Path tablePath = new Path(tempDir.resolve("table").toUri());
+        TableRootOnlyLocalFileIO tableFileIO = new TableRootOnlyLocalFileIO(tablePath);
+        FileIOLoader clientLoader =
+                new FileIOLoader() {
+                    @Override
+                    public String getScheme() {
+                        return "file";
+                    }
+
+                    @Override
+                    public LocalFileIO load(Path path) {
+                        return clientFileIO;
+                    }
+                };
+        CatalogContext catalogContext = CatalogContext.create(new Options(), clientLoader, null);
+        FormatTable table =
+                createTable(
+                        tableFileIO, tablePath, partitionManager(catalog), false, catalogContext);
+
+        List<Split> splits = new FormatTableScan(table, null, null).plan().splits();
+        List<Path> plannedFiles = plannedFiles(splits);
+
+        assertThat(plannedFiles).containsExactly(dataFile);
+        assertThat(splits)
+                .allSatisfy(
+                        split ->
+                                assertThat(((FormatDataSplit) split).useCatalogContextFileIO())
+                                        .isTrue());
+        assertThat(tableFileIO.listedPaths).isEmpty();
     }
 
     @Test
@@ -505,7 +709,8 @@ class CatalogManagedPartitionScanTest {
                     List<Map<String, String>> partitions,
                     boolean ignoreIfExists,
                     @Nullable List<PartitionStatistics> statistics,
-                    boolean replaceStatistics) {
+                    boolean replaceStatistics,
+                    @Nullable List<Map<String, String>> partitionOptions) {
                 throw new UnsupportedOperationException();
             }
 
@@ -521,25 +726,38 @@ class CatalogManagedPartitionScanTest {
             Path tablePath,
             FormatTablePartitionManager partitionManager,
             boolean valueOnlyPath) {
+        return createTable(fileIO, tablePath, partitionManager, valueOnlyPath, null);
+    }
+
+    private FormatTable createTable(
+            LocalFileIO fileIO,
+            Path tablePath,
+            FormatTablePartitionManager partitionManager,
+            boolean valueOnlyPath,
+            @Nullable CatalogContext catalogContext) {
         RowType rowType =
                 RowType.builder()
                         .field("year", DataTypes.INT())
                         .field("month", DataTypes.INT())
                         .field("id", DataTypes.INT())
                         .build();
-        return FormatTable.builder()
-                .fileIO(fileIO)
-                .identifier(IDENTIFIER)
-                .rowType(rowType)
-                .partitionKeys(Arrays.asList("year", "month"))
-                .location(tablePath.toString())
-                .format(FormatTable.Format.CSV)
-                .options(
-                        Collections.singletonMap(
-                                FORMAT_TABLE_PARTITION_ONLY_VALUE_IN_PATH.key(),
-                                Boolean.toString(valueOnlyPath)))
-                .partitionManager(partitionManager)
-                .build();
+        FormatTable.Builder builder =
+                FormatTable.builder()
+                        .fileIO(fileIO)
+                        .identifier(IDENTIFIER)
+                        .rowType(rowType)
+                        .partitionKeys(Arrays.asList("year", "month"))
+                        .location(tablePath.toString())
+                        .format(FormatTable.Format.CSV)
+                        .options(
+                                Collections.singletonMap(
+                                        FORMAT_TABLE_PARTITION_ONLY_VALUE_IN_PATH.key(),
+                                        Boolean.toString(valueOnlyPath)))
+                        .partitionManager(partitionManager);
+        if (catalogContext != null) {
+            builder.catalogContext(catalogContext);
+        }
+        return builder.build();
     }
 
     private FormatTable createStringPartitionTable(
@@ -584,10 +802,22 @@ class CatalogManagedPartitionScanTest {
     }
 
     private static Partition partition(String year, String month) {
+        return partition(year, month, null);
+    }
+
+    private static Partition partition(String year, String month, @Nullable String location) {
+        return partitionWithOptions(
+                year,
+                month,
+                location == null ? null : Collections.singletonMap(PATH.key(), location));
+    }
+
+    private static Partition partitionWithOptions(
+            String year, String month, @Nullable Map<String, String> options) {
         Map<String, String> spec = new LinkedHashMap<>();
         spec.put("year", year);
         spec.put("month", month);
-        return new Partition(spec, 0, 0, 0, 0, -1, false);
+        return new Partition(spec, 0, 0, 0, 0, -1, false, null, null, null, null, options);
     }
 
     private static List<Path> plannedFiles(List<Split> splits) {
@@ -600,11 +830,28 @@ class CatalogManagedPartitionScanTest {
 
     private static class TrackingLocalFileIO extends LocalFileIO {
 
-        private final List<Path> listedPaths = new ArrayList<>();
+        protected final List<Path> listedPaths = new ArrayList<>();
 
         @Override
         public FileStatus[] listStatus(Path path) throws IOException {
             listedPaths.add(path);
+            return super.listStatus(path);
+        }
+    }
+
+    private static class TableRootOnlyLocalFileIO extends TrackingLocalFileIO {
+
+        private final Path tableRoot;
+
+        private TableRootOnlyLocalFileIO(Path tableRoot) {
+            this.tableRoot = tableRoot;
+        }
+
+        @Override
+        public FileStatus[] listStatus(Path path) throws IOException {
+            if (!FormatTablePartitionPathResolver.isWithin(path, tableRoot)) {
+                throw new AssertionError("The table FileIO must not list an external location.");
+            }
             return super.listStatus(path);
         }
     }

--- a/paimon-core/src/test/java/org/apache/paimon/table/format/FormatDataSplitTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/table/format/FormatDataSplitTest.java
@@ -25,6 +25,7 @@ import org.apache.paimon.utils.InstantiationUtil;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
+import java.io.ObjectStreamClass;
 import java.util.Arrays;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -46,6 +47,7 @@ public class FormatDataSplitTest {
         assertThat(deserialized).isEqualTo(split);
         assertThat(deserialized.files()).isEqualTo(split.files());
         assertThat(deserialized.partition()).isEqualTo(split.partition());
+        assertThat(deserialized.useCatalogContextFileIO()).isFalse();
         assertThat(deserialized.fileCount()).isEqualTo(2);
         // readSize: whole file -> fileSize (1024), range -> length (512).
         assertThat(deserialized.totalSize()).isEqualTo(1024L + 512L);
@@ -62,5 +64,29 @@ public class FormatDataSplitTest {
         assertThat(f1.offset()).isEqualTo(100L);
         assertThat(f1.length()).isEqualTo(512L);
         assertThat(f1.readSize()).isEqualTo(512L);
+    }
+
+    @Test
+    public void testCatalogContextFileIORouteSurvivesSerialization()
+            throws IOException, ClassNotFoundException {
+        FormatDataSplit split =
+                new FormatDataSplit(
+                        Arrays.asList(new FileMeta(new Path("oss://archive/data.csv"), 10L)),
+                        null,
+                        true);
+
+        FormatDataSplit deserialized =
+                InstantiationUtil.deserializeObject(
+                        InstantiationUtil.serializeObject(split), getClass().getClassLoader());
+
+        assertThat(deserialized).isEqualTo(split);
+        assertThat(deserialized.useCatalogContextFileIO()).isTrue();
+    }
+
+    @Test
+    public void testSerialVersionUIDsStayCompatible() {
+        assertThat(ObjectStreamClass.lookup(FormatDataSplit.class).getSerialVersionUID())
+                .isEqualTo(3L);
+        assertThat(ObjectStreamClass.lookup(FileMeta.class).getSerialVersionUID()).isEqualTo(1L);
     }
 }

--- a/paimon-core/src/test/java/org/apache/paimon/table/format/FormatReadBuilderTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/table/format/FormatReadBuilderTest.java
@@ -18,6 +18,7 @@
 
 package org.apache.paimon.table.format;
 
+import org.apache.paimon.catalog.CatalogContext;
 import org.apache.paimon.catalog.Identifier;
 import org.apache.paimon.data.BinaryString;
 import org.apache.paimon.data.GenericRow;
@@ -27,8 +28,10 @@ import org.apache.paimon.format.FileFormatFactory;
 import org.apache.paimon.format.FormatWriter;
 import org.apache.paimon.format.FormatWriterFactory;
 import org.apache.paimon.format.csv.CsvFileFormat;
+import org.apache.paimon.fs.FileIOLoader;
 import org.apache.paimon.fs.Path;
 import org.apache.paimon.fs.PositionOutputStream;
+import org.apache.paimon.fs.SeekableInputStream;
 import org.apache.paimon.fs.local.LocalFileIO;
 import org.apache.paimon.options.Options;
 import org.apache.paimon.predicate.Predicate;
@@ -50,8 +53,10 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -257,6 +262,59 @@ public class FormatReadBuilderTest {
         assertThat(partialResult.get(0).getString(1).toString()).isEqualTo("Alice");
     }
 
+    @Test
+    public void testExternalSplitUsesCatalogContextFileIOAfterSerialization() throws Exception {
+        RowType rowType =
+                RowType.builder()
+                        .field("id", DataTypes.INT())
+                        .field("name", DataTypes.STRING())
+                        .build();
+        LocalFileIO clientFileIO = LocalFileIO.create();
+        Path externalPath = new Path(tempPath.resolve("external").toUri());
+        Path csvFile = new Path(externalPath, "data.csv");
+        clientFileIO.mkdirs(externalPath);
+        try (PositionOutputStream out = clientFileIO.newOutputStream(csvFile, false)) {
+            out.write("1,Alice\n".getBytes(StandardCharsets.UTF_8));
+        }
+
+        Path tablePath = new Path(tempPath.resolve("table").toUri());
+        FileIOLoader clientLoader = new LocalFileIOLoader(clientFileIO);
+        FormatTable table =
+                FormatTable.builder()
+                        .fileIO(new TableRootOnlyLocalFileIO(tablePath))
+                        .identifier(Identifier.create("test_db", "external_csv"))
+                        .rowType(rowType)
+                        .partitionKeys(Collections.emptyList())
+                        .location(tablePath.toString())
+                        .format(FormatTable.Format.CSV)
+                        .options(Collections.singletonMap("file.format", "csv"))
+                        .catalogContext(CatalogContext.create(new Options(), clientLoader, null))
+                        .build();
+        FormatReadBuilder readBuilder =
+                InstantiationUtil.deserializeObject(
+                        InstantiationUtil.serializeObject(new FormatReadBuilder(table)),
+                        getClass().getClassLoader());
+        FormatDataSplit split =
+                InstantiationUtil.deserializeObject(
+                        InstantiationUtil.serializeObject(
+                                new FormatDataSplit(
+                                        Collections.singletonList(
+                                                new FormatDataSplit.FileMeta(
+                                                        csvFile,
+                                                        clientFileIO.getFileSize(csvFile))),
+                                        null,
+                                        true)),
+                        getClass().getClassLoader());
+
+        List<InternalRow> rows = readAllRows(readBuilder.createReader(split), rowType);
+
+        assertThatNoException().isThrownBy(() -> InstantiationUtil.serializeObject(readBuilder));
+        assertThat(rows).hasSize(1);
+        assertThat(rows.get(0).getInt(0)).isEqualTo(1);
+        assertThat(rows.get(0).getString(1).toString()).isEqualTo("Alice");
+        assertThat(split.useCatalogContextFileIO()).isTrue();
+    }
+
     private List<InternalRow> readAllRows(RecordReader<InternalRow> reader, RowType rowType)
             throws IOException {
         InternalRowSerializer serializer = new InternalRowSerializer(rowType);
@@ -310,5 +368,41 @@ public class FormatReadBuilderTest {
             batch.releaseBatch();
         }
         return size;
+    }
+
+    private static class TableRootOnlyLocalFileIO extends LocalFileIO {
+
+        private final Path tableRoot;
+
+        private TableRootOnlyLocalFileIO(Path tableRoot) {
+            this.tableRoot = tableRoot;
+        }
+
+        @Override
+        public SeekableInputStream newInputStream(Path path) throws IOException {
+            if (!FormatTablePartitionPathResolver.isWithin(path, tableRoot)) {
+                throw new AssertionError("The table FileIO must not read an external split.");
+            }
+            return super.newInputStream(path);
+        }
+    }
+
+    private static class LocalFileIOLoader implements FileIOLoader {
+
+        private final LocalFileIO fileIO;
+
+        private LocalFileIOLoader(LocalFileIO fileIO) {
+            this.fileIO = fileIO;
+        }
+
+        @Override
+        public String getScheme() {
+            return "file";
+        }
+
+        @Override
+        public LocalFileIO load(Path path) {
+            return fileIO;
+        }
     }
 }

--- a/paimon-core/src/test/java/org/apache/paimon/table/format/FormatTableCommitRegistryValidationTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/table/format/FormatTableCommitRegistryValidationTest.java
@@ -1,0 +1,168 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.table.format;
+
+import org.apache.paimon.catalog.Identifier;
+import org.apache.paimon.fs.Path;
+import org.apache.paimon.fs.local.LocalFileIO;
+import org.apache.paimon.partition.Partition;
+import org.apache.paimon.partition.PartitionStatistics;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.apache.paimon.CoreOptions.PARTITION_DEFAULT_NAME;
+import static org.apache.paimon.CoreOptions.PATH;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.anyMap;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/** Partition registry validation tests for {@link FormatTableCommit}. */
+class FormatTableCommitRegistryValidationTest {
+
+    @TempDir java.nio.file.Path tempDir;
+
+    @Test
+    void testTruncateRejectsNonLeadingPrefixBeforeMutationWhenFullRegistryIsRequired()
+            throws Exception {
+        MutationTrackingLocalFileIO fileIO = new MutationTrackingLocalFileIO();
+        Path tablePath = new Path(new Path(tempDir.toUri()), "truncate-non-leading-prefix");
+        Map<String, String> november2024 = partitionSpec("2024", "11");
+        Map<String, String> november2025 = partitionSpec("2025", "11");
+        Path data2024 = new Path(tablePath, "year=2024/month=11/data-2024.csv");
+        Path data2025 = new Path(tablePath, "year=2025/month=11/data-2025.csv");
+        fileIO.writeFile(data2024, "2024", false);
+        fileIO.writeFile(data2025, "2025", false);
+        FormatTablePartitionManager partitionManager = mock(FormatTablePartitionManager.class);
+        when(partitionManager.listPartitions(Collections.emptyMap(), null))
+                .thenReturn(
+                        Arrays.asList(
+                                partitionAt(november2024, null), partitionAt(november2025, null)));
+        FormatTableCommit commit =
+                new FormatTableCommit(
+                        tablePath.toString(),
+                        Arrays.asList("year", "month"),
+                        fileIO,
+                        false,
+                        PARTITION_DEFAULT_NAME.defaultValue(),
+                        false,
+                        Identifier.create("location_db", "location_table"),
+                        null,
+                        null,
+                        null,
+                        partitionManager,
+                        /* dynamicPartitionOverwrite */ true);
+        fileIO.startTrackingMutations();
+
+        assertThatThrownBy(
+                        () ->
+                                commit.truncatePartitions(
+                                        Collections.singletonList(
+                                                Collections.singletonMap("month", "11"))))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage(
+                        "Partition spec {month=11} is not a leading prefix of partition keys "
+                                + "[year, month].");
+
+        assertThat(fileIO.exists(data2024)).isTrue();
+        assertThat(fileIO.exists(data2025)).isTrue();
+        assertThat(fileIO.deleteCalls()).isZero();
+        assertThat(fileIO.mkdirsCalls()).isZero();
+        verify(partitionManager, never()).listPartitions(anyMap(), isNull());
+        verify(partitionManager, never())
+                .createPartitions(anyList(), anyBoolean(), any(), anyBoolean(), any());
+    }
+
+    private static Partition partitionAt(Map<String, String> spec, String location) {
+        Map<String, String> options =
+                location == null ? null : Collections.singletonMap(PATH.key(), location);
+        return new Partition(
+                spec,
+                0,
+                0,
+                0,
+                0,
+                PartitionStatistics.UNKNOWN_TOTAL_BUCKETS,
+                false,
+                null,
+                null,
+                null,
+                null,
+                options);
+    }
+
+    private static Map<String, String> partitionSpec(String year, String month) {
+        LinkedHashMap<String, String> spec = new LinkedHashMap<>();
+        spec.put("year", year);
+        spec.put("month", month);
+        return spec;
+    }
+
+    private static class MutationTrackingLocalFileIO extends LocalFileIO {
+
+        private final AtomicInteger deleteCalls = new AtomicInteger();
+        private final AtomicInteger mkdirsCalls = new AtomicInteger();
+        private boolean tracking;
+
+        private void startTrackingMutations() {
+            deleteCalls.set(0);
+            mkdirsCalls.set(0);
+            tracking = true;
+        }
+
+        @Override
+        public boolean delete(Path path, boolean recursive) throws IOException {
+            if (tracking) {
+                deleteCalls.incrementAndGet();
+            }
+            return super.delete(path, recursive);
+        }
+
+        @Override
+        public boolean mkdirs(Path path) throws IOException {
+            if (tracking) {
+                mkdirsCalls.incrementAndGet();
+            }
+            return super.mkdirs(path);
+        }
+
+        private int deleteCalls() {
+            return deleteCalls.get();
+        }
+
+        private int mkdirsCalls() {
+            return mkdirsCalls.get();
+        }
+    }
+}

--- a/paimon-core/src/test/java/org/apache/paimon/table/format/FormatTableCommitStatisticsTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/table/format/FormatTableCommitStatisticsTest.java
@@ -19,6 +19,7 @@
 package org.apache.paimon.table.format;
 
 import org.apache.paimon.CoreOptions;
+import org.apache.paimon.PagedList;
 import org.apache.paimon.catalog.Catalog;
 import org.apache.paimon.catalog.CatalogLoader;
 import org.apache.paimon.catalog.Identifier;
@@ -310,9 +311,9 @@ class FormatTableCommitStatisticsTest {
                 .containsExactlyInAnyOrder(spec("2025", "10"), spec("2025", "11"));
         // Red line: emptying a partition zeroes its statistics, it never unregisters it.
         verify(partitionManager, never()).dropPartitions(anyList());
-        // One catalog request for the complete specs, not one per partition.
-        verify(partitionManager).listPartitionsByNames(anyList());
-        verify(partitionManager, never()).listPartitions(any(), any());
+        // One authoritative request for the complete registry, then local selection.
+        verify(partitionManager).listPartitions(Collections.emptyMap(), null);
+        verify(partitionManager, never()).listPartitionsByNames(anyList());
         // Statistics route by the spec they carry, so every partition needs its own.
         assertThat(reported.statistics)
                 .extracting(PartitionStatistics::spec)
@@ -385,7 +386,7 @@ class FormatTableCommitStatisticsTest {
         Path tablePath = new Path(tempDir.toUri());
         FormatTablePartitionManager partitionManager = mock(FormatTablePartitionManager.class);
         Map<String, String> prefix = Collections.singletonMap("year", "2025");
-        when(partitionManager.listPartitions(prefix, null))
+        when(partitionManager.listPartitions(Collections.emptyMap(), null))
                 .thenReturn(
                         Arrays.asList(
                                 partition(spec("2025", "10")), partition(spec("2025", "11"))));
@@ -475,7 +476,7 @@ class FormatTableCommitStatisticsTest {
         // A refused deletion is not a concurrent one: the rows are still readable, so reporting
         // the partition as holding nothing would hide them.
         verify(partitionManager, never())
-                .createPartitions(anyList(), anyBoolean(), anyList(), anyBoolean());
+                .createPartitions(anyList(), anyBoolean(), anyList(), anyBoolean(), any());
         assertThat(fileIO.exists(new Path(tablePath, "year=2025/month=10/data.csv"))).isTrue();
     }
 
@@ -487,7 +488,7 @@ class FormatTableCommitStatisticsTest {
         registered(partitionManager, spec("2025", "10"), spec("2025", "11"));
         doThrow(new RuntimeException("the catalog is unreachable"))
                 .when(partitionManager)
-                .createPartitions(anyList(), anyBoolean(), anyList(), anyBoolean());
+                .createPartitions(anyList(), anyBoolean(), anyList(), anyBoolean(), any());
         writeDataFile(fileIO, tablePath, "year=2025/month=10", "data.csv", 4096);
         writeDataFile(fileIO, tablePath, "year=2025/month=11", "data.csv", 2048);
 
@@ -776,7 +777,8 @@ class FormatTableCommitStatisticsTest {
                         specs.capture(),
                         eq(true),
                         statistics.capture(),
-                        replaceStatistics.capture());
+                        replaceStatistics.capture(),
+                        isNull());
         return new Reported(
                 new ArrayList<>(specs.getValue()),
                 new ArrayList<>(statistics.getValue()),
@@ -879,7 +881,8 @@ class FormatTableCommitStatisticsTest {
                 List<Map<String, String>> partitions,
                 boolean ignoreIfExists,
                 @Nullable List<PartitionStatistics> statistics,
-                boolean replaceStatistics) {
+                boolean replaceStatistics,
+                @Nullable List<Map<String, String>> partitionOptions) {
             createPartitions(partitions, ignoreIfExists);
             if (statistics == null) {
                 return;
@@ -913,12 +916,28 @@ class FormatTableCommitStatisticsTest {
         @Override
         public List<Partition> listPartitions(
                 Map<String, String> prefix, @Nullable Predicate filter) {
-            throw new UnsupportedOperationException();
+            List<Partition> found = new ArrayList<>();
+            for (Map<String, String> partitionSpec : registered) {
+                if (prefix.entrySet().stream()
+                        .allMatch(
+                                entry ->
+                                        entry.getValue()
+                                                .equals(partitionSpec.get(entry.getKey())))) {
+                    found.add(partition(partitionSpec));
+                }
+            }
+            return found;
         }
 
         @Override
         public List<Partition> listPartitionsByNames(List<Map<String, String>> partitions) {
-            throw new UnsupportedOperationException();
+            List<Partition> found = new ArrayList<>();
+            for (Map<String, String> partitionSpec : partitions) {
+                if (registered.contains(partitionSpec)) {
+                    found.add(partition(partitionSpec));
+                }
+            }
+            return found;
         }
 
         @Override
@@ -1015,7 +1034,7 @@ class FormatTableCommitStatisticsTest {
 
         verify(partitionManager).createPartitions(Collections.singletonList(staticPartition), true);
         verify(partitionManager, never())
-                .createPartitions(anyList(), eq(true), any(), anyBoolean());
+                .createPartitions(anyList(), eq(true), any(), anyBoolean(), any());
     }
 
     @Test
@@ -1028,6 +1047,10 @@ class FormatTableCommitStatisticsTest {
         AtomicInteger requests = new AtomicInteger();
         List<Map<String, String>> registered = new ArrayList<>();
         List<PartitionStatistics> appliedStatistics = new ArrayList<>();
+        when(catalog.listPartitionsPaged(TABLE, 1000, null, null))
+                .thenReturn(new PagedList<>(Collections.emptyList(), null));
+        when(catalog.listPartitionsByNames(eq(TABLE), anyList()))
+                .thenReturn(Collections.emptyList());
         doAnswer(
                         invocation -> {
                             @SuppressWarnings("unchecked")
@@ -1106,7 +1129,7 @@ class FormatTableCommitStatisticsTest {
         FormatTablePartitionManager partitionManager = mock(FormatTablePartitionManager.class);
         doThrow(new RuntimeException("catalog says 429"))
                 .when(partitionManager)
-                .createPartitions(anyList(), anyBoolean(), any(), anyBoolean());
+                .createPartitions(anyList(), anyBoolean(), any(), anyBoolean(), any());
         writeDataFile(fileIO, tablePath, "year=2025/month=10", "old-data.csv", 4096);
         CommitMessage message = writtenFile(fileIO, tablePath, "year=2025/month=10", 3, 128);
         Path written = ((TwoPhaseCommitMessage) message).getCommitter().targetPath();
@@ -1143,7 +1166,8 @@ class FormatTableCommitStatisticsTest {
                 List<Map<String, String>> partitions,
                 boolean ignoreIfExists,
                 @Nullable List<PartitionStatistics> statistics,
-                boolean replaceStatistics) {
+                boolean replaceStatistics,
+                @Nullable List<Map<String, String>> partitionOptions) {
             if (statistics == null) {
                 calls.add("registration");
                 return;
@@ -1160,12 +1184,12 @@ class FormatTableCommitStatisticsTest {
         @Override
         public List<Partition> listPartitions(
                 Map<String, String> prefix, @Nullable Predicate filter) {
-            throw new UnsupportedOperationException();
+            return Collections.emptyList();
         }
 
         @Override
         public List<Partition> listPartitionsByNames(List<Map<String, String>> partitions) {
-            throw new UnsupportedOperationException();
+            return Collections.emptyList();
         }
 
         @Override

--- a/paimon-core/src/test/java/org/apache/paimon/table/format/FormatTableCommitStatisticsTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/table/format/FormatTableCommitStatisticsTest.java
@@ -67,6 +67,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
@@ -1045,7 +1046,7 @@ class FormatTableCommitStatisticsTest {
                             return null;
                         })
                 .when(catalog)
-                .createPartitions(any(), anyList(), anyBoolean(), any(), anyBoolean());
+                .createPartitions(any(), anyList(), anyBoolean(), any(), anyBoolean(), isNull());
         FormatTablePartitionManager partitionManager =
                 FormatTablePartitionManager.create(TABLE, PARTITION_KEYS, () -> catalog);
         List<CommitMessage> messages = new ArrayList<>();

--- a/paimon-core/src/test/java/org/apache/paimon/table/format/FormatTableCommitTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/table/format/FormatTableCommitTest.java
@@ -19,6 +19,7 @@
 package org.apache.paimon.table.format;
 
 import org.apache.paimon.CoreOptions;
+import org.apache.paimon.PagedList;
 import org.apache.paimon.catalog.Catalog;
 import org.apache.paimon.catalog.FileSystemCatalog;
 import org.apache.paimon.catalog.Identifier;
@@ -87,6 +88,7 @@ import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.api.Assertions.entry;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.isNull;
@@ -101,6 +103,601 @@ import static org.mockito.Mockito.when;
 class FormatTableCommitTest {
 
     @TempDir java.nio.file.Path tempDir;
+
+    @Test
+    void testAppendRejectsRegisteredCustomLocationBeforeAnyTableMutation() throws Exception {
+        MutationTrackingLocalFileIO fileIO = new MutationTrackingLocalFileIO();
+        Path tablePath = new Path(new Path(tempDir.toUri()), "append-custom-location");
+        Map<String, String> spec = Collections.singletonMap("part", "external");
+        Path defaultPartitionPath = new Path(tablePath, "part=external");
+        Path targetPath = new Path(defaultPartitionPath, "data-new.csv");
+        TwoPhaseOutputStream.Committer committer = mock(TwoPhaseOutputStream.Committer.class);
+        when(committer.targetPath()).thenReturn(targetPath);
+        FormatTablePartitionManager partitionManager = mock(FormatTablePartitionManager.class);
+        when(partitionManager.listPartitionsByNames(Collections.singletonList(spec)))
+                .thenReturn(
+                        Collections.singletonList(
+                                partitionAt(spec, "file:/external/part=external")));
+        when(partitionManager.listPartitions(Collections.emptyMap(), null))
+                .thenReturn(
+                        Collections.singletonList(
+                                partitionAt(spec, "file:/external/part=external")));
+        FormatTableCommit commit =
+                new FormatTableCommit(
+                        tablePath.toString(),
+                        Collections.singletonList("part"),
+                        fileIO,
+                        false,
+                        PARTITION_DEFAULT_NAME.defaultValue(),
+                        false,
+                        Identifier.create("location_db", "location_table"),
+                        null,
+                        null,
+                        null,
+                        partitionManager,
+                        /* dynamicPartitionOverwrite */ true);
+        fileIO.startTrackingMutations();
+
+        assertThatThrownBy(
+                        () ->
+                                commit.commit(
+                                        Collections.singletonList(
+                                                new TwoPhaseCommitMessage(committer))))
+                .isInstanceOf(RuntimeException.class)
+                .hasRootCauseInstanceOf(UnsupportedOperationException.class)
+                .hasRootCauseMessage(
+                        "Writing catalog-managed Format Table partition {part=external} with "
+                                + "custom location 'file:/external/part=external' is not "
+                                + "supported.");
+
+        assertThat(fileIO.deleteCalls()).isZero();
+        assertThat(fileIO.mkdirsCalls()).isZero();
+        assertThat(fileIO.exists(defaultPartitionPath)).isFalse();
+        verify(committer, never()).commit(fileIO);
+        verify(committer, never()).clean(fileIO);
+        verify(partitionManager, never())
+                .createPartitions(anyList(), anyBoolean(), any(), anyBoolean(), isNull());
+    }
+
+    @Test
+    void testAppendAllowsRegisteredPartitionWithUnrelatedOption() throws Exception {
+        LocalFileIO fileIO = LocalFileIO.create();
+        Path tablePath = new Path(new Path(tempDir.toUri()), "append-unrelated-option");
+        Map<String, String> spec = Collections.singletonMap("part", "p");
+        TwoPhaseOutputStream.Committer committer = mock(TwoPhaseOutputStream.Committer.class);
+        when(committer.targetPath()).thenReturn(new Path(tablePath, "part=p/data-new.csv"));
+        Partition partition =
+                partitionWithOptions(spec, Collections.singletonMap("owner", "data-platform"));
+        FormatTablePartitionManager partitionManager = mock(FormatTablePartitionManager.class);
+        when(partitionManager.listPartitionsByNames(Collections.singletonList(spec)))
+                .thenReturn(Collections.singletonList(partition));
+        when(partitionManager.listPartitions(Collections.emptyMap(), null))
+                .thenReturn(Collections.singletonList(partition));
+        FormatTableCommit commit =
+                new FormatTableCommit(
+                        tablePath.toString(),
+                        Collections.singletonList("part"),
+                        fileIO,
+                        false,
+                        PARTITION_DEFAULT_NAME.defaultValue(),
+                        false,
+                        Identifier.create("location_db", "location_table"),
+                        null,
+                        null,
+                        null,
+                        partitionManager,
+                        /* dynamicPartitionOverwrite */ true);
+
+        commit.commit(Collections.singletonList(new TwoPhaseCommitMessage(committer)));
+
+        verify(committer).commit(fileIO);
+        verify(partitionManager).createPartitions(anyList(), eq(true));
+    }
+
+    @Test
+    void testStaticOverwriteRejectsCustomLocationBeforeDeletingOldData() throws Exception {
+        MutationTrackingLocalFileIO fileIO = new MutationTrackingLocalFileIO();
+        Path tablePath = new Path(new Path(tempDir.toUri()), "overwrite-custom-location");
+        Map<String, String> spec = Collections.singletonMap("part", "external");
+        Path oldData = new Path(tablePath, "part=external/data-old.csv");
+        fileIO.writeFile(oldData, "old", false);
+        FormatTablePartitionManager partitionManager = mock(FormatTablePartitionManager.class);
+        when(partitionManager.listPartitionsByNames(Collections.singletonList(spec)))
+                .thenReturn(
+                        Collections.singletonList(
+                                partitionAt(spec, "file:/external/part=external")));
+        when(partitionManager.listPartitions(Collections.emptyMap(), null))
+                .thenReturn(
+                        Collections.singletonList(
+                                partitionAt(spec, "file:/external/part=external")));
+        FormatTableCommit commit =
+                new FormatTableCommit(
+                        tablePath.toString(),
+                        Collections.singletonList("part"),
+                        fileIO,
+                        false,
+                        PARTITION_DEFAULT_NAME.defaultValue(),
+                        true,
+                        Identifier.create("location_db", "location_table"),
+                        spec,
+                        null,
+                        null,
+                        partitionManager,
+                        /* dynamicPartitionOverwrite */ true);
+        fileIO.startTrackingMutations();
+
+        assertThatThrownBy(() -> commit.commit(Collections.emptyList()))
+                .isInstanceOf(RuntimeException.class)
+                .hasRootCauseInstanceOf(UnsupportedOperationException.class)
+                .hasRootCauseMessage(
+                        "Overwriting catalog-managed Format Table partition {part=external} with "
+                                + "custom location 'file:/external/part=external' is not "
+                                + "supported.");
+
+        assertThat(fileIO.exists(oldData)).isTrue();
+        assertThat(fileIO.deleteCalls()).isZero();
+        assertThat(fileIO.mkdirsCalls()).isZero();
+        verify(partitionManager, never())
+                .createPartitions(anyList(), anyBoolean(), any(), anyBoolean(), isNull());
+    }
+
+    @Test
+    void testStaticOverwriteRejectsCustomLocationInsideTableRoot() throws Exception {
+        MutationTrackingLocalFileIO fileIO = new MutationTrackingLocalFileIO();
+        Path tablePath = new Path(new Path(tempDir.toUri()), "overwrite-future-default-location");
+        Map<String, String> customSpec = Collections.singletonMap("part", "external");
+        Map<String, String> targetSpec = Collections.singletonMap("part", "future");
+        Path targetPartitionPath = new Path(tablePath, "part=future");
+        Path customData = new Path(targetPartitionPath, "data-custom.csv");
+        fileIO.writeFile(customData, "custom", false);
+        FormatTablePartitionManager partitionManager = mock(FormatTablePartitionManager.class);
+        when(partitionManager.listPartitionsByNames(Collections.singletonList(targetSpec)))
+                .thenReturn(Collections.emptyList());
+        when(partitionManager.listPartitions(Collections.emptyMap(), null))
+                .thenReturn(
+                        Collections.singletonList(
+                                partitionAt(customSpec, targetPartitionPath.toString())));
+        FormatTableCommit commit =
+                new FormatTableCommit(
+                        tablePath.toString(),
+                        Collections.singletonList("part"),
+                        fileIO,
+                        false,
+                        PARTITION_DEFAULT_NAME.defaultValue(),
+                        true,
+                        Identifier.create("location_db", "location_table"),
+                        targetSpec,
+                        null,
+                        null,
+                        partitionManager,
+                        /* dynamicPartitionOverwrite */ true);
+        fileIO.startTrackingMutations();
+
+        Throwable failure = catchThrowable(() -> commit.commit(Collections.emptyList()));
+        assertThat(failure).isInstanceOf(RuntimeException.class);
+        assertThat(failure.getCause())
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessage(
+                        "Catalog returned an invalid custom location for partition "
+                                + "{part=external} of Format Table location_db.location_table.");
+
+        assertThat(fileIO.exists(customData)).isTrue();
+        assertThat(fileIO.deleteCalls()).isZero();
+        assertThat(fileIO.mkdirsCalls()).isZero();
+        verify(partitionManager, never())
+                .createPartitions(anyList(), anyBoolean(), any(), anyBoolean(), isNull());
+    }
+
+    @Test
+    void testAppendRejectsCustomLocationInsideTableRoot() throws Exception {
+        MutationTrackingLocalFileIO fileIO = new MutationTrackingLocalFileIO();
+        Path tablePath = new Path(new Path(tempDir.toUri()), "append-future-default-location");
+        Map<String, String> customSpec = Collections.singletonMap("part", "external");
+        Map<String, String> targetSpec = Collections.singletonMap("part", "future");
+        Path targetPartitionPath = new Path(tablePath, "part=future");
+        Path customData = new Path(targetPartitionPath, "data-custom.csv");
+        Path targetPath = new Path(targetPartitionPath, "data-new.csv");
+        fileIO.writeFile(customData, "custom", false);
+        TwoPhaseOutputStream.Committer committer = mock(TwoPhaseOutputStream.Committer.class);
+        when(committer.targetPath()).thenReturn(targetPath);
+        FormatTablePartitionManager partitionManager = mock(FormatTablePartitionManager.class);
+        when(partitionManager.listPartitionsByNames(Collections.singletonList(targetSpec)))
+                .thenReturn(Collections.emptyList());
+        when(partitionManager.listPartitions(Collections.emptyMap(), null))
+                .thenReturn(
+                        Collections.singletonList(
+                                partitionAt(customSpec, targetPartitionPath.toString())));
+        FormatTableCommit commit =
+                new FormatTableCommit(
+                        tablePath.toString(),
+                        Collections.singletonList("part"),
+                        fileIO,
+                        false,
+                        PARTITION_DEFAULT_NAME.defaultValue(),
+                        false,
+                        Identifier.create("location_db", "location_table"),
+                        null,
+                        null,
+                        null,
+                        partitionManager,
+                        /* dynamicPartitionOverwrite */ true);
+        fileIO.startTrackingMutations();
+
+        Throwable failure =
+                catchThrowable(
+                        () ->
+                                commit.commit(
+                                        Collections.singletonList(
+                                                new TwoPhaseCommitMessage(committer))));
+        assertThat(failure).isInstanceOf(RuntimeException.class);
+        assertThat(failure.getCause())
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessage(
+                        "Catalog returned an invalid custom location for partition "
+                                + "{part=external} of Format Table location_db.location_table.");
+
+        assertThat(fileIO.exists(customData)).isTrue();
+        assertThat(fileIO.exists(targetPath)).isFalse();
+        assertThat(fileIO.deleteCalls()).isZero();
+        assertThat(fileIO.mkdirsCalls()).isZero();
+        verify(committer, never()).commit(fileIO);
+        verify(committer, never()).clean(fileIO);
+        verify(partitionManager, never())
+                .createPartitions(anyList(), anyBoolean(), any(), anyBoolean(), isNull());
+    }
+
+    @Test
+    void testAppendWithEmptyMessagesRejectsCustomLocationInsideStaticPrefix() throws Exception {
+        MutationTrackingLocalFileIO fileIO = new MutationTrackingLocalFileIO();
+        Path tablePath = new Path(new Path(tempDir.toUri()), "append-partial-static-owned-prefix");
+        Map<String, String> staticPrefix = Collections.singletonMap("year", "2025");
+        Map<String, String> customSpec = partitionSpec("2024", "11");
+        Path staticPrefixPath = new Path(tablePath, "year=2025");
+        FormatTablePartitionManager partitionManager = mock(FormatTablePartitionManager.class);
+        when(partitionManager.listPartitions(Collections.emptyMap(), null))
+                .thenReturn(
+                        Collections.singletonList(
+                                partitionAt(customSpec, staticPrefixPath.toString())));
+        FormatTableCommit commit =
+                new FormatTableCommit(
+                        tablePath.toString(),
+                        Arrays.asList("year", "month"),
+                        fileIO,
+                        false,
+                        PARTITION_DEFAULT_NAME.defaultValue(),
+                        false,
+                        Identifier.create("location_db", "location_table"),
+                        staticPrefix,
+                        null,
+                        null,
+                        partitionManager,
+                        /* dynamicPartitionOverwrite */ true);
+        fileIO.startTrackingMutations();
+
+        Throwable failure = catchThrowable(() -> commit.commit(Collections.emptyList()));
+        assertThat(failure).isInstanceOf(RuntimeException.class);
+        assertThat(failure.getCause())
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessage(
+                        "Catalog returned an invalid custom location for partition "
+                                + "{year=2024, month=11} of Format Table "
+                                + "location_db.location_table.");
+
+        assertThat(fileIO.exists(staticPrefixPath)).isFalse();
+        assertThat(fileIO.deleteCalls()).isZero();
+        assertThat(fileIO.mkdirsCalls()).isZero();
+        verify(partitionManager).listPartitions(Collections.emptyMap(), null);
+        verify(partitionManager, never()).listPartitions(staticPrefix, null);
+        verify(partitionManager, never()).listPartitionsByNames(anyList());
+        verify(partitionManager, never()).createPartitions(anyList(), anyBoolean());
+        verify(partitionManager, never())
+                .createPartitions(anyList(), anyBoolean(), any(), anyBoolean(), isNull());
+    }
+
+    @Test
+    void testDynamicOverwriteRejectsAffectedCustomLocationBeforeReplacingData() throws Exception {
+        MutationTrackingLocalFileIO fileIO = new MutationTrackingLocalFileIO();
+        Path tablePath = new Path(new Path(tempDir.toUri()), "dynamic-overwrite-custom-location");
+        Map<String, String> spec = Collections.singletonMap("part", "external");
+        Path oldData = new Path(tablePath, "part=external/data-old.csv");
+        fileIO.writeFile(oldData, "old", false);
+        TwoPhaseOutputStream.Committer committer = mock(TwoPhaseOutputStream.Committer.class);
+        when(committer.targetPath()).thenReturn(new Path(tablePath, "part=external/data-new.csv"));
+        FormatTablePartitionManager partitionManager = mock(FormatTablePartitionManager.class);
+        when(partitionManager.listPartitionsByNames(Collections.singletonList(spec)))
+                .thenReturn(
+                        Collections.singletonList(
+                                partitionAt(spec, "file:/external/part=external")));
+        when(partitionManager.listPartitions(Collections.emptyMap(), null))
+                .thenReturn(
+                        Collections.singletonList(
+                                partitionAt(spec, "file:/external/part=external")));
+        FormatTableCommit commit =
+                new FormatTableCommit(
+                        tablePath.toString(),
+                        Collections.singletonList("part"),
+                        fileIO,
+                        false,
+                        PARTITION_DEFAULT_NAME.defaultValue(),
+                        true,
+                        Identifier.create("location_db", "location_table"),
+                        null,
+                        null,
+                        null,
+                        partitionManager,
+                        /* dynamicPartitionOverwrite */ true);
+        fileIO.startTrackingMutations();
+
+        assertThatThrownBy(
+                        () ->
+                                commit.commit(
+                                        Collections.singletonList(
+                                                new TwoPhaseCommitMessage(committer))))
+                .isInstanceOf(RuntimeException.class)
+                .hasRootCauseInstanceOf(UnsupportedOperationException.class)
+                .hasRootCauseMessage(
+                        "Overwriting catalog-managed Format Table partition {part=external} with "
+                                + "custom location 'file:/external/part=external' is not "
+                                + "supported.");
+
+        assertThat(fileIO.exists(oldData)).isTrue();
+        assertThat(fileIO.deleteCalls()).isZero();
+        assertThat(fileIO.mkdirsCalls()).isZero();
+        verify(committer, never()).commit(fileIO);
+        verify(committer, never()).clean(fileIO);
+        verify(partitionManager, never())
+                .createPartitions(anyList(), anyBoolean(), any(), anyBoolean(), isNull());
+    }
+
+    @Test
+    void testDynamicOverwriteRejectsCustomLocationInsideTableRoot() throws Exception {
+        MutationTrackingLocalFileIO fileIO = new MutationTrackingLocalFileIO();
+        Path tablePath =
+                new Path(new Path(tempDir.toUri()), "dynamic-overwrite-future-default-location");
+        Map<String, String> customSpec = Collections.singletonMap("part", "external");
+        Map<String, String> targetSpec = Collections.singletonMap("part", "future");
+        Path targetPartitionPath = new Path(tablePath, "part=future");
+        Path customData = new Path(targetPartitionPath, "data-custom.csv");
+        Path targetPath = new Path(targetPartitionPath, "data-new.csv");
+        fileIO.writeFile(customData, "custom", false);
+        TwoPhaseOutputStream.Committer committer = mock(TwoPhaseOutputStream.Committer.class);
+        when(committer.targetPath()).thenReturn(targetPath);
+        FormatTablePartitionManager partitionManager = mock(FormatTablePartitionManager.class);
+        when(partitionManager.listPartitionsByNames(Collections.singletonList(targetSpec)))
+                .thenReturn(Collections.emptyList());
+        when(partitionManager.listPartitions(Collections.emptyMap(), null))
+                .thenReturn(
+                        Collections.singletonList(
+                                partitionAt(customSpec, targetPartitionPath.toString())));
+        FormatTableCommit commit =
+                new FormatTableCommit(
+                        tablePath.toString(),
+                        Collections.singletonList("part"),
+                        fileIO,
+                        false,
+                        PARTITION_DEFAULT_NAME.defaultValue(),
+                        true,
+                        Identifier.create("location_db", "location_table"),
+                        null,
+                        null,
+                        null,
+                        partitionManager,
+                        /* dynamicPartitionOverwrite */ true);
+        fileIO.startTrackingMutations();
+
+        Throwable failure =
+                catchThrowable(
+                        () ->
+                                commit.commit(
+                                        Collections.singletonList(
+                                                new TwoPhaseCommitMessage(committer))));
+        assertThat(failure).isInstanceOf(RuntimeException.class);
+        assertThat(failure.getCause())
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessage(
+                        "Catalog returned an invalid custom location for partition "
+                                + "{part=external} of Format Table location_db.location_table.");
+
+        assertThat(fileIO.exists(customData)).isTrue();
+        assertThat(fileIO.exists(targetPath)).isFalse();
+        assertThat(fileIO.deleteCalls()).isZero();
+        assertThat(fileIO.mkdirsCalls()).isZero();
+        verify(committer, never()).commit(fileIO);
+        verify(committer, never()).clean(fileIO);
+        verify(partitionManager, never())
+                .createPartitions(anyList(), anyBoolean(), any(), anyBoolean(), isNull());
+    }
+
+    @Test
+    void testStaticPrefixOverwriteRejectsCustomDescendantBeforeDeletingAnyPartition()
+            throws Exception {
+        MutationTrackingLocalFileIO fileIO = new MutationTrackingLocalFileIO();
+        Path tablePath = new Path(new Path(tempDir.toUri()), "prefix-overwrite-custom-location");
+        Map<String, String> prefix = Collections.singletonMap("year", "2025");
+        Map<String, String> defaultSpec = partitionSpec("2025", "10");
+        Map<String, String> customSpec = partitionSpec("2025", "11");
+        Path defaultData = new Path(tablePath, "year=2025/month=10/data-old.csv");
+        Path customResidue = new Path(tablePath, "year=2025/month=11/data-old.csv");
+        fileIO.writeFile(defaultData, "default", false);
+        fileIO.writeFile(customResidue, "residue", false);
+        FormatTablePartitionManager partitionManager = mock(FormatTablePartitionManager.class);
+        when(partitionManager.listPartitions(prefix, null))
+                .thenReturn(
+                        Arrays.asList(
+                                partitionAt(defaultSpec, null),
+                                partitionAt(customSpec, "file:/external/year=2025/month=11")));
+        when(partitionManager.listPartitions(Collections.emptyMap(), null))
+                .thenReturn(
+                        Arrays.asList(
+                                partitionAt(defaultSpec, null),
+                                partitionAt(customSpec, "file:/external/year=2025/month=11")));
+        FormatTableCommit commit =
+                new FormatTableCommit(
+                        tablePath.toString(),
+                        Arrays.asList("year", "month"),
+                        fileIO,
+                        false,
+                        PARTITION_DEFAULT_NAME.defaultValue(),
+                        true,
+                        Identifier.create("location_db", "location_table"),
+                        prefix,
+                        null,
+                        null,
+                        partitionManager,
+                        /* dynamicPartitionOverwrite */ true);
+        fileIO.startTrackingMutations();
+
+        assertThatThrownBy(() -> commit.commit(Collections.emptyList()))
+                .isInstanceOf(RuntimeException.class)
+                .hasRootCauseInstanceOf(UnsupportedOperationException.class)
+                .hasRootCauseMessage(
+                        "Overwriting catalog-managed Format Table partition "
+                                + "{year=2025, month=11} with custom location "
+                                + "'file:/external/year=2025/month=11' is not supported.");
+
+        assertThat(fileIO.exists(defaultData)).isTrue();
+        assertThat(fileIO.exists(customResidue)).isTrue();
+        assertThat(fileIO.deleteCalls()).isZero();
+        assertThat(fileIO.mkdirsCalls()).isZero();
+        verify(partitionManager, never())
+                .createPartitions(anyList(), anyBoolean(), any(), anyBoolean(), isNull());
+    }
+
+    @Test
+    void testStaticPrefixOverwriteRejectsCustomLocationInsideTableRoot() throws Exception {
+        MutationTrackingLocalFileIO fileIO = new MutationTrackingLocalFileIO();
+        Path tablePath =
+                new Path(new Path(tempDir.toUri()), "prefix-overwrite-future-default-location");
+        Map<String, String> prefix = Collections.singletonMap("year", "2025");
+        Map<String, String> customSpec = partitionSpec("2024", "external");
+        Path targetPrefixPath = new Path(tablePath, "year=2025");
+        Path customLocation = new Path(targetPrefixPath, "month=future");
+        Path customData = new Path(customLocation, "data-custom.csv");
+        fileIO.writeFile(customData, "custom", false);
+        FormatTablePartitionManager partitionManager = mock(FormatTablePartitionManager.class);
+        when(partitionManager.listPartitions(prefix, null)).thenReturn(Collections.emptyList());
+        when(partitionManager.listPartitions(Collections.emptyMap(), null))
+                .thenReturn(
+                        Collections.singletonList(
+                                partitionAt(customSpec, customLocation.toString())));
+        FormatTableCommit commit =
+                new FormatTableCommit(
+                        tablePath.toString(),
+                        Arrays.asList("year", "month"),
+                        fileIO,
+                        false,
+                        PARTITION_DEFAULT_NAME.defaultValue(),
+                        true,
+                        Identifier.create("location_db", "location_table"),
+                        prefix,
+                        null,
+                        null,
+                        partitionManager,
+                        /* dynamicPartitionOverwrite */ true);
+        fileIO.startTrackingMutations();
+
+        Throwable failure = catchThrowable(() -> commit.commit(Collections.emptyList()));
+        assertThat(failure).isInstanceOf(RuntimeException.class);
+        assertThat(failure.getCause())
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessage(
+                        "Catalog returned an invalid custom location for partition "
+                                + "{year=2024, month=external} of Format Table "
+                                + "location_db.location_table.");
+
+        assertThat(fileIO.exists(customData)).isTrue();
+        assertThat(fileIO.deleteCalls()).isZero();
+        assertThat(fileIO.mkdirsCalls()).isZero();
+        verify(partitionManager, never())
+                .createPartitions(anyList(), anyBoolean(), any(), anyBoolean(), isNull());
+    }
+
+    @Test
+    void testStaticOverwriteAllowsRegisteredDefaultPathWithOtherCustomPartition() throws Exception {
+        LocalFileIO fileIO = LocalFileIO.create();
+        Path tablePath = new Path(new Path(tempDir.toUri()), "overwrite-registered-default");
+        Map<String, String> targetSpec = Collections.singletonMap("part", "default");
+        Map<String, String> customSpec = Collections.singletonMap("part", "external");
+        Path oldData = new Path(tablePath, "part=default/data-old.csv");
+        fileIO.writeFile(oldData, "old", false);
+        FormatTablePartitionManager partitionManager = mock(FormatTablePartitionManager.class);
+        when(partitionManager.listPartitionsByNames(Collections.singletonList(targetSpec)))
+                .thenReturn(Collections.singletonList(partitionAt(targetSpec, null)));
+        when(partitionManager.listPartitions(Collections.emptyMap(), null))
+                .thenReturn(
+                        Arrays.asList(
+                                partitionAt(targetSpec, null),
+                                partitionAt(customSpec, "file:/external/part=external")));
+        FormatTableCommit commit =
+                new FormatTableCommit(
+                        tablePath.toString(),
+                        Collections.singletonList("part"),
+                        fileIO,
+                        false,
+                        PARTITION_DEFAULT_NAME.defaultValue(),
+                        true,
+                        Identifier.create("location_db", "location_table"),
+                        targetSpec,
+                        null,
+                        null,
+                        partitionManager,
+                        /* dynamicPartitionOverwrite */ true);
+
+        commit.commit(Collections.emptyList());
+
+        assertThat(fileIO.exists(oldData)).isFalse();
+        assertThat(fileIO.exists(new Path(tablePath, "part=default"))).isTrue();
+        verify(partitionManager)
+                .createPartitions(anyList(), eq(true), anyList(), eq(true), isNull());
+    }
+
+    @Test
+    void testWholeTableOverwriteRejectsCustomLocationBeforeDeletingAnyPartition() throws Exception {
+        MutationTrackingLocalFileIO fileIO = new MutationTrackingLocalFileIO();
+        Path tablePath = new Path(new Path(tempDir.toUri()), "whole-overwrite-custom-location");
+        Map<String, String> defaultSpec = Collections.singletonMap("part", "default");
+        Map<String, String> customSpec = Collections.singletonMap("part", "external");
+        Path defaultData = new Path(tablePath, "part=default/data-old.csv");
+        Path customResidue = new Path(tablePath, "part=external/data-old.csv");
+        fileIO.writeFile(defaultData, "default", false);
+        fileIO.writeFile(customResidue, "residue", false);
+        FormatTablePartitionManager partitionManager = mock(FormatTablePartitionManager.class);
+        when(partitionManager.listPartitions(Collections.emptyMap(), null))
+                .thenReturn(
+                        Arrays.asList(
+                                partitionAt(defaultSpec, null),
+                                partitionAt(customSpec, "file:/external/part=external")));
+        FormatTableCommit commit =
+                new FormatTableCommit(
+                        tablePath.toString(),
+                        Collections.singletonList("part"),
+                        fileIO,
+                        false,
+                        PARTITION_DEFAULT_NAME.defaultValue(),
+                        true,
+                        Identifier.create("location_db", "location_table"),
+                        null,
+                        null,
+                        null,
+                        partitionManager,
+                        /* dynamicPartitionOverwrite */ false);
+        fileIO.startTrackingMutations();
+
+        assertThatThrownBy(() -> commit.commit(Collections.emptyList()))
+                .isInstanceOf(RuntimeException.class)
+                .hasRootCauseInstanceOf(UnsupportedOperationException.class)
+                .hasRootCauseMessage(
+                        "Overwriting catalog-managed Format Table partition {part=external} with "
+                                + "custom location 'file:/external/part=external' is not "
+                                + "supported.");
+
+        assertThat(fileIO.exists(defaultData)).isTrue();
+        assertThat(fileIO.exists(customResidue)).isTrue();
+        assertThat(fileIO.deleteCalls()).isZero();
+        assertThat(fileIO.mkdirsCalls()).isZero();
+        verify(partitionManager, never())
+                .createPartitions(anyList(), anyBoolean(), any(), anyBoolean(), isNull());
+    }
 
     @Test
     void testPartitionRegistrationFailureDeletesPublishedTarget() throws Exception {
@@ -140,7 +737,7 @@ class FormatTableCommitTest {
         assertThat(fileIO.exists(targetPath)).isFalse();
         verify(partitionManager).createPartitions(anyList(), eq(true));
         verify(partitionManager, never())
-                .createPartitions(anyList(), eq(true), any(), anyBoolean());
+                .createPartitions(anyList(), eq(true), any(), anyBoolean(), isNull());
     }
 
     @Test
@@ -153,6 +750,8 @@ class FormatTableCommitTest {
         Catalog catalog = mock(Catalog.class);
         List<Map<String, String>> registeredPartitions = new ArrayList<>();
         RuntimeException registrationFailure = new RuntimeException("registration response lost");
+        when(catalog.listPartitionsPaged(eq(identifier), anyInt(), isNull(), isNull()))
+                .thenReturn(new PagedList<>(Collections.emptyList(), null));
         doAnswer(
                         invocation -> {
                             List<Map<String, String>> batch = invocation.getArgument(1);
@@ -361,7 +960,7 @@ class FormatTableCommitTest {
 
         verify(committer).discard(fileIO);
         verify(partitionManager, never())
-                .createPartitions(anyList(), eq(true), any(), anyBoolean());
+                .createPartitions(anyList(), eq(true), any(), anyBoolean(), isNull());
     }
 
     @Test
@@ -404,7 +1003,7 @@ class FormatTableCommitTest {
 
         verify(committer).discard(fileIO);
         verify(partitionManager, never())
-                .createPartitions(anyList(), eq(true), any(), anyBoolean());
+                .createPartitions(anyList(), eq(true), any(), anyBoolean(), isNull());
         assertThat(fileIO.exists(targetPath)).isFalse();
     }
 
@@ -850,6 +1449,36 @@ class FormatTableCommitTest {
     }
 
     @Test
+    void testTruncateTableRejectsCustomLocationBeforeDeletingOrReporting() throws Exception {
+        MutationTrackingLocalFileIO fileIO = new MutationTrackingLocalFileIO();
+        Path tablePath = new Path(new Path(tempDir.toUri()), "truncate-custom-location");
+        Map<String, String> spec = Collections.singletonMap("part", "external");
+        Path defaultData = new Path(tablePath, "part=external/data-old.csv");
+        fileIO.writeFile(defaultData, "old", false);
+        FormatTablePartitionManager partitionManager = mock(FormatTablePartitionManager.class);
+        when(partitionManager.listPartitions(Collections.emptyMap(), null))
+                .thenReturn(
+                        Collections.singletonList(
+                                partitionAt(spec, "file:/external/part=external")));
+        FormatTableCommit commit =
+                truncatingCommit(tablePath, fileIO, false, partitionManager, "part");
+        fileIO.startTrackingMutations();
+
+        assertThatThrownBy(commit::truncateTable)
+                .isInstanceOf(UnsupportedOperationException.class)
+                .hasMessage(
+                        "Truncating catalog-managed Format Table partition {part=external} with "
+                                + "custom location 'file:/external/part=external' is not "
+                                + "supported.");
+
+        assertThat(fileIO.exists(defaultData)).isTrue();
+        assertThat(fileIO.deleteCalls()).isZero();
+        assertThat(fileIO.mkdirsCalls()).isZero();
+        verify(partitionManager, never())
+                .createPartitions(anyList(), anyBoolean(), any(), anyBoolean(), isNull());
+    }
+
+    @Test
     void testTruncateTableOnlyEmptiesTheDirectoriesThatAreItsPartitions() throws Exception {
         LocalFileIO fileIO = LocalFileIO.create();
         Path tablePath = new Path(tempDir.toUri());
@@ -932,6 +1561,151 @@ class FormatTableCommitTest {
         assertThat(fileIO.exists(octoberData)).isFalse();
         assertThat(fileIO.exists(october)).isTrue();
         assertThat(fileIO.exists(novemberData)).isTrue();
+    }
+
+    @Test
+    void testTruncateNamedPartitionRejectsCustomLocationBeforeDeletingOrReporting()
+            throws Exception {
+        MutationTrackingLocalFileIO fileIO = new MutationTrackingLocalFileIO();
+        Path tablePath = new Path(new Path(tempDir.toUri()), "truncate-named-custom-location");
+        Map<String, String> spec = partitionSpec("2025", "10");
+        Path defaultData = new Path(tablePath, "year=2025/month=10/data-old.csv");
+        fileIO.writeFile(defaultData, "old", false);
+        FormatTablePartitionManager partitionManager = mock(FormatTablePartitionManager.class);
+        when(partitionManager.listPartitionsByNames(Collections.singletonList(spec)))
+                .thenReturn(
+                        Collections.singletonList(
+                                partitionAt(spec, "file:/external/year=2025/month=10")));
+        when(partitionManager.listPartitions(Collections.emptyMap(), null))
+                .thenReturn(
+                        Collections.singletonList(
+                                partitionAt(spec, "file:/external/year=2025/month=10")));
+        FormatTableCommit commit =
+                truncatingCommit(tablePath, fileIO, false, partitionManager, "year", "month");
+        fileIO.startTrackingMutations();
+
+        assertThatThrownBy(() -> commit.truncatePartitions(Collections.singletonList(spec)))
+                .isInstanceOf(UnsupportedOperationException.class)
+                .hasMessage(
+                        "Truncating catalog-managed Format Table partition "
+                                + "{year=2025, month=10} with custom location "
+                                + "'file:/external/year=2025/month=10' is not supported.");
+
+        assertThat(fileIO.exists(defaultData)).isTrue();
+        assertThat(fileIO.deleteCalls()).isZero();
+        assertThat(fileIO.mkdirsCalls()).isZero();
+        verify(partitionManager, never())
+                .createPartitions(anyList(), anyBoolean(), any(), anyBoolean(), isNull());
+    }
+
+    @Test
+    void testTruncateNamedPartitionRejectsIncompleteSpecFromFullRegistryBeforeMutation()
+            throws Exception {
+        MutationTrackingLocalFileIO fileIO = new MutationTrackingLocalFileIO();
+        Path tablePath = new Path(new Path(tempDir.toUri()), "truncate-named-incomplete-spec");
+        Map<String, String> targetSpec = partitionSpec("2025", "10");
+        Map<String, String> incompleteSpec = Collections.singletonMap("year", "2025");
+        Path oldData = new Path(tablePath, "year=2025/month=10/data-old.csv");
+        fileIO.writeFile(oldData, "old", false);
+        FormatTablePartitionManager partitionManager = mock(FormatTablePartitionManager.class);
+        when(partitionManager.listPartitions(Collections.emptyMap(), null))
+                .thenReturn(Collections.singletonList(partitionAt(incompleteSpec, null)));
+        FormatTableCommit commit =
+                truncatingCommit(tablePath, fileIO, false, partitionManager, "year", "month");
+        fileIO.startTrackingMutations();
+
+        assertThatThrownBy(() -> commit.truncatePartitions(Collections.singletonList(targetSpec)))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessage(
+                        "Catalog returned incomplete partition spec {year=2025} for Format Table "
+                                + "truncate_db.truncate_table.");
+
+        assertThat(fileIO.exists(oldData)).isTrue();
+        assertThat(fileIO.deleteCalls()).isZero();
+        assertThat(fileIO.mkdirsCalls()).isZero();
+        verify(partitionManager).listPartitions(Collections.emptyMap(), null);
+        verify(partitionManager, never()).listPartitionsByNames(anyList());
+        verify(partitionManager, never()).createPartitions(anyList(), anyBoolean());
+        verify(partitionManager, never())
+                .createPartitions(anyList(), anyBoolean(), any(), anyBoolean(), isNull());
+    }
+
+    @Test
+    void testTruncateNamedPartitionRejectsCustomLocationInsideTableRootBeforeMutation()
+            throws Exception {
+        MutationTrackingLocalFileIO fileIO = new MutationTrackingLocalFileIO();
+        Path tablePath = new Path(new Path(tempDir.toUri()), "truncate-named-overlapping-location");
+        Map<String, String> targetSpec = partitionSpec("2025", "10");
+        Map<String, String> customSpec = partitionSpec("2024", "11");
+        Path targetPartitionPath = new Path(tablePath, "year=2025/month=10");
+        Path customData = new Path(targetPartitionPath, "data-custom.csv");
+        fileIO.writeFile(customData, "custom", false);
+        FormatTablePartitionManager partitionManager = mock(FormatTablePartitionManager.class);
+        when(partitionManager.listPartitions(Collections.emptyMap(), null))
+                .thenReturn(
+                        Arrays.asList(
+                                partitionAt(targetSpec, null),
+                                partitionAt(customSpec, targetPartitionPath.toString())));
+        FormatTableCommit commit =
+                truncatingCommit(tablePath, fileIO, false, partitionManager, "year", "month");
+        fileIO.startTrackingMutations();
+
+        assertThatThrownBy(() -> commit.truncatePartitions(Collections.singletonList(targetSpec)))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessage(
+                        "Catalog returned an invalid custom location for partition "
+                                + "{year=2024, month=11} of Format Table "
+                                + "truncate_db.truncate_table.");
+
+        assertThat(fileIO.exists(customData)).isTrue();
+        assertThat(fileIO.deleteCalls()).isZero();
+        assertThat(fileIO.mkdirsCalls()).isZero();
+        verify(partitionManager).listPartitions(Collections.emptyMap(), null);
+        verify(partitionManager, never()).listPartitionsByNames(anyList());
+        verify(partitionManager, never())
+                .createPartitions(anyList(), anyBoolean(), any(), anyBoolean(), isNull());
+    }
+
+    @Test
+    void testTruncatePrefixRejectsCustomDescendantBeforeMutatingDefaultDescendant()
+            throws Exception {
+        MutationTrackingLocalFileIO fileIO = new MutationTrackingLocalFileIO();
+        Path tablePath = new Path(new Path(tempDir.toUri()), "truncate-prefix-custom-location");
+        Map<String, String> prefix = Collections.singletonMap("year", "2025");
+        Map<String, String> defaultSpec = partitionSpec("2025", "10");
+        Map<String, String> customSpec = partitionSpec("2025", "11");
+        Path defaultData = new Path(tablePath, "year=2025/month=10/data-old.csv");
+        Path customResidue = new Path(tablePath, "year=2025/month=11/data-old.csv");
+        fileIO.writeFile(defaultData, "default", false);
+        fileIO.writeFile(customResidue, "residue", false);
+        FormatTablePartitionManager partitionManager = mock(FormatTablePartitionManager.class);
+        when(partitionManager.listPartitions(prefix, null))
+                .thenReturn(
+                        Arrays.asList(
+                                partitionAt(defaultSpec, null),
+                                partitionAt(customSpec, "file:/external/year=2025/month=11")));
+        when(partitionManager.listPartitions(Collections.emptyMap(), null))
+                .thenReturn(
+                        Arrays.asList(
+                                partitionAt(defaultSpec, null),
+                                partitionAt(customSpec, "file:/external/year=2025/month=11")));
+        FormatTableCommit commit =
+                truncatingCommit(tablePath, fileIO, false, partitionManager, "year", "month");
+        fileIO.startTrackingMutations();
+
+        assertThatThrownBy(() -> commit.truncatePartitions(Collections.singletonList(prefix)))
+                .isInstanceOf(UnsupportedOperationException.class)
+                .hasMessage(
+                        "Truncating catalog-managed Format Table partition "
+                                + "{year=2025, month=11} with custom location "
+                                + "'file:/external/year=2025/month=11' is not supported.");
+
+        assertThat(fileIO.exists(defaultData)).isTrue();
+        assertThat(fileIO.exists(customResidue)).isTrue();
+        assertThat(fileIO.deleteCalls()).isZero();
+        assertThat(fileIO.mkdirsCalls()).isZero();
+        verify(partitionManager, never())
+                .createPartitions(anyList(), anyBoolean(), any(), anyBoolean(), isNull());
     }
 
     @Test
@@ -1441,7 +2215,7 @@ class FormatTableCommitTest {
             assertThat(thirdFinished.await(3, TimeUnit.SECONDS)).isTrue();
             assertThat(activePublishes).hasValue(1);
             verify(partitionManager, never())
-                    .createPartitions(anyList(), eq(true), any(), anyBoolean());
+                    .createPartitions(anyList(), eq(true), any(), anyBoolean(), isNull());
             for (TwoPhaseOutputStream.Committer committer : committers) {
                 verify(committer, never()).clean(fileIO);
             }
@@ -1453,7 +2227,8 @@ class FormatTableCommitTest {
             for (TwoPhaseOutputStream.Committer committer : committers) {
                 verify(committer).clean(fileIO);
             }
-            verify(partitionManager).createPartitions(anyList(), eq(true), any(), eq(false));
+            verify(partitionManager)
+                    .createPartitions(anyList(), eq(true), any(), eq(false), isNull());
         } finally {
             releaseFirst.countDown();
             releaseSecond.countDown();
@@ -2025,7 +2800,8 @@ class FormatTableCommitTest {
         ArgumentCaptor<List<PartitionStatistics>> statistics =
                 ArgumentCaptor.forClass((Class) List.class);
         verify(partitionManager)
-                .createPartitions(specs.capture(), eq(true), statistics.capture(), eq(true));
+                .createPartitions(
+                        specs.capture(), eq(true), statistics.capture(), eq(true), isNull());
         assertThat(specs.getValue()).containsExactly(owned);
         assertThat(statistics.getValue())
                 .singleElement()
@@ -2081,7 +2857,7 @@ class FormatTableCommitTest {
                             return null;
                         })
                 .when(partitionManager)
-                .createPartitions(anyList(), eq(true), anyList(), eq(true));
+                .createPartitions(anyList(), eq(true), anyList(), eq(true), isNull());
         FormatTableCommit commit =
                 new FormatTableCommit(
                         tablePath.toString(),
@@ -2110,7 +2886,8 @@ class FormatTableCommitTest {
         ArgumentCaptor<List<PartitionStatistics>> statistics =
                 ArgumentCaptor.forClass((Class) List.class);
         verify(partitionManager)
-                .createPartitions(specs.capture(), eq(true), statistics.capture(), eq(true));
+                .createPartitions(
+                        specs.capture(), eq(true), statistics.capture(), eq(true), isNull());
         assertThat(specs.getValue()).containsExactlyInAnyOrderElementsOf(expectedSpecs);
         assertThat(statistics.getValue())
                 .hasSize(8)
@@ -2201,6 +2978,17 @@ class FormatTableCommitTest {
         writeOldFiles(partitionFileIO, namedPartitionPath, 3);
         FormatTablePartitionManager partitionManager = mock(FormatTablePartitionManager.class);
         when(partitionManager.listPartitionsByNames(anyList()))
+                .thenReturn(
+                        Collections.singletonList(
+                                new Partition(
+                                        Collections.singletonMap("part", "p"),
+                                        0,
+                                        0,
+                                        0,
+                                        0,
+                                        -1,
+                                        false)));
+        when(partitionManager.listPartitions(Collections.emptyMap(), null))
                 .thenReturn(
                         Collections.singletonList(
                                 new Partition(
@@ -3026,6 +3814,68 @@ class FormatTableCommitTest {
         }
     }
 
+    private static class MutationTrackingLocalFileIO extends LocalFileIO {
+
+        private final AtomicInteger deleteCalls = new AtomicInteger();
+        private final AtomicInteger mkdirsCalls = new AtomicInteger();
+        private boolean tracking;
+
+        private void startTrackingMutations() {
+            deleteCalls.set(0);
+            mkdirsCalls.set(0);
+            tracking = true;
+        }
+
+        @Override
+        public boolean delete(Path path, boolean recursive) throws IOException {
+            if (tracking) {
+                deleteCalls.incrementAndGet();
+            }
+            return super.delete(path, recursive);
+        }
+
+        @Override
+        public boolean mkdirs(Path path) throws IOException {
+            if (tracking) {
+                mkdirsCalls.incrementAndGet();
+            }
+            return super.mkdirs(path);
+        }
+
+        private int deleteCalls() {
+            return deleteCalls.get();
+        }
+
+        private int mkdirsCalls() {
+            return mkdirsCalls.get();
+        }
+    }
+
+    private static Partition partitionAt(Map<String, String> spec, String location) {
+        return partitionWithOptions(
+                spec,
+                location == null
+                        ? null
+                        : Collections.singletonMap(CoreOptions.PATH.key(), location));
+    }
+
+    private static Partition partitionWithOptions(
+            Map<String, String> spec, Map<String, String> options) {
+        return new Partition(
+                spec,
+                0,
+                0,
+                0,
+                0,
+                PartitionStatistics.UNKNOWN_TOTAL_BUCKETS,
+                false,
+                null,
+                null,
+                null,
+                null,
+                options);
+    }
+
     private static Map<String, String> partitionSpec(String year, String month) {
         LinkedHashMap<String, String> spec = new LinkedHashMap<>();
         spec.put("year", year);
@@ -3087,7 +3937,8 @@ class FormatTableCommitTest {
             FormatTablePartitionManager partitionManager) {
         ArgumentCaptor<List<Map<String, String>>> captor =
                 ArgumentCaptor.forClass((Class) List.class);
-        verify(partitionManager).createPartitions(captor.capture(), eq(true), any(), anyBoolean());
+        verify(partitionManager)
+                .createPartitions(captor.capture(), eq(true), any(), anyBoolean(), isNull());
         assertThat(captor.getValue()).hasSize(1);
         return captor.getValue().get(0);
     }

--- a/paimon-core/src/test/java/org/apache/paimon/table/format/FormatTableCommitTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/table/format/FormatTableCommitTest.java
@@ -89,6 +89,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
@@ -159,7 +160,8 @@ class FormatTableCommitTest {
                             throw registrationFailure;
                         })
                 .when(catalog)
-                .createPartitions(eq(identifier), anyList(), eq(true), eq(null), eq(false));
+                .createPartitions(
+                        eq(identifier), anyList(), eq(true), eq(null), eq(false), isNull());
         FormatTablePartitionManager partitionManager =
                 FormatTablePartitionManager.create(
                         identifier, Collections.singletonList("part"), () -> catalog);
@@ -191,7 +193,8 @@ class FormatTableCommitTest {
         assertThat(registeredPartitions).containsExactly(Collections.singletonMap("part", "p"));
         assertThat(fileIO.exists(targetPath)).isFalse();
         verify(catalog, never())
-                .createPartitions(eq(identifier), anyList(), eq(true), anyList(), eq(false));
+                .createPartitions(
+                        eq(identifier), anyList(), eq(true), anyList(), eq(false), isNull());
     }
 
     @Test

--- a/paimon-core/src/test/java/org/apache/paimon/table/format/FormatTablePartitionPathResolverTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/table/format/FormatTablePartitionPathResolverTest.java
@@ -1,0 +1,516 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.table.format;
+
+import org.apache.paimon.CoreOptions;
+import org.apache.paimon.catalog.CatalogContext;
+import org.apache.paimon.fs.Path;
+import org.apache.paimon.options.Options;
+import org.apache.paimon.partition.Partition;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.hdfs.HAUtilClient;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import java.time.Duration;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertTimeoutPreemptively;
+
+/** Tests for the canonical and ownership contract of custom partition locations. */
+class FormatTablePartitionPathResolverTest {
+
+    private static final Path TABLE_PATH = new Path("file:/warehouse/table");
+    private static final String TABLE_NAME = "db.table";
+
+    @ParameterizedTest
+    @ValueSource(
+            strings = {
+                "",
+                " ",
+                " file:/archive/dt=2026",
+                "file:/archive/dt=2026 ",
+                "/tmp/archive",
+                "relative/path",
+                "oss:/archive",
+                "oss:///archive",
+                "oss://user@bucket/archive",
+                "oss://bucket/",
+                "file:/",
+                "file://localhost/archive/dt=2026",
+                "oss://bucket/archive?version=1",
+                "oss://bucket/archive#fragment",
+                "oss://bucket/archive\\child",
+                "oss://bucket/a/./b",
+                "oss://bucket/a/../b",
+                "oss://bucket/a/%2e%2e/b",
+                "oss://bucket/a%2f../b",
+                "oss://bucket/a%2F%2e%2E/b",
+                "oss://bucket/a/%252e%252e/b",
+                "oss://bucket/a/%25252e%25252e/b",
+                "oss://bucket/a/%2e%252e/b",
+                "oss://bucket/archive/%2564t%253D2026",
+                "oss://bucket/a%252f%252e%252e%252fb",
+                "oss://bucket/a%25252f%25252e%25252e%25252fb",
+                "oss://bucket/archive%5c..%5csecret",
+                "oss://bucket/archive%3Fversion=1",
+                "oss://bucket/archive%23fragment",
+                "oss://bucket/archive%",
+                "oss://bucket/archive%2",
+                "oss://bucket/archive%GG"
+            })
+    void testRejectsInvalidCustomLocation(String location) {
+        FormatTablePartitionPathResolver resolver = resolver();
+
+        assertThatThrownBy(() -> resolver.resolve(spec(), location))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("invalid custom location")
+                .hasMessageContaining(TABLE_NAME);
+    }
+
+    @Test
+    void testRejectsRawControlCharacter() {
+        String location = "oss://bucket/archive" + (char) 0 + "child";
+
+        assertThatThrownBy(() -> resolver().resolve(spec(), location))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("invalid custom location")
+                .hasMessageContaining(TABLE_NAME);
+    }
+
+    @Test
+    void testRejectsNullPathOptionFromCatalog() {
+        Map<String, String> options = new HashMap<>();
+        options.put(CoreOptions.PATH.key(), null);
+        Partition partition =
+                new Partition(spec(), 0, 0, 0, 0, -1, false, null, null, null, null, options);
+
+        assertThatThrownBy(
+                        () ->
+                                FormatTablePartitionRegistryValidator.validatePartitionLocations(
+                                        Collections.singletonList(partition),
+                                        Arrays.asList("year", "month"),
+                                        TABLE_PATH,
+                                        TABLE_NAME,
+                                        false,
+                                        null))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("path option");
+    }
+
+    @Test
+    void testCanonicalizesSchemeAuthoritySeparatorsAndPercentEncoding() {
+        String location = "OSS://BUCKET//archive///%64t%3D2026%2Fmonth%3D09/";
+
+        Path resolved = resolver().resolve(spec(), location);
+
+        assertThat(resolved.toString()).isEqualTo("oss://bucket/archive/dt=2026/month=09");
+    }
+
+    @Test
+    void testCanonicalizesFileLocationWithoutAuthority() {
+        Path resolved = resolver().resolve(spec(), "FILE:///archive//dt=2026/");
+
+        assertThat(resolved.toString()).isEqualTo("file:/archive/dt=2026");
+    }
+
+    @Test
+    void testRejectsAuthoritylessHdfsLocationWithoutCatalogContext() {
+        assertThatThrownBy(() -> resolver().resolve(spec(), "hdfs:///archive/dt=2026"))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("invalid custom location")
+                .hasRootCauseMessage(
+                        "Authorityless HDFS location requires an HDFS default filesystem.");
+    }
+
+    @Test
+    void testAcceptsAbfsFilesystemAuthorityButRejectsCredentials() {
+        Path resolved =
+                resolver()
+                        .resolve(
+                                spec(),
+                                "ABFS://filesystem@ACCOUNT.dfs.core.windows.net/archive/dt=2026");
+
+        assertThat(resolved.toString())
+                .isEqualTo("abfs://filesystem@account.dfs.core.windows.net/archive/dt=2026");
+        assertThat(
+                        resolver()
+                                .resolve(
+                                        spec("secure"),
+                                        "ABFSS://filesystem@ACCOUNT.dfs.core.windows.net/archive/dt=2026")
+                                .toString())
+                .isEqualTo("abfss://filesystem@account.dfs.core.windows.net/archive/dt=2026");
+        assertThatThrownBy(
+                        () ->
+                                resolver()
+                                        .resolve(
+                                                spec(),
+                                                "abfs://user:password@account.dfs.core.windows.net/archive/dt=2026"))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("invalid custom location");
+    }
+
+    @Test
+    void testAbfsAndAbfssShareOneOwnershipIdentity() {
+        Path tableRoot =
+                new Path("abfss://filesystem@account.dfs.core.windows.net/warehouse/table");
+        FormatTablePartitionPathResolver tableResolver =
+                new FormatTablePartitionPathResolver(tableRoot, TABLE_NAME, false);
+
+        assertThatThrownBy(
+                        () ->
+                                tableResolver.resolve(
+                                        spec(),
+                                        "abfs://filesystem@account.dfs.core.windows.net/warehouse/table"))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("invalid custom location");
+        assertThat(
+                        FormatTablePartitionPathResolver.isWithin(
+                                new Path(
+                                        "abfs://filesystem@account.dfs.core.windows.net/warehouse/table/dt=2026"),
+                                tableRoot))
+                .isTrue();
+
+        FormatTablePartitionPathResolver ownership = resolver();
+        LinkedHashMap<String, String> first = spec("first");
+        LinkedHashMap<String, String> second = spec("second");
+        assertThat(
+                        ownership.validateAndRecord(
+                                first,
+                                ownership.resolve(
+                                        first,
+                                        "abfs://filesystem@account.dfs.core.windows.net/archive/shared")))
+                .isTrue();
+        assertThatThrownBy(
+                        () ->
+                                ownership.validateAndRecord(
+                                        first,
+                                        ownership.resolve(
+                                                first,
+                                                "abfss://filesystem@account.dfs.core.windows.net/archive/shared")))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("overlapping locations");
+        assertThatThrownBy(
+                        () ->
+                                ownership.validateAndRecord(
+                                        second,
+                                        ownership.resolve(
+                                                second,
+                                                "abfss://filesystem@account.dfs.core.windows.net/archive/shared")))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("overlapping locations");
+    }
+
+    @Test
+    void testRejectsDefaultHdfsPortAliasOfTableRoot() {
+        FormatTablePartitionPathResolver resolver =
+                new FormatTablePartitionPathResolver(
+                        new Path("hdfs://namenode:8020/warehouse/table"), TABLE_NAME, false);
+
+        assertThatThrownBy(() -> resolver.resolve(spec(), "hdfs://namenode/warehouse/table"))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("invalid custom location");
+    }
+
+    @Test
+    void testRejectsCustomLocationsInvolvingViewFsAliases() {
+        FormatTablePartitionPathResolver viewFsTable =
+                new FormatTablePartitionPathResolver(
+                        new Path("viewfs://cluster/warehouse/table"), TABLE_NAME, false);
+
+        assertThatThrownBy(
+                        () -> viewFsTable.resolve(spec(), "hdfs://namenode:8020/warehouse/table"))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("invalid custom location");
+        assertThatThrownBy(() -> resolver().resolve(spec(), "viewfs://cluster/archive/dt=2026"))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("invalid custom location");
+    }
+
+    @Test
+    void testResolvesAuthoritylessHdfsAgainstCatalogDefault() {
+        Configuration hadoopConf = new Configuration(false);
+        hadoopConf.set("fs.defaultFS", "hdfs://localhost:8020");
+        CatalogContext context = CatalogContext.create(new Options(), hadoopConf);
+        FormatTablePartitionPathResolver resolver =
+                new FormatTablePartitionPathResolver(
+                        new Path("hdfs://localhost:8020/warehouse/table"),
+                        TABLE_NAME,
+                        false,
+                        context);
+
+        Path resolved = resolver.resolve(spec("external"), "hdfs:///archive/dt=2026");
+        assertThat(resolved.toUri().getAuthority()).isEqualTo("localhost:8020");
+        assertThat(resolved.toUri().getPath()).isEqualTo("/archive/dt=2026");
+        assertThatThrownBy(() -> resolver.resolve(spec(), "hdfs:///warehouse/table"))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("invalid custom location");
+    }
+
+    @Test
+    void testAuthoritylessHdfsCanonicalizationIsIdempotentForLogicalNameservice() {
+        Configuration hadoopConf = new Configuration(false);
+        hadoopConf.set("fs.defaultFS", "hdfs://MYNS");
+        hadoopConf.set("dfs.nameservices", "MYNS");
+        CatalogContext context = CatalogContext.create(new Options(), hadoopConf);
+
+        Path canonical =
+                FormatTablePartitionPathResolver.canonicalizeCustomLocation(
+                        "hdfs:///archive/dt=2026", context);
+        Path canonicalAgain =
+                FormatTablePartitionPathResolver.canonicalizeCustomLocation(
+                        canonical.toString(), context);
+
+        assertThat(canonical.toString()).isEqualTo("hdfs://MYNS/archive/dt=2026");
+        assertThat(canonicalAgain).isEqualTo(canonical);
+        assertThat(HAUtilClient.isLogicalUri(hadoopConf, canonical.toUri())).isTrue();
+    }
+
+    @Test
+    void testCaseAmbiguousLogicalNameservicesFailClosed() {
+        Configuration hadoopConf = new Configuration(false);
+        hadoopConf.set("dfs.nameservices", "MYNS,myns");
+        CatalogContext context = CatalogContext.create(new Options(), hadoopConf);
+
+        assertThatThrownBy(
+                        () ->
+                                FormatTablePartitionPathResolver.canonicalizeCustomLocation(
+                                        "hdfs://MYNS/archive/dt=2026", context))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("multiple logical nameservices");
+    }
+
+    @Test
+    void testLogicalNameservicePortAliasCannotBypassOwnership() {
+        Configuration hadoopConf = new Configuration(false);
+        hadoopConf.set("dfs.nameservices", "mycluster");
+        CatalogContext context = CatalogContext.create(new Options(), hadoopConf);
+        Path tableRoot = new Path("hdfs://mycluster/warehouse/table");
+        FormatTablePartitionPathResolver resolver =
+                new FormatTablePartitionPathResolver(tableRoot, TABLE_NAME, false, context);
+
+        assertThatThrownBy(() -> resolver.resolve(spec(), "hdfs://mycluster:8020/warehouse/table"))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("invalid custom location");
+        assertThat(
+                        FormatTablePartitionPathResolver.isWithin(
+                                new Path("hdfs://mycluster:8020/warehouse/table/year=2025"),
+                                tableRoot,
+                                context))
+                .isTrue();
+    }
+
+    @Test
+    void testLogicalNameserviceMemberAliasCannotBypassOwnership() {
+        Configuration hadoopConf = new Configuration(false);
+        hadoopConf.set("dfs.nameservices", "mycluster");
+        hadoopConf.set("dfs.ha.namenodes.mycluster", "nn1,nn2");
+        hadoopConf.set("dfs.namenode.rpc-address.mycluster.nn1", "nn1:8020");
+        hadoopConf.set("dfs.namenode.rpc-address.mycluster.nn2", "nn2:8020");
+        CatalogContext context = CatalogContext.create(new Options(), hadoopConf);
+        Path tableRoot = new Path("hdfs://mycluster/warehouse/table");
+        FormatTablePartitionPathResolver resolver =
+                new FormatTablePartitionPathResolver(tableRoot, TABLE_NAME, false, context);
+
+        assertThatThrownBy(() -> resolver.resolve(spec(), "hdfs://nn1:8020/warehouse/table"))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("invalid custom location");
+        assertThat(
+                        FormatTablePartitionPathResolver.isWithin(
+                                new Path("hdfs://nn1/warehouse/table/year=2025"),
+                                tableRoot,
+                                context))
+                .isTrue();
+        assertThat(
+                        FormatTablePartitionPathResolver.canonicalizeCustomLocation(
+                                        "hdfs://nn1:8020/archive/dt=2026", context)
+                                .toString())
+                .isEqualTo("hdfs://mycluster/archive/dt=2026");
+    }
+
+    @Test
+    void testFederatedNameserviceMemberAliasCannotBypassOwnership() {
+        Configuration hadoopConf = new Configuration(false);
+        hadoopConf.set("dfs.nameservices", "federated");
+        hadoopConf.set("dfs.namenode.rpc-address.federated", "nn1:8020");
+        CatalogContext context = CatalogContext.create(new Options(), hadoopConf);
+        Path tableRoot = new Path("hdfs://federated/warehouse/table");
+        FormatTablePartitionPathResolver resolver =
+                new FormatTablePartitionPathResolver(tableRoot, TABLE_NAME, false, context);
+
+        assertThatThrownBy(() -> resolver.resolve(spec(), "hdfs://nn1:8020/warehouse/table"))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("invalid custom location");
+        assertThat(
+                        FormatTablePartitionPathResolver.isWithin(
+                                new Path("hdfs://nn1/warehouse/table/year=2025"),
+                                tableRoot,
+                                context))
+                .isTrue();
+    }
+
+    @Test
+    void testHdfsCanonicalIdentityIsUsedForFileIoRouting() {
+        Configuration hadoopConf = new Configuration(false);
+        hadoopConf.set("fs.defaultFS", "hdfs://localhost:8020");
+        CatalogContext context = CatalogContext.create(new Options(), hadoopConf);
+        Path tableRoot = new Path("hdfs://localhost:8020/warehouse/table");
+
+        assertThat(
+                        FormatTablePartitionPathResolver.isWithin(
+                                new Path("hdfs://localhost/warehouse/table/year=2025"),
+                                tableRoot,
+                                context))
+                .isTrue();
+        assertThat(
+                        FormatTablePartitionPathResolver.isWithin(
+                                new Path("hdfs:///warehouse/table/year=2025"), tableRoot, context))
+                .isTrue();
+    }
+
+    @ParameterizedTest
+    @ValueSource(
+            strings = {
+                "file:/warehouse/table",
+                "FILE:///warehouse//table/",
+                "file:/warehouse/table/custom/location",
+                "file:/warehouse/table/year=2025",
+                "file:/warehouse/table/year=2025/month=11",
+                "file:/warehouse/table/year=2025/month=11/subdir",
+                "file:/warehouse/table/year%3D2025%2Fmonth%3D11",
+                "file:/warehouse"
+            })
+    void testRejectsLocationOwnedByTableOrDefaultPartition(String location) {
+        assertThatThrownBy(() -> resolver().resolve(spec(), location))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("invalid custom location")
+                .hasMessageContaining(TABLE_NAME);
+    }
+
+    @Test
+    void testS3SchemeAliasesShareOneOwnershipIdentity() {
+        Path tableRoot = new Path("s3://bucket/warehouse/table");
+        FormatTablePartitionPathResolver tableResolver =
+                new FormatTablePartitionPathResolver(tableRoot, TABLE_NAME, false);
+
+        assertThatThrownBy(() -> tableResolver.resolve(spec(), "s3a://bucket/warehouse/table"))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("invalid custom location");
+        assertThat(
+                        FormatTablePartitionPathResolver.isWithin(
+                                new Path("s3n://bucket/warehouse/table/year=2025"), tableRoot))
+                .isTrue();
+
+        FormatTablePartitionPathResolver ownership = resolver();
+        LinkedHashMap<String, String> first = spec("first");
+        LinkedHashMap<String, String> second = spec("second");
+        assertThat(
+                        ownership.validateAndRecord(
+                                first, ownership.resolve(first, "s3a://bucket/archive/shared")))
+                .isTrue();
+        assertThatThrownBy(
+                        () ->
+                                ownership.validateAndRecord(
+                                        second,
+                                        ownership.resolve(second, "s3n://bucket/archive/shared")))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("overlapping locations");
+    }
+
+    @Test
+    void testOwnershipValidationScalesToLargePartitionRegistries() {
+        assertTimeoutPreemptively(
+                Duration.ofSeconds(3),
+                () -> {
+                    FormatTablePartitionPathResolver resolver = resolver();
+                    for (int partition = 0; partition < 25_000; partition++) {
+                        LinkedHashMap<String, String> spec = spec("month-" + partition);
+                        Path path =
+                                resolver.resolve(
+                                        spec, "oss://bucket/archive/partition-" + partition);
+                        assertThat(resolver.validateAndRecord(spec, path)).isTrue();
+                    }
+                });
+    }
+
+    @Test
+    void testPathSegmentBoundariesDistinguishPrefixesFromAncestors() {
+        FormatTablePartitionPathResolver resolver = resolver();
+        LinkedHashMap<String, String> first = spec("first");
+        LinkedHashMap<String, String> second = spec("second");
+        LinkedHashMap<String, String> child = spec("child");
+
+        assertThat(
+                        resolver.validateAndRecord(
+                                first, resolver.resolve(first, "oss://bucket/archive/a-b")))
+                .isTrue();
+        assertThat(
+                        resolver.validateAndRecord(
+                                second, resolver.resolve(second, "oss://bucket/archive/a")))
+                .isTrue();
+        assertThatThrownBy(
+                        () ->
+                                resolver.validateAndRecord(
+                                        child,
+                                        resolver.resolve(child, "oss://bucket/archive/a/child")))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("overlapping locations");
+
+        FormatTablePartitionPathResolver reverseOrder = resolver();
+        LinkedHashMap<String, String> descendant = spec("descendant");
+        LinkedHashMap<String, String> ancestor = spec("ancestor");
+        assertThat(
+                        reverseOrder.validateAndRecord(
+                                descendant,
+                                reverseOrder.resolve(
+                                        descendant, "oss://bucket/archive/root/child")))
+                .isTrue();
+        assertThatThrownBy(
+                        () ->
+                                reverseOrder.validateAndRecord(
+                                        ancestor,
+                                        reverseOrder.resolve(
+                                                ancestor, "oss://bucket/archive/root")))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("overlapping locations");
+    }
+
+    private static FormatTablePartitionPathResolver resolver() {
+        return new FormatTablePartitionPathResolver(TABLE_PATH, TABLE_NAME, false);
+    }
+
+    private static LinkedHashMap<String, String> spec() {
+        return spec("11");
+    }
+
+    private static LinkedHashMap<String, String> spec(String month) {
+        LinkedHashMap<String, String> spec = new LinkedHashMap<>();
+        spec.put("year", "2025");
+        spec.put("month", month);
+        return spec;
+    }
+}

--- a/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/format/FormatTablePartitionRepair.java
+++ b/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/format/FormatTablePartitionRepair.java
@@ -194,7 +194,7 @@ public class FormatTablePartitionRepair {
             sortByCanonicalPath(measured, partitionKeys);
             if (!measured.isEmpty()) {
                 partitionManager.createPartitions(
-                        measured, true, statsCollector.collect(measured), true);
+                        measured, true, statsCollector.collect(measured), true, null);
             }
         } else if (!addDiff.isEmpty()) {
             partitionManager.createPartitions(addDiff, true);

--- a/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/format/FormatTablePartitionRepair.java
+++ b/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/format/FormatTablePartitionRepair.java
@@ -152,9 +152,13 @@ public class FormatTablePartitionRepair {
             boolean dropPartitions,
             @Nullable FormatTablePartitionStatsCollector statsCollector) {
         Set<Map<String, String>> registeredPartitions = new HashSet<>();
+        Set<Map<String, String>> customLocationPartitions = new HashSet<>();
         for (Partition partition :
                 partitionManager.listPartitions(Collections.<String, String>emptyMap(), null)) {
             registeredPartitions.add(partition.spec());
+            if (hasCustomLocation(partition)) {
+                customLocationPartitions.add(partition.spec());
+            }
         }
 
         Set<Map<String, String>> filesystemSet = new HashSet<>(filesystemPartitions);
@@ -171,7 +175,8 @@ public class FormatTablePartitionRepair {
         List<Map<String, String>> dropDiff = new ArrayList<>();
         if (dropPartitions) {
             for (Map<String, String> partition : registeredPartitions) {
-                if (!filesystemSet.contains(partition)) {
+                if (!filesystemSet.contains(partition)
+                        && !customLocationPartitions.contains(partition)) {
                     dropDiff.add(partition);
                 }
             }
@@ -187,7 +192,8 @@ public class FormatTablePartitionRepair {
             // exists to correct. Without ADD it stays inside the already registered set.
             List<Map<String, String>> measured = new ArrayList<>();
             for (Map<String, String> partition : filesystemPartitions) {
-                if (addPartitions || registeredPartitions.contains(partition)) {
+                if ((addPartitions || registeredPartitions.contains(partition))
+                        && !customLocationPartitions.contains(partition)) {
                     measured.add(partition);
                 }
             }
@@ -203,6 +209,17 @@ public class FormatTablePartitionRepair {
             partitionManager.dropPartitions(dropDiff);
         }
         return addDiff.size() + dropDiff.size();
+    }
+
+    private static boolean hasCustomLocation(Partition partition) {
+        Map<String, String> options = partition.options();
+        if (options == null || !options.containsKey(CoreOptions.PATH.key())) {
+            return false;
+        }
+        if (options.get(CoreOptions.PATH.key()) == null) {
+            throw new IllegalStateException("Partition path option must not be null.");
+        }
+        return true;
     }
 
     /** Sort partitions by their canonical path for a stable, deterministic apply order. */

--- a/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/PaimonPartitionManagement.scala
+++ b/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/PaimonPartitionManagement.scala
@@ -29,7 +29,7 @@ import org.apache.spark.internal.Logging
 import org.apache.spark.sql.Row
 import org.apache.spark.sql.catalyst.{CatalystTypeConverters, InternalRow}
 import org.apache.spark.sql.catalyst.util.CharVarcharUtils
-import org.apache.spark.sql.connector.catalog.SupportsAtomicPartitionManagement
+import org.apache.spark.sql.connector.catalog.{SupportsAtomicPartitionManagement, TableCatalog}
 import org.apache.spark.sql.types.StructType
 
 import java.util.{Map => JMap, Objects}
@@ -175,16 +175,33 @@ trait PaimonPartitionManagement extends SupportsAtomicPartitionManagement with L
           val partitions = partitionManager.listPartitionsByNames(Seq(partitionSpec).asJava)
           if (!partitions.isEmpty) {
             val partition = partitions.get(0)
-            Map(
-              PartitionStatistics.FIELD_RECORD_COUNT -> partition.recordCount().toString,
-              PartitionStatistics.FIELD_FILE_SIZE_IN_BYTES -> partition
-                .fileSizeInBytes()
-                .toString,
-              PartitionStatistics.FIELD_FILE_COUNT -> partition.fileCount().toString,
-              PartitionStatistics.FIELD_LAST_FILE_CREATION_TIME -> partition
-                .lastFileCreationTime()
-                .toString
-            ).asJava
+            val metadata = new java.util.HashMap[String, String]()
+            Option(partition.options()).foreach(metadata.putAll)
+            metadata
+              .keySet()
+              .asScala
+              .filter(TableCatalog.PROP_LOCATION.equalsIgnoreCase)
+              .toSeq
+              .foreach(metadata.remove)
+            val pathOption = CoreOptions.PATH.key()
+            if (metadata.containsKey(pathOption)) {
+              val path = metadata.remove(pathOption)
+              if (path == null) {
+                throw new IllegalStateException(
+                  s"Catalog returned a null $pathOption option for partition ${partition.spec()} " +
+                    s"of Format Table ${formatTable.fullName()}.")
+              }
+              metadata.put(TableCatalog.PROP_LOCATION, path)
+            }
+            metadata.put(PartitionStatistics.FIELD_RECORD_COUNT, partition.recordCount().toString)
+            metadata.put(
+              PartitionStatistics.FIELD_FILE_SIZE_IN_BYTES,
+              partition.fileSizeInBytes().toString)
+            metadata.put(PartitionStatistics.FIELD_FILE_COUNT, partition.fileCount().toString)
+            metadata.put(
+              PartitionStatistics.FIELD_LAST_FILE_CREATION_TIME,
+              partition.lastFileCreationTime().toString)
+            metadata
           } else {
             Map.empty[String, String].asJava
           }

--- a/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/commands/PaimonAnalyzeFormatTablePartitionsCommand.scala
+++ b/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/commands/PaimonAnalyzeFormatTablePartitionsCommand.scala
@@ -18,12 +18,14 @@
 
 package org.apache.paimon.spark.commands
 
+import org.apache.paimon.CoreOptions
+import org.apache.paimon.fs.Path
 import org.apache.paimon.partition.PartitionStatistics
 import org.apache.paimon.spark.catalyst.analysis.PaimonResolvePartitionSpec
 import org.apache.paimon.spark.format.PaimonFormatTable
 import org.apache.paimon.spark.leafnode.PaimonLeafRunnableCommand
 import org.apache.paimon.spark.util.OptionUtils
-import org.apache.paimon.table.format.FormatTablePartitionStatsCollector
+import org.apache.paimon.table.format.{FormatTablePartitionRegistryValidator, FormatTablePartitionStatsCollector}
 
 import org.apache.spark.sql.{Row, SparkSession}
 import org.apache.spark.sql.PaimonUtils.normalizePartitionSpec
@@ -32,7 +34,7 @@ import org.apache.spark.sql.catalyst.expressions.GenericInternalRow
 import org.apache.spark.sql.types.{StringType, StructField, StructType}
 import org.apache.spark.unsafe.types.UTF8String
 
-import java.util.{List => JList, Map => JMap}
+import java.util.{Collections, List => JList, Map => JMap, Objects}
 
 import scala.collection.JavaConverters._
 import scala.collection.immutable.ListMap
@@ -62,11 +64,34 @@ case class PaimonAnalyzeFormatTablePartitionsCommand(
 
   override def run(sparkSession: SparkSession): Seq[Row] = {
     val prefix = leadingPrefix(sparkSession)
-    val partitions = v2Table.partitionManager
-      .listPartitions(prefix.asJava, null)
+    val manager = v2Table.partitionManager
+    val registry = manager
+      .listPartitions(Collections.emptyMap[String, String](), null)
       .asScala
-      .map(_.spec())
       .toList
+    FormatTablePartitionRegistryValidator.validatePartitionLocations(
+      registry.asJava,
+      v2Table.table.partitionKeys(),
+      new Path(v2Table.table.location()),
+      v2Table.name(),
+      CoreOptions.fromMap(v2Table.table.options()).formatTablePartitionOnlyValueInPath(),
+      v2Table.table.catalogContext()
+    )
+    val registeredPartitions = registry.filter(
+      partition =>
+        prefix.forall { case (key, value) => Objects.equals(value, partition.spec().get(key)) })
+    val customLocationPartitions = registeredPartitions.filter {
+      partition =>
+        val options = partition.options()
+        options != null && options.containsKey(CoreOptions.PATH.key())
+    }
+    if (customLocationPartitions.nonEmpty) {
+      throw new UnsupportedOperationException(
+        s"ANALYZE TABLE cannot measure partitions with a custom location in Format Table " +
+          s"${v2Table.name()}: " +
+          customLocationPartitions.map(_.spec()).mkString("[", ", ", "]"))
+    }
+    val partitions = registeredPartitions.map(_.spec())
 
     if (partitions.isEmpty && prefix.nonEmpty) {
       throw new NoSuchPartitionException(

--- a/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/commands/PaimonAnalyzeFormatTablePartitionsCommand.scala
+++ b/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/commands/PaimonAnalyzeFormatTablePartitionsCommand.scala
@@ -87,7 +87,7 @@ case class PaimonAnalyzeFormatTablePartitionsCommand(
           measureOnExecutors(sparkSession, partitions, parallelism)
         }
       v2Table.partitionManager
-        .createPartitions(partitions.asJava, true, statistics, true)
+        .createPartitions(partitions.asJava, true, statistics, true, null)
     }
     Seq.empty[Row]
   }

--- a/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/execution/PaimonFormatTablePartitionDdlExec.scala
+++ b/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/execution/PaimonFormatTablePartitionDdlExec.scala
@@ -113,9 +113,9 @@ case class PaimonAddFormatTablePartitionsExec(
  * partitions (tables using filesystem partition discovery always fail with a clear error). Complete
  * specs are resolved against the catalog registration first: missing specs fail with
  * [[NoSuchPartitionsException]] unless IF EXISTS was given, and only registered specs are
- * unregistered and have their directories deleted, so data that is merely awaiting registration
- * (e.g. by MSCK REPAIR TABLE) is never removed. Partial specs resolve to the registered leaf
- * partitions they cover.
+ * unregistered. Default-location directories are deleted; custom-location data and data merely
+ * awaiting registration (e.g. by MSCK REPAIR TABLE) are not. Partial specs resolve to the
+ * registered leaf partitions they cover.
  */
 case class PaimonDropFormatTablePartitionsExec(
     table: PaimonFormatTable,
@@ -132,11 +132,8 @@ case class PaimonDropFormatTablePartitionsExec(
         table)
     }
     if (purge) {
-      // Match Spark's v2 default for purgePartitions. DROP PARTITION on a Format Table with
-      // catalog-managed partitions already removes the partition data, so PURGE adds nothing.
       throw new UnsupportedOperationException(
-        s"DROP PARTITION ... PURGE is not supported for Format Table ${table.name()}. " +
-          "DROP PARTITION already removes the partition data.")
+        s"DROP PARTITION ... PURGE is not supported for Format Table ${table.name()}.")
     }
     if (partSpecs.isEmpty) {
       return Seq.empty
@@ -145,11 +142,10 @@ case class PaimonDropFormatTablePartitionsExec(
     val partitionKeyCount = table.table.partitionKeys().size()
     val (completeSpecs, partialSpecs) =
       partSpecs.partition(_.ident.numFields == partitionKeyCount)
-    val registration = table
-      .formatTablePartitionsRegistered(
-        completeSpecs.map(_.names.toArray).toArray,
-        completeSpecs.map(_.ident).toArray)
-      .toSeq
+    val requestedSpecs = completeSpecs ++ partialSpecs
+    val (registration, partitions) = table.resolveFormatTablePartitionsForDrop(
+      requestedSpecs.map(_.names.toArray).toArray,
+      requestedSpecs.map(_.ident).toArray)
     val missingSpecs = completeSpecs.zip(registration).collect { case (spec, false) => spec }
     if (missingSpecs.nonEmpty && !ifExists) {
       throw new NoSuchPartitionsException(
@@ -158,17 +154,11 @@ case class PaimonDropFormatTablePartitionsExec(
         table.partitionSchema)
     }
 
-    val specsToDrop =
-      completeSpecs.zip(registration).collect { case (spec, true) => spec } ++ partialSpecs
-    if (specsToDrop.nonEmpty) {
-      // Catalog-managed semantics (PaimonPartitionManagement#dropFormatTablePartitions): resolve
-      // partial specs, unregister the exact catalog partitions, then delete their directories
-      // with the table FileIO client-side. A directory-deletion failure stays unregistered so
-      // partially deleted data is not exposed again.
+    if (partitions.nonEmpty) {
+      // Resolve partial specs, unregister the exact partitions, and delete only default-location
+      // directories. A deletion failure stays unregistered so partial data is not exposed again.
       PaimonFormatTablePartitionDdlExec.refreshingCache(refreshCache) {
-        table.dropFormatTablePartitions(
-          specsToDrop.map(_.names.toArray).toArray,
-          specsToDrop.map(_.ident).toArray)
+        table.dropCatalogRegisteredPartitions(partitions)
       }
     }
     Seq.empty

--- a/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/format/PaimonFormatTable.scala
+++ b/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/format/PaimonFormatTable.scala
@@ -21,10 +21,11 @@ package org.apache.paimon.spark.format
 import org.apache.paimon.CoreOptions
 import org.apache.paimon.format.csv.CsvOptions
 import org.apache.paimon.fs.Path
+import org.apache.paimon.partition.Partition
 import org.apache.paimon.spark.{BaseTable, FormatTableScanBuilder}
 import org.apache.paimon.spark.write.{BaseV2WriteBuilder, PaimonWriteRequirement}
 import org.apache.paimon.table.FormatTable
-import org.apache.paimon.table.format.FormatTablePartitionManager
+import org.apache.paimon.table.format.{FormatTablePartitionManager, FormatTablePartitionPathResolver, FormatTablePartitionRegistryValidator}
 import org.apache.paimon.table.sink.BatchTableCommit
 import org.apache.paimon.types.RowType
 import org.apache.paimon.utils.{PartitionPathUtils, StringUtils}
@@ -47,7 +48,8 @@ import java.util
 import java.util.{Collections, Locale, Map => JMap, Objects}
 
 import scala.collection.JavaConverters._
-import scala.collection.mutable.{ArrayBuffer, HashSet}
+import scala.collection.mutable
+import scala.collection.mutable.ArrayBuffer
 
 case class PaimonFormatTable(table: FormatTable)
   extends BaseTable
@@ -59,6 +61,8 @@ case class PaimonFormatTable(table: FormatTable)
   // manager; tables using filesystem partition discovery return null and rely on the directory
   // layout instead.
   private[spark] def partitionManager: FormatTablePartitionManager = table.partitionManager()
+
+  private val partitionPathOption = CoreOptions.PATH.key()
 
   /**
    * A Format Table uses catalog-managed partitions exactly when the catalog gave it a partition
@@ -204,8 +208,22 @@ case class PaimonFormatTable(table: FormatTable)
     val requested =
       rows.zip(partitionNames).map { case (row, names) => toPaimonPartition(row, names.toSeq) }
     val registered = requirePartitionManager().listPartitionsByNames(requested.toSeq.asJava)
-    val registeredSpecs = registered.asScala.map(_.spec().asScala.toMap).toSet
-    requested.map(spec => registeredSpecs.contains(spec.asScala.toMap))
+    val pathsBySpec = mutable.LinkedHashMap.empty[Map[String, String], String]
+    registered.asScala.foreach {
+      partition =>
+        val spec = validateCatalogRegisteredPartition(partition.spec()).asScala.toMap
+        val path = customPartitionPath(partition)
+        pathsBySpec.get(spec).foreach {
+          previousPath =>
+            if (!Objects.equals(previousPath, path)) {
+              throw new IllegalStateException(
+                s"Catalog returned conflicting locations for partition $spec of Format Table " +
+                  s"${table.fullName()}.")
+            }
+        }
+        pathsBySpec.put(spec, path)
+    }
+    requested.map(spec => pathsBySpec.contains(spec.asScala.toMap))
   }
 
   /**
@@ -241,19 +259,67 @@ case class PaimonFormatTable(table: FormatTable)
       rows: Array[InternalRow],
       maps: Array[JMap[String, String]],
       ignoreIfExists: Boolean): Unit = {
-    if (maps.exists(_.keySet().asScala.exists(_.equalsIgnoreCase("location")))) {
-      throw new UnsupportedOperationException(
-        s"ADD PARTITION with LOCATION is not supported for Format Table ${table.fullName()}.")
-    }
+    require(
+      rows.length == maps.length,
+      s"Expected one option map per partition, but found ${rows.length} partitions and " +
+        s"${maps.length} option maps.")
     val onlyValueInPath =
       CoreOptions.fromMap(table.options()).formatTablePartitionOnlyValueInPath()
     val partitionKeys = table.partitionKeys().asScala.toSeq
     rows.foreach(row => requireNameablePartitionValues("ADD PARTITION", row, partitionKeys))
-    val specs = rows.map(row => toPaimonPartition(row, partitionKeys.take(row.numFields))).toSeq
-    // Resolve (and path-safety validate) every directory before mutating anything.
+    val partitions = rows
+      .zip(maps)
+      .map {
+        case (row, properties) =>
+          val spec = toPaimonPartition(row, partitionKeys.take(row.numFields))
+          require(properties != null, s"Partition options must not be null for $spec.")
+          require(
+            properties
+              .entrySet()
+              .asScala
+              .forall(entry => entry.getKey != null && entry.getValue != null),
+            s"Partition options must not contain null keys or values for $spec."
+          )
+          val options = new util.LinkedHashMap[String, String](properties)
+          val locationKeys =
+            options.keySet().asScala.filter(TableCatalog.PROP_LOCATION.equalsIgnoreCase).toSeq
+          require(
+            locationKeys.size <= 1,
+            s"Partition options contain multiple location keys for $spec: " +
+              locationKeys.mkString("[", ", ", "]"))
+          require(
+            locationKeys.isEmpty || !options.containsKey(partitionPathOption),
+            s"Partition options must not contain both ${TableCatalog.PROP_LOCATION} and " +
+              s"$partitionPathOption for $spec."
+          )
+          locationKeys.headOption.foreach {
+            key => options.put(partitionPathOption, options.remove(key))
+          }
+          if (options.containsKey(partitionPathOption)) {
+            options.put(
+              partitionPathOption,
+              normalizeCustomPartitionLocation(
+                options.get(partitionPathOption),
+                spec,
+                onlyValueInPath))
+          }
+          spec -> options
+      }
+      .toSeq
+    val specs = partitions.map(_._1)
+    // Resolve (and path-safety validate) every default directory before mutating anything.
     val partitionPaths =
-      specs.map(spec => resolvePartitionPathWithinTable(orderedSpec(spec), onlyValueInPath))
-    requirePartitionManager().createPartitions(specs.asJava, ignoreIfExists)
+      partitions.collect {
+        case (spec, options) if customPartitionPath(options, spec) == null =>
+          resolvePartitionPathWithinTable(orderedSpec(spec), onlyValueInPath)
+      }
+    val partitionOptions: Seq[JMap[String, String]] = partitions.map(_._2)
+    if (partitionOptions.forall(_.isEmpty)) {
+      requirePartitionManager().createPartitions(specs.asJava, ignoreIfExists)
+    } else {
+      requirePartitionManager()
+        .createPartitions(specs.asJava, ignoreIfExists, null, false, partitionOptions.asJava)
+    }
     // Create the partition directories client-side (symmetric with DROP deleting them), so an
     // added partition exists on the filesystem and a subsequent scan returns an empty partition
     // rather than depending on lazy directory creation, matching Hive ADD PARTITION semantics.
@@ -261,81 +327,143 @@ case class PaimonFormatTable(table: FormatTable)
     partitionPaths.foreach(partitionPath => fileIO.mkdirs(partitionPath))
   }
 
+  private def normalizeCustomPartitionLocation(
+      location: String,
+      spec: JMap[String, String],
+      onlyValueInPath: Boolean): String = {
+    try {
+      FormatTablePartitionPathResolver
+        .resolveCustomLocation(
+          new Path(table.location()),
+          orderedSpec(spec),
+          onlyValueInPath,
+          location,
+          table.catalogContext())
+        .toString
+    } catch {
+      case error: IllegalArgumentException =>
+        throw new IllegalArgumentException(
+          s"ADD PARTITION ... LOCATION is invalid for partition $spec of Format Table " +
+            s"${table.fullName()}.",
+          error)
+    }
+  }
+
   /**
-   * Drops the given partitions: complete specs are unregistered and their directories deleted
-   * as-is, partial specs are expanded to the registered leaf partitions they cover. Callers are
-   * responsible for resolving which complete specs are actually registered first (see
-   * [[formatTablePartitionsRegistered]]), so unregistered data directories are never deleted.
+   * Drops the registered partitions covered by the given specs. Complete specs that are not
+   * registered are ignored; partial specs are expanded to the registered leaf partitions they
+   * cover.
    */
   private[spark] def dropFormatTablePartitions(
       partitionNames: Array[Array[String]],
       rows: Array[InternalRow]): Boolean = {
+    val (_, partitions) = resolveFormatTablePartitionsForDrop(partitionNames, rows)
+    dropCatalogRegisteredPartitions(partitions)
+  }
+
+  /**
+   * Resolves DROP requests from one validated view of the catalog registry. The boolean array is
+   * aligned with the requests and tells callers which complete specs are registered; partial-spec
+   * entries are not used for existence reporting. The returned partitions are the deduplicated
+   * registered leaves covered by all requests.
+   */
+  private[spark] def resolveFormatTablePartitionsForDrop(
+      partitionNames: Array[Array[String]],
+      rows: Array[InternalRow]): (Array[Boolean], Seq[Partition]) = {
+    if (rows.isEmpty) {
+      return (Array.empty[Boolean], Seq.empty)
+    }
     val partitionKeyCount = table.partitionKeys().size()
     rows.zip(partitionNames).foreach {
       case (row, names) => requireNameablePartitionValues("DROP PARTITION", row, names.toSeq)
     }
     val requested =
       rows.zip(partitionNames).map { case (row, names) => toPaimonPartition(row, names.toSeq) }
-    val partitions = ArrayBuffer.empty[JMap[String, String]]
-    val seenPartitions = HashSet.empty[Map[String, String]]
+    val onlyValueInPath =
+      CoreOptions.fromMap(table.options()).formatTablePartitionOnlyValueInPath()
+    // Reject invalid specs even when the catalog has no matching partition.
+    requested.foreach(spec => resolvePartitionPathWithinTable(orderedSpec(spec), onlyValueInPath))
+    val manager = requirePartitionManager()
+    val registry = manager.listPartitions(Collections.emptyMap[String, String](), null)
+    FormatTablePartitionRegistryValidator.validatePartitionLocations(
+      registry,
+      table.partitionKeys(),
+      new Path(table.location()),
+      table.fullName(),
+      onlyValueInPath,
+      table.catalogContext())
 
-    def addPartition(partition: JMap[String, String]): Unit = {
-      if (seenPartitions.add(partition.asScala.toMap)) {
-        partitions += partition
-      }
-    }
-
-    // Preserve exact requests as-is and let discovery add only missing complete leaves.
-    requested.filter(_.size() == partitionKeyCount).foreach(addPartition)
-    val partialSpecs = requested.filter(_.size() < partitionKeyCount).toSeq.distinct
-    if (partialSpecs.nonEmpty) {
-      def matchesRequestedPartial(partition: JMap[String, String]): Boolean = {
-        partialSpecs.exists(_.asScala.forall {
-          case (key, value) => Objects.equals(value, partition.get(key))
-        })
-      }
-
-      // One unfiltered traversal resolves every partial spec; the requested constraints are
-      // enforced client-side.
-      requirePartitionManager()
-        .listPartitions(Collections.emptyMap[String, String](), null)
-        .asScala
-        .foreach {
-          partition =>
-            val validated = validateCatalogRegisteredPartition(partition.spec())
-            if (matchesRequestedPartial(validated)) {
-              addPartition(validated)
-            }
+    val bySpec = mutable.LinkedHashMap.empty[Map[String, String], Partition]
+    registry.asScala.foreach {
+      partition =>
+        val spec = validateCatalogRegisteredPartition(partition.spec()).asScala.toMap
+        bySpec.get(spec) match {
+          case Some(previous)
+              if !Objects.equals(customPartitionPath(previous), customPartitionPath(partition)) =>
+            throw new IllegalStateException(
+              s"Catalog returned conflicting locations for partition $spec of Format Table " +
+                s"${table.fullName()}.")
+          case Some(_) =>
+          case None => bySpec.put(spec, partition)
         }
     }
-    dropCatalogRegisteredPartitions(partitions.toSeq)
+
+    val registered =
+      requested.map(spec => spec.size() == partitionKeyCount && bySpec.contains(spec.asScala.toMap))
+    val partitions = ArrayBuffer.empty[Partition]
+    val requestedMaps = requested.map(_.asScala.toMap)
+    // Requests with the same column set share one hash index. This keeps the common batch of
+    // complete specs O(requests + registry), while preserving direct partial DROP support for
+    // arbitrary column subsets without testing every request against every registered partition.
+    val requestedByColumns = requestedMaps
+      .groupBy(_.keySet)
+      .map { case (columns, specs) => columns -> specs.toSet }
+    bySpec.foreach {
+      case (registeredSpec, partition) if requestedByColumns.exists {
+            case (columns, specs) =>
+              specs.contains(registeredSpec.filter { case (key, _) => columns.contains(key) })
+          } =>
+        partitions += partition
+      case _ =>
+    }
+    (registered, partitions.toSeq)
   }
 
-  private def dropCatalogRegisteredPartitions(partitions: Seq[JMap[String, String]]): Boolean = {
-    // Unregister first so new queries stop seeing the partition, then delete the data directory
-    // with the table FileIO (client-side; the server never deletes data). A deletion failure leaves
-    // the possibly incomplete directory invisible; it must not be registered again automatically.
+  private[spark] def dropCatalogRegisteredPartitions(partitions: Seq[Partition]): Boolean = {
     if (partitions.isEmpty) {
       return true
     }
 
     val onlyValueInPath =
       CoreOptions.fromMap(table.options()).formatTablePartitionOnlyValueInPath()
-    // Resolve (and path-safety validate) every partition directory before any mutation, so a
-    // traversal attempt ('.'/'..') fails the whole DROP before unregistering anything.
-    val partitionPaths =
-      partitions.map(spec => resolvePartitionPathWithinTable(orderedSpec(spec), onlyValueInPath))
-    logInfo("Try to drop catalog-registered partitions: " + partitions.mkString(","))
-    requirePartitionManager().dropPartitions(partitions.asJava)
     val fileIO = table.fileIO()
-    partitionPaths.foreach {
-      partitionPath =>
-        val deleted = fileIO.delete(partitionPath, true)
-        if (!deleted && fileIO.exists(partitionPath)) {
-          throw new java.io.IOException(
-            s"FileIO reported that partition directory $partitionPath was not deleted.")
+    val resolved = partitions.map {
+      partition =>
+        val spec = validateCatalogRegisteredPartition(partition.spec())
+        val defaultPath = if (customPartitionPath(partition) == null) {
+          Some(resolvePartitionPathWithinTable(orderedSpec(spec), onlyValueInPath))
+        } else {
+          None
         }
+        (spec, defaultPath)
     }
+
+    val specs = resolved.map(_._1)
+    logInfo("Try to drop catalog-registered partitions: " + specs.mkString(","))
+    requirePartitionManager().dropPartitions(specs.asJava)
+    // Default-location partitions keep the existing unregister-then-delete ordering. A deletion
+    // failure leaves the incomplete directory invisible. Custom locations are never probed or
+    // deleted.
+    resolved
+      .flatMap(_._2)
+      .foreach {
+        partitionPath =>
+          val deleted = fileIO.delete(partitionPath, true)
+          if (!deleted && fileIO.exists(partitionPath)) {
+            throw new java.io.IOException(
+              s"FileIO reported that partition directory $partitionPath was not deleted.")
+          }
+      }
     true
   }
 
@@ -352,6 +480,25 @@ case class PaimonFormatTable(table: FormatTable)
     val ordered = new util.LinkedHashMap[String, String]()
     partitionKeys.foreach(key => ordered.put(key, partition.get(key)))
     ordered
+  }
+
+  private def customPartitionPath(partition: Partition): String =
+    customPartitionPath(partition.options(), partition.spec())
+
+  private def customPartitionPath(
+      options: JMap[String, String],
+      spec: JMap[String, String]): String = {
+    if (options == null || !options.containsKey(partitionPathOption)) {
+      null
+    } else {
+      val path = options.get(partitionPathOption)
+      if (path == null) {
+        throw new IllegalStateException(
+          s"Catalog returned a null $partitionPathOption option for partition $spec of " +
+            s"Format Table ${table.fullName()}.")
+      }
+      path
+    }
   }
 
   private def orderedSpec(spec: JMap[String, String]): util.LinkedHashMap[String, String] = {

--- a/paimon-spark/paimon-spark-common/src/test/java/org/apache/paimon/spark/format/FormatTablePartitionRepairTest.java
+++ b/paimon-spark/paimon-spark-common/src/test/java/org/apache/paimon/spark/format/FormatTablePartitionRepairTest.java
@@ -763,7 +763,8 @@ class FormatTablePartitionRepairTest {
                 List<Map<String, String>> partitions,
                 boolean ignoreIfExists,
                 @Nullable List<PartitionStatistics> statistics,
-                boolean replaceStatistics) {
+                boolean replaceStatistics,
+                @Nullable List<Map<String, String>> partitionOptions) {
             createdPartitions.add(new ArrayList<>(partitions));
             createIgnoreFlags.add(ignoreIfExists);
             reportedStatistics.add(statistics == null ? null : new ArrayList<>(statistics));

--- a/paimon-spark/paimon-spark-common/src/test/java/org/apache/paimon/spark/format/FormatTablePartitionRepairTest.java
+++ b/paimon-spark/paimon-spark-common/src/test/java/org/apache/paimon/spark/format/FormatTablePartitionRepairTest.java
@@ -172,6 +172,65 @@ class FormatTablePartitionRepairTest {
     }
 
     @Test
+    void dropRepairNeverUnregistersACustomLocation() {
+        RecordingPartitionManager catalog = new RecordingPartitionManager();
+        catalog.registerAtLocation(
+                spec("dt", "20260714"), tempDir.resolve("external").toUri().toString());
+
+        int applied =
+                FormatTablePartitionRepair.apply(
+                        catalog,
+                        Collections.emptyList(),
+                        Collections.singletonList("dt"),
+                        false,
+                        true);
+
+        // Its absence below the table root says nothing about a custom-located partition.
+        assertThat(applied).isZero();
+        assertThat(catalog.droppedPartitions).isEmpty();
+        assertThat(catalog.createdPartitions).isEmpty();
+    }
+
+    @Test
+    void unrelatedPartitionOptionDoesNotMakeTheLocationCustom() {
+        RecordingPartitionManager catalog = new RecordingPartitionManager();
+        catalog.registerWithOptions(
+                spec("dt", "20260714"), Collections.singletonMap("owner", "spark"));
+
+        int applied =
+                FormatTablePartitionRepair.apply(
+                        catalog,
+                        Collections.emptyList(),
+                        Collections.singletonList("dt"),
+                        false,
+                        true);
+
+        assertThat(applied).isEqualTo(1);
+        assertThat(catalog.droppedPartitions)
+                .containsExactly(Collections.singletonList(spec("dt", "20260714")));
+    }
+
+    @Test
+    void nullPathOptionFailsClosed() {
+        RecordingPartitionManager catalog = new RecordingPartitionManager();
+        Map<String, String> options = new LinkedHashMap<>();
+        options.put(CoreOptions.PATH.key(), null);
+        catalog.registerWithOptions(spec("dt", "20260714"), options);
+
+        assertThatThrownBy(
+                        () ->
+                                FormatTablePartitionRepair.apply(
+                                        catalog,
+                                        Collections.emptyList(),
+                                        Collections.singletonList("dt"),
+                                        false,
+                                        true))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("path option must not be null");
+        assertThat(catalog.droppedPartitions).isEmpty();
+    }
+
+    @Test
     void addOnlyNeverDropsStaleCatalogPartitions() {
         RecordingPartitionManager catalog = new RecordingPartitionManager();
         catalog.register(Collections.singletonList(spec("dt", "20260714")));
@@ -515,6 +574,34 @@ class FormatTablePartitionRepairTest {
     }
 
     @Test
+    void repairNeverMeasuresACustomLocationFromTheDefaultDirectory() throws Exception {
+        java.nio.file.Path defaultDirectory =
+                Files.createDirectories(tempDir.resolve("dt=20260701"));
+        Files.write(
+                defaultDirectory.resolve("stale.csv"),
+                Collections.singletonList("1"),
+                StandardCharsets.UTF_8);
+
+        RecordingPartitionManager catalog = new RecordingPartitionManager();
+        catalog.registerAtLocation(
+                spec("dt", "20260701"), tempDir.resolve("external").toUri().toString());
+        FormatTable table = formatTable(tempDir.toUri().toString(), catalog);
+
+        int applied =
+                FormatTablePartitionRepair.repair(
+                        new PaimonFormatTable(table),
+                        true,
+                        true,
+                        new FormatTablePartitionStatsCollector(table, 1));
+
+        // The directory below the table root is residue, not the custom partition's data.
+        assertThat(applied).isZero();
+        assertThat(catalog.createdPartitions).isEmpty();
+        assertThat(catalog.reportedStatistics).isEmpty();
+        assertThat(catalog.droppedPartitions).isEmpty();
+    }
+
+    @Test
     void repairWritesNothingWhenMeasuringAPartitionFailsToList() throws Exception {
         Files.write(
                 Files.createDirectories(tempDir.resolve("dt=20260701")).resolve("data.csv"),
@@ -747,6 +834,8 @@ class FormatTablePartitionRepairTest {
         private static final long serialVersionUID = 1L;
 
         private final List<Map<String, String>> registered = new ArrayList<>();
+        private final Map<Map<String, String>, Map<String, String>> partitionOptions =
+                new LinkedHashMap<>();
         private final List<Map<String, String>> requestedPrefixes = new ArrayList<>();
         private final List<List<Map<String, String>>> createdPartitions = new ArrayList<>();
         private final List<Boolean> createIgnoreFlags = new ArrayList<>();
@@ -756,6 +845,17 @@ class FormatTablePartitionRepairTest {
 
         private void register(List<Map<String, String>> partitions) {
             registered.addAll(partitions);
+        }
+
+        private void registerAtLocation(Map<String, String> partition, String location) {
+            registerWithOptions(
+                    partition, Collections.singletonMap(CoreOptions.PATH.key(), location));
+        }
+
+        private void registerWithOptions(
+                Map<String, String> partition, Map<String, String> options) {
+            registered.add(partition);
+            partitionOptions.put(partition, options);
         }
 
         @Override
@@ -787,7 +887,20 @@ class FormatTablePartitionRepairTest {
             requestedPrefixes.add(prefix);
             List<Partition> partitions = new ArrayList<>(registered.size());
             for (Map<String, String> spec : registered) {
-                partitions.add(new Partition(spec, 0L, 0L, 0L, 0L, 0, false));
+                partitions.add(
+                        new Partition(
+                                spec,
+                                0L,
+                                0L,
+                                0L,
+                                0L,
+                                0,
+                                false,
+                                null,
+                                null,
+                                null,
+                                null,
+                                partitionOptions.get(spec)));
             }
             return partitions;
         }

--- a/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/execution/FormatTablePartitionDdlPlanningTest.scala
+++ b/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/execution/FormatTablePartitionDdlPlanningTest.scala
@@ -18,6 +18,7 @@
 
 package org.apache.paimon.spark.execution
 
+import org.apache.paimon.CoreOptions
 import org.apache.paimon.catalog.{CatalogContext, Identifier}
 import org.apache.paimon.fs.{FileIO, Path}
 import org.apache.paimon.fs.local.LocalFileIO
@@ -86,6 +87,18 @@ class FormatTablePartitionDdlPlanningTest extends PaimonSparkTestWithRestCatalog
         Map("dt" -> "20260715", "hh" -> "10"),
         Map("dt" -> "20260716", "hh" -> "11")))
     assert(refreshCalls == 1)
+  }
+
+  test("catalog-managed ADD stores LOCATION as a partition path option") {
+    val (table, gateway) = formatTable(withCatalogManagedPartitions = true)
+    val location =
+      new Path(Files.createTempDirectory("format-table-custom-location").toUri).toString
+    val part = partition(20260715, 10).copy(location = Some(location))
+
+    runCommand(
+      PaimonAddFormatTablePartitionsExec(table, Seq(part), ignoreIfExists = false, () => ()))
+
+    assert(gateway.createdOptions == Seq(Map(CoreOptions.PATH.key() -> location.stripSuffix("/"))))
   }
 
   test("mock service owns partial repeats, all repeats, atomic failure, and concurrent ADD") {
@@ -317,7 +330,8 @@ class FormatTablePartitionDdlPlanningTest extends PaimonSparkTestWithRestCatalog
 
     var refreshCalls = 0
     runCommand(command.copy(refreshCache = () => refreshCalls += 1))
-    assert(gateway.lookupCalls == 1)
+    assert(gateway.lookupCalls == 0)
+    assert(gateway.registryLoads == 1)
     assert(gateway.dropCalls == 1)
     assert(gateway.dropped.map(_.asScala.toMap) == Seq(Map("dt" -> "20260715", "hh" -> "10")))
     assert(refreshCalls == 1)
@@ -382,7 +396,7 @@ class FormatTablePartitionDdlPlanningTest extends PaimonSparkTestWithRestCatalog
       override def listPartitions(
           prefix: JMap[String, String],
           filter: Predicate): JList[Partition] =
-        throw new AssertionError("Complete specs must resolve through list-by-names")
+        Collections.emptyList()
     }
 
     try {
@@ -409,6 +423,78 @@ class FormatTablePartitionDdlPlanningTest extends PaimonSparkTestWithRestCatalog
     }
   }
 
+  test("mixed DROP keeps complete existence aligned when a partial spec precedes it") {
+    val fileIO = LocalFileIO.create()
+    val tablePath = new Path(Files.createTempDirectory("format-table-drop-mixed-order").toUri)
+    val partialMatch = Map("dt" -> "20260715", "hh" -> "10")
+    val completeMatch = Map("dt" -> "20260716", "hh" -> "11")
+    val unrelated = Map("dt" -> "20260717", "hh" -> "12")
+    val partialDir = new Path(tablePath, "dt=20260715/hh=10")
+    val completeDir = new Path(tablePath, "dt=20260716/hh=11")
+    val unrelatedDir = new Path(tablePath, "dt=20260717/hh=12")
+    var listCalls = 0
+    var listByNamesCalls = 0
+    var dropCalls = 0
+    var dropped = Seq.empty[Map[String, String]]
+    var refreshCalls = 0
+    val gateway = new FormatTablePartitionManager {
+      override def createPartitions(
+          partitions: JList[JMap[String, String]],
+          ignoreIfExists: Boolean,
+          statistics: JList[PartitionStatistics],
+          replaceStatistics: Boolean,
+          partitionOptions: JList[JMap[String, String]]): Unit = {}
+
+      override def dropPartitions(partitions: JList[JMap[String, String]]): Unit = {
+        dropCalls += 1
+        dropped = partitions.asScala.map(_.asScala.toMap).toSeq
+      }
+
+      override def listPartitionsByNames(
+          partitions: JList[JMap[String, String]]): JList[Partition] = {
+        listByNamesCalls += 1
+        registeredPartitions(completeMatch)
+      }
+
+      override def listPartitions(
+          prefix: JMap[String, String],
+          filter: Predicate): JList[Partition] = {
+        listCalls += 1
+        registeredPartitions(partialMatch, completeMatch, unrelated)
+      }
+    }
+
+    try {
+      fileIO.mkdirs(partialDir)
+      fileIO.mkdirs(completeDir)
+      fileIO.mkdirs(unrelatedDir)
+      val table = new PaimonFormatTable(
+        rawFormatTable(withCatalogManagedPartitions = true, gateway, tablePath.toString, fileIO))
+      val partialFirst =
+        ResolvedPartitionSpec(Seq("hh"), new GenericInternalRow(Array[Any](10)))
+
+      // A partial request has no existence bit, so placing it first exposes positional drift.
+      runCommand(
+        PaimonDropFormatTablePartitionsExec(
+          table,
+          Seq(partialFirst, partition(20260716, 11)),
+          ifExists = false,
+          purge = false,
+          () => refreshCalls += 1))
+
+      assert(listCalls == 1)
+      assert(listByNamesCalls == 0)
+      assert(dropCalls == 1)
+      assert(dropped == Seq(partialMatch, completeMatch))
+      assert(refreshCalls == 1)
+      assert(!fileIO.exists(partialDir))
+      assert(!fileIO.exists(completeDir))
+      assert(fileIO.exists(unrelatedDir))
+    } finally {
+      fileIO.delete(tablePath, true)
+    }
+  }
+
   test(
     "catalog-managed DROP IF EXISTS drops only registered partitions and preserves pending data") {
     val fileIO = LocalFileIO.create()
@@ -416,7 +502,7 @@ class FormatTablePartitionDdlPlanningTest extends PaimonSparkTestWithRestCatalog
     val registeredSpec = Map("dt" -> "20260716", "hh" -> "11")
     val registeredDir = new Path(tablePath, "dt=20260716/hh=11")
     val pendingDir = new Path(tablePath, "dt=20260715/hh=10")
-    var lookedUp = Seq.empty[Map[String, String]]
+    var registryLoads = 0
     var dropped = Seq.empty[Map[String, String]]
     var refreshCalls = 0
     val gateway = new FormatTablePartitionManager {
@@ -432,16 +518,15 @@ class FormatTablePartitionDdlPlanningTest extends PaimonSparkTestWithRestCatalog
       }
 
       override def listPartitionsByNames(
-          partitions: JList[JMap[String, String]]): JList[Partition] = {
-        lookedUp = partitions.asScala.map(_.asScala.toMap).toSeq
-        registeredPartitions(
-          partitions.asScala.map(_.asScala.toMap).filter(_ == registeredSpec).toSeq: _*)
-      }
+          partitions: JList[JMap[String, String]]): JList[Partition] =
+        throw new AssertionError("DROP must validate one complete registry view")
 
       override def listPartitions(
           prefix: JMap[String, String],
-          filter: Predicate): JList[Partition] =
-        throw new AssertionError("Complete specs must resolve through list-by-names")
+          filter: Predicate): JList[Partition] = {
+        registryLoads += 1
+        registeredPartitions(registeredSpec)
+      }
     }
 
     try {
@@ -458,10 +543,7 @@ class FormatTablePartitionDdlPlanningTest extends PaimonSparkTestWithRestCatalog
           purge = false,
           () => refreshCalls += 1))
 
-      assert(
-        lookedUp == Seq(
-          Map("dt" -> "20260715", "hh" -> "10"),
-          Map("dt" -> "20260716", "hh" -> "11")))
+      assert(registryLoads == 1)
       assert(dropped == Seq(registeredSpec))
       assert(fileIO.exists(pendingDir))
       assert(!fileIO.exists(registeredDir))
@@ -512,7 +594,7 @@ class FormatTablePartitionDdlPlanningTest extends PaimonSparkTestWithRestCatalog
       override def listPartitions(
           prefix: JMap[String, String],
           filter: Predicate): JList[Partition] =
-        throw new AssertionError("Exact specs must resolve through list-by-names")
+        registeredPartitions(registered.toSeq: _*)
     }
     var refreshCalls = 0
 
@@ -584,7 +666,7 @@ class FormatTablePartitionDdlPlanningTest extends PaimonSparkTestWithRestCatalog
       override def listPartitions(
           prefix: JMap[String, String],
           filter: Predicate): JList[Partition] =
-        throw new AssertionError("Exact specs must resolve through list-by-names")
+        registeredPartitions(registered.toSeq: _*)
     }
     val firstFileIO = LocalFileIO.create
     var refreshCalls = 0
@@ -921,7 +1003,9 @@ class FormatTablePartitionDdlPlanningTest extends PaimonSparkTestWithRestCatalog
   private class RecordingGateway extends FormatTablePartitionManager {
     var createCalls = 0
     var lookupCalls = 0
+    var registryLoads = 0
     var created = Seq.empty[JMap[String, String]]
+    var createdOptions = Seq.empty[Map[String, String]]
     var ignoreIfExists = false
     var dropCalls = 0
     var dropped = Seq.empty[JMap[String, String]]
@@ -934,6 +1018,9 @@ class FormatTablePartitionDdlPlanningTest extends PaimonSparkTestWithRestCatalog
         partitionOptions: JList[JMap[String, String]]): Unit = {
       createCalls += 1
       created = partitions.asScala.toSeq
+      createdOptions = Option(partitionOptions)
+        .map(_.asScala.map(_.asScala.toMap).toSeq)
+        .getOrElse(Seq.empty)
       this.ignoreIfExists = ignoreIfExists
     }
 
@@ -950,8 +1037,12 @@ class FormatTablePartitionDdlPlanningTest extends PaimonSparkTestWithRestCatalog
       registeredPartitions(partitions.asScala.map(_.asScala.toMap).toSeq: _*)
     }
 
-    override def listPartitions(prefix: JMap[String, String], filter: Predicate): JList[Partition] =
-      Collections.emptyList()
+    override def listPartitions(
+        prefix: JMap[String, String],
+        filter: Predicate): JList[Partition] = {
+      registryLoads += 1
+      registeredPartitions(Map("dt" -> "20260715", "hh" -> "10"))
+    }
   }
 
   private class AtomicGateway(initial: Set[Map[String, String]])

--- a/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/execution/FormatTablePartitionDdlPlanningTest.scala
+++ b/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/execution/FormatTablePartitionDdlPlanningTest.scala
@@ -370,7 +370,8 @@ class FormatTablePartitionDdlPlanningTest extends PaimonSparkTestWithRestCatalog
           partitions: JList[JMap[String, String]],
           ignoreIfExists: Boolean,
           statistics: JList[PartitionStatistics],
-          replaceStatistics: Boolean): Unit = {}
+          replaceStatistics: Boolean,
+          partitionOptions: JList[JMap[String, String]]): Unit = {}
 
       override def dropPartitions(partitions: JList[JMap[String, String]]): Unit = dropCalls += 1
 
@@ -423,7 +424,8 @@ class FormatTablePartitionDdlPlanningTest extends PaimonSparkTestWithRestCatalog
           partitions: JList[JMap[String, String]],
           ignoreIfExists: Boolean,
           statistics: JList[PartitionStatistics],
-          replaceStatistics: Boolean): Unit = {}
+          replaceStatistics: Boolean,
+          partitionOptions: JList[JMap[String, String]]): Unit = {}
 
       override def dropPartitions(partitions: JList[JMap[String, String]]): Unit = {
         dropped = partitions.asScala.map(_.asScala.toMap).toSeq
@@ -492,7 +494,8 @@ class FormatTablePartitionDdlPlanningTest extends PaimonSparkTestWithRestCatalog
           partitions: JList[JMap[String, String]],
           ignoreIfExists: Boolean,
           statistics: JList[PartitionStatistics],
-          replaceStatistics: Boolean): Unit = {
+          replaceStatistics: Boolean,
+          partitionOptions: JList[JMap[String, String]]): Unit = {
         val specs = partitions.asScala.map(_.asScala.toMap).toSeq
         compensationCreates :+= ((specs, ignoreIfExists))
         registered ++= specs
@@ -559,7 +562,8 @@ class FormatTablePartitionDdlPlanningTest extends PaimonSparkTestWithRestCatalog
           partitions: JList[JMap[String, String]],
           ignoreIfExists: Boolean,
           statistics: JList[PartitionStatistics],
-          replaceStatistics: Boolean): Unit = {
+          replaceStatistics: Boolean,
+          partitionOptions: JList[JMap[String, String]]): Unit = {
         val specs = partitions.asScala.map(_.asScala.toMap).toSeq
         compensationCreates :+= ((specs, ignoreIfExists))
         registered ++= specs
@@ -625,7 +629,8 @@ class FormatTablePartitionDdlPlanningTest extends PaimonSparkTestWithRestCatalog
           partitions: JList[JMap[String, String]],
           ignoreIfExists: Boolean,
           statistics: JList[PartitionStatistics],
-          replaceStatistics: Boolean): Unit = {}
+          replaceStatistics: Boolean,
+          partitionOptions: JList[JMap[String, String]]): Unit = {}
 
       override def dropPartitions(partitions: JList[JMap[String, String]]): Unit = {
         dropped = partitions.asScala.map(_.asScala.toMap).toSeq
@@ -669,7 +674,8 @@ class FormatTablePartitionDdlPlanningTest extends PaimonSparkTestWithRestCatalog
           partitions: JList[JMap[String, String]],
           ignoreIfExists: Boolean,
           statistics: JList[PartitionStatistics],
-          replaceStatistics: Boolean): Unit = {}
+          replaceStatistics: Boolean,
+          partitionOptions: JList[JMap[String, String]]): Unit = {}
 
       override def dropPartitions(partitions: JList[JMap[String, String]]): Unit = {
         dropped = partitions.asScala.map(_.asScala.toMap).toSeq
@@ -727,7 +733,8 @@ class FormatTablePartitionDdlPlanningTest extends PaimonSparkTestWithRestCatalog
           partitions: JList[JMap[String, String]],
           ignoreIfExists: Boolean,
           statistics: JList[PartitionStatistics],
-          replaceStatistics: Boolean): Unit = {}
+          replaceStatistics: Boolean,
+          partitionOptions: JList[JMap[String, String]]): Unit = {}
 
       override def dropPartitions(partitions: JList[JMap[String, String]]): Unit = dropCalls += 1
 
@@ -923,7 +930,8 @@ class FormatTablePartitionDdlPlanningTest extends PaimonSparkTestWithRestCatalog
         partitions: JList[JMap[String, String]],
         ignoreIfExists: Boolean,
         statistics: JList[PartitionStatistics],
-        replaceStatistics: Boolean): Unit = {
+        replaceStatistics: Boolean,
+        partitionOptions: JList[JMap[String, String]]): Unit = {
       createCalls += 1
       created = partitions.asScala.toSeq
       this.ignoreIfExists = ignoreIfExists
@@ -958,7 +966,8 @@ class FormatTablePartitionDdlPlanningTest extends PaimonSparkTestWithRestCatalog
         partitionsToCreate: JList[JMap[String, String]],
         ignoreIfExists: Boolean,
         statistics: JList[PartitionStatistics],
-        replaceStatistics: Boolean): Unit = synchronized {
+        replaceStatistics: Boolean,
+        partitionOptions: JList[JMap[String, String]]): Unit = synchronized {
       val batch = partitionsToCreate.asScala.map(_.asScala.toMap).toSeq
       batches :+= batch
       val duplicates = batch.filter(partitions.contains)

--- a/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/format/FormatTablePartitionManagementTest.scala
+++ b/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/format/FormatTablePartitionManagementTest.scala
@@ -18,6 +18,7 @@
 
 package org.apache.paimon.spark.format
 
+import org.apache.paimon.CoreOptions
 import org.apache.paimon.catalog.{CatalogContext, Identifier}
 import org.apache.paimon.fs.{FileIO, Path}
 import org.apache.paimon.fs.local.LocalFileIO
@@ -32,6 +33,7 @@ import org.apache.spark.SparkFunSuite
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.analysis.{NoSuchPartitionException, NoSuchPartitionsException}
 import org.apache.spark.sql.catalyst.expressions.GenericInternalRow
+import org.apache.spark.sql.connector.catalog.TableCatalog
 import org.apache.spark.unsafe.types.UTF8String
 
 import java.lang.reflect.{InvocationHandler, InvocationTargetException, Method, Proxy}
@@ -96,11 +98,10 @@ class FormatTablePartitionManagementTest extends SparkFunSuite {
       val sparkTable = new PaimonFormatTable(table)
       sparkTable.createFormatTablePartitions(
         Array(partitionRow(20260715, 10)),
-        Array[JMap[String, String]](Collections.emptyMap()),
+        Array(Map("owner" -> "spark").asJava),
         ignoreIfExists = true)
 
-      // ADD PARTITION creates the directory client-side, so a scan sees an empty partition
-      // rather than failing on a missing directory (Hive ADD PARTITION semantics).
+      // An unrelated option does not turn a default-location partition into a custom one.
       assert(fileIO.exists(partitionDir))
     } finally {
       fileIO.delete(tablePath, true)
@@ -143,7 +144,208 @@ class FormatTablePartitionManagementTest extends SparkFunSuite {
     assert(dropCalls == 0)
   }
 
-  test("catalog-managed ADD with LOCATION is rejected before any catalog RPC") {
+  test("catalog-managed ADD converts LOCATION and preserves the other options") {
+    var createCalls = 0
+    var forwardedOptions = Seq.empty[Map[String, String]]
+    val gateway = new FormatTablePartitionManager {
+      override def createPartitions(
+          partitions: JList[JMap[String, String]],
+          ignoreIfExists: Boolean,
+          statistics: JList[PartitionStatistics],
+          replaceStatistics: Boolean,
+          partitionOptions: JList[JMap[String, String]]): Unit = {
+        createCalls += 1
+        forwardedOptions = partitionOptions.asScala.map(_.asScala.toMap).toSeq
+      }
+
+      override def dropPartitions(partitions: JList[JMap[String, String]]): Unit = {}
+
+      override def listPartitionsByNames(
+          partitions: JList[JMap[String, String]]): JList[Partition] =
+        Collections.emptyList()
+
+      override def listPartitions(
+          prefix: JMap[String, String],
+          filter: Predicate): JList[Partition] =
+        Collections.emptyList()
+    }
+
+    val tablePath =
+      new Path(Files.createTempDirectory("catalog-partition-format-add-location").toUri)
+    val externalPath =
+      new Path(Files.createTempDirectory("catalog-partition-format-add-external").toUri)
+    val directPath =
+      new Path(Files.createTempDirectory("catalog-partition-format-add-direct-path").toUri)
+    val requestedLocation =
+      "FILE://" + externalPath.toUri.getPath.replace("/", "//") + "/"
+    val requestedPath = "FILE://" + directPath.toUri.getPath.replace("/", "//") + "/"
+    val properties = Map("LOCATION" -> requestedLocation, "owner" -> "spark").asJava
+    val pathOptions = Map(CoreOptions.PATH.key() -> requestedPath, "kind" -> "archive").asJava
+    val sparkTable =
+      new PaimonFormatTable(
+        formatTableWithCatalogManagedPartitions(
+          location = tablePath.toString,
+          partitionManager = gateway))
+    try {
+      sparkTable.createFormatTablePartitions(
+        Array(
+          new GenericInternalRow(Array[Any](20260715, 10)),
+          new GenericInternalRow(Array[Any](20260716, 11))),
+        Array(properties, pathOptions),
+        ignoreIfExists = true
+      )
+
+      assert(createCalls == 1)
+      assert(
+        forwardedOptions == Seq(
+          Map(CoreOptions.PATH.key() -> externalPath.toString.stripSuffix("/"), "owner" -> "spark"),
+          Map(CoreOptions.PATH.key() -> directPath.toString.stripSuffix("/"), "kind" -> "archive")
+        ))
+      assert(properties.asScala.toMap == Map("LOCATION" -> requestedLocation, "owner" -> "spark"))
+      assert(
+        pathOptions.asScala.toMap ==
+          Map(CoreOptions.PATH.key() -> requestedPath, "kind" -> "archive"))
+      assert(!sparkTable.table.fileIO().exists(new Path(tablePath, "dt=20260715/hh=10")))
+      assert(!sparkTable.table.fileIO().exists(new Path(tablePath, "dt=20260716/hh=11")))
+    } finally {
+      sparkTable.table.fileIO().delete(tablePath, true)
+      sparkTable.table.fileIO().delete(externalPath, true)
+      sparkTable.table.fileIO().delete(directPath, true)
+    }
+  }
+
+  test("catalog-managed ADD rejects malformed partition options before catalog access") {
+    val gateway = new InMemoryPartitionManager
+    val sparkTable =
+      new PaimonFormatTable(formatTableWithCatalogManagedPartitions(partitionManager = gateway))
+    val row = partitionRow(20260715, 10)
+
+    intercept[IllegalArgumentException] {
+      sparkTable.createFormatTablePartitions(
+        Array(row),
+        Array.empty[JMap[String, String]],
+        ignoreIfExists = true)
+    }
+    intercept[IllegalArgumentException] {
+      sparkTable.createFormatTablePartitions(
+        Array(row),
+        Array[JMap[String, String]](null),
+        ignoreIfExists = true)
+    }
+
+    val nullKey = new java.util.LinkedHashMap[String, String]()
+    nullKey.put(null, "value")
+    intercept[IllegalArgumentException] {
+      sparkTable.createFormatTablePartitions(Array(row), Array(nullKey), ignoreIfExists = true)
+    }
+
+    val duplicateLocation = new java.util.LinkedHashMap[String, String]()
+    duplicateLocation.put("location", "file:/first")
+    duplicateLocation.put("LOCATION", "file:/second")
+    intercept[IllegalArgumentException] {
+      sparkTable.createFormatTablePartitions(
+        Array(row),
+        Array(duplicateLocation),
+        ignoreIfExists = true)
+    }
+
+    val locationAndPath = new java.util.LinkedHashMap[String, String]()
+    locationAndPath.put(TableCatalog.PROP_LOCATION, "file:/location")
+    locationAndPath.put(CoreOptions.PATH.key(), "file:/path")
+    intercept[IllegalArgumentException] {
+      sparkTable.createFormatTablePartitions(
+        Array(row),
+        Array(locationAndPath),
+        ignoreIfExists = true)
+    }
+
+    assert(gateway.createRequests.isEmpty)
+  }
+
+  test("catalog-managed partition metadata exposes path as location and preserves options") {
+    val spec = partitionSpec(20260715, 10)
+    val storedOptions = new java.util.HashMap[String, String]()
+    storedOptions.put(CoreOptions.PATH.key(), "file:/external/dt=20260715/hh=10")
+    storedOptions.put("LOCATION", "file:/stale")
+    storedOptions.put("owner", "spark")
+    storedOptions.put(PartitionStatistics.FIELD_RECORD_COUNT, "stale")
+    val partition =
+      new Partition(spec.asJava, 7L, 11L, 3L, 13L, 0, false, null, null, null, null, storedOptions)
+    val gateway = partitionManagerReturning(partition)
+    val sparkTable =
+      new PaimonFormatTable(formatTableWithCatalogManagedPartitions(partitionManager = gateway))
+
+    val metadata = sparkTable.loadPartitionMetadata(partitionRow(20260715, 10)).asScala.toMap
+
+    assert(!metadata.contains(CoreOptions.PATH.key()))
+    assert(metadata(TableCatalog.PROP_LOCATION) == "file:/external/dt=20260715/hh=10")
+    assert(!metadata.contains("LOCATION"))
+    assert(metadata("owner") == "spark")
+    assert(metadata(PartitionStatistics.FIELD_RECORD_COUNT) == "7")
+    assert(metadata(PartitionStatistics.FIELD_FILE_SIZE_IN_BYTES) == "11")
+    assert(storedOptions.containsKey(CoreOptions.PATH.key()))
+    assert(storedOptions.containsKey("LOCATION"))
+    assert(!storedOptions.containsKey(TableCatalog.PROP_LOCATION))
+  }
+
+  test("catalog-managed partition metadata ignores location options without a path") {
+    val options = new java.util.HashMap[String, String]()
+    options.put("LOCATION", "file:/not-the-partition-path")
+    options.put("owner", "spark")
+    val partition =
+      new Partition(
+        partitionSpec(20260715, 10).asJava,
+        0L,
+        0L,
+        0L,
+        0L,
+        0,
+        false,
+        null,
+        null,
+        null,
+        null,
+        options)
+    val sparkTable =
+      new PaimonFormatTable(
+        formatTableWithCatalogManagedPartitions(
+          partitionManager = partitionManagerReturning(partition)))
+
+    val metadata = sparkTable.loadPartitionMetadata(partitionRow(20260715, 10)).asScala.toMap
+
+    assert(!metadata.keys.exists(TableCatalog.PROP_LOCATION.equalsIgnoreCase))
+    assert(metadata("owner") == "spark")
+    assert(options.containsKey("LOCATION"))
+  }
+
+  test("catalog-managed partition metadata rejects a null path option") {
+    val options = new java.util.HashMap[String, String]()
+    options.put(CoreOptions.PATH.key(), null)
+    val partition =
+      new Partition(
+        partitionSpec(20260715, 10).asJava,
+        0L,
+        0L,
+        0L,
+        0L,
+        0,
+        false,
+        null,
+        null,
+        null,
+        null,
+        options)
+    val sparkTable =
+      new PaimonFormatTable(
+        formatTableWithCatalogManagedPartitions(
+          partitionManager = partitionManagerReturning(partition)))
+
+    intercept[IllegalStateException] {
+      sparkTable.loadPartitionMetadata(partitionRow(20260715, 10))
+    }
+  }
+
+  test("catalog-managed ADD rejects locations owned by the table before catalog RPC") {
     var createCalls = 0
     val gateway = new FormatTablePartitionManager {
       override def createPartitions(
@@ -165,17 +367,29 @@ class FormatTablePartitionManagementTest extends SparkFunSuite {
         Collections.emptyList()
     }
 
+    val tablePath =
+      new Path(Files.createTempDirectory("catalog-partition-format-add-owned-location").toUri)
     val sparkTable =
-      new PaimonFormatTable(formatTableWithCatalogManagedPartitions(partitionManager = gateway))
-    val error = intercept[UnsupportedOperationException] {
-      sparkTable.createFormatTablePartitions(
-        Array(new GenericInternalRow(Array[Any](20260715, 10))),
-        Array(Map("location" -> "file:/tmp/custom").asJava),
-        ignoreIfExists = true)
-    }
+      new PaimonFormatTable(
+        formatTableWithCatalogManagedPartitions(
+          location = tablePath.toString,
+          partitionManager = gateway))
+    val defaultPath = new Path(tablePath, "dt=20260715/hh=10")
+    try {
+      Seq(tablePath, defaultPath, tablePath.getParent).foreach {
+        location =>
+          intercept[IllegalArgumentException] {
+            sparkTable.createFormatTablePartitions(
+              Array(new GenericInternalRow(Array[Any](20260715, 10))),
+              Array(Map("location" -> location.toString).asJava),
+              ignoreIfExists = true)
+          }
+      }
 
-    assert(error.getMessage.contains("LOCATION"))
-    assert(createCalls == 0)
+      assert(createCalls == 0)
+    } finally {
+      sparkTable.table.fileIO().delete(tablePath, true)
+    }
   }
 
   test("catalog-managed ADD rejects a partition value that would escape the table location") {
@@ -269,12 +483,12 @@ class FormatTablePartitionManagementTest extends SparkFunSuite {
 
       override def listPartitionsByNames(
           partitions: JList[JMap[String, String]]): JList[Partition] =
-        Collections.emptyList()
+        registeredPartitions(partitions.asScala.map(_.asScala.toMap).toSeq: _*)
 
       override def listPartitions(
           prefix: JMap[String, String],
           filter: Predicate): JList[Partition] =
-        Collections.emptyList()
+        registeredPartitions(partitionSpec(20260715, 10))
     }
 
     try {
@@ -294,6 +508,255 @@ class FormatTablePartitionManagementTest extends SparkFunSuite {
       assert(!fileIO.exists(partitionDir))
     } finally {
       fileIO.delete(tablePath, true)
+    }
+  }
+
+  test("catalog-managed DROP rejects a custom location that owns the target default directory") {
+    val fileIO = LocalFileIO.create()
+    val tablePath =
+      new Path(
+        Files.createTempDirectory("catalog-partition-format-drop-overlapping-location").toUri)
+    val customSpec = partitionSpec(20260715, 10)
+    val targetSpec = partitionSpec(20260716, 11)
+    val targetDir = new Path(tablePath, "dt=20260716/hh=11")
+    val marker = new Path(targetDir, "marker.csv")
+    val customPartition =
+      new Partition(
+        customSpec.asJava,
+        0L,
+        0L,
+        0L,
+        0L,
+        0,
+        false,
+        null,
+        null,
+        null,
+        null,
+        Map(CoreOptions.PATH.key() -> targetDir.toString).asJava)
+    val targetPartition =
+      new Partition(targetSpec.asJava, 0L, 0L, 0L, 0L, 0, false)
+    var dropCalls = 0
+    val gateway = new FormatTablePartitionManager {
+      override def createPartitions(
+          partitions: JList[JMap[String, String]],
+          ignoreIfExists: Boolean,
+          statistics: JList[PartitionStatistics],
+          replaceStatistics: Boolean,
+          partitionOptions: JList[JMap[String, String]]): Unit = {}
+
+      override def dropPartitions(partitions: JList[JMap[String, String]]): Unit = dropCalls += 1
+
+      override def listPartitionsByNames(
+          partitions: JList[JMap[String, String]]): JList[Partition] =
+        Collections.singletonList(targetPartition)
+
+      override def listPartitions(
+          prefix: JMap[String, String],
+          filter: Predicate): JList[Partition] =
+        Seq(customPartition, targetPartition).asJava
+    }
+
+    try {
+      fileIO.writeFile(marker, "target", false)
+      val sparkTable =
+        new PaimonFormatTable(
+          formatTableWithCatalogManagedPartitions(fileIO, tablePath.toString, gateway))
+
+      val error = intercept[IllegalStateException] {
+        sparkTable.dropFormatTablePartitions(
+          Array(Array("dt", "hh")),
+          Array(partitionRow(20260716, 11)))
+      }
+
+      assert(error.getMessage.contains("invalid custom location"))
+      assert(dropCalls == 0)
+      assert(fileIO.exists(marker))
+    } finally {
+      fileIO.delete(tablePath, true)
+    }
+  }
+
+  test("catalog-managed DROP of a custom-location partition leaves all data in place") {
+    val fileIO = LocalFileIO.create()
+    val tablePath =
+      new Path(Files.createTempDirectory("catalog-partition-format-drop-location-residue").toUri)
+    val defaultDir = new Path(tablePath, "dt=20260715/hh=10")
+    val externalDir =
+      new Path(Files.createTempDirectory("catalog-partition-format-drop-location-external").toUri)
+    val spec = partitionSpec(20260715, 10)
+    var dropCalls = 0
+    val customPartition =
+      new Partition(
+        spec.asJava,
+        0L,
+        0L,
+        0L,
+        0L,
+        0,
+        false,
+        null,
+        null,
+        null,
+        null,
+        Map(CoreOptions.PATH.key() -> externalDir.toString).asJava)
+    val gateway = new FormatTablePartitionManager {
+      override def createPartitions(
+          partitions: JList[JMap[String, String]],
+          ignoreIfExists: Boolean,
+          statistics: JList[PartitionStatistics],
+          replaceStatistics: Boolean,
+          partitionOptions: JList[JMap[String, String]]): Unit = {}
+
+      override def dropPartitions(partitions: JList[JMap[String, String]]): Unit = dropCalls += 1
+
+      override def listPartitionsByNames(
+          partitions: JList[JMap[String, String]]): JList[Partition] =
+        Collections.singletonList(customPartition)
+
+      override def listPartitions(
+          prefix: JMap[String, String],
+          filter: Predicate): JList[Partition] =
+        Collections.singletonList(customPartition)
+    }
+
+    try {
+      fileIO.writeFile(new Path(defaultDir, "residue.csv"), "default", false)
+      fileIO.writeFile(new Path(externalDir, "external.csv"), "external", false)
+      val sparkTable =
+        new PaimonFormatTable(
+          formatTableWithCatalogManagedPartitions(fileIO, tablePath.toString, gateway))
+
+      assert(
+        sparkTable
+          .dropFormatTablePartitions(Array(Array("dt", "hh")), Array(partitionRow(20260715, 10))))
+
+      assert(dropCalls == 1)
+      assert(fileIO.exists(defaultDir))
+      assert(fileIO.exists(externalDir))
+    } finally {
+      fileIO.delete(tablePath, true)
+      fileIO.delete(externalDir, true)
+    }
+  }
+
+  test("catalog-managed DROP rejects a null path option") {
+    val options = new java.util.HashMap[String, String]()
+    options.put(CoreOptions.PATH.key(), null)
+    val partition =
+      new Partition(
+        partitionSpec(20260715, 10).asJava,
+        0L,
+        0L,
+        0L,
+        0L,
+        0,
+        false,
+        null,
+        null,
+        null,
+        null,
+        options)
+    val sparkTable =
+      new PaimonFormatTable(
+        formatTableWithCatalogManagedPartitions(
+          partitionManager = partitionManagerReturning(partition)))
+
+    intercept[IllegalStateException] {
+      sparkTable.dropCatalogRegisteredPartitions(Seq(partition))
+    }
+  }
+
+  test("catalog-managed DROP unregisters a custom location without deleting its data") {
+    val fileIO = LocalFileIO.create()
+    val tablePath =
+      new Path(Files.createTempDirectory("catalog-partition-format-drop-location-table").toUri)
+    val externalDir =
+      new Path(Files.createTempDirectory("catalog-partition-format-drop-location-data").toUri)
+    val externalFile = new Path(externalDir, "external.csv")
+    val tableUri = tablePath.toUri.normalize()
+    val tableRoot = tableUri.getPath.stripSuffix("/")
+    def isWithinTable(path: Path): Boolean = {
+      val candidate = path.toUri.normalize()
+      candidate.getScheme == tableUri.getScheme &&
+      candidate.getAuthority == tableUri.getAuthority &&
+      (candidate.getPath.stripSuffix("/") == tableRoot ||
+        candidate.getPath.startsWith(tableRoot + "/"))
+    }
+    val guardedFileIO = Proxy
+      .newProxyInstance(
+        classOf[FileIO].getClassLoader,
+        Array(classOf[FileIO]),
+        new InvocationHandler {
+          override def invoke(proxy: Any, method: Method, args: Array[AnyRef]): AnyRef = {
+            Option(args).getOrElse(Array.empty[AnyRef]).foreach {
+              case path: Path if !isWithinTable(path) =>
+                throw new AssertionError(
+                  s"DROP must not access path outside table root $tablePath: $path via ${method.getName}")
+              case _ =>
+            }
+            try {
+              method.invoke(fileIO, Option(args).getOrElse(Array.empty[AnyRef]): _*)
+            } catch {
+              case error: InvocationTargetException => throw error.getCause
+            }
+          }
+        }
+      )
+      .asInstanceOf[FileIO]
+    val spec = partitionSpec(20260715, 10)
+    val customPartition =
+      new Partition(
+        spec.asJava,
+        0L,
+        0L,
+        0L,
+        0L,
+        0,
+        false,
+        null,
+        null,
+        null,
+        null,
+        Map(CoreOptions.PATH.key() -> externalDir.toString).asJava)
+    var dropped = Seq.empty[Map[String, String]]
+    val gateway = new FormatTablePartitionManager {
+      override def createPartitions(
+          partitions: JList[JMap[String, String]],
+          ignoreIfExists: Boolean,
+          statistics: JList[PartitionStatistics],
+          replaceStatistics: Boolean,
+          partitionOptions: JList[JMap[String, String]]): Unit = {}
+
+      override def dropPartitions(partitions: JList[JMap[String, String]]): Unit = {
+        dropped = partitions.asScala.map(_.asScala.toMap).toSeq
+      }
+
+      override def listPartitionsByNames(
+          partitions: JList[JMap[String, String]]): JList[Partition] =
+        Collections.singletonList(customPartition)
+
+      override def listPartitions(
+          prefix: JMap[String, String],
+          filter: Predicate): JList[Partition] =
+        Collections.singletonList(customPartition)
+    }
+
+    try {
+      fileIO.writeFile(externalFile, "external", false)
+      val sparkTable =
+        new PaimonFormatTable(
+          formatTableWithCatalogManagedPartitions(guardedFileIO, tablePath.toString, gateway))
+
+      assert(
+        sparkTable
+          .dropFormatTablePartitions(Array(Array("dt", "hh")), Array(partitionRow(20260715, 10))))
+
+      assert(dropped == Seq(spec))
+      assert(fileIO.exists(externalFile))
+    } finally {
+      fileIO.delete(tablePath, true)
+      fileIO.delete(externalDir, true)
     }
   }
 
@@ -753,6 +1216,27 @@ class FormatTablePartitionManagementTest extends SparkFunSuite {
         Collections.emptyList()
     }
 
+  private def partitionManagerReturning(partition: Partition): FormatTablePartitionManager =
+    new FormatTablePartitionManager {
+      override def createPartitions(
+          partitions: JList[JMap[String, String]],
+          ignoreIfExists: Boolean,
+          statistics: JList[PartitionStatistics],
+          replaceStatistics: Boolean,
+          partitionOptions: JList[JMap[String, String]]): Unit = {}
+
+      override def dropPartitions(partitions: JList[JMap[String, String]]): Unit = {}
+
+      override def listPartitionsByNames(
+          partitions: JList[JMap[String, String]]): JList[Partition] =
+        Collections.singletonList(partition)
+
+      override def listPartitions(
+          prefix: JMap[String, String],
+          filter: Predicate): JList[Partition] =
+        Collections.singletonList(partition)
+    }
+
   private class InMemoryPartitionManager(initialPartitions: Seq[Map[String, String]] = Seq.empty)
     extends FormatTablePartitionManager {
 
@@ -821,10 +1305,10 @@ class FormatTablePartitionManagementTest extends SparkFunSuite {
     override def dropPartitions(partitions: JList[JMap[String, String]]): Unit = dropCalls += 1
 
     override def listPartitionsByNames(partitions: JList[JMap[String, String]]): JList[Partition] =
-      Collections.emptyList()
+      registeredPartitions(partitions.asScala.map(_.asScala.toMap).toSeq: _*)
 
     override def listPartitions(prefix: JMap[String, String], filter: Predicate): JList[Partition] =
-      Collections.emptyList()
+      registeredPartitions(partitionSpec(20260715, 10))
   }
 
   private def partitionRow(dt: Int, hh: Int): InternalRow =

--- a/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/format/FormatTablePartitionManagementTest.scala
+++ b/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/format/FormatTablePartitionManagementTest.scala
@@ -54,7 +54,8 @@ class FormatTablePartitionManagementTest extends SparkFunSuite {
           partitions: JList[JMap[String, String]],
           ignoreIfExists: Boolean,
           statistics: JList[PartitionStatistics],
-          replaceStatistics: Boolean): Unit = {
+          replaceStatistics: Boolean,
+          partitionOptions: JList[JMap[String, String]]): Unit = {
         forwardedPartitions = partitions.asScala.toSeq
         forwardedIgnoreIfExists = ignoreIfExists
       }
@@ -113,7 +114,8 @@ class FormatTablePartitionManagementTest extends SparkFunSuite {
           partitions: JList[JMap[String, String]],
           ignoreIfExists: Boolean,
           statistics: JList[PartitionStatistics],
-          replaceStatistics: Boolean): Unit = {}
+          replaceStatistics: Boolean,
+          partitionOptions: JList[JMap[String, String]]): Unit = {}
 
       override def dropPartitions(partitions: JList[JMap[String, String]]): Unit = dropCalls += 1
 
@@ -148,7 +150,8 @@ class FormatTablePartitionManagementTest extends SparkFunSuite {
           partitions: JList[JMap[String, String]],
           ignoreIfExists: Boolean,
           statistics: JList[PartitionStatistics],
-          replaceStatistics: Boolean): Unit = createCalls += 1
+          replaceStatistics: Boolean,
+          partitionOptions: JList[JMap[String, String]]): Unit = createCalls += 1
 
       override def dropPartitions(partitions: JList[JMap[String, String]]): Unit = {}
 
@@ -182,7 +185,8 @@ class FormatTablePartitionManagementTest extends SparkFunSuite {
           partitions: JList[JMap[String, String]],
           ignoreIfExists: Boolean,
           statistics: JList[PartitionStatistics],
-          replaceStatistics: Boolean): Unit = createCalls += 1
+          replaceStatistics: Boolean,
+          partitionOptions: JList[JMap[String, String]]): Unit = createCalls += 1
 
       override def dropPartitions(partitions: JList[JMap[String, String]]): Unit = {}
 
@@ -254,7 +258,8 @@ class FormatTablePartitionManagementTest extends SparkFunSuite {
           partitions: JList[JMap[String, String]],
           ignoreIfExists: Boolean,
           statistics: JList[PartitionStatistics],
-          replaceStatistics: Boolean): Unit = {}
+          replaceStatistics: Boolean,
+          partitionOptions: JList[JMap[String, String]]): Unit = {}
 
       override def dropPartitions(partitions: JList[JMap[String, String]]): Unit = {
         // Ordering contract: the directory must still exist when the catalog unregisters.
@@ -308,7 +313,8 @@ class FormatTablePartitionManagementTest extends SparkFunSuite {
           partitions: JList[JMap[String, String]],
           ignoreIfExists: Boolean,
           statistics: JList[PartitionStatistics],
-          replaceStatistics: Boolean): Unit = {}
+          replaceStatistics: Boolean,
+          partitionOptions: JList[JMap[String, String]]): Unit = {}
 
       override def dropPartitions(partitions: JList[JMap[String, String]]): Unit = {
         dropped = partitions.asScala.map(_.asScala.toMap).toSeq
@@ -426,7 +432,8 @@ class FormatTablePartitionManagementTest extends SparkFunSuite {
           partitions: JList[JMap[String, String]],
           ignoreIfExists: Boolean,
           statistics: JList[PartitionStatistics],
-          replaceStatistics: Boolean): Unit = {}
+          replaceStatistics: Boolean,
+          partitionOptions: JList[JMap[String, String]]): Unit = {}
 
       override def dropPartitions(partitions: JList[JMap[String, String]]): Unit = {
         dropped = partitions.asScala.map(_.asScala.toMap).toSeq
@@ -471,7 +478,8 @@ class FormatTablePartitionManagementTest extends SparkFunSuite {
           partitions: JList[JMap[String, String]],
           ignoreIfExists: Boolean,
           statistics: JList[PartitionStatistics],
-          replaceStatistics: Boolean): Unit = {}
+          replaceStatistics: Boolean,
+          partitionOptions: JList[JMap[String, String]]): Unit = {}
 
       override def dropPartitions(partitions: JList[JMap[String, String]]): Unit = dropCalls += 1
 
@@ -521,7 +529,8 @@ class FormatTablePartitionManagementTest extends SparkFunSuite {
           partitions: JList[JMap[String, String]],
           ignoreIfExists: Boolean,
           statistics: JList[PartitionStatistics],
-          replaceStatistics: Boolean): Unit =
+          replaceStatistics: Boolean,
+          partitionOptions: JList[JMap[String, String]]): Unit =
         throw new AssertionError("An ambiguous DROP must not recreate catalog partitions")
 
       override def dropPartitions(partitions: JList[JMap[String, String]]): Unit = {
@@ -729,7 +738,8 @@ class FormatTablePartitionManagementTest extends SparkFunSuite {
           partitions: JList[JMap[String, String]],
           ignoreIfExists: Boolean,
           statistics: JList[PartitionStatistics],
-          replaceStatistics: Boolean): Unit = {}
+          replaceStatistics: Boolean,
+          partitionOptions: JList[JMap[String, String]]): Unit = {}
 
       override def dropPartitions(partitions: JList[JMap[String, String]]): Unit = {}
 
@@ -759,7 +769,8 @@ class FormatTablePartitionManagementTest extends SparkFunSuite {
         partitions: JList[JMap[String, String]],
         ignoreIfExists: Boolean,
         statistics: JList[PartitionStatistics],
-        replaceStatistics: Boolean): Unit = synchronized {
+        replaceStatistics: Boolean,
+        partitionOptions: JList[JMap[String, String]]): Unit = synchronized {
       val requested = partitions.asScala.map(_.asScala.toMap).toSeq
       requests :+= ((requested, ignoreIfExists))
       if (!ignoreIfExists) {
@@ -804,7 +815,8 @@ class FormatTablePartitionManagementTest extends SparkFunSuite {
         partitions: JList[JMap[String, String]],
         ignoreIfExists: Boolean,
         statistics: JList[PartitionStatistics],
-        replaceStatistics: Boolean): Unit = {}
+        replaceStatistics: Boolean,
+        partitionOptions: JList[JMap[String, String]]): Unit = {}
 
     override def dropPartitions(partitions: JList[JMap[String, String]]): Unit = dropCalls += 1
 

--- a/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/sql/CatalogManagedPartitionAnalyzeTest.scala
+++ b/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/sql/CatalogManagedPartitionAnalyzeTest.scala
@@ -18,17 +18,22 @@
 
 package org.apache.paimon.spark.sql
 
+import org.apache.paimon.CoreOptions
 import org.apache.paimon.catalog.Identifier
 import org.apache.paimon.fs.Path
 import org.apache.paimon.partition.{Partition, PartitionStatistics}
 import org.apache.paimon.spark.PaimonSparkTestWithRestCatalogBase
+import org.apache.paimon.spark.commands.PaimonAnalyzeFormatTablePartitionsCommand
+import org.apache.paimon.spark.format.PaimonFormatTable
 import org.apache.paimon.table.FormatTable
+import org.apache.paimon.table.format.FormatTablePartitionManager
 
 import org.apache.spark.sql.catalyst.analysis.NoSuchPartitionException
 import org.apache.spark.sql.catalyst.optimizer.BuildRight
 import org.apache.spark.sql.execution.joins.{BroadcastHashJoinExec, SortMergeJoinExec}
+import org.mockito.Mockito.{mock, when}
 
-import java.util.Locale
+import java.util.{Collections, Locale}
 
 import scala.collection.JavaConverters._
 
@@ -664,6 +669,83 @@ class CatalogManagedPartitionAnalyzeTest extends PaimonSparkTestWithRestCatalogB
     }
   }
 
+  test("ANALYZE fails before updating a custom-located partition") {
+    val tableName = "analyze_custom_location"
+    withTable(tableName) {
+      createTable(tableName)
+      val external = new Path(new Path(tempDBDir.toURI), "analyze-custom-location")
+      formatTable(tableName)
+        .fileIO()
+        .writeFile(new Path(external, "data.csv"), "1,payload\n", false)
+      sql(
+        s"ALTER TABLE ${qualified(tableName)} ADD PARTITION " +
+          s"(dt = '20260101', hour = '00') LOCATION '${external.toString}'")
+
+      val before = statisticsOf(tableName, "20260101", "00")
+      val error = intercept[Exception] {
+        sql(
+          s"ANALYZE TABLE ${qualified(tableName)} PARTITION " +
+            s"(dt = '20260101', hour = '00') COMPUTE STATISTICS NOSCAN").collect()
+      }
+
+      val messages = causeMessages(error)
+      assert(messages.contains("custom location"), messages)
+      assert(statisticsOf(tableName, "20260101", "00") == before)
+      assert(formatTable(tableName).fileIO().exists(new Path(external, "data.csv")))
+    }
+  }
+
+  test("scoped ANALYZE validates an unselected custom owner of the selected default") {
+    val tableName = "analyze_unselected_custom_owner"
+    withTable(tableName) {
+      createTable(tableName)
+      val table = formatTable(tableName)
+      val selected = Map("dt" -> "20260101", "hour" -> "00")
+      val owner = Map("dt" -> "20260102", "hour" -> "00")
+      val selectedDefaultPath = new Path(table.location(), "dt=20260101/hour=00")
+      val selectedDefault =
+        new Path("file", null, selectedDefaultPath.toUri.getPath).toString
+      val manager = mock(classOf[FormatTablePartitionManager])
+      when(manager.listPartitions(Collections.emptyMap[String, String](), null))
+        .thenReturn(
+          Seq(
+            analyzePartition(selected),
+            analyzePartition(owner, Map(CoreOptions.PATH.key() -> selectedDefault))).asJava)
+      val sparkTable =
+        new PaimonFormatTable(MsckTestFixtures.withPartitionManager(table, manager))
+
+      val error = intercept[IllegalStateException] {
+        PaimonAnalyzeFormatTablePartitionsCommand(
+          sparkTable,
+          Map("dt" -> Some("20260101"), "hour" -> Some("00")),
+          noScan = true).run(spark)
+      }
+
+      assert(error.getMessage.contains("invalid custom location"), error)
+    }
+  }
+
+  test("ANALYZE preserves unrelated partition options") {
+    val tableName = "analyze_partition_options"
+    withTable(tableName) {
+      createTable(tableName)
+      writeCsvPartition(tableName, "20260101", "00", 1)
+      val spec = Map("dt" -> "20260101", "hour" -> "00").asJava
+      paimonCatalog.createPartitions(
+        Identifier.create(dbName0, tableName),
+        List(spec).asJava,
+        true,
+        null,
+        false,
+        List(Map("owner" -> "spark").asJava).asJava
+      )
+
+      sql(s"ANALYZE TABLE ${qualified(tableName)} COMPUTE STATISTICS NOSCAN").collect()
+
+      assert(statisticsOf(tableName, "20260101", "00").options().get("owner") == "spark")
+    }
+  }
+
   test("ANALYZE is rejected for a format table discovering partitions from the filesystem") {
     val tableName = "analyze_filesystem_partitions"
     withTable(tableName) {
@@ -687,6 +769,24 @@ class CatalogManagedPartitionAnalyzeTest extends PaimonSparkTestWithRestCatalogB
   }
 
   private def qualified(tableName: String): String = s"paimon.$dbName0.$tableName"
+
+  private def analyzePartition(
+      spec: Map[String, String],
+      options: Map[String, String] = Map.empty): Partition =
+    new Partition(
+      spec.asJava,
+      PartitionStatistics.UNKNOWN,
+      PartitionStatistics.UNKNOWN,
+      PartitionStatistics.UNKNOWN,
+      PartitionStatistics.UNKNOWN,
+      PartitionStatistics.UNKNOWN_TOTAL_BUCKETS,
+      false,
+      null,
+      null,
+      null,
+      null,
+      if (options.isEmpty) null else options.asJava
+    )
 
   private def createTable(tableName: String): Unit = {
     sql(s"""CREATE TABLE $tableName (id INT, payload STRING, dt STRING, hour STRING)

--- a/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/sql/CatalogManagedPartitionAnalyzeTest.scala
+++ b/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/sql/CatalogManagedPartitionAnalyzeTest.scala
@@ -487,7 +487,8 @@ class CatalogManagedPartitionAnalyzeTest extends PaimonSparkTestWithRestCatalogB
             0L,
             0L,
             PartitionStatistics.UNKNOWN_TOTAL_BUCKETS)).asJava,
-        true
+        true,
+        null
       )
 
       val zeroed = getFormatTableScan(s"SELECT * FROM ${qualified(tableName)}").estimateStatistics

--- a/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/sql/CatalogManagedPartitionDdlParityTest.scala
+++ b/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/sql/CatalogManagedPartitionDdlParityTest.scala
@@ -18,6 +18,7 @@
 
 package org.apache.paimon.spark.sql
 
+import org.apache.paimon.CoreOptions
 import org.apache.paimon.catalog.Identifier
 import org.apache.paimon.fs.Path
 import org.apache.paimon.spark.PaimonSparkTestWithRestCatalogBase
@@ -35,6 +36,42 @@ import scala.collection.JavaConverters._
  * the session's case sensitivity.
  */
 class CatalogManagedPartitionDdlParityTest extends PaimonSparkTestWithRestCatalogBase {
+
+  test("ADD PARTITION LOCATION reads external data without creating the default directory") {
+    val tableName = "ddl_add_location"
+    withTable(tableName) {
+      createTable(tableName)
+      withTempDir {
+        externalDir =>
+          val table = formatTable(tableName)
+          val externalLocation = new Path(externalDir.toURI.toString).toString
+          table
+            .fileIO()
+            .writeFile(new Path(externalLocation, "part-00001.csv"), "1,a\n", false)
+
+          sql(
+            s"ALTER TABLE ${qualified(tableName)} ADD " +
+              s"PARTITION (dt = '20260101', hour = '00') " +
+              s"LOCATION '$externalLocation'")
+
+          val partitions =
+            paimonCatalog
+              .listPartitions(Identifier.create(dbName0, tableName))
+              .asScala
+          assert(partitions.size == 1)
+          assert(partitions.head.options().get(CoreOptions.PATH.key()) == externalLocation)
+          assert(
+            !table
+              .fileIO()
+              .exists(new Path(table.location(), "dt=20260101/hour=00")))
+          checkAnswer(
+            sql(
+              s"SELECT id, payload, dt, hour FROM ${qualified(tableName)} " +
+                s"WHERE dt = '20260101' AND hour = '00'"),
+            Seq(Row(1, "a", "20260101", "00")))
+      }
+    }
+  }
 
   test("ADD PARTITION IF NOT EXISTS is a repeatable no-op, a strict repeat is an error") {
     val tableName = "ddl_add_if_not_exists"

--- a/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/sql/CatalogManagedPartitionMsckRepairTest.scala
+++ b/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/sql/CatalogManagedPartitionMsckRepairTest.scala
@@ -631,7 +631,8 @@ private[sql] class StatefulFaultCatalog(initial: Set[Map[String, String]] = Set.
       partitions: JList[JMap[String, String]],
       ignoreIfExists: Boolean,
       statistics: JList[PartitionStatistics],
-      replaceStatistics: Boolean): Unit = {
+      replaceStatistics: Boolean,
+      partitionOptions: JList[JMap[String, String]]): Unit = {
     createCalls += 1
     state ++= partitions.asScala.map(_.asScala.toMap)
     if (failCreateAfterApply) {
@@ -720,8 +721,14 @@ private[sql] class FaultInjectingFormatTablePartitionManager(delegate: FormatTab
       partitions: JList[JMap[String, String]],
       ignoreIfExists: Boolean,
       statistics: JList[PartitionStatistics],
-      replaceStatistics: Boolean): Unit = {
-    delegate.createPartitions(partitions, ignoreIfExists, statistics, replaceStatistics)
+      replaceStatistics: Boolean,
+      partitionOptions: JList[JMap[String, String]]): Unit = {
+    delegate.createPartitions(
+      partitions,
+      ignoreIfExists,
+      statistics,
+      replaceStatistics,
+      partitionOptions)
     MsckFaultInjection.createCalls += 1
   }
 


### PR DESCRIPTION
## Summary

Support Spark `ADD PARTITION ... LOCATION` for internal, catalog-managed Format Tables. Custom locations are stored in the generic partition `options` map under `path`.

## Changes

- Extend the existing `POST .../partitions` request with position-aligned `partitionOptions`. The endpoint and response stay unchanged, and unknown options are preserved.
- Resolve and validate `options["path"]` in Core. Custom locations must be absolute, outside the table directory, and non-overlapping.
- Read registered custom locations while preventing Paimon from writing, deleting, truncating, or analyzing their data.
- Map Spark partition `location` to Paimon `path`. `DROP PARTITION` only unregisters a custom location, and `MSCK REPAIR TABLE` leaves it unchanged.

## Testing

- [x] REST API JSON, REST catalog, caching catalog, and delegate catalog tests
- [x] Core Format Table partition manager, scan, commit, and statistics suites: 174 tests
- [x] Spark partition management, DDL, ANALYZE, MSCK, and repair suites: 129 tests
- [x] REST OpenAPI validation: 56 catalog operations and 6 management operations
- [x] Spotless, Checkstyle, and diff checks

## Notes

Upgrade the REST server and every reader before registering custom locations. PyPaimon does not support them yet and will be handled separately.

The commits are ordered REST API → Core → Spark.

Catalog implementations overriding the extended `createPartitions` method must accept the new `partitionOptions` argument.

Follow-up to #8750 and #8751.