### PR TITLE
[common] Fail on a short remote read instead of caching zero padding

### DIFF
--- a/paimon-common/src/main/java/org/apache/paimon/fs/cache/CachingSeekableInputStream.java
+++ b/paimon-common/src/main/java/org/apache/paimon/fs/cache/CachingSeekableInputStream.java
@@ -195,7 +195,11 @@ public class CachingSeekableInputStream extends SeekableInputStream implements V
         }
         synchronized (stream) {
             stream.seek(offset);
-            return readFully(stream, size);
+            // must not tolerate a short read: the block is handed to putBlock, so a zero-padded
+            // tail would be cached and returned as file content for every later read
+            byte[] buf = new byte[size];
+            IOUtils.readFully(stream, buf, 0, size);
+            return buf;
         }
     }
 
@@ -234,21 +238,6 @@ public class CachingSeekableInputStream extends SeekableInputStream implements V
         if (closed) {
             throw new IOException("Stream is closed: " + path);
         }
-    }
-
-    private static byte[] readFully(SeekableInputStream in, int size) throws IOException {
-        byte[] buf = new byte[size];
-        int remaining = size;
-        int off = 0;
-        while (remaining > 0) {
-            int n = in.read(buf, off, remaining);
-            if (n < 0) {
-                break;
-            }
-            off += n;
-            remaining -= n;
-        }
-        return buf;
     }
 
     @Override

--- a/paimon-common/src/test/java/org/apache/paimon/fs/cache/CachingFileIOTest.java
+++ b/paimon-common/src/test/java/org/apache/paimon/fs/cache/CachingFileIOTest.java
@@ -139,6 +139,23 @@ class CachingFileIOTest {
     }
 
     @Test
+    void testShortRemoteReadIsNotCachedAsZeroPaddedBlock() throws IOException {
+        byte[] data = "truncated".getBytes();
+        MockFileIO delegate = new MockFileIO();
+        // the status says 8 bytes more than the stream can hand out
+        delegate.addTruncatedFile("snapshot-1", data, data.length + 8);
+
+        LocalDiskCacheManager cache = new LocalDiskCacheManager(cacheDir, Long.MAX_VALUE, 64);
+        CachingFileIO cachingIO = newCachingFileIO(delegate, cache, EnumSet.of(FileType.META), 64);
+
+        try (SeekableInputStream s = cachingIO.newInputStream(new Path("snapshot-1"))) {
+            assertThatThrownBy(() -> readAll(s, data.length + 8))
+                    .isInstanceOf(IOException.class)
+                    .hasMessageContaining("Premature EOF");
+        }
+    }
+
+    @Test
     void testMetaFileIsCached() throws IOException {
         byte[] data = "snapshot data".getBytes();
         MockFileIO delegate = new MockFileIO();
@@ -976,6 +993,7 @@ class CachingFileIOTest {
                 new ConcurrentHashMap<>();
 
         private final Map<String, byte[]> files = new HashMap<>();
+        private final Map<String, Long> reportedLengths = new HashMap<>();
         // concurrent so the thread-safety tests below can count from several reader threads
         private final Map<String, Integer> fileStatusCalls = new ConcurrentHashMap<>();
         private final Map<String, Integer> newInputStreamCalls = new ConcurrentHashMap<>();
@@ -1022,6 +1040,12 @@ class CachingFileIOTest {
 
         void addFile(String name, byte[] data) {
             files.put(name, data);
+        }
+
+        /** Reports a length beyond the bytes on hand, the way a truncated remote file does. */
+        void addTruncatedFile(String name, byte[] data, long reportedLength) {
+            files.put(name, data);
+            reportedLengths.put(name, reportedLength);
         }
 
         int getFileStatusCallCount(String name) {
@@ -1084,7 +1108,7 @@ class CachingFileIOTest {
             return new FileStatus() {
                 @Override
                 public long getLen() {
-                    return data.length;
+                    return reportedLengths.getOrDefault(name, (long) data.length);
                 }
 
                 @Override


### PR DESCRIPTION
### Purpose

`CachingSeekableInputStream.readRemote` fills a block with a private `readFully` that breaks out of its loop on EOF and returns the partially filled buffer, zero-padded. `readBlock` hands that buffer to `cache.putBlock`, so one short remote read becomes a durable wrong answer — persisted to disk under `LocalDiskCacheManager` — for every later read of the block.

The `VectoredReadable` branch two lines above already uses `preadFully`, which throws. Use `IOUtils.readFully`, already imported here, and drop the local copy.

### Tests

`CachingFileIOTest#testShortRemoteReadIsNotCachedAsZeroPaddedBlock`.

Written with Claude Code; reasoning and verification are mine.
