### PR TITLE
[format] Fail fast when skipping DELTA_LENGTH_BYTE_ARRAY data past end of page

### DIFF
--- a/paimon-format/src/main/java/org/apache/paimon/format/parquet/reader/VectorizedDeltaLengthByteArrayReader.java
+++ b/paimon-format/src/main/java/org/apache/paimon/format/parquet/reader/VectorizedDeltaLengthByteArrayReader.java
@@ -81,9 +81,16 @@ public class VectorizedDeltaLengthByteArrayReader extends VectorizedReaderBase
     @Override
     public void skipBinary(int total) {
         for (int i = 0; i < total; i++) {
-            int remaining = lengthsVector.getInt(currentRow + i);
-            while (remaining > 0) {
-                remaining -= in.skip(remaining);
+            int length = lengthsVector.getInt(currentRow + i);
+            // A corrupt length can be negative, and skipFully would then move the stream
+            // backwards instead of forwards.
+            if (length < 0) {
+                throw new ParquetDecodingException("Negative byte array length: " + length);
+            }
+            try {
+                in.skipFully(length);
+            } catch (IOException e) {
+                throw new ParquetDecodingException("Failed to skip " + length + " bytes", e);
             }
         }
         currentRow += total;

--- a/paimon-format/src/test/java/org/apache/paimon/format/parquet/reader/DeltaLengthByteArrayEncodingTest.java
+++ b/paimon-format/src/test/java/org/apache/paimon/format/parquet/reader/DeltaLengthByteArrayEncodingTest.java
@@ -25,16 +25,21 @@ import org.apache.commons.lang3.RandomStringUtils;
 import org.apache.parquet.bytes.ByteBufferInputStream;
 import org.apache.parquet.bytes.DirectByteBufferAllocator;
 import org.apache.parquet.column.values.Utils;
+import org.apache.parquet.column.values.delta.DeltaBinaryPackingValuesWriterForInteger;
 import org.apache.parquet.column.values.deltalengthbytearray.DeltaLengthByteArrayValuesWriter;
+import org.apache.parquet.io.ParquetDecodingException;
 import org.apache.parquet.io.api.Binary;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.util.Arrays;
 import java.util.Random;
 
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 /** Test for delta length byte array encoding. */
 public class DeltaLengthByteArrayEncodingTest {
@@ -125,6 +130,36 @@ public class DeltaLengthByteArrayEncodingTest {
         for (int i = 0; i < values.length; i++) {
             assertEquals(values[i].length(), writableColumnVector.getInt(i));
         }
+    }
+
+    @Test
+    public void testSkipPastEndOfPage() throws Exception {
+        writeData(writer, values);
+        byte[] page = writer.getBytes().toByteArray();
+        // Drop three bytes of data. The lengths at the front of the page still add up to
+        // more than the page holds, which is what a truncated page looks like.
+        byte[] truncated = Arrays.copyOf(page, page.length - 3);
+        reader.initFromPage(values.length, ByteBufferInputStream.wrap(ByteBuffer.wrap(truncated)));
+
+        ParquetDecodingException e =
+                assertThrows(
+                        ParquetDecodingException.class, () -> reader.skipBinary(values.length));
+        assertEquals("Failed to skip " + values[2].length() + " bytes", e.getMessage());
+    }
+
+    @Test
+    public void testSkipNegativeLength() throws Exception {
+        // A length section that decodes to a negative value cannot be produced by the
+        // writer, so write one directly and append no data at all.
+        DeltaBinaryPackingValuesWriterForInteger lengthWriter =
+                new DeltaBinaryPackingValuesWriterForInteger(
+                        64 * 1024, 64 * 1024, new DirectByteBufferAllocator());
+        lengthWriter.writeInteger(-1);
+        reader.initFromPage(1, lengthWriter.getBytes().toInputStream());
+
+        ParquetDecodingException e =
+                assertThrows(ParquetDecodingException.class, () -> reader.skipBinary(1));
+        assertEquals("Negative byte array length: -1", e.getMessage());
     }
 
     private void writeData(DeltaLengthByteArrayValuesWriter writer, String[] values) {


### PR DESCRIPTION
### Purpose

close #9570

`VectorizedDeltaLengthByteArrayReader.skipBinary` walked each value's declared length like this:

```java
int remaining = lengthsVector.getInt(currentRow + i);
while (remaining > 0) {
    remaining -= in.skip(remaining);
}
```

On a truncated or corrupt page the declared length exceeds the bytes left, and `ByteBufferInputStream.skip` returns -1 once the stream is dry, so `remaining` grows by one per iteration. The loop ends only when the int wraps negative, about 2^31 iterations, measured at 0.9s per value, and then the method returns with no error at all. The page stream is empty by then, so a later read on the same page reports `Failed to read N bytes` against a value that is not the corrupt one, and if the skip was the page's last operation nothing is reported at all. Reading the same page instead of skipping it fails cleanly and immediately, since `readBinary` and `getBytes` call `in.slice(length)` and convert the `EOFException`; the skip path was the only one that did not.

The fix uses `in.skipFully(length)`, which skips or throws `EOFException`, matching those two methods and parquet-mr's own `DeltaLengthByteArrayValuesReader.skip`. That alone would regress on a negative declared length: `SingleBufferInputStream.skip` computes `Math.min(remaining, n)` and would move the position backwards, where the old loop did nothing while `currentRow` advanced, misaligning the reader silently. So a negative length is rejected explicitly. The exception carries its cause because the `EOFException` message says how far the skip got, which the wrapper text drops.

### Tests

Both go in the existing `DeltaLengthByteArrayEncodingTest`, which already covers this reader including two skip cases. One writes the page normally and then drops three bytes off the data section, so the lengths still describe more data than the page holds. The other writes a length section that decodes to -1 through `DeltaBinaryPackingValuesWriterForInteger`, since no writer produces that.

Against the unfixed reader both fail with "Expected ParquetDecodingException to be thrown, but nothing was thrown", the truncation one after spinning for 0.9s. That is also the evidence for the wraparound described above.

`mvn -pl paimon-format test` on JDK 8: 598 tests, 0 failures. `spotless:check` and `checkstyle:check` are clean.

Not included, to keep this to one thing: `VectorizedPlainValuesReader.skipBinary` is a bare `in.skip(len)` that ignores the return value too. Its symptom is different, a silent under-skip rather than a spin, and PLAIN is the common encoding, so making it throw would turn files that read today, misaligned, into hard failures. That seems worth its own discussion.
