### PR TITLE
[format] Keep parsing remaining fields after a malformed one in PERMISSIVE CSV mode

### DIFF
--- a/paimon-format/src/main/java/org/apache/paimon/format/csv/CsvParser.java
+++ b/paimon-format/src/main/java/org/apache/paimon/format/csv/CsvParser.java
@@ -180,7 +180,8 @@ public class CsvParser {
                 row.setField(i, parseResult.getValue());
             } else if (mode == PERMISSIVE
                     && (parseResult == null || !parseResult.getLeft() || exception != null)) {
-                break;
+                // Only this field is malformed, so keep parsing the rest of the row.
+                row.setField(i, null);
             } else if (mode == DROPMALFORMED
                     && (parseResult == null || !parseResult.getLeft() || exception != null)) {
                 return null;

--- a/paimon-format/src/test/java/org/apache/paimon/format/csv/CsvFileFormatTest.java
+++ b/paimon-format/src/test/java/org/apache/paimon/format/csv/CsvFileFormatTest.java
@@ -640,6 +640,44 @@ public class CsvFileFormatTest extends FormatReadWriteTest {
     }
 
     @Test
+    public void testCsvPermissiveKeepsFieldsAfterMalformed() throws IOException {
+        RowType rowType = DataTypes.ROW(DataTypes.INT(), DataTypes.STRING(), DataTypes.DOUBLE());
+        Options options = new Options();
+        options.set(CsvOptions.MODE, CsvOptions.Mode.PERMISSIVE);
+        FileFormat format =
+                new CsvFileFormatFactory().create(new FormatContext(options, 1024, 1024));
+        Path testFile = new Path(parent, "permissive_first_" + UUID.randomUUID() + ".csv");
+
+        // Malformed field in the first position: PERMISSIVE must null only the
+        // offending field and keep the valid fields after it.
+        fileIO.writeFile(testFile, "x,Alice,1.5\n3,Carol,3.5", false);
+        List<InternalRow> result = read(format, rowType, rowType, testFile);
+        assertThat(result).hasSize(2);
+        assertThat(result.get(0).isNullAt(0)).isTrue();
+        assertThat(result.get(0).getString(1)).isEqualTo(fromString("Alice"));
+        assertThat(result.get(0).getDouble(2)).isEqualTo(1.5);
+        assertThat(result.get(1).getInt(0)).isEqualTo(3);
+        assertThat(result.get(1).getString(1)).isEqualTo(fromString("Carol"));
+        assertThat(result.get(1).getDouble(2)).isEqualTo(3.5);
+
+        // PERMISSIVE is the default mode, so this format is built without setting csv.mode.
+        // Covers a malformed field in the middle and two malformed fields in one row.
+        RowType midRowType = DataTypes.ROW(DataTypes.INT(), DataTypes.DOUBLE(), DataTypes.STRING());
+        FileFormat defaultFormat =
+                new CsvFileFormatFactory().create(new FormatContext(new Options(), 1024, 1024));
+        Path midFile = new Path(parent, "permissive_middle_" + UUID.randomUUID() + ".csv");
+        fileIO.writeFile(midFile, "1,oops,world\ny,bad,keep", false);
+        List<InternalRow> midResult = read(defaultFormat, midRowType, midRowType, midFile);
+        assertThat(midResult).hasSize(2);
+        assertThat(midResult.get(0).getInt(0)).isEqualTo(1);
+        assertThat(midResult.get(0).isNullAt(1)).isTrue();
+        assertThat(midResult.get(0).getString(2)).isEqualTo(fromString("world"));
+        assertThat(midResult.get(1).isNullAt(0)).isTrue();
+        assertThat(midResult.get(1).isNullAt(1)).isTrue();
+        assertThat(midResult.get(1).getString(2)).isEqualTo(fromString("keep"));
+    }
+
+    @Test
     public void testCsvParserParseField() {
         RowType rowType =
                 DataTypes.ROW(


### PR DESCRIPTION
### Purpose

close #9555

`CsvParser.parse` walks the projected fields in a `for` loop. In PERMISSIVE mode the branch that handles a malformed field broke out of that loop, so every later field of the row kept the null it was initialized with, even when those fields parse fine. `csv.mode` defaults to PERMISSIVE and the option is documented as setting the malformed field to null, so a plain `SELECT` over a CSV table returned wrong data with nothing thrown and nothing logged. Only a row whose malformed field was the last projected column read correctly.

This regressed in #6856. Before it the mode was handled by a `switch`, where `case PERMISSIVE: break;` left the switch and the loop went on to the next field; that commit turned the switch into an if-else chain and the same `break` now leaves the loop. This nulls only the offending field.

### Tests

`CsvFileFormatTest.testCsvPermissiveKeepsFieldsAfterMalformed` reads two files. The first covers a malformed field in the first position, `x,Alice,1.5` read as `(INT, STRING, DOUBLE)`, followed by a clean row so the per-row state reset stays pinned. The second is built from `new Options()`, since PERMISSIVE is the default mode, and covers a malformed field in the middle (`1,oops,world`) plus two malformed fields in one row (`y,bad,keep`). That last row goes through both ways a field can fail: `y` makes `parseInt` return null, and `bad` makes `Double.parseDouble` throw.

Against the unfixed parser the first block fails with `expected: Alice but was: null` and the second block fails on the same assertion for `world`. A malformed field in the last projected column behaves identically before and after this change, and `testCsvModeWriteRead` and `testSpecialCases` already cover that shape, so the new test does not repeat it.

`mvn -pl paimon-format test` on JDK 8: 597 tests, 0 failures. `spotless:check` and `checkstyle:check` are clean.

One note on the shape of the fix: the PERMISSIVE branch keeps an explicit `row.setField(i, null)`. On a freshly allocated `GenericRow` that is a no-op, so the behavior change comes from dropping the `break`; the statement is there so the branch states the documented contract instead of reading as an unhandled case.
