### PR TITLE
[parquet] Push down StartsWith as Parquet binary range

### DIFF
--- a/paimon-format/src/main/java/org/apache/parquet/filter2/predicate/ParquetFilters.java
+++ b/paimon-format/src/main/java/org/apache/parquet/filter2/predicate/ParquetFilters.java
@@ -186,7 +186,21 @@ public class ParquetFilters {
 
         @Override
         public FilterPredicate visitStartsWith(FieldRef fieldRef, Object literal) {
-            throw new UnsupportedOperationException();
+            Operators.Column<?> column = toParquetColumn(fieldRef);
+            if (!(column instanceof Operators.BinaryColumn)) {
+                throw new UnsupportedOperationException();
+            }
+
+            Binary prefix = (Binary) toParquetObject(literal, fieldRef);
+            if (prefix.length() == 0) {
+                throw new UnsupportedOperationException();
+            }
+
+            FilterPredicate lower = FilterApi.gtEq((Operators.BinaryColumn) column, prefix);
+            Binary upper = nextBinary(prefix);
+            return upper == null
+                    ? lower
+                    : FilterApi.and(lower, FilterApi.lt((Operators.BinaryColumn) column, upper));
         }
 
         @Override
@@ -416,6 +430,20 @@ public class ParquetFilters {
                 return Binary.fromReusedByteArray((byte[]) value);
             }
             throw new UnsupportedOperationException();
+        }
+
+        /** Returns the smallest binary value strictly greater than all values with this prefix. */
+        @Nullable
+        private Binary nextBinary(Binary prefix) {
+            byte[] bytes = prefix.getBytes();
+            for (int i = bytes.length - 1; i >= 0; i--) {
+                int value = bytes[i] & 0xff;
+                if (value != 0xff) {
+                    bytes[i] = (byte) (value + 1);
+                    return Binary.fromConstantByteArray(bytes, 0, i + 1);
+                }
+            }
+            return null;
         }
 
         private Decimal normalizeDecimal(Decimal decimal, DecimalType fieldType) {

--- a/paimon-format/src/test/java/org/apache/paimon/format/parquet/ParquetFiltersTest.java
+++ b/paimon-format/src/test/java/org/apache/paimon/format/parquet/ParquetFiltersTest.java
@@ -216,6 +216,43 @@ class ParquetFiltersTest {
     }
 
     @Test
+    public void testStartsWithIsPushedToParquet() {
+        RowType rowType =
+                new RowType(
+                        Collections.singletonList(new DataField(0, "string1", new VarCharType())));
+        MessageType schema = ParquetSchemaConverter.convertToParquetMessageType(rowType);
+        PredicateBuilder builder = new PredicateBuilder(rowType);
+
+        FilterCompat.Filter filter =
+                ParquetFilters.convert(
+                        Collections.singletonList(builder.startsWith(0, "abc")), schema, true);
+        assertThat(filter).isInstanceOf(FilterPredicateCompat.class);
+        FilterPredicate parquetPredicate =
+                ((FilterPredicateCompat) filter).getFilterPredicate();
+        assertThat(parquetPredicate)
+                .isEqualTo(
+                        FilterApi.and(
+                                FilterApi.gtEq(
+                                        FilterApi.binaryColumn("string1"), Binary.fromString("abc")),
+                                FilterApi.lt(
+                                        FilterApi.binaryColumn("string1"), Binary.fromString("abd"))));
+    }
+
+    @Test
+    public void testEndsWithIsNotPushedToParquet() {
+        RowType rowType =
+                new RowType(
+                        Collections.singletonList(new DataField(0, "string1", new VarCharType())));
+        MessageType schema = ParquetSchemaConverter.convertToParquetMessageType(rowType);
+        PredicateBuilder builder = new PredicateBuilder(rowType);
+
+        FilterCompat.Filter filter =
+                ParquetFilters.convert(
+                        Collections.singletonList(builder.endsWith(0, "abc")), schema, true);
+        assertThat(filter).isEqualTo(FilterCompat.NOOP);
+    }
+
+    @Test
     public void testInFilterLong() {
         RowType rowType =
                 new RowType(Collections.singletonList(new DataField(0, "col1", new BigIntType())));

--- a/paimon-format/src/test/java/org/apache/paimon/format/parquet/ParquetFiltersTest.java
+++ b/paimon-format/src/test/java/org/apache/paimon/format/parquet/ParquetFiltersTest.java
@@ -227,15 +227,16 @@ class ParquetFiltersTest {
                 ParquetFilters.convert(
                         Collections.singletonList(builder.startsWith(0, "abc")), schema, true);
         assertThat(filter).isInstanceOf(FilterPredicateCompat.class);
-        FilterPredicate parquetPredicate =
-                ((FilterPredicateCompat) filter).getFilterPredicate();
+        FilterPredicate parquetPredicate = ((FilterPredicateCompat) filter).getFilterPredicate();
         assertThat(parquetPredicate)
                 .isEqualTo(
                         FilterApi.and(
                                 FilterApi.gtEq(
-                                        FilterApi.binaryColumn("string1"), Binary.fromString("abc")),
+                                        FilterApi.binaryColumn("string1"),
+                                        Binary.fromString("abc")),
                                 FilterApi.lt(
-                                        FilterApi.binaryColumn("string1"), Binary.fromString("abd"))));
+                                        FilterApi.binaryColumn("string1"),
+                                        Binary.fromString("abd"))));
     }
 
     @Test


### PR DESCRIPTION
### Purpose
 Support Parquet predicate pushdown for Paimon's `StartsWith` predicates.
  A prefix predicate is converted into a Parquet binary range:
  `[prefix, nextPrefix)`
### Tests
  - Verify StartsWith is converted to a Parquet FilterPredicate.
  - Verify the generated lower and upper binary bounds.
  - Verify EndsWith remains unsupported and returns FilterCompat.NOOP.