### PR TITLE
[api] Trim whitespace in the bucket-key option value

### DIFF
--- a/paimon-api/src/main/java/org/apache/paimon/schema/TableSchema.java
+++ b/paimon-api/src/main/java/org/apache/paimon/schema/TableSchema.java
@@ -214,7 +214,11 @@ public class TableSchema implements Serializable {
         if (StringUtils.isNullOrWhitespaceOnly(key)) {
             return Collections.emptyList();
         }
-        List<String> bucketKeys = Arrays.asList(key.split(","));
+        List<String> bucketKeys =
+                Arrays.stream(key.split(","))
+                        .map(String::trim)
+                        .filter(s -> !s.isEmpty())
+                        .collect(Collectors.toList());
         if (notContainsAll(fieldNames(), bucketKeys)) {
             throw new RuntimeException(
                     String.format(

--- a/paimon-api/src/test/java/org/apache/paimon/schema/TableSchemaTest.java
+++ b/paimon-api/src/test/java/org/apache/paimon/schema/TableSchemaTest.java
@@ -85,6 +85,26 @@ class TableSchemaTest {
         assertThat(optimized.dataFileSchema(null).fieldNames()).containsExactly("id", "name");
     }
 
+    @Test
+    void testBucketKeyTrimsWhitespaceAroundSeparator() {
+        Map<String, String> options = new HashMap<>();
+        options.put(CoreOptions.BUCKET_KEY.key(), " id , name ");
+        assertThat(bucketKeySchema(options).bucketKeys()).containsExactly("id", "name");
+    }
+
+    private static TableSchema bucketKeySchema(Map<String, String> options) {
+        return new TableSchema(
+                1L,
+                Arrays.asList(
+                        new DataField(1, "id", DataTypes.INT()),
+                        new DataField(2, "name", DataTypes.STRING())),
+                2,
+                Collections.emptyList(),
+                Collections.emptyList(),
+                options,
+                "");
+    }
+
     private static TableSchema nestedSchema(Map<String, String> options) {
         return new TableSchema(
                 1L,


### PR DESCRIPTION
### Purpose

`TableSchema.originalBucketKeys` splits `bucket-key` on `,` without trimming, so `'bucket-key' = 'id, name'` keeps the leading space in the second name and fails the field-name check two lines later with `Field names [id, name] should contains all bucket keys [id,  name]`. The identically formatted `'primary-key' = 'id, name'` is accepted, because `Schema` trims both `primary-key` and `partition`.

`SparkCatalog.resolveColumnNameList` already pre-trims to work around this, so only the Flink SQL, Hive and Java/REST paths hit it.

### Tests

`TableSchemaTest#testBucketKeyTrimsWhitespaceAroundSeparator`.

Written with Claude Code; reasoning and verification are mine.
