### PR TITLE
[core] Fix stale option key in clustering.strategy description

### DIFF
--- a/docs/generated/core_configuration.html
+++ b/docs/generated/core_configuration.html
@@ -294,7 +294,7 @@ under the License.
             <td><h5>clustering.strategy</h5></td>
             <td style="word-wrap: break-word;">"auto"</td>
             <td>String</td>
-            <td>Specifies the comparison algorithm used for range partitioning, including 'zorder', 'hilbert', and 'order', corresponding to the z-order curve algorithm, hilbert curve algorithm, and basic type comparison algorithm, respectively. When not configured, it will automatically determine the algorithm based on the number of columns in 'clustering.by-columns'. 'order' is used for 1 column, 'zorder' for less than 5 columns, and 'hilbert' for 5 or more columns.</td>
+            <td>Specifies the comparison algorithm used for range partitioning, including 'zorder', 'hilbert', and 'order', corresponding to the z-order curve algorithm, hilbert curve algorithm, and basic type comparison algorithm, respectively. When not configured, it will automatically determine the algorithm based on the number of columns in 'clustering.columns'. 'order' is used for 1 column, 'zorder' for less than 5 columns, and 'hilbert' for 5 or more columns.</td>
         </tr>
         <tr>
             <td><h5>commit.callback.#.param</h5></td>

--- a/paimon-api/src/main/java/org/apache/paimon/CoreOptions.java
+++ b/paimon-api/src/main/java/org/apache/paimon/CoreOptions.java
@@ -2450,7 +2450,7 @@ public class CoreOptions implements Serializable {
                             "Specifies the comparison algorithm used for range partitioning, including 'zorder', 'hilbert', and 'order', "
                                     + "corresponding to the z-order curve algorithm, hilbert curve algorithm, and basic type comparison algorithm, "
                                     + "respectively. When not configured, it will automatically determine the algorithm based on the number of columns "
-                                    + "in 'clustering.by-columns'. 'order' is used for 1 column, 'zorder' for less than 5 columns, "
+                                    + "in 'clustering.columns'. 'order' is used for 1 column, 'zorder' for less than 5 columns, "
                                     + "and 'hilbert' for 5 or more columns.");
 
     public static final ConfigOption<Boolean> CLUSTERING_INCREMENTAL =


### PR DESCRIPTION

### Purpose

- The description of `clustering.strategy` says the algorithm is chosen from the number of columns in `'clustering.by-columns'`, but no such option key exists in Paimon.
- The primary key is `clustering.columns`, with `sink.clustering.by-columns` kept only as its fallback. Users following the current text silently get no clustering.
- This completes the rename started in `2558c585c` (added `clustering.columns`, made `sink.clustering.by-columns` a fallback) and continued in `4e7e4188e` (dropped the deprecated `sink.` prefix but kept the old suffix). It does not restore the `sink.` prefix.
- `docs/generated/core_configuration.html` renders the same string, so both files are updated together, matching #9104.

### Tests

- Description string only, no behavior change — no new tests.
- `mvn -pl paimon-api clean install` passed (checkstyle, spotless, 184 unit tests).
- `ConfigOptionsDocsCompletenessITCase` in `paimon-docs` passed; reverting only the HTML makes it fail on `clustering.strategy`.


