### PR TITLE
[format] Close the ParquetFileReader when post-construction setup fails

### DIFF
--- a/paimon-format/src/main/java/org/apache/paimon/format/parquet/ParquetReaderFactory.java
+++ b/paimon-format/src/main/java/org/apache/paimon/format/parquet/ParquetReaderFactory.java
@@ -151,57 +151,67 @@ public class ParquetReaderFactory implements FormatReaderFactory {
             throw t;
         }
 
-        ShreddingReadPlan readPlan =
-                ShreddingReadPlanFactories.createReadPlan(
-                        readType,
-                        readFieldMetadata(reader),
-                        fileSchema,
-                        shreddingReadPlanFactories(readType));
-        DataField[] physicalReadFields = readFields(readPlan.physicalRowType());
-        RequestedSchema requestedSchema =
-                readPlan.isIdentity()
-                        ? getOrCreateRequestedSchema(fileSchema)
-                        : createRequestedSchema(fileSchema, physicalReadFields);
+        // The reader owns the open stream from here, so close it if the setup below fails.
+        try {
+            ShreddingReadPlan readPlan =
+                    ShreddingReadPlanFactories.createReadPlan(
+                            readType,
+                            readFieldMetadata(reader),
+                            fileSchema,
+                            shreddingReadPlanFactories(readType));
+            DataField[] physicalReadFields = readFields(readPlan.physicalRowType());
+            RequestedSchema requestedSchema =
+                    readPlan.isIdentity()
+                            ? getOrCreateRequestedSchema(fileSchema)
+                            : createRequestedSchema(fileSchema, physicalReadFields);
 
-        if (LOG.isDebugEnabled()) {
-            LOG.debug(
-                    "Create reader of the parquet file {}, the fileSchema is {}, the requestedSchema is {}.",
-                    context.filePath(),
-                    fileSchema,
-                    requestedSchema.messageType);
-        }
-
-        int configuredBatchSize = computeBatchSize(reader, requestedSchema.messageType);
-        Preconditions.checkArgument(
-                configuredBatchSize > 0,
-                "Parquet read batch size should be positive: %s",
-                configuredBatchSize);
-        ReadBatchSizer readBatchSizer = context.readBatchSizer();
-        int initialBatchSize =
-                readBatchSizer == null
-                        ? configuredBatchSize
-                        : readBatchSizer.batchSize().orElse(configuredBatchSize);
-        reader.setRequestedSchema(requestedSchema.messageType);
-        WritableColumnVector[] writableVectors =
-                createWritableVectors(initialBatchSize, physicalReadFields);
-        IntFunction<WritableColumnVector[]> vectorFactory =
-                size -> createWritableVectors(size, physicalReadFields);
-
-        VectorizedParquetRecordReader parquetReader =
-                new VectorizedParquetRecordReader(
+            if (LOG.isDebugEnabled()) {
+                LOG.debug(
+                        "Create reader of the parquet file {}, the fileSchema is {}, the requestedSchema is {}.",
                         context.filePath(),
-                        reader,
                         fileSchema,
-                        requestedSchema.fields,
-                        writableVectors,
-                        initialBatchSize,
-                        configuredBatchSize,
-                        context.fileIO(),
-                        readBatchSizer,
-                        vectorFactory);
-        return readPlan.isIdentity()
-                ? parquetReader
-                : new ShreddingFormatReader(parquetReader, readPlan);
+                        requestedSchema.messageType);
+            }
+
+            int configuredBatchSize = computeBatchSize(reader, requestedSchema.messageType);
+            Preconditions.checkArgument(
+                    configuredBatchSize > 0,
+                    "Parquet read batch size should be positive: %s",
+                    configuredBatchSize);
+            ReadBatchSizer readBatchSizer = context.readBatchSizer();
+            int initialBatchSize =
+                    readBatchSizer == null
+                            ? configuredBatchSize
+                            : readBatchSizer.batchSize().orElse(configuredBatchSize);
+            reader.setRequestedSchema(requestedSchema.messageType);
+            WritableColumnVector[] writableVectors =
+                    createWritableVectors(initialBatchSize, physicalReadFields);
+            IntFunction<WritableColumnVector[]> vectorFactory =
+                    size -> createWritableVectors(size, physicalReadFields);
+
+            VectorizedParquetRecordReader parquetReader =
+                    new VectorizedParquetRecordReader(
+                            context.filePath(),
+                            reader,
+                            fileSchema,
+                            requestedSchema.fields,
+                            writableVectors,
+                            initialBatchSize,
+                            configuredBatchSize,
+                            context.fileIO(),
+                            readBatchSizer,
+                            vectorFactory);
+            return readPlan.isIdentity()
+                    ? parquetReader
+                    : new ShreddingFormatReader(parquetReader, readPlan);
+        } catch (Throwable t) {
+            try {
+                reader.close();
+            } catch (Throwable closeFailure) {
+                t.addSuppressed(closeFailure);
+            }
+            throw t;
+        }
     }
 
     private RequestedSchema getOrCreateRequestedSchema(MessageType fileSchema) {

--- a/paimon-format/src/test/java/org/apache/paimon/format/parquet/ParquetReaderFactoryLeakTest.java
+++ b/paimon-format/src/test/java/org/apache/paimon/format/parquet/ParquetReaderFactoryLeakTest.java
@@ -1,0 +1,139 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.format.parquet;
+
+import org.apache.paimon.data.GenericRow;
+import org.apache.paimon.data.InternalRow;
+import org.apache.paimon.format.FileFormat;
+import org.apache.paimon.format.FormatReaderContext;
+import org.apache.paimon.format.FormatWriter;
+import org.apache.paimon.fs.Path;
+import org.apache.paimon.fs.PositionOutputStream;
+import org.apache.paimon.fs.SeekableInputStream;
+import org.apache.paimon.fs.local.LocalFileIO;
+import org.apache.paimon.options.Options;
+import org.apache.paimon.reader.FileRecordReader;
+import org.apache.paimon.types.DataTypes;
+import org.apache.paimon.types.RowType;
+
+import org.apache.parquet.hadoop.ParquetFileReader;
+import org.apache.parquet.schema.MessageType;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.IOException;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/** Tests that {@link ParquetReaderFactory#createReader} closes the file exactly once. */
+class ParquetReaderFactoryLeakTest {
+
+    @TempDir java.nio.file.Path tempDir;
+
+    private final RowType rowType = RowType.of(DataTypes.INT());
+
+    @Test
+    void testSetupFailureAfterReaderExistsClosesFile() throws IOException {
+        Path file = writeParquet();
+        CountingFileIO fileIO = new CountingFileIO();
+
+        // computeBatchSize is called after the ParquetFileReader has been constructed, so a
+        // zero batch size fails the check inside the region this test is about.
+        ParquetReaderFactory factory =
+                new ParquetReaderFactory(new Options(), rowType, 1024, null) {
+                    @Override
+                    protected int computeBatchSize(
+                            ParquetFileReader reader, MessageType requestedSchema) {
+                        return 0;
+                    }
+                };
+
+        assertThatThrownBy(() -> factory.createReader(context(fileIO, file)))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("Parquet read batch size should be positive");
+        assertThat(fileIO.closed).hasValue(1);
+    }
+
+    @Test
+    void testSuccessfulReadClosesFileOnce() throws IOException {
+        Path file = writeParquet();
+        CountingFileIO fileIO = new CountingFileIO();
+
+        ParquetReaderFactory factory = new ParquetReaderFactory(new Options(), rowType, 1024, null);
+        try (FileRecordReader<InternalRow> reader = factory.createReader(context(fileIO, file))) {
+            assertThat(reader.readBatch().next().getInt(0)).isEqualTo(1);
+        }
+        assertThat(fileIO.closed).hasValue(1);
+    }
+
+    private FormatReaderContext context(CountingFileIO fileIO, Path file) throws IOException {
+        return new FormatReaderContext(fileIO, file, fileIO.getFileSize(file), null, null);
+    }
+
+    private Path writeParquet() throws IOException {
+        Path file = new Path(tempDir.toUri().toString(), "a.parquet");
+        FileFormat format = FileFormat.fromIdentifier("parquet", new Options());
+        try (PositionOutputStream out = LocalFileIO.create().newOutputStream(file, false)) {
+            FormatWriter writer = format.createWriterFactory(rowType).create(out, "zstd");
+            writer.addElement(GenericRow.of(1));
+            writer.close();
+        }
+        return file;
+    }
+
+    private static class CountingFileIO extends LocalFileIO {
+
+        private final AtomicInteger closed = new AtomicInteger();
+
+        @Override
+        public SeekableInputStream newInputStream(Path path) throws IOException {
+            SeekableInputStream inner = super.newInputStream(path);
+            return new SeekableInputStream() {
+
+                @Override
+                public void seek(long desired) throws IOException {
+                    inner.seek(desired);
+                }
+
+                @Override
+                public long getPos() throws IOException {
+                    return inner.getPos();
+                }
+
+                @Override
+                public int read() throws IOException {
+                    return inner.read();
+                }
+
+                @Override
+                public int read(byte[] b, int off, int len) throws IOException {
+                    return inner.read(b, off, len);
+                }
+
+                @Override
+                public void close() throws IOException {
+                    closed.incrementAndGet();
+                    inner.close();
+                }
+            };
+        }
+    }
+}


### PR DESCRIPTION
### Purpose

close #9575

`ParquetReaderFactory.createReader` closes what it opened if reading the footer or constructing the `ParquetFileReader` throws. The stretch after that was not covered: building the shredding read plan, resolving the requested schema, checking the batch size, allocating the writable vectors and constructing `VectorizedParquetRecordReader` can all throw, and at that point the reader is only a local variable, so the caller cannot close it and the open stream is lost. This wraps that stretch too, with the same `catch (Throwable)` shape as the block directly above it, closing `reader` instead of `inputStream`.

Two notes on reading the diff. Ignoring whitespace it is 10 added lines, one comment plus `try {` plus the eight-line catch; the rest of the churn is the indentation of the wrapped block, so `git diff -w` is the useful view. And the two catches are mutually exclusive, so nothing is closed twice.

What makes it worth fixing is that `DataFileRecordReader` treats an `IOException` or `RuntimeException` from `createReader` as a corrupt file when `scan.ignore-corrupt-files` is on: it logs a WARN, returns null and the scan continues, so each unreadable file costs one descriptor and nothing says so. Reaching it does not need a damaged file. A column whose stored type does not match the read type throws `Schema evolution not supported.` from `VectorizedParquetRecordReader`'s constructor, and a case-insensitive read of two columns differing only in case throws `Found duplicate field(s)` from the requested-schema build.

### Tests

`ParquetReaderFactoryLeakTest` overrides `computeBatchSize` to return zero, which fails the positive-batch-size check inside the newly protected stretch. That is a deterministic trigger rather than a schema quirk, and it uses the method's documented extension point: the javadoc says subclasses may override it for per-file batch sizing, and the `checkArgument` exists to reject a non-positive result from exactly that.

The `FileIO` counts `close()` calls per stream rather than recording a boolean, so the second test pins a successful read at exactly one close. That one passes against the unfixed code as well, which is the point of it: it guards against a careless unconditional close. The leak test fails against the unfixed code on the close count.

`mvn -pl paimon-format clean test` on JDK 8: 598 tests, 0 failures. `spotless:check` and `checkstyle:check` are clean.

No overlap with #9550, which touches `clipParquetType` and `ParquetSchemaConverter` rather than `createReader`.
