### PR TITLE
[arrow] Fix second-precision timestamp conversion for pre-epoch values

### DIFF
--- a/paimon-arrow/src/main/java/org/apache/paimon/arrow/ArrowUtils.java
+++ b/paimon-arrow/src/main/java/org/apache/paimon/arrow/ArrowUtils.java
@@ -325,7 +325,7 @@ public class ArrowUtils {
 
     private static long nonCastedTimestampToEpoch(Timestamp timestamp, int precision) {
         if (precision == 0) {
-            return timestamp.getMillisecond() / 1000;
+            return Math.floorDiv(timestamp.getMillisecond(), 1000L);
         } else if (precision >= 1 && precision <= 3) {
             return timestamp.getMillisecond();
         } else if (precision >= 4 && precision <= 6) {

--- a/paimon-arrow/src/test/java/org/apache/paimon/arrow/vector/ArrowFormatWriterTest.java
+++ b/paimon-arrow/src/test/java/org/apache/paimon/arrow/vector/ArrowFormatWriterTest.java
@@ -164,6 +164,26 @@ public class ArrowFormatWriterTest {
     }
 
     @Test
+    public void testWritePreEpochSecondPrecisionTimestamp() {
+        RowType rowType =
+                RowType.of(DataTypes.TIMESTAMP(0), DataTypes.TIMESTAMP_WITH_LOCAL_TIME_ZONE(0));
+        try (ArrowFormatWriter writer = new ArrowFormatWriter(rowType, 16, true)) {
+            // 1969-12-31T23:59:59.500, i.e. 500 millis before the epoch
+            Timestamp preEpoch = Timestamp.fromEpochMillis(-500);
+            writer.write(GenericRow.of(preEpoch, preEpoch));
+            writer.flush();
+
+            VectorSchemaRoot vectorSchemaRoot = writer.getVectorSchemaRoot();
+            ArrowBatchReader arrowBatchReader = new ArrowBatchReader(rowType, true);
+            InternalRow row = arrowBatchReader.readBatch(vectorSchemaRoot).iterator().next();
+
+            // sub-second millis must be truncated towards negative infinity, not towards zero
+            assertThat(row.getTimestamp(0, 0).toString()).isEqualTo("1969-12-31T23:59:59");
+            assertThat(row.getTimestamp(1, 0).toString()).isEqualTo("1969-12-31T23:59:59");
+        }
+    }
+
+    @Test
     public void testMissingMapColumnVectorizedRoundTrip() {
         RowType inputRowType = RowType.builder().field("id", DataTypes.INT()).build();
         RowType projectedRowType =


### PR DESCRIPTION

### Purpose

fix #9599

- `ArrowUtils.nonCastedTimestampToEpoch()` computed the epoch second for `precision == 0` as `timestamp.getMillisecond() / 1000`. Java integer division truncates towards zero, so a pre-epoch value with sub-second millis moves forward across the epoch boundary: `-500` (`1969-12-31T23:59:59.500`) becomes `0`, i.e. `1970-01-01T00:00:00Z`.
- Use `Math.floorDiv` so truncation goes towards negative infinity. The 1-3, 4-6 and 7-9 precision branches are already negative-safe and are untouched.
- This aligns the write direction with the read direction, fixed the same way in #9299 (`Arrow2PaimonVectorConverter.convertEpochToTimestamp`).

### Tests

- Added `ArrowFormatWriterTest#testWritePreEpochSecondPrecisionTimestamp`: an `ArrowFormatWriter` -> `ArrowBatchReader` round trip over `TIMESTAMP(0)` and `TIMESTAMP_LTZ(0)`. It fails on master (`expected: "1969-12-31T23:59:59" but was: "1970-01-01T00:00"`) and passes with the fix.
- `mvn -pl paimon-arrow clean install` — 71 tests passed, 0 failures.


