### PR TITLE
[docs] Document the VECTOR data type

### DIFF
--- a/docs/docs/concepts/data-types.md
+++ b/docs/docs/concepts/data-types.md
@@ -204,5 +204,13 @@ All data types supported by Paimon are as follows:
           <code>Note: Requires 'row-tracking.enabled' and 'data-evolution.enabled' to be set to true. See <a href="../multimodal-table/blob">Blob Type</a> for details.</code>
       </td>
     </tr>
+    <tr>
+      <td><code>VECTOR&lt;t, n&gt;</code></td>
+      <td><code>Data type of a fixed-length dense vector.</code><br><br>
+          <code>Paimon supports defining columns of type VECTOR&lt;t, n&gt;, where t is the element type and n is the vector dimension. t must be one of BOOLEAN, TINYINT, SMALLINT, INT, BIGINT, FLOAT, DOUBLE. n must have a value between 1 and 2,147,483,647 (both inclusive). If a vector value is not null, its elements cannot be null.</code><br><br>
+          <code>A VECTOR column cannot be used as a primary key column, a partition column, or for sorting.</code><br><br>
+          <code>Note: Dedicated vector file storage requires 'vector.file.format', 'row-tracking.enabled' and 'data-evolution.enabled'. See <a href="../multimodal-table/vector">Vector Storage</a> for details.</code>
+      </td>
+    </tr>
     </tbody>
 </table>


### PR DESCRIPTION

### Purpose

fix #9601

- The table in `docs/docs/concepts/data-types.md` claims to list all supported types, but `DataTypeRoot` has 25 constants and the table has 24 rows — only `VECTOR` is missing.
- The new row summarizes and links wording that already exists in `docs/docs/multimodal-table/vector.mdx`; it introduces no new facts.
- The row was never removed: `git log --follow -S 'VECTOR'` returns 0 commits both on this file and on its pre-Docusaurus path `docs/content/concepts/data-types.md`. Introducing commit 160a3cdcb (#7204) touched no `docs/` file; by contrast d9b57982c (#9251) updated this table in the same commit that added GEOMETRY/GEOGRAPHY.
- Formatting mirrors the adjacent `BLOB` row.

### Tests

- Docs-only, one file, +8/-0. No behavior change, no test added.
- `yarn build` was not run. Render safety was checked statically: the row reuses the HTML shape of the existing rows, `docusaurus.config.js` sets `markdown.format: 'detect'` with `mdx1Compat`, and the link target exists.


