### PR TITLE
[format] Compare array wrapper-group names case-insensitively in ParquetReaderUtil

### DIFF
--- a/paimon-format/src/main/java/org/apache/paimon/format/parquet/reader/ParquetReaderUtil.java
+++ b/paimon-format/src/main/java/org/apache/paimon/format/parquet/reader/ParquetReaderUtil.java
@@ -44,7 +44,6 @@ import org.apache.parquet.schema.Type;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Objects;
 import java.util.stream.Collectors;
 
 import static org.apache.paimon.format.parquet.ParquetSchemaConverter.convertToPaimonField;
@@ -168,7 +167,9 @@ public class ParquetReaderUtil {
             if (columnIO instanceof GroupColumnIO) {
                 GroupColumnIO groupColumnIO = (GroupColumnIO) columnIO;
                 if (!StringUtils.isNullOrWhitespaceOnly(fieldName)) {
-                    while (!Objects.equals(groupColumnIO.getName(), fieldName)) {
+                    // Column lookup is case-insensitive; the wrapper-group names can
+                    // therefore differ in case from the requested field name.
+                    while (!groupColumnIO.getName().equalsIgnoreCase(fieldName)) {
                         groupColumnIO = (GroupColumnIO) groupColumnIO.getChild(0);
                     }
                     elementTypeColumnIO = groupColumnIO;

--- a/paimon-format/src/test/java/org/apache/paimon/format/parquet/ParquetCaseInsensitiveReadTest.java
+++ b/paimon-format/src/test/java/org/apache/paimon/format/parquet/ParquetCaseInsensitiveReadTest.java
@@ -18,7 +18,10 @@
 
 package org.apache.paimon.format.parquet;
 
+import org.apache.paimon.data.BinaryString;
+import org.apache.paimon.data.GenericArray;
 import org.apache.paimon.data.GenericRow;
+import org.apache.paimon.data.InternalArray;
 import org.apache.paimon.data.InternalRow;
 import org.apache.paimon.format.FormatReaderContext;
 import org.apache.paimon.fs.Path;
@@ -119,6 +122,29 @@ class ParquetCaseInsensitiveReadTest {
     }
 
     @Test
+    void testArrayCaseInsensitiveColumnMatching() throws Exception {
+        Path path = writeArrayMixedCaseParquet();
+
+        // Lowercase name for a column the file spells "Tags" + caseSensitive=false.
+        RowType readType =
+                RowType.builder().field("tags", DataTypes.ARRAY(DataTypes.STRING())).build();
+
+        List<InternalRow> rows = read(path, readType, false);
+
+        assertThat(rows).hasSize(2);
+        InternalArray first = rows.get(0).getArray(0);
+        assertThat(first.size()).isEqualTo(2);
+        assertThat(first.getString(0).toString()).isEqualTo("a");
+        assertThat(first.getString(1).toString()).isEqualTo("b");
+        // A second row of a different length, so a wrong offset and a wrong length differ.
+        InternalArray second = rows.get(1).getArray(0);
+        assertThat(second.size()).isEqualTo(3);
+        assertThat(second.getString(0).toString()).isEqualTo("c");
+        assertThat(second.getString(1).toString()).isEqualTo("d");
+        assertThat(second.getString(2).toString()).isEqualTo("e");
+    }
+
+    @Test
     void testAmbiguousCaseInsensitiveMatchFails() throws Exception {
         Path path = writeDuplicateCaseParquet();
 
@@ -163,6 +189,14 @@ class ParquetCaseInsensitiveReadTest {
                 case ROW:
                     RowType child = (RowType) rowType.getTypeAt(i);
                     values[i] = copy(row.getRow(i, child.getFieldCount()), child);
+                    break;
+                case ARRAY:
+                    InternalArray array = row.getArray(i);
+                    BinaryString[] strings = new BinaryString[array.size()];
+                    for (int j = 0; j < array.size(); j++) {
+                        strings[j] = array.isNullAt(j) ? null : array.getString(j).copy();
+                    }
+                    values[i] = new GenericArray(strings);
                     break;
                 default:
                     throw new UnsupportedOperationException(
@@ -240,6 +274,33 @@ class ParquetCaseInsensitiveReadTest {
                 factory ->
                         Collections.singletonList(
                                 factory.newGroup().append("col", "a").append("COL", "b")));
+    }
+
+    private Path writeArrayMixedCaseParquet() throws Exception {
+        MessageType schema =
+                MessageTypeParser.parseMessageType(
+                        "message root {\n"
+                                + "  optional group Tags (LIST) {\n"
+                                + "    repeated group list {\n"
+                                + "      optional binary element (UTF8);\n"
+                                + "    }\n"
+                                + "  }\n"
+                                + "}");
+
+        return write(
+                schema,
+                factory -> {
+                    List<Group> groups = new ArrayList<>();
+                    for (String[] pair : new String[][] {{"a", "b"}, {"c", "d", "e"}}) {
+                        Group g = factory.newGroup();
+                        Group tags = g.addGroup("Tags");
+                        for (String v : pair) {
+                            tags.addGroup("list").append("element", v);
+                        }
+                        groups.add(g);
+                    }
+                    return groups;
+                });
     }
 
     private interface GroupSupplier {


### PR DESCRIPTION
### Purpose

close #9567

`buildFieldsList` descends through an array's wrapper groups by comparing each group's name with the table field name:

```java
while (!Objects.equals(groupColumnIO.getName(), fieldName)) {
    groupColumnIO = (GroupColumnIO) groupColumnIO.getChild(0);
}
```

That comparison is case sensitive, while the two other name lookups in the same file, `lookupColumnByName` and `getTypeIgnoreCase`, ignore case. With catalog `case-sensitive = false` the requested schema keeps the file's spelling, so a column the file spells `Tags` read as `tags` never matched: the loop walked `Tags` to `list` to `element`, and casting the element's `PrimitiveColumnIO` to `GroupColumnIO` threw `ClassCastException`. This compares without case here too.

`lookupColumnByName` has ignored case since #5905, and `getTypeIgnoreCase` was added by #8337, which is where case-insensitive reads came from. Its tests cover scalar and nested-row columns but no array column, which is why this went unnoticed. MAP and MULTISET are not affected, since `getMapKeyValueColumn` descends structurally on `getChildrenCount() == 1` and never compares a name.

One thing I deliberately left alone. The loop's only exit is the name matching, so if a column's name ever fails to match for some reason other than case, it still descends until the cast fails. After this change the loop body is unreachable for every caller in the repo today: the top-level and declared-ROW-child paths look the column up by the same name they then compare, the file-only extra ROW fields carry `parquetType.getName()` verbatim, and the array and map element recursions pass an empty field name, which short-circuits before the loop. That is how it happens to be today rather than something enforced, so a guard may well be worth adding, but turning an unreachable state into a `break` would swap a crash for silently reading the wrong element column, and adding a thrown exception is a change of its own. Happy to follow up separately.

### Tests

`ParquetCaseInsensitiveReadTest.testArrayCaseInsensitiveColumnMatching` writes a three-level LIST spelled `Tags` and reads it as `tags` with `caseSensitive=false`. The two rows hold two and three elements, so the assertions separate a wrong offset from a wrong length. The column is genuinely resolved rather than null-filled: a name miss would leave the value null and `first.size()` would throw instead of comparing.

Against the unfixed reader it fails with `ClassCastException: PrimitiveColumnIO cannot be cast to GroupColumnIO`.

`mvn -pl paimon-format test` on JDK 8: 597 tests, 0 failures. `spotless:check` and `checkstyle:check` are clean.
