### PR TITLE
[vortex] Fix predicate pushdown literals for DATE and second-precision TIMESTAMP

### DIFF
--- a/paimon-vortex/paimon-vortex-format/src/main/java/org/apache/paimon/format/vortex/VortexPredicateConverter.java
+++ b/paimon-vortex/paimon-vortex-format/src/main/java/org/apache/paimon/format/vortex/VortexPredicateConverter.java
@@ -147,8 +147,9 @@ public class VortexPredicateConverter implements PredicateVisitor<Expression> {
             case SMALLINT:
                 return Expression.literal((Short) value);
             case INTEGER:
-            case DATE:
                 return Expression.literal((Integer) value);
+            case DATE:
+                return Expression.literalDate((Integer) value, Expression.TimeUnit.DAYS);
             case BIGINT:
                 return Expression.literal((Long) value);
             case FLOAT:
@@ -179,7 +180,10 @@ public class VortexPredicateConverter implements PredicateVisitor<Expression> {
 
     private static Expression toTimestampLiteral(
             Timestamp ts, int precision, @Nullable String timeZone) {
-        if (precision <= 3) {
+        if (precision == 0) {
+            return Expression.literalTimestamp(
+                    ts.getMillisecond() / 1000, Expression.TimeUnit.SECONDS, timeZone);
+        } else if (precision <= 3) {
             return Expression.literalTimestamp(
                     ts.getMillisecond(), Expression.TimeUnit.MILLISECONDS, timeZone);
         } else if (precision <= 6) {

--- a/paimon-vortex/paimon-vortex-format/src/test/java/org/apache/paimon/format/vortex/VortexPredicateConverterTest.java
+++ b/paimon-vortex/paimon-vortex-format/src/test/java/org/apache/paimon/format/vortex/VortexPredicateConverterTest.java
@@ -361,6 +361,69 @@ public class VortexPredicateConverterTest {
         assertEquals(BinaryString.fromString("hello"), rows.get(0).getString(2));
     }
 
+    @Test
+    public void testDateSemantic(@TempDir java.nio.file.Path tempDir) throws Exception {
+        // f_date >= 20 (epoch day) should return rows with f_date=20,30
+        RowType dateRowType = RowType.builder().field("f_date", DataTypes.DATE()).build();
+        PredicateBuilder dateBuilder = new PredicateBuilder(dateRowType);
+        List<InternalRow> rows =
+                roundTrip(
+                        tempDir,
+                        dateRowType,
+                        new GenericRow[] {GenericRow.of(10), GenericRow.of(20), GenericRow.of(30)},
+                        Collections.singletonList(dateBuilder.greaterOrEqual(0, 20)));
+        assertEquals(2, rows.size());
+        assertEquals(20, rows.get(0).getInt(0));
+        assertEquals(30, rows.get(1).getInt(0));
+    }
+
+    @Test
+    public void testTimestampSecondsPrecisionSemantic(@TempDir java.nio.file.Path tempDir)
+            throws Exception {
+        // f_ts >= 2000s should return rows with f_ts=2000s,3000s
+        RowType tsRowType = RowType.builder().field("f_ts", DataTypes.TIMESTAMP(0)).build();
+        PredicateBuilder tsBuilder = new PredicateBuilder(tsRowType);
+        List<InternalRow> rows =
+                roundTrip(
+                        tempDir,
+                        tsRowType,
+                        new GenericRow[] {
+                            GenericRow.of(Timestamp.fromEpochMillis(1_000_000L)),
+                            GenericRow.of(Timestamp.fromEpochMillis(2_000_000L)),
+                            GenericRow.of(Timestamp.fromEpochMillis(3_000_000L))
+                        },
+                        Collections.singletonList(
+                                tsBuilder.greaterOrEqual(
+                                        0, Timestamp.fromEpochMillis(2_000_000L))));
+        assertEquals(2, rows.size());
+        assertEquals(2_000_000L, rows.get(0).getTimestamp(0, 0).getMillisecond());
+        assertEquals(3_000_000L, rows.get(1).getTimestamp(0, 0).getMillisecond());
+    }
+
+    @Test
+    public void testTimestampLtzSecondsPrecisionSemantic(@TempDir java.nio.file.Path tempDir)
+            throws Exception {
+        // f_ts_ltz == 2000s should return only the row with f_ts_ltz=2000s
+        RowType tsRowType =
+                RowType.builder()
+                        .field("f_ts_ltz", DataTypes.TIMESTAMP_WITH_LOCAL_TIME_ZONE(0))
+                        .build();
+        PredicateBuilder tsBuilder = new PredicateBuilder(tsRowType);
+        List<InternalRow> rows =
+                roundTrip(
+                        tempDir,
+                        tsRowType,
+                        new GenericRow[] {
+                            GenericRow.of(Timestamp.fromEpochMillis(1_000_000L)),
+                            GenericRow.of(Timestamp.fromEpochMillis(2_000_000L)),
+                            GenericRow.of(Timestamp.fromEpochMillis(3_000_000L))
+                        },
+                        Collections.singletonList(
+                                tsBuilder.equal(0, Timestamp.fromEpochMillis(2_000_000L))));
+        assertEquals(1, rows.size());
+        assertEquals(2_000_000L, rows.get(0).getTimestamp(0, 0).getMillisecond());
+    }
+
     private List<InternalRow> roundTrip(
             java.nio.file.Path tempDir,
             RowType rowType,


### PR DESCRIPTION

### Purpose

fix #9557

- `toLiteral()` made DATE an `i32` literal and precision-0 TIMESTAMP a MILLISECONDS one, while the writer records `vortex.date[days]` / `vortex.timestamp[s]`. Vortex does not implicitly cast, so the scan fails with `Cannot compare scalars with incompatible types`. `millis / 1000` matches `ArrowUtils.nonCastedTimestampToEpoch()`.
- Origin: `77670e7ea` had a `precision <= 0` branch marked `// seconds`. `609745ec1` added `TimeUnit.SECONDS`/`DAYS`/`literalDate`, moved DECIMAL to `literalDecimal`, but folded that branch into `precision <= 3`, leaving DATE and precision 0 behind.
- These filters now push down, joining the existing `VortexRecordsReader.returnedPosition` mismatch that already affects other types under deletion vectors / row lineage (separate issue).

### Tests

- Added three round-trip cases to `VortexPredicateConverterTest` (DATE `>=`, TIMESTAMP(0) `>=`, TIMESTAMP_LTZ(0) `=`) reusing its `roundTrip(...)` helper. All fail on master.
- `mvn -pl paimon-vortex/paimon-vortex-format -DfailIfNoTests=false clean install` on JDK 11 / darwin-aarch64 — 67 tests, 0 failures/errors, 4 skipped (`JavaPyVortexE2ETest`, CI-covered); checkstyle/spotless/enforcer passed.

