### PR TITLE
[core] Clean up data file extra files

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/append/AppendOnlyWriter.java
+++ b/paimon-core/src/main/java/org/apache/paimon/append/AppendOnlyWriter.java
@@ -288,7 +288,7 @@ public class AppendOnlyWriter implements BatchRecordWriter, MemoryOwner {
         for (DataFileMeta file : compactAfter) {
             // appendOnlyCompactManager will rewrite the file and no file upgrade will occur, so we
             // can directly delete the file in compactAfter.
-            fileIO.deleteQuietly(pathFactory.toPath(file));
+            file.collectFiles(pathFactory).forEach(fileIO::deleteQuietly);
         }
 
         sinkWriter.close();
@@ -315,7 +315,7 @@ public class AppendOnlyWriter implements BatchRecordWriter, MemoryOwner {
             } finally {
                 // remove small files
                 for (DataFileMeta file : files) {
-                    fileIO.deleteQuietly(pathFactory.toPath(file));
+                    file.collectFiles(pathFactory).forEach(fileIO::deleteQuietly);
                 }
             }
         }

--- a/paimon-core/src/main/java/org/apache/paimon/operation/FileStoreCommitImpl.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/FileStoreCommitImpl.java
@@ -714,7 +714,7 @@ public class FileStoreCommitImpl implements FileStoreCommit {
             dataFilesToDelete.addAll(commitMessage.compactIncrement().changelogFiles());
 
             for (DataFileMeta file : dataFilesToDelete) {
-                fileIO.deleteQuietly(dataPathFactory.toPath(file));
+                file.collectFiles(dataPathFactory).forEach(fileIO::deleteQuietly);
             }
 
             List<IndexFileMeta> indexFilesToDelete = new ArrayList<>();

--- a/paimon-core/src/test/java/org/apache/paimon/append/AppendOnlyWriterTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/append/AppendOnlyWriterTest.java
@@ -376,6 +376,8 @@ public class AppendOnlyWriterTest {
             writer.write(row(j, String.format("%03d", j), PART));
         }
         writer.sync();
+        assertThat(Files.walk(tempDir).filter(Files::isRegularFile))
+                .anyMatch(path -> path.getFileName().toString().endsWith(".index"));
 
         // writer closed unexpectedly
         writer.close();
@@ -1321,6 +1323,8 @@ public class AppendOnlyWriterTest {
         long maxSeq = toCompact.get(size - 1).maxSequenceNumber();
         Path path = pathFactory.newPath("compact-");
         LocalFileIO.create().newOutputStream(path, false).close();
+        Path extraPath = new Path(path.getParent(), path.getName() + ".index");
+        LocalFileIO.create().newOutputStream(extraPath, false).close();
         return DataFileMeta.forAppend(
                 path.getName(),
                 toCompact.stream().mapToLong(DataFileMeta::fileSize).sum(),
@@ -1350,7 +1354,7 @@ public class AppendOnlyWriterTest {
                 minSeq,
                 maxSeq,
                 toCompact.get(0).schemaId(),
-                Collections.emptyList(),
+                Collections.singletonList(extraPath.getName()),
                 null,
                 FileSource.APPEND,
                 null,

--- a/paimon-core/src/test/java/org/apache/paimon/operation/FileStoreCommitTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/operation/FileStoreCommitTest.java
@@ -37,6 +37,7 @@ import org.apache.paimon.index.IndexFileMeta;
 import org.apache.paimon.index.IndexPathFactory;
 import org.apache.paimon.io.CompactIncrement;
 import org.apache.paimon.io.DataFileMeta;
+import org.apache.paimon.io.DataFilePathFactory;
 import org.apache.paimon.io.DataIncrement;
 import org.apache.paimon.manifest.FileKind;
 import org.apache.paimon.manifest.IndexManifestEntry;
@@ -1125,6 +1126,66 @@ public class FileStoreCommitTest {
         assertThat(store.fileIO().exists(compactNewPath)).isFalse();
         assertThat(store.fileIO().exists(dataDeletedPath)).isTrue();
         assertThat(store.fileIO().exists(compactDeletedPath)).isTrue();
+    }
+
+    @Test
+    public void testAbortDataFileWithExtraFiles() throws Exception {
+        TestAppendFileStore store = TestAppendFileStore.createAppendStore(tempDir, new HashMap<>());
+        BinaryRow partition = gen.getPartition(gen.next());
+        DataFilePathFactory pathFactory =
+                store.pathFactory().createDataFilePathFactory(partition, 0);
+
+        Path dataNewPath = pathFactory.newPath();
+        DataFileMeta dataNew = createDataFileWithExtraFile(store, dataNewPath, false);
+        Path compactNewPath = new Path(tempDir.resolve("external-compact-new.orc").toUri());
+        DataFileMeta compactNew = createDataFileWithExtraFile(store, compactNewPath, true);
+
+        CommitMessage commitMessage =
+                new CommitMessageImpl(
+                        partition,
+                        0,
+                        store.options().bucket(),
+                        new DataIncrement(
+                                Collections.singletonList(dataNew),
+                                Collections.emptyList(),
+                                Collections.emptyList()),
+                        new CompactIncrement(
+                                Collections.emptyList(),
+                                Collections.singletonList(compactNew),
+                                Collections.emptyList()));
+
+        try (FileStoreCommitImpl commit = store.newCommit()) {
+            commit.abort(Collections.singletonList(commitMessage));
+        }
+
+        for (Path path : dataNew.collectFiles(pathFactory)) {
+            assertThat(store.fileIO().exists(path)).isFalse();
+        }
+        for (Path path : compactNew.collectFiles(pathFactory)) {
+            assertThat(store.fileIO().exists(path)).isFalse();
+        }
+    }
+
+    private static DataFileMeta createDataFileWithExtraFile(
+            TestAppendFileStore store, Path path, boolean external) throws Exception {
+        store.fileIO().newOutputStream(path, false).close();
+        Path extraPath = new Path(path.getParent(), path.getName() + ".index");
+        store.fileIO().newOutputStream(extraPath, false).close();
+        return DataFileMeta.forAppend(
+                path.getName(),
+                0,
+                0,
+                EMPTY_STATS,
+                0,
+                0,
+                0,
+                Collections.singletonList(extraPath.getName()),
+                null,
+                null,
+                null,
+                external ? path.toString() : null,
+                null,
+                null);
     }
 
     private static IndexFileMeta createIndexFile(


### PR DESCRIPTION
### Purpose

Clean up data file extra files together with their main files in append-only writer temporary cleanup and commit abort paths.

- Clean compaction and rewrite outputs through `DataFileMeta.collectFiles`.
- Clean aborted new and compacted data files, including external-path sidecar files.
- Add regression coverage for both cleanup paths.

### Tests

- `mvn -pl paimon-core -Pfast-build -DwildcardSuites=none -Dtest=AppendOnlyWriterTest,FileStoreCommitTest test` (88 tests passed)
- `mvn -pl paimon-core -DskipTests compile`