### PR TITLE
[format] Read BINARY-encoded decimals at scratch index 0 in parquet updater

### DIFF
--- a/paimon-format/src/main/java/org/apache/paimon/format/parquet/reader/ParquetVectorUpdaterFactory.java
+++ b/paimon-format/src/main/java/org/apache/paimon/format/parquet/reader/ParquetVectorUpdaterFactory.java
@@ -1221,8 +1221,10 @@ public class ParquetVectorUpdaterFactory {
         @Override
         public void readValue(
                 int offset, WritableColumnVector values, VectorizedValuesReader valuesReader) {
-            valuesReader.readBinary(1, bytesVector, offset);
-            BigInteger value = new BigInteger(bytesVector.getBytes(offset).getBytes());
+            // The scratch vector has capacity 1: always read at index 0, never at the
+            // target row offset.
+            valuesReader.readBinary(1, bytesVector, 0);
+            BigInteger value = new BigInteger(bytesVector.getBytes(0).getBytes());
             BigDecimal decimal = new BigDecimal(value, parquetScale);
             putDecimal(values, offset, decimal);
         }

--- a/paimon-format/src/test/java/org/apache/paimon/format/parquet/ParquetTypeWideningTest.java
+++ b/paimon-format/src/test/java/org/apache/paimon/format/parquet/ParquetTypeWideningTest.java
@@ -28,6 +28,7 @@ import org.apache.paimon.predicate.Predicate;
 import org.apache.paimon.predicate.PredicateBuilder;
 import org.apache.paimon.reader.RecordReader;
 import org.apache.paimon.types.DataTypes;
+import org.apache.paimon.types.DecimalType;
 import org.apache.paimon.types.RowType;
 
 import org.apache.hadoop.conf.Configuration;
@@ -37,6 +38,7 @@ import org.apache.parquet.example.data.simple.SimpleGroupFactory;
 import org.apache.parquet.hadoop.ParquetWriter;
 import org.apache.parquet.hadoop.example.ExampleParquetWriter;
 import org.apache.parquet.hadoop.util.HadoopOutputFile;
+import org.apache.parquet.io.api.Binary;
 import org.apache.parquet.schema.LogicalTypeAnnotation;
 import org.apache.parquet.schema.MessageType;
 import org.apache.parquet.schema.MessageTypeParser;
@@ -46,6 +48,8 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
 import java.io.File;
+import java.math.BigDecimal;
+import java.math.BigInteger;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -66,6 +70,9 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
  * pushdown have to cope.
  *
  * <p>Column names mirror midas_prod.tbl_imp, where this was found.
+ *
+ * <p>The same harness covers the other way a foreign file can surprise the reader: a physical
+ * encoding Paimon's own writer never produces, with the declared and stored types agreeing.
  */
 class ParquetTypeWideningTest {
 
@@ -629,6 +636,42 @@ class ParquetTypeWideningTest {
         assertThat(longs(rows, 1)).containsExactly(100L, 200L, 300L);
     }
 
+    @Test
+    void testBinaryDecimalReadsEveryRowOfAPage() throws Exception {
+        // Paimon's own writer never emits DECIMAL on BINARY, so this shape only comes from
+        // external writers, and dictionary encoding has to be off: a dictionary page is
+        // decoded by decodeSingleDictionaryId, which does not go through the updater's
+        // scratch vector.
+        for (int precision : new int[] {5, 20}) {
+            MessageType schema =
+                    new MessageType(
+                            "root",
+                            Collections.singletonList(
+                                    Types.optional(PrimitiveTypeName.BINARY)
+                                            .as(LogicalTypeAnnotation.decimalType(2, precision))
+                                            .named("price")));
+            Path path =
+                    writeGroups(
+                            schema,
+                            (group, i) ->
+                                    group.append(
+                                            "price",
+                                            Binary.fromConstantByteArray(
+                                                    BigInteger.valueOf((i + 1) * 100L)
+                                                            .toByteArray())),
+                            false);
+
+            RowType readType =
+                    RowType.builder().field("price", DataTypes.DECIMAL(precision, 2)).build();
+            List<Object[]> rows = read(readType, path, null);
+
+            assertThat(rows).hasSize(3);
+            assertThat(rows.get(0)[0]).isEqualTo(new BigDecimal("1.00"));
+            assertThat(rows.get(1)[0]).isEqualTo(new BigDecimal("2.00"));
+            assertThat(rows.get(2)[0]).isEqualTo(new BigDecimal("3.00"));
+        }
+    }
+
     // ------------------------------------------------------------------
     // Helpers
     // ------------------------------------------------------------------
@@ -707,6 +750,12 @@ class ParquetTypeWideningTest {
                 case DOUBLE:
                     values[i] = row.getDouble(i);
                     break;
+                case DECIMAL:
+                    DecimalType decimalType = (DecimalType) readType.getTypeAt(i);
+                    values[i] =
+                            row.getDecimal(i, decimalType.getPrecision(), decimalType.getScale())
+                                    .toBigDecimal();
+                    break;
                 default:
                     throw new UnsupportedOperationException(
                             "Unhandled type in test: " + readType.getTypeAt(i));
@@ -750,6 +799,12 @@ class ParquetTypeWideningTest {
 
     private Path writeGroups(MessageType schema, BiConsumer<Group, Integer> appender)
             throws Exception {
+        return writeGroups(schema, appender, true);
+    }
+
+    private Path writeGroups(
+            MessageType schema, BiConsumer<Group, Integer> appender, boolean dictionaryEncoding)
+            throws Exception {
         Path path = new Path(folder.getPath(), UUID.randomUUID().toString());
         Configuration conf = new Configuration();
         try (ParquetWriter<Group> writer =
@@ -758,6 +813,7 @@ class ParquetTypeWideningTest {
                                         new org.apache.hadoop.fs.Path(path.toString()), conf))
                         .withType(schema)
                         .withConf(conf)
+                        .withDictionaryEncoding(dictionaryEncoding)
                         .withWriterVersion(ParquetProperties.WriterVersion.PARQUET_1_0)
                         .build()) {
             for (int i = 0; i < 3; i++) {


### PR DESCRIPTION
### Purpose

close #9562

`BinaryToDecimalUpdater` allocates a scratch `HeapBytesVector` of capacity 1 and then indexes it with the target row's offset:

```java
this.bytesVector = new HeapBytesVector(1);
...
valuesReader.readBinary(1, bytesVector, offset);
BigInteger value = new BigInteger(bytesVector.getBytes(offset).getBytes());
```

`HeapBytesVector.putByteArray` writes `start[elementNum]`, and `start` has one slot, so the second row of any non-dictionary page throws `ArrayIndexOutOfBoundsException`. Reading and getting at index 0 is consistent with the capacity; the target vector is still written at the real `offset` by `putDecimal`. The scratch vector was introduced in #5582 together with the 32-bit and 64-bit decimal targets; before that the read went into the batch-sized target vector, where `offset` was in range, which is where the index came from.

The Parquet spec allows DECIMAL on BINARY, but Paimon's own writer emits INT32, INT64 or FIXED_LEN_BYTE_ARRAY for decimals, so only externally written files reach this updater: parquet-avro maps an Avro `bytes` field carrying a decimal logical type onto BINARY, which is what Debezium and Kafka Connect produce. Paimon reads such files through a format table, and through `migrate_table` or clone, which rename the source files rather than rewriting them.

### Tests

`ParquetTypeWideningTest.testBinaryDecimalReadsEveryRowOfAPage` writes a three-row file with `optional binary price (DECIMAL(scale=2))` using `ExampleParquetWriter` and reads it back through `ParquetReaderFactory`, for precision 5 and 20, which covers two of `putDecimal`'s three output branches, the int-backed and the byte-backed one.

Two conditions the test has to get right. Dictionary encoding must be off, since a dictionary page is decoded by `decodeSingleDictionaryId` and never touches the scratch vector, and with the writer default three small decimals do end up in a dictionary page; `writeGroups` therefore takes a flag, with the existing two-argument callers left on the previous default. And the read type has to name the column `price`, because a name mismatch makes the reader fill the column with nulls and the test then fails on fixed code too.

Against the unfixed reader it fails with `ArrayIndexOutOfBoundsException: 1` in `VectorizedPlainValuesReader.readBinary`, reached through `VectorizedParquetRecordReader.nextBatch`, so the test exercises the real reader stack rather than the updater in isolation.

`mvn -pl paimon-format test` on JDK 8: 597 tests, 0 failures. `spotless:check` and `checkstyle:check` are clean.

One thing this does not touch: `BinaryToDecimalUpdater` does not check the file's decimal scale against the Paimon type's the way `FixedLenByteArrayToDecimalUpdater` does, and `IntegerToDecimalUpdater` and `LongToDecimalUpdater` do not either. A mismatch there is read as a silently rescaled value. That is pre-existing across three updaters and adding the check would turn files that read today into hard failures, so it seems better as its own issue.
