### PR TITLE
[vortex] Honor write.batch-memory in the writer factory

### DIFF
--- a/paimon-vortex/paimon-vortex-format/src/main/java/org/apache/paimon/format/vortex/VortexFileFormat.java
+++ b/paimon-vortex/paimon-vortex-format/src/main/java/org/apache/paimon/format/vortex/VortexFileFormat.java
@@ -79,7 +79,13 @@ public class VortexFileFormat extends FileFormat {
     @Override
     public FormatWriterFactory createWriterFactory(RowType type) {
         return new VortexWriterFactory(
-                () -> new ArrowFormatCWriter(type, formatContext.writeBatchSize(), true));
+                () ->
+                        new ArrowFormatCWriter(
+                                type,
+                                formatContext.writeBatchSize(),
+                                true,
+                                formatContext.writeBatchMemory().getBytes(),
+                                null));
     }
 
     @Override

--- a/paimon-vortex/paimon-vortex-format/src/main/java/org/apache/paimon/format/vortex/VortexWriterFactory.java
+++ b/paimon-vortex/paimon-vortex-format/src/main/java/org/apache/paimon/format/vortex/VortexWriterFactory.java
@@ -18,6 +18,7 @@
 
 package org.apache.paimon.format.vortex;
 
+import org.apache.paimon.annotation.VisibleForTesting;
 import org.apache.paimon.arrow.vector.ArrowFormatCWriter;
 import org.apache.paimon.format.FormatWriter;
 import org.apache.paimon.format.FormatWriterFactory;
@@ -40,6 +41,11 @@ public class VortexWriterFactory implements FormatWriterFactory, SupportsDirectW
 
     public VortexWriterFactory(Supplier<ArrowFormatCWriter> cWriterSupplier) {
         this.cWriterSupplier = cWriterSupplier;
+    }
+
+    @VisibleForTesting
+    Supplier<ArrowFormatCWriter> cWriterSupplier() {
+        return cWriterSupplier;
     }
 
     @Override

--- a/paimon-vortex/paimon-vortex-format/src/test/java/org/apache/paimon/format/vortex/VortexFileFormatTest.java
+++ b/paimon-vortex/paimon-vortex-format/src/test/java/org/apache/paimon/format/vortex/VortexFileFormatTest.java
@@ -18,13 +18,19 @@
 
 package org.apache.paimon.format.vortex;
 
+import org.apache.paimon.arrow.vector.ArrowFormatCWriter;
+import org.apache.paimon.data.GenericRow;
 import org.apache.paimon.format.FileFormatFactory;
+import org.apache.paimon.options.MemorySize;
 import org.apache.paimon.options.Options;
 import org.apache.paimon.types.DataTypes;
 import org.apache.paimon.types.RowType;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -62,6 +68,33 @@ public class VortexFileFormatTest {
                         new FileFormatFactory.FormatContext(new Options(), 1024, 1024));
         RowType rowType = RowType.of(DataTypes.INT(), DataTypes.STRING());
         assertDoesNotThrow(() -> format.createWriterFactory(rowType));
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
+    public void testWriterFactoryHonorsWriteBatchMemory(boolean limitMemory) {
+        int writeBatchSize = 1024;
+        FileFormatFactory.FormatContext formatContext =
+                limitMemory
+                        ? new FileFormatFactory.FormatContext(
+                                new Options(), 1024, writeBatchSize, MemorySize.parse("1 kb"))
+                        : new FileFormatFactory.FormatContext(new Options(), 1024, writeBatchSize);
+        VortexFileFormat format = new VortexFileFormat(formatContext);
+        RowType rowType = RowType.of(DataTypes.BYTES(), DataTypes.BYTES());
+        VortexWriterFactory factory = (VortexWriterFactory) format.createWriterFactory(rowType);
+
+        GenericRow row = new GenericRow(2);
+        row.setField(0, new byte[1024]);
+        row.setField(1, new byte[1024]);
+
+        try (ArrowFormatCWriter writer = factory.cWriterSupplier().get()) {
+            // the memory limit is only re-checked every 32 rows
+            for (int i = 0; i < 32; i++) {
+                assertThat(writer.write(row)).isTrue();
+            }
+            // this row is still far below write-batch-size, so only the memory limit can reject it
+            assertThat(writer.write(row)).isEqualTo(!limitMemory);
+        }
     }
 
     @Test


### PR DESCRIPTION
### Purpose

fix #9559

- `VortexFileFormat.createWriterFactory()` never passed `write.batch-memory` to `ArrowFormatCWriter`, so only `write.batch-size` bounded a batch. This passes it through.
- #7543 passed it; #8040 dropped it when `ArrowFormatCWriter` replaced `ArrowFormatWriter`. If that was intentional, please close this — #9559 asks the same.
- Among Arrow-VSR-backed native writers, orc, lance and mosaic already consume it; vortex did not. parquet/avro do not use it.
- Defaults (128 MB) are unaffected; the limit bites only with a lowered option or very wide rows.
- No docs change: the option is already generated from the untouched `CoreOptions`.

### Tests

- Added `VortexFileFormatTest#testWriterFactoryHonorsWriteBatchMemory`: at a 1 kb limit `write()` is rejected before `write.batch-size`; at 128 MB it is not.
- `mvn -pl paimon-vortex/paimon-vortex-format clean install` (JDK 11) — 66 tests, 0 failures, 4 skipped; checkstyle, spotless, enforcer green.
- No existing test sets `write.batch-memory`, so none change behavior.
