### PR TITLE
[format] Give each row-format reader its own projected-row wrapper

### DIFF
--- a/paimon-format/src/main/java/org/apache/paimon/format/row/RowFileFormat.java
+++ b/paimon-format/src/main/java/org/apache/paimon/format/row/RowFileFormat.java
@@ -25,7 +25,6 @@ import org.apache.paimon.format.FormatWriterFactory;
 import org.apache.paimon.options.MemorySize;
 import org.apache.paimon.predicate.Predicate;
 import org.apache.paimon.types.RowType;
-import org.apache.paimon.utils.NestedProjectedRow;
 
 import javax.annotation.Nullable;
 
@@ -51,9 +50,7 @@ public class RowFileFormat extends FileFormat {
             RowType dataSchemaRowType,
             RowType projectedRowType,
             @Nullable List<Predicate> filters) {
-        NestedProjectedRow projection =
-                NestedProjectedRow.create(dataSchemaRowType, projectedRowType);
-        return new RowFormatReaderFactory(dataSchemaRowType, projection);
+        return new RowFormatReaderFactory(dataSchemaRowType, projectedRowType);
     }
 
     @Override

--- a/paimon-format/src/main/java/org/apache/paimon/format/row/RowFormatReaderFactory.java
+++ b/paimon-format/src/main/java/org/apache/paimon/format/row/RowFormatReaderFactory.java
@@ -28,8 +28,6 @@ import org.apache.paimon.types.RowType;
 import org.apache.paimon.utils.IOUtils;
 import org.apache.paimon.utils.NestedProjectedRow;
 
-import javax.annotation.Nullable;
-
 import java.io.IOException;
 
 /** Factory for creating {@link RowFormatReader}. */
