### PR TITLE
[docs] Regenerate the configuration reference

### DIFF
--- a/docs/generated/core_configuration.html
+++ b/docs/generated/core_configuration.html
@@ -561,6 +561,12 @@ under the License.
             <td>Maximum selected row ratio for reading a row-store sidecar file. The value must be in (0, 1]. The sidecar is used only when the selected row ratio is no more than this value and the selected row count is no more than data-evolution.row-sidecar.max-selected-rows.</td>
         </tr>
         <tr>
+            <td><h5>data-evolution.write-cols-optimization.enabled</h5></td>
+            <td style="word-wrap: break-word;">false</td>
+            <td>Boolean</td>
+            <td>Whether to omit write columns from data file metadata when a data evolution file contains all non-dedicated columns. Readers always support the omitted metadata, but writing it is disabled by default for compatibility with older readers.</td>
+        </tr>
+        <tr>
             <td><h5>data-file.external-paths</h5></td>
             <td style="word-wrap: break-word;">(none)</td>
             <td>String</td>

--- a/docs/generated/flink_connector_configuration.html
+++ b/docs/generated/flink_connector_configuration.html
@@ -27,12 +27,6 @@ under the License.
     </thead>
     <tbody>
         <tr>
-            <td><h5>compaction.bucket-distribution-strategy</h5></td>
-            <td style="word-wrap: break-word;">linear</td>
-            <td><p>Enum</p></td>
-            <td>Defines how dedicated bucket compaction jobs distribute compact buckets to writers. 'linear' uses the existing stable partition-plus-bucket mapping. 'size-aware-batch' assigns bounded full-compaction bucket splits by total data file size and forwards them to writers to reduce compaction long tail.<br /><br />Possible values:<ul><li>"linear": Distribute compact buckets by the existing stable partition-plus-bucket channel mapping.</li><li>"size-aware-batch": For bounded full compaction, assign compact bucket splits by total data file size and forward them to writers to reduce long-tail compaction tasks.</li></ul></td>
-        </tr>
-        <tr>
             <td><h5>changelog.precommit-compact.thread-num</h5></td>
             <td style="word-wrap: break-word;">(none)</td>
             <td>Integer</td>
@@ -43,6 +37,12 @@ under the License.
             <td style="word-wrap: break-word;">(none)</td>
             <td>String</td>
             <td>Commit listener will be called after a successful commit. This option list custom commit listener identifiers separated by comma.</td>
+        </tr>
+        <tr>
+            <td><h5>compaction.bucket-distribution-strategy</h5></td>
+            <td style="word-wrap: break-word;">linear</td>
+            <td><p>Enum</p></td>
+            <td>Defines how dedicated bucket compaction jobs distribute compact buckets to writers. 'linear' uses the existing stable partition-plus-bucket mapping. 'size-aware-batch' assigns bounded full-compaction bucket splits by total data file size and forwards them to writers to reduce compaction long tail.<br /><br />Possible values:<ul><li>"linear": Distribute compact buckets by the existing stable partition-plus-bucket channel mapping.</li><li>"size-aware-batch": For bounded full compaction, assign compact bucket splits by total data file size and forward them to writers to reduce long-tail compaction tasks.</li></ul></td>
         </tr>
         <tr>
             <td><h5>end-input.watermark</h5></td>


### PR DESCRIPTION
### Purpose

`ConfigOptionsDocsCompletenessITCase` is failing on master, and therefore on every pull request built against it:

```
Documentation is outdated, please regenerate it according to the instructions in paimon-docs/README.md.
	Problems:
		Option data-evolution.write-cols-optimization.enabled in class org.apache.paimon.CoreOptions is not documented.
```

The option was added in #9574 without regenerating the reference. This runs the command `paimon-docs/README.md` gives:

```
mvn package -Pgenerate-docs -pl paimon-docs -nsu -DskipTests -am
```

That produces two changes. The first is the missing row in `core_configuration.html`, which is the failure above. The second is in `flink_connector_configuration.html`: the generator sorts `compaction.bucket-distribution-strategy` between `commit.callbacks` and `end-input.watermark`, while the committed file has it at the top of the table, where it was added by hand in #8583. The completeness check does not compare ordering, so that one has been sitting there unnoticed; regenerating picks it up.

### Tests

`mvn -pl paimon-docs -am test -Dtest=ConfigOptionsDocsCompletenessITCase` on JDK 8: 1 test, 0 failures. It fails without these two files.

Note for anyone reproducing it: the test has to be run with `-am`, or it loads a stale `paimon-api` from the local repository and reports the reverse problem, that the documented options do not exist.
