### PR TITLE
[format] Support sep as fallback key of csv.field-delimiter

### DIFF
--- a/paimon-format/src/main/java/org/apache/paimon/format/csv/CsvOptions.java
+++ b/paimon-format/src/main/java/org/apache/paimon/format/csv/CsvOptions.java
@@ -33,7 +33,7 @@ public class CsvOptions {
             ConfigOptions.key("csv.field-delimiter")
                     .stringType()
                     .defaultValue(",")
-                    .withFallbackKeys("field-delimiter", "seq", "delimiter")
+                    .withFallbackKeys("field-delimiter", "seq", "delimiter", "sep")
                     .withDescription("The field delimiter for CSV or TXT format");
 
     public static final ConfigOption<String> LINE_DELIMITER =

--- a/paimon-format/src/test/java/org/apache/paimon/format/csv/CsvFileFormatTest.java
+++ b/paimon-format/src/test/java/org/apache/paimon/format/csv/CsvFileFormatTest.java
@@ -212,7 +212,7 @@ public class CsvFileFormatTest extends FormatReadWriteTest {
                         GenericRow.of(1, BinaryString.fromString("Alice")),
                         GenericRow.of(2, BinaryString.fromString("Bob")));
 
-        for (String fallbackKey : new String[] {"field-delimiter", "seq", "delimiter"}) {
+        for (String fallbackKey : new String[] {"field-delimiter", "seq", "delimiter", "sep"}) {
             Options options = new Options();
             options.set(fallbackKey, ";");
 


### PR DESCRIPTION
### Purpose

`csv.field-delimiter` accepts `field-delimiter`, `seq` and `delimiter` as fallback keys, but not `sep`. Setting `sep` is silently ignored and the delimiter falls back to the default `,`.

The other fallback keys in `CsvOptions` mirror Spark's CSV option names one for one (`lineSep`, `quote`, `escape`, `header`, `nullvalue`, `mode`); `sep` is the only one missing. Same reason as #9170, which added `delimiter`.

### Tests

`CsvFileFormatTest#testCsvFieldDelimiterFallbackKeys`, extending the existing parameterized fallback-key list.

Written with Claude Code; reasoning and verification are mine.