@@ -38,11 +36,11 @@ public class RowFormatReaderFactory implements FormatReaderFactory {
     private static final int TAIL_PREFETCH_SIZE = 64 * 1024;
 
     private final RowType rowType;
-    @Nullable private final NestedProjectedRow projection;
+    private final RowType projectedRowType;
 
-    public RowFormatReaderFactory(RowType rowType, @Nullable NestedProjectedRow projection) {
+    public RowFormatReaderFactory(RowType rowType, RowType projectedRowType) {
         this.rowType = rowType;
-        this.projection = projection;
+        this.projectedRowType = projectedRowType;
     }
 
     @Override
@@ -77,7 +75,15 @@ public class RowFormatReaderFactory implements FormatReaderFactory {
             }
 
             return new RowFormatReader(
-                    in, path, footer, blockIndex, rowType, projection, context.selection());
+                    in,
+                    path,
+                    footer,
+                    blockIndex,
+                    rowType,
+                    // Each reader needs its own wrapper: it is mutated in place per row,
+                    // so sharing one instance across readers corrupts interleaved reads.
+                    NestedProjectedRow.create(rowType, projectedRowType),
+                    context.selection());
         } catch (Throwable t) {
             IOUtils.closeQuietly(in);
             throw t;

--- a/paimon-format/src/test/java/org/apache/paimon/format/row/RowFormatReadWriteTest.java
+++ b/paimon-format/src/test/java/org/apache/paimon/format/row/RowFormatReadWriteTest.java
@@ -606,6 +606,58 @@ public class RowFormatReadWriteTest {
     }
 
     @Test
+    public void testInterleavedReadersDoNotShareProjectedRow() throws IOException {
+        RowType fullType =
+                new RowType(
+                        Arrays.asList(
+                                new DataField(0, "a", new IntType()),
+                                new DataField(1, "b", new VarCharType(100))));
+        // The projection has to drop a column: for an identical schema
+        // NestedProjectedRow.create returns null and no wrapper is involved.
+        RowType projectedType = new RowType(Arrays.asList(new DataField(0, "a", new IntType())));
+
+        Path pathA = new Path(tempDir.toUri().toString(), "interleaved_a.row");
+        Path pathB = new Path(tempDir.toUri().toString(), "interleaved_b.row");
+        FileFormat format = FileFormat.fromIdentifier("row", new Options());
+        writeRows(
+                format,
+                fullType,
+                pathA,
+                Arrays.asList(GenericRow.of(1, BinaryString.fromString("A"))));
+        writeRows(
+                format,
+                fullType,
+                pathB,
+                Arrays.asList(GenericRow.of(2, BinaryString.fromString("B"))));
+
+        LocalFileIO fileIO = new LocalFileIO();
+        FormatReaderFactory readerFactory =
+                format.createReaderFactory(fullType, projectedType, new ArrayList<>());
+        try (FileRecordReader<InternalRow> readerA =
+                        readerFactory.createReader(
+                                new FormatReaderContext(
+                                        fileIO, pathA, fileIO.getFileSize(pathA), null, null));
+                FileRecordReader<InternalRow> readerB =
+                        readerFactory.createReader(
+                                new FormatReaderContext(
+                                        fileIO, pathB, fileIO.getFileSize(pathB), null, null))) {
+            FileRecordIterator<InternalRow> batchA = readerA.readBatch();
+            assertThat(batchA).isNotNull();
+            InternalRow rowA = batchA.next();
+            assertThat(rowA.getInt(0)).isEqualTo(1);
+
+            FileRecordIterator<InternalRow> batchB = readerB.readBatch();
+            assertThat(batchB).isNotNull();
+            InternalRow rowB = batchB.next();
+            assertThat(rowB.getInt(0)).isEqualTo(2);
+
+            // Reading from B must leave the row A handed out alone.
+            assertThat(rowA).isNotSameAs(rowB);
+            assertThat(rowA.getInt(0)).isEqualTo(1);
+        }
+    }
+
+    @Test
     public void testProjectionMultipleColumns() throws IOException {
         RowType fullType =
                 new RowType(


### PR DESCRIPTION
### Purpose

close #9560

`RowFileFormat.createReaderFactory` built one `NestedProjectedRow` and `RowFormatReaderFactory` handed that same instance to every reader it created. The iterator mutates the wrapper in place per row, and `NestedProjectedRow.replaceRow` returns `this`, so two readers from one factory hand out the same row object: reading from one overwrites the row whose consumer is still holding it. That breaks `RecordReader.readBatch`, which documents that the returned iterator and the objects in it may be held onto for some time and should not be reused. This creates the projection per reader instead.

Any consumer that holds a row from one reader while advancing another reader of the same factory is affected. In this codebase that is merge-on-read: `KeyValueFileReaderFactory` caches one `FormatReaderMapping` per `(schemaId, formatIdentifier)`, `MergeTreeReaders` opens one reader per sorted run through it, and `SortMergeReaderWithMinHeap` and the loser tree hold each run's current `KeyValue` while advancing the others. That path is traced from the code and not reproduced here: it needs a primary-key table with `file.format = 'row'`, two overlapping sorted runs, and a column projection.

The change also drops the `@Nullable` on `projectedRowType`. It was correct on the `NestedProjectedRow` field it replaced, since `create` returns null when the two schemas are equal, but not on a `RowType` that `create` dereferences; `FileFormat.createReaderFactory` declares only `filters` as nullable and all call sites pass a real `RowType`.

### Tests

`RowFormatReadWriteTest.testInterleavedReadersDoNotShareProjectedRow` writes two single-row files, opens a reader for each from one factory, reads a row from A, then reads from B and checks that A's row is neither the same object as B's nor overwritten. The projection has to drop a column: with an identical schema `NestedProjectedRow.create` returns null, no wrapper is involved, and the test would pass against the old code too. The comment in the test says so.

Against the pre-fix code it fails on `assertThat(rowA).isNotSameAs(rowB)` with `Expected not same: org.apache.paimon.utils.NestedProjectedRow@...`, which names the mechanism rather than just a wrong value. The final assertion is not redundant with it: two distinct wrappers over one shared underlying row would satisfy `isNotSameAs` and still fail the value check.

`mvn -pl paimon-format test` on JDK 8: 597 tests, 0 failures. `spotless:check` and `checkstyle:check` are clean.
