### PR TITLE
[oss]support cross bucket migration of oss files

### DIFF
--- a/paimon-filesystems/paimon-oss-impl/src/main/java/org/apache/paimon/oss/OSSFileIO.java
+++ b/paimon-filesystems/paimon-oss-impl/src/main/java/org/apache/paimon/oss/OSSFileIO.java
@@ -21,6 +21,7 @@ package org.apache.paimon.oss;
 import org.apache.paimon.catalog.CatalogContext;
 import org.apache.paimon.data.BlobDescriptor;
 import org.apache.paimon.fs.FileIO;
+import org.apache.paimon.fs.FileStatus;
 import org.apache.paimon.fs.HadoopOptionsProvider;
 import org.apache.paimon.fs.Path;
 import org.apache.paimon.fs.TwoPhaseOutputStream;
@@ -37,14 +38,22 @@ import com.aliyun.oss.common.comm.ServiceClient;
 import com.aliyun.oss.internal.OSSHeaders;
 import com.aliyun.oss.internal.OSSMultipartOperation;
 import com.aliyun.oss.internal.OSSObjectOperation;
+import com.aliyun.oss.model.AbortMultipartUploadRequest;
+import com.aliyun.oss.model.CompleteMultipartUploadRequest;
 import com.aliyun.oss.model.CopyObjectRequest;
 import com.aliyun.oss.model.CopyObjectResult;
 import com.aliyun.oss.model.InitiateMultipartUploadRequest;
 import com.aliyun.oss.model.InitiateMultipartUploadResult;
+import com.aliyun.oss.model.ListObjectsRequest;
+import com.aliyun.oss.model.OSSObjectSummary;
+import com.aliyun.oss.model.ObjectListing;
 import com.aliyun.oss.model.ObjectMetadata;
+import com.aliyun.oss.model.PartETag;
 import com.aliyun.oss.model.PutObjectRequest;
 import com.aliyun.oss.model.PutObjectResult;
+import com.aliyun.oss.model.UploadPartCopyRequest;
 import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FileAlreadyExistsException;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.aliyun.oss.AliyunOSSFileSystem;
 import org.apache.hadoop.fs.aliyun.oss.AliyunOSSFileSystemStore;
@@ -52,12 +61,15 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.ByteArrayInputStream;
+import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.net.URI;
 import java.nio.charset.StandardCharsets;
 import java.time.Duration;
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
@@ -111,6 +123,9 @@ public class OSSFileIO extends HadoopCompliantFileIO implements HadoopOptionsPro
     private static final String SSE_METHOD_AES256 = "AES256";
     private static final String SSE_METHOD_KMS = "KMS";
     private static final String SSE_DATA_SM4 = "SM4";
+
+    /** Minimum part size for multipart upload-copy, OSS requires every non-tail part >= 5MB. */
+    private static final long CROSS_BUCKET_COPY_PART_SIZE = 8L * 1024 * 1024;
 
     private static final Map<String, String> CASE_SENSITIVE_KEYS =
             new HashMap<String, String>() {
@@ -266,6 +281,322 @@ public class OSSFileIO extends HadoopCompliantFileIO implements HadoopOptionsPro
         } catch (Exception e) {
             throw new IOException("Failed to atomic write " + path, e);
         }
+    }
+
+    /**
+     * Rename across buckets, mirroring {@link AliyunOSSFileSystem#rename}.
+     *
+     * <p>The underlying {@code AliyunOSSFileSystem.rename} only supports copy within the same
+     * bucket, because {@code AliyunOSSFileSystemStore} pins a single {@code bucketName} and calls
+     * {@code copyObject(bucketName, srcKey, bucketName, dstKey)}. The {@link OSSClient} held by
+     * that store, however, accepts distinct source/destination buckets as long as they are in the
+     * same region. So for cross-bucket renames we bypass the Hadoop layer and drive {@code
+     * OSSClient} directly, but keep exactly the same rename semantics as {@code
+     * AliyunOSSFileSystem.rename}: root/path-containment checks, destination existence/type
+     * handling, directory rewrite to {@code dst/srcName}, empty-directory marker creation,
+     * file/directory dispatch and delete-after-copy. Copy itself is a single {@code copyObject}
+     * first, falling back to multipart {@code uploadPartCopy} when the object is larger than 1GB or
+     * a shallow copy is not supported. Cross-region copy is not supported by the OSS server-side
+     * copy API and will surface as an {@link OSSException}.
+     *
+     * @param src source path.
+     * @param dst destination path.
+     * @return true if the rename succeeds.
+     */
+    @Override
+    public boolean rename(Path src, Path dst) throws IOException {
+        URI srcUri = src.toUri();
+        URI dstUri = dst.toUri();
+        String srcBucket = srcUri.getHost();
+        String dstBucket = dstUri.getHost();
+        // Same bucket (or authority missing): fall back to the Hadoop rename path, which keeps
+        // the original semantics including directory handling and delete-after-copy.
+        if (srcBucket == null || dstBucket == null || srcBucket.equals(dstBucket)) {
+            return super.rename(src, dst);
+        }
+
+        OSSClient ossClient;
+        try {
+            ossClient = ossClient(src);
+        } catch (IOException e) {
+            throw e;
+        } catch (Exception e) {
+            throw new IOException("Failed to access OSSClient for cross-bucket rename", e);
+        }
+        return renameCrossBucket(ossClient, srcBucket, dstBucket, src, dst);
+    }
+
+    /**
+     * Cross-bucket rename whose control flow mirrors {@link AliyunOSSFileSystem#rename}. Existence
+     * and type checks go through this {@link OSSFileIO} (which selects the right per-bucket {@link
+     * AliyunOSSFileSystem}), while the actual copy is driven on {@code ossClient}.
+     */
+    private boolean renameCrossBucket(
+            OSSClient ossClient, String srcBucket, String dstBucket, Path src, Path dst)
+            throws IOException {
+        // Cannot rename the root of a filesystem.
+        if (src.getParent() == null) {
+            LOG.debug("Cannot rename the root of a filesystem");
+            return false;
+        }
+        // Reject renaming a directory into a subdirectory of itself.
+        Path parent = dst.getParent();
+        while (parent != null && !src.equals(parent)) {
+            parent = parent.getParent();
+        }
+        if (parent != null) {
+            return false;
+        }
+
+        FileStatus srcStatus = getFileStatus(src);
+        FileStatus dstStatus;
+        try {
+            dstStatus = getFileStatus(dst);
+        } catch (FileNotFoundException fnde) {
+            dstStatus = null;
+        }
+
+        if (dstStatus == null) {
+            // If dst doesn't exist, its parent must exist and be a directory.
+            FileStatus dstParentStatus = getFileStatus(dst.getParent());
+            if (!dstParentStatus.isDir()) {
+                throw new IOException(
+                        String.format(
+                                "Failed to rename %s to %s, %s is a file",
+                                src, dst, dst.getParent()));
+            }
+        } else {
+            if (srcStatus.getPath().equals(dstStatus.getPath())) {
+                return !srcStatus.isDir();
+            } else if (dstStatus.isDir()) {
+                // If dst is a directory, rewrite to dst/srcName.
+                dst = new Path(dst, src.getName());
+                FileStatus[] statuses;
+                try {
+                    statuses = listStatus(dst);
+                } catch (FileNotFoundException fnde) {
+                    statuses = null;
+                }
+                if (statuses != null && statuses.length > 0) {
+                    // If dst exists and not a directory / not empty.
+                    throw new FileAlreadyExistsException(
+                            String.format(
+                                    "Failed to rename %s to %s, file already exists or not empty!",
+                                    src, dst));
+                }
+            } else {
+                // If dst is not a directory.
+                throw new FileAlreadyExistsException(
+                        String.format("Failed to rename %s to %s, file already exists!", src, dst));
+            }
+        }
+
+        boolean succeed;
+        if (srcStatus.isDir()) {
+            succeed = copyDirectoryCrossBucket(ossClient, srcBucket, dstBucket, src, dst);
+        } else {
+            succeed =
+                    copyFileCrossBucket(
+                            ossClient,
+                            srcBucket,
+                            pathToObjectKey(src.toUri()),
+                            dstBucket,
+                            pathToObjectKey(dst.toUri()),
+                            srcStatus.getLen());
+        }
+        return src.equals(dst) || (succeed && delete(src, true));
+    }
+
+    /** OSS object keys are the URI path with the leading '/' stripped. */
+    private static String pathToObjectKey(URI uri) {
+        String path = uri.getPath();
+        if (path == null || path.isEmpty()) {
+            return "";
+        }
+        return path.startsWith("/") ? path.substring(1) : path;
+    }
+
+    /** Ensures {@code key} carries a trailing slash, treating it as an OSS directory prefix. */
+    private static String maybeAddTrailingSlash(String key) {
+        if (key.isEmpty()) {
+            return key;
+        }
+        return key.endsWith("/") ? key : key + "/";
+    }
+
+    /**
+     * Copy a single file across buckets, mirroring {@code AliyunOSSFileSystemStore.copyFile}:
+     * single {@code copyObject} first, fall back to multipart {@code uploadPartCopy} on failure
+     * (object larger than 1GB or shallow copy not supported).
+     */
+    private boolean copyFileCrossBucket(
+            OSSClient ossClient,
+            String srcBucket,
+            String srcKey,
+            String dstBucket,
+            String dstKey,
+            long contentLength)
+            throws IOException {
+        SseConfig sse = configuredSse();
+        try {
+            CopyObjectRequest request = new CopyObjectRequest(srcBucket, srcKey, dstBucket, dstKey);
+            if (sse != null) {
+                applySse(request, sse);
+            }
+            ossClient.copyObject(request);
+            return true;
+        } catch (OSSException e) {
+            LOG.debug(
+                    "Single cross-bucket copy failed for {} -> {}, fallback to multipartCopy: {}",
+                    srcKey,
+                    dstKey,
+                    e.getMessage());
+            return multipartCopyCrossBucket(
+                    ossClient, srcBucket, srcKey, dstBucket, dstKey, contentLength, sse);
+        }
+    }
+
+    /**
+     * Copy a single object across buckets via multipart upload-copy. Required when the object is
+     * larger than 1GB or when the OSS server does not support a shallow single-copy between the
+     * source and destination (e.g. differing storage classes). Preserves content-type and user
+     * metadata, which multipart copy does not copy by default.
+     */
+    private boolean multipartCopyCrossBucket(
+            OSSClient ossClient,
+            String srcBucket,
+            String srcKey,
+            String dstBucket,
+            String dstKey,
+            long contentLength,
+            SseConfig sse)
+            throws IOException {
+        ObjectMetadata srcMeta = ossClient.getObjectMetadata(srcBucket, srcKey);
+        ObjectMetadata newMeta = new ObjectMetadata();
+        if (srcMeta.getContentType() != null) {
+            newMeta.setContentType(srcMeta.getContentType());
+        }
+        if (srcMeta.getUserMetadata() != null && !srcMeta.getUserMetadata().isEmpty()) {
+            newMeta.setUserMetadata(srcMeta.getUserMetadata());
+        }
+        if (sse != null) {
+            newMeta = applySse(newMeta, sse);
+        }
+
+        InitiateMultipartUploadRequest initiateRequest =
+                new InitiateMultipartUploadRequest(dstBucket, dstKey);
+        initiateRequest.setObjectMetadata(newMeta);
+        InitiateMultipartUploadResult initiateResult =
+                ossClient.initiateMultipartUpload(initiateRequest);
+        String uploadId = initiateResult.getUploadId();
+
+        List<PartETag> partETags = new ArrayList<>();
+        try {
+            long partSize = CROSS_BUCKET_COPY_PART_SIZE;
+            long remaining = contentLength;
+            long offset = 0;
+            int partNumber = 1;
+            // OSS requires every non-tail part to be >= 100KB; a single tail part may be smaller.
+            while (remaining > 0) {
+                long size = Math.min(partSize, remaining);
+                UploadPartCopyRequest partRequest =
+                        new UploadPartCopyRequest(srcBucket, srcKey, dstBucket, dstKey);
+                partRequest.setUploadId(uploadId);
+                partRequest.setPartSize(size);
+                partRequest.setBeginIndex(offset);
+                partRequest.setPartNumber(partNumber);
+                partETags.add(ossClient.uploadPartCopy(partRequest).getPartETag());
+                offset += size;
+                remaining -= size;
+                partNumber++;
+            }
+            ossClient.completeMultipartUpload(
+                    new CompleteMultipartUploadRequest(dstBucket, dstKey, uploadId, partETags));
+            return true;
+        } catch (Exception e) {
+            try {
+                ossClient.abortMultipartUpload(
+                        new AbortMultipartUploadRequest(dstBucket, dstKey, uploadId));
+            } catch (Exception abortException) {
+                LOG.warn(
+                        "Failed to abort multipart upload for {} -> {}",
+                        srcKey,
+                        dstKey,
+                        abortException);
+            }
+            throw new IOException(
+                    "Failed to multipart copy "
+                            + srcBucket
+                            + "/"
+                            + srcKey
+                            + " to "
+                            + dstBucket
+                            + "/"
+                            + dstKey,
+                    e);
+        }
+    }
+
+    /**
+     * Copy a directory (an OSS prefix) across buckets, mirroring {@code
+     * AliyunOSSFileSystem.copyDirectory}: create the empty-directory marker at the destination
+     * prefix, then enumerate every object under the source prefix and copy each one. Returns false
+     * if the destination would be a subdirectory of the source.
+     */
+    private boolean copyDirectoryCrossBucket(
+            OSSClient ossClient, String srcBucket, String dstBucket, Path srcPath, Path dstPath)
+            throws IOException {
+        String srcKey = maybeAddTrailingSlash(pathToObjectKey(srcPath.toUri()));
+        String dstKey = maybeAddTrailingSlash(pathToObjectKey(dstPath.toUri()));
+
+        // Cross-bucket: src and dst live in different buckets, so dst can never be a subdirectory
+        // of src (the same-bucket self-containment guard from AliyunOSSFileSystem.copyDirectory
+        // does not apply here and would false-positive when the two buckets share a key prefix).
+
+        // Create the empty-directory marker at the destination, like store.storeEmptyFile(dstKey).
+        storeEmptyDir(ossClient, dstBucket, dstKey);
+
+        String nextMarker = null;
+        do {
+            ListObjectsRequest request = new ListObjectsRequest(srcBucket);
+            request.setPrefix(srcKey);
+            request.setMaxKeys(1000);
+            if (nextMarker != null) {
+                request.setMarker(nextMarker);
+            }
+            ObjectListing listing = ossClient.listObjects(request);
+            for (OSSObjectSummary summary : listing.getObjectSummaries()) {
+                String childSrcKey = summary.getKey();
+                // Skip the directory marker object itself if present.
+                if (childSrcKey.equals(srcKey)) {
+                    continue;
+                }
+                String childDstKey = dstKey.concat(childSrcKey.substring(srcKey.length()));
+                copyFileCrossBucket(
+                        ossClient,
+                        srcBucket,
+                        childSrcKey,
+                        dstBucket,
+                        childDstKey,
+                        summary.getSize());
+            }
+            nextMarker = listing.getNextMarker();
+        } while (nextMarker != null);
+        return true;
+    }
+
+    /**
+     * Create a zero-length object with a trailing slash to act as an OSS directory marker,
+     * equivalent to {@code AliyunOSSFileSystemStore.storeEmptyFile}.
+     */
+    private void storeEmptyDir(OSSClient ossClient, String bucket, String key) throws IOException {
+        ObjectMetadata dirMeta = new ObjectMetadata();
+        dirMeta.setContentLength(0);
+        SseConfig sse = configuredSse();
+        if (sse != null) {
+            dirMeta = applySse(dirMeta, sse);
+        }
+        ossClient.putObject(bucket, key, new ByteArrayInputStream(new byte[0]), dirMeta);
     }
 
     @Override

--- a/paimon-filesystems/paimon-oss-impl/src/main/java/org/apache/paimon/oss/OSSFileIO.java
+++ b/paimon-filesystems/paimon-oss-impl/src/main/java/org/apache/paimon/oss/OSSFileIO.java
@@ -127,6 +127,12 @@ public class OSSFileIO extends HadoopCompliantFileIO implements HadoopOptionsPro
     /** Minimum part size for multipart upload-copy, OSS requires every non-tail part >= 5MB. */
     private static final long CROSS_BUCKET_COPY_PART_SIZE = 8L * 1024 * 1024;
 
+    /** Maximum number of parts OSS allows in a single multipart upload. */
+    private static final long CROSS_BUCKET_COPY_MAX_PART_COUNT = 10_000;
+
+    /** Maximum size of a single OSS upload-part-copy, in bytes (5 GiB). */
+    private static final long CROSS_BUCKET_COPY_MAX_PART_SIZE = 5L * 1024 * 1024 * 1024;
+
     private static final Map<String, String> CASE_SENSITIVE_KEYS =
             new HashMap<String, String>() {
                 {
@@ -492,11 +498,16 @@ public class OSSFileIO extends HadoopCompliantFileIO implements HadoopOptionsPro
 
         List<PartETag> partETags = new ArrayList<>();
         try {
-            long partSize = CROSS_BUCKET_COPY_PART_SIZE;
+            long partSize =
+                    optimalPartSize(
+                            contentLength,
+                            CROSS_BUCKET_COPY_PART_SIZE,
+                            CROSS_BUCKET_COPY_MAX_PART_SIZE,
+                            CROSS_BUCKET_COPY_MAX_PART_COUNT);
             long remaining = contentLength;
             long offset = 0;
             int partNumber = 1;
-            // OSS requires every non-tail part to be >= 100KB; a single tail part may be smaller.
+            // OSS requires every non-tail part to be >= 5 MiB; a single tail part may be smaller.
             while (remaining > 0) {
                 long size = Math.min(partSize, remaining);
                 UploadPartCopyRequest partRequest =
@@ -535,6 +546,46 @@ public class OSSFileIO extends HadoopCompliantFileIO implements HadoopOptionsPro
                             + dstKey,
                     e);
         }
+    }
+
+    /**
+     * Pick a multipart copy part size that keeps {@code contentLength} within the service's {@code
+     * maxPartCount} limit, clamped to {@code [minPartSize, maxPartSize]}.
+     *
+     * <p>The default {@code minPartSize} (8 MiB) suffices for ordinary objects, but a fixed part
+     * size makes any object larger than {@code minPartSize * maxPartCount} (~78 GiB) overflow the
+     * 10,000-part cap and fail mid-copy. When that would happen, the part size is raised so the
+     * resulting part count stays at or below {@code maxPartCount}, rounded up to keep parts aligned
+     * and never producing more than {@code maxPartCount} parts.
+     */
+    static long optimalPartSize(
+            long contentLength, long minPartSize, long maxPartSize, long maxPartCount) {
+        checkArgument(minPartSize > 0, "minPartSize must be positive");
+        checkArgument(maxPartSize >= minPartSize, "maxPartSize must be >= minPartSize");
+        checkArgument(maxPartCount > 0, "maxPartCount must be positive");
+        if (contentLength <= 0) {
+            return minPartSize;
+        }
+        long partSize = minPartSize;
+        // ceil(contentLength / maxPartCount) is the smallest part size that fits the cap.
+        long required = divideRoundingUp(contentLength, maxPartCount);
+        if (required > partSize) {
+            // Round up to minPartSize so every part stays a clean multiple of the minimum and
+            // non-tail parts never drop below OSS's lower bound.
+            partSize = divideRoundingUp(required, minPartSize) * minPartSize;
+        }
+        if (partSize > maxPartSize) {
+            // The object is too large to copy within the part-count and per-part-size limits of
+            // a single multipart upload; clamp to the max and let OSS reject the oversized upload
+            // rather than silently sending too many parts.
+            partSize = maxPartSize;
+        }
+        return partSize;
+    }
+
+    /** Returns {@code ceil(dividend / divisor)} for non-negative {@code dividend}. */
+    private static long divideRoundingUp(long dividend, long divisor) {
+        return (dividend + divisor - 1) / divisor;
     }
 
     /**

--- a/paimon-filesystems/paimon-oss-impl/src/test/java/org/apache/paimon/oss/OSSFileIOTest.java
+++ b/paimon-filesystems/paimon-oss-impl/src/test/java/org/apache/paimon/oss/OSSFileIOTest.java
@@ -18,8 +18,11 @@
 
 package org.apache.paimon.oss;
 
+import org.apache.paimon.catalog.CatalogContext;
 import org.apache.paimon.data.BlobDescriptor;
+import org.apache.paimon.fs.FileStatus;
 import org.apache.paimon.fs.Path;
+import org.apache.paimon.options.Options;
 
 import com.aliyun.oss.ClientConfiguration;
 import com.aliyun.oss.ClientException;
@@ -37,21 +40,28 @@ import com.aliyun.oss.internal.OSSUtils;
 import com.aliyun.oss.model.AbortMultipartUploadRequest;
 import com.aliyun.oss.model.CompleteMultipartUploadRequest;
 import com.aliyun.oss.model.CopyObjectRequest;
+import com.aliyun.oss.model.CopyObjectResult;
 import com.aliyun.oss.model.InitiateMultipartUploadRequest;
 import com.aliyun.oss.model.InitiateMultipartUploadResult;
+import com.aliyun.oss.model.OSSObjectSummary;
+import com.aliyun.oss.model.ObjectListing;
 import com.aliyun.oss.model.ObjectMetadata;
 import com.aliyun.oss.model.UploadPartCopyRequest;
 import com.aliyun.oss.model.UploadPartCopyResult;
+import org.apache.hadoop.conf.Configuration;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 
+import java.io.IOException;
 import java.net.MalformedURLException;
 import java.net.URI;
 import java.net.URL;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.time.Duration;
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -652,5 +662,307 @@ public class OSSFileIOTest {
         assertThatThrownBy(() -> OSSFileIO.resolveSse(" ", "", null))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessageContaining("blank");
+    }
+
+    // ------------------------------------------------------------------------
+    //  Cross-bucket rename
+    // ------------------------------------------------------------------------
+
+    /** A file status with a known path, length and directory flag. */
+    private static FileStatus status(Path path, long len, boolean dir) {
+        return new FileStatus() {
+            @Override
+            public long getLen() {
+                return len;
+            }
+
+            @Override
+            public boolean isDir() {
+                return dir;
+            }
+
+            @Override
+            public Path getPath() {
+                return path;
+            }
+
+            @Override
+            public long getModificationTime() {
+                return 0;
+            }
+
+            @Override
+            public long getAccessTime() {
+                return 0;
+            }
+
+            @Override
+            public String getOwner() {
+                return "test";
+            }
+        };
+    }
+
+    /**
+     * A {@link OSSFileIO} that injects a mock {@link OSSClient} and stubs the FileIO-level
+     * filesystem probes ({@code getFileStatus}/{@code listStatus}/{@code delete}/{@code exists}) so
+     * the cross-bucket rename can be exercised without a real Hadoop filesystem.
+     */
+    private static final class RenameTestOSSFileIO extends OSSFileIO {
+        private final OSSClient client;
+        final Map<Path, FileStatus> statuses = new HashMap<>();
+        final Map<Path, FileStatus[]> listings = new HashMap<>();
+        final java.util.Set<Path> deleted = new java.util.HashSet<>();
+
+        private RenameTestOSSFileIO(OSSClient client) {
+            this.client = client;
+            // Initialize hadoopOptions so configuredSse()/rename do not NPE.
+            configure(CatalogContext.create(new Options(), new Configuration()));
+        }
+
+        @Override
+        OSSClient ossClient(Path path) {
+            return client;
+        }
+
+        @Override
+        public FileStatus getFileStatus(Path path) throws IOException {
+            FileStatus status = statuses.get(path);
+            if (status == null) {
+                throw new java.io.FileNotFoundException(path.toString());
+            }
+            return status;
+        }
+
+        @Override
+        public FileStatus[] listStatus(Path path) throws IOException {
+            FileStatus[] statuses = listings.get(path);
+            if (statuses == null) {
+                throw new java.io.FileNotFoundException(path.toString());
+            }
+            return statuses;
+        }
+
+        @Override
+        public boolean delete(Path path, boolean recursive) {
+            deleted.add(path);
+            return true;
+        }
+
+        @Override
+        public boolean exists(Path path) {
+            return statuses.containsKey(path);
+        }
+    }
+
+    @Test
+    public void testCrossBucketRenameCopiesFileAndDeletesSource() throws Exception {
+        OSSClient client = mock(OSSClient.class);
+        when(client.copyObject(any(CopyObjectRequest.class))).thenReturn(new CopyObjectResult());
+
+        Path src = new Path("oss://src-bucket/dir/file.txt");
+        Path dst = new Path("oss://dst-bucket/dir/file.txt");
+
+        RenameTestOSSFileIO fileIO = new RenameTestOSSFileIO(client);
+        fileIO.statuses.put(src, status(src, 5, false));
+        fileIO.statuses.put(dst.getParent(), status(dst.getParent(), 0, true));
+
+        boolean renamed = fileIO.rename(src, dst);
+
+        assertThat(renamed).isTrue();
+        ArgumentCaptor<CopyObjectRequest> captor = ArgumentCaptor.forClass(CopyObjectRequest.class);
+        verify(client).copyObject(captor.capture());
+        assertThat(captor.getValue().getSourceBucketName()).isEqualTo("src-bucket");
+        assertThat(captor.getValue().getSourceKey()).isEqualTo("dir/file.txt");
+        assertThat(captor.getValue().getDestinationBucketName()).isEqualTo("dst-bucket");
+        assertThat(captor.getValue().getDestinationKey()).isEqualTo("dir/file.txt");
+        assertThat(fileIO.deleted).contains(src);
+    }
+
+    @Test
+    public void testCrossBucketRenameSameBucketFallsBackToSuper() throws Exception {
+        // Same bucket must NOT reach the cross-bucket OSSClient copy path.
+        OSSClient client = mock(OSSClient.class);
+        RenameTestOSSFileIO fileIO = new RenameTestOSSFileIO(client);
+
+        Path src = new Path("oss://bucket/a.txt");
+        Path dst = new Path("oss://bucket/b.txt");
+
+        // The super.rename path needs a real filesystem; we only assert it does not invoke the
+        // OSSClient copy (it throws before that because no fs is configured, which is fine).
+        assertThatThrownBy(() -> fileIO.rename(src, dst)).isInstanceOf(Exception.class);
+        verify(client, never()).copyObject(any(CopyObjectRequest.class));
+    }
+
+    @Test
+    public void testCrossBucketRenameRejectsRoot() throws Exception {
+        OSSClient client = mock(OSSClient.class);
+        RenameTestOSSFileIO fileIO = new RenameTestOSSFileIO(client);
+
+        Path src = new Path("oss://src-bucket/");
+        Path dst = new Path("oss://dst-bucket/child");
+
+        boolean renamed = fileIO.rename(src, dst);
+
+        assertThat(renamed).isFalse();
+        verify(client, never()).copyObject(any(CopyObjectRequest.class));
+    }
+
+    @Test
+    public void testCrossBucketRenameExistingFileThrows() throws Exception {
+        OSSClient client = mock(OSSClient.class);
+        Path src = new Path("oss://src-bucket/file.txt");
+        Path dst = new Path("oss://dst-bucket/file.txt");
+
+        RenameTestOSSFileIO fileIO = new RenameTestOSSFileIO(client);
+        fileIO.statuses.put(src, status(src, 5, false));
+        fileIO.statuses.put(dst, status(dst, 5, false));
+
+        assertThatThrownBy(() -> fileIO.rename(src, dst))
+                .isInstanceOf(org.apache.hadoop.fs.FileAlreadyExistsException.class)
+                .hasMessageContaining("file already exists");
+        verify(client, never()).copyObject(any(CopyObjectRequest.class));
+        assertThat(fileIO.deleted).doesNotContain(src);
+    }
+
+    @Test
+    public void testCrossBucketRenameIntoDirectoryBecomesSubdir() throws Exception {
+        OSSClient client = mock(OSSClient.class);
+        when(client.copyObject(any(CopyObjectRequest.class))).thenReturn(new CopyObjectResult());
+
+        Path src = new Path("oss://src-bucket/file.txt");
+        Path existingDstDir = new Path("oss://dst-bucket/existing-dir");
+        Path rewritten = new Path(existingDstDir, "file.txt");
+
+        RenameTestOSSFileIO fileIO = new RenameTestOSSFileIO(client);
+        fileIO.statuses.put(src, status(src, 5, false));
+        fileIO.statuses.put(existingDstDir, status(existingDstDir, 0, true));
+        // dst/srcName does not exist yet and is empty.
+        fileIO.listings.put(rewritten, new FileStatus[0]);
+
+        boolean renamed = fileIO.rename(src, existingDstDir);
+
+        assertThat(renamed).isTrue();
+        ArgumentCaptor<CopyObjectRequest> captor = ArgumentCaptor.forClass(CopyObjectRequest.class);
+        verify(client).copyObject(captor.capture());
+        assertThat(captor.getValue().getDestinationKey()).isEqualTo("existing-dir/file.txt");
+        assertThat(captor.getValue().getSourceBucketName()).isEqualTo("src-bucket");
+        assertThat(captor.getValue().getDestinationBucketName()).isEqualTo("dst-bucket");
+    }
+
+    @Test
+    public void testCrossBucketRenameIntoNonEmptyDirectoryThrows() throws Exception {
+        OSSClient client = mock(OSSClient.class);
+        Path src = new Path("oss://src-bucket/file.txt");
+        Path existingDstDir = new Path("oss://dst-bucket/existing-dir");
+        Path rewritten = new Path(existingDstDir, "file.txt");
+
+        RenameTestOSSFileIO fileIO = new RenameTestOSSFileIO(client);
+        fileIO.statuses.put(src, status(src, 5, false));
+        fileIO.statuses.put(existingDstDir, status(existingDstDir, 0, true));
+        // dst/srcName already holds a file -> not empty.
+        fileIO.listings.put(rewritten, new FileStatus[] {status(rewritten, 1, false)});
+
+        assertThatThrownBy(() -> fileIO.rename(src, existingDstDir))
+                .isInstanceOf(org.apache.hadoop.fs.FileAlreadyExistsException.class)
+                .hasMessageContaining("not empty");
+        verify(client, never()).copyObject(any(CopyObjectRequest.class));
+    }
+
+    @Test
+    public void testCrossBucketRenameFailsWhenDstParentMissing() throws Exception {
+        OSSClient client = mock(OSSClient.class);
+        Path src = new Path("oss://src-bucket/file.txt");
+        Path dst = new Path("oss://dst-bucket/missing-parent/file.txt");
+
+        RenameTestOSSFileIO fileIO = new RenameTestOSSFileIO(client);
+        fileIO.statuses.put(src, status(src, 5, false));
+        // dst and dst.getParent() both absent.
+
+        assertThatThrownBy(() -> fileIO.rename(src, dst)).isInstanceOf(IOException.class);
+        verify(client, never()).copyObject(any(CopyObjectRequest.class));
+        assertThat(fileIO.deleted).doesNotContain(src);
+    }
+
+    @Test
+    public void testCrossBucketRenameDirectoryCopiesEachChild() throws Exception {
+        OSSClient client = mock(OSSClient.class);
+        when(client.copyObject(any(CopyObjectRequest.class))).thenReturn(new CopyObjectResult());
+
+        Path srcDir = new Path("oss://src-bucket/dir");
+        Path dstDir = new Path("oss://dst-bucket/dir");
+
+        RenameTestOSSFileIO fileIO = new RenameTestOSSFileIO(client);
+        fileIO.statuses.put(srcDir, status(srcDir, 0, true));
+        fileIO.statuses.put(dstDir.getParent(), status(dstDir.getParent(), 0, true));
+
+        // The directory copy lists children directly via the OSSClient.
+        OSSObjectSummary childA = new OSSObjectSummary();
+        childA.setKey("dir/a.txt");
+        childA.setSize(1);
+        OSSObjectSummary childB = new OSSObjectSummary();
+        childB.setKey("dir/b.txt");
+        childB.setSize(2);
+        ObjectListing listing = mock(ObjectListing.class);
+        when(listing.getObjectSummaries())
+                .thenReturn(new ArrayList<>(java.util.Arrays.asList(childA, childB)));
+        when(listing.getNextMarker()).thenReturn(null);
+        when(client.listObjects(any(com.aliyun.oss.model.ListObjectsRequest.class)))
+                .thenReturn(listing);
+
+        boolean renamed = fileIO.rename(srcDir, dstDir);
+
+        assertThat(renamed).isTrue();
+        ArgumentCaptor<CopyObjectRequest> captor = ArgumentCaptor.forClass(CopyObjectRequest.class);
+        verify(client, times(2)).copyObject(captor.capture());
+        List<String> dstKeys =
+                captor.getAllValues().stream()
+                        .map(CopyObjectRequest::getDestinationKey)
+                        .collect(java.util.stream.Collectors.toList());
+        assertThat(dstKeys).containsExactlyInAnyOrder("dir/a.txt", "dir/b.txt");
+        // Directory marker is created at the destination prefix.
+        verify(client)
+                .putObject(
+                        eq("dst-bucket"),
+                        eq("dir/"),
+                        any(java.io.InputStream.class),
+                        any(ObjectMetadata.class));
+        assertThat(fileIO.deleted).contains(srcDir);
+    }
+
+    @Test
+    public void testCrossBucketRenameFallsBackToMultipartCopy() throws Exception {
+        OSSClient client = mock(OSSClient.class);
+        // Single copy fails -> multipart copy path.
+        when(client.copyObject(any(CopyObjectRequest.class)))
+                .thenThrow(
+                        new OSSException("msg", "RequestError", "req", "host", null, null, "PUT"));
+        InitiateMultipartUploadResult init = new InitiateMultipartUploadResult();
+        init.setUploadId("upload-id");
+        when(client.initiateMultipartUpload(any(InitiateMultipartUploadRequest.class)))
+                .thenReturn(init);
+        ObjectMetadata srcMeta = new ObjectMetadata();
+        srcMeta.setContentLength(10);
+        srcMeta.setContentType("text/plain");
+        when(client.getObjectMetadata("src-bucket", "dir/file.txt")).thenReturn(srcMeta);
+        com.aliyun.oss.model.UploadPartCopyResult partResult =
+                new com.aliyun.oss.model.UploadPartCopyResult();
+        partResult.setPartNumber(1);
+        partResult.setETag("etag-1");
+        when(client.uploadPartCopy(any(UploadPartCopyRequest.class))).thenReturn(partResult);
+
+        Path src = new Path("oss://src-bucket/dir/file.txt");
+        Path dst = new Path("oss://dst-bucket/dir/file.txt");
+
+        RenameTestOSSFileIO fileIO = new RenameTestOSSFileIO(client);
+        fileIO.statuses.put(src, status(src, 10, false));
+        fileIO.statuses.put(dst.getParent(), status(dst.getParent(), 0, true));
+
+        boolean renamed = fileIO.rename(src, dst);
+
+        assertThat(renamed).isTrue();
+        verify(client).initiateMultipartUpload(any(InitiateMultipartUploadRequest.class));
+        verify(client).uploadPartCopy(any(UploadPartCopyRequest.class));
+        verify(client).completeMultipartUpload(any(CompleteMultipartUploadRequest.class));
     }
 }

--- a/paimon-filesystems/paimon-oss-impl/src/test/java/org/apache/paimon/oss/OSSFileIOTest.java
+++ b/paimon-filesystems/paimon-oss-impl/src/test/java/org/apache/paimon/oss/OSSFileIOTest.java
@@ -71,6 +71,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.contains;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.atMost;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
@@ -964,5 +965,113 @@ public class OSSFileIOTest {
         verify(client).initiateMultipartUpload(any(InitiateMultipartUploadRequest.class));
         verify(client).uploadPartCopy(any(UploadPartCopyRequest.class));
         verify(client).completeMultipartUpload(any(CompleteMultipartUploadRequest.class));
+    }
+
+    // ------------------------------------------------------------------------
+    //  Multipart copy part sizing
+    // ------------------------------------------------------------------------
+
+    /** The default 8 MiB part size must not overflow OSS's 10,000-part limit for large objects. */
+    @Test
+    public void testOptimalPartSizeStaysWithinPartCount() {
+        long minPartSize = 8L * 1024 * 1024;
+        long maxPartSize = 5L * 1024 * 1024 * 1024;
+        long maxPartCount = 10_000;
+
+        // A small object keeps the default 8 MiB part size.
+        assertThat(OSSFileIO.optimalPartSize(1, minPartSize, maxPartSize, maxPartCount))
+                .isEqualTo(minPartSize);
+        assertThat(
+                        OSSFileIO.optimalPartSize(
+                                minPartSize * maxPartCount, minPartSize, maxPartSize, maxPartCount))
+                .isEqualTo(minPartSize);
+
+        // Exactly at the threshold (8 MiB * 10,000) the default part size still fits: 10,000 parts.
+        long threshold = minPartSize * maxPartCount;
+        assertThat(partCount(threshold, optimal(threshold))).isLessThanOrEqualTo(maxPartCount);
+
+        // One byte over the threshold forces a larger part size so the count stays <= 10,000.
+        long over = threshold + 1;
+        long overPartSize = optimal(over);
+        assertThat(overPartSize).isGreaterThan(minPartSize);
+        assertThat(partCount(over, overPartSize)).isLessThanOrEqualTo(maxPartCount);
+
+        // Every part but the optional tail is a clean multiple of 8 MiB (the minimum).
+        assertThat(overPartSize % minPartSize).isZero();
+
+        // A pathological object near the absolute limit is clamped to the 5 GiB max part size.
+        long huge = maxPartSize * maxPartCount + 1;
+        assertThat(optimal(huge)).isEqualTo(maxPartSize);
+    }
+
+    /**
+     * A multipart copy of an object just past the 10,000-part threshold must use a larger part size
+     * and never request part number 10,001.
+     */
+    @Test
+    public void testCrossBucketRenameMultipartCopySizesPartsForLargeObject() throws Exception {
+        long minPartSize = 8L * 1024 * 1024;
+        long maxPartCount = 10_000;
+        // One byte past the 8 MiB * 10,000 threshold: would need 10,001 parts at 8 MiB.
+        long contentLength = minPartSize * maxPartCount + 1;
+
+        OSSClient client = mock(OSSClient.class);
+        when(client.copyObject(any(CopyObjectRequest.class)))
+                .thenThrow(
+                        new OSSException("msg", "RequestError", "req", "host", null, null, "PUT"));
+        InitiateMultipartUploadResult init = new InitiateMultipartUploadResult();
+        init.setUploadId("upload-id");
+        when(client.initiateMultipartUpload(any(InitiateMultipartUploadRequest.class)))
+                .thenReturn(init);
+        ObjectMetadata srcMeta = new ObjectMetadata();
+        srcMeta.setContentLength(contentLength);
+        when(client.getObjectMetadata("src-bucket", "dir/file.txt")).thenReturn(srcMeta);
+        when(client.uploadPartCopy(any(UploadPartCopyRequest.class)))
+                .thenAnswer(
+                        invocation -> {
+                            UploadPartCopyRequest request = invocation.getArgument(0);
+                            com.aliyun.oss.model.UploadPartCopyResult result =
+                                    new com.aliyun.oss.model.UploadPartCopyResult();
+                            result.setPartNumber(request.getPartNumber());
+                            result.setETag("etag-" + request.getPartNumber());
+                            return result;
+                        });
+
+        Path src = new Path("oss://src-bucket/dir/file.txt");
+        Path dst = new Path("oss://dst-bucket/dir/file.txt");
+
+        RenameTestOSSFileIO fileIO = new RenameTestOSSFileIO(client);
+        fileIO.statuses.put(src, status(src, contentLength, false));
+        fileIO.statuses.put(dst.getParent(), status(dst.getParent(), 0, true));
+
+        boolean renamed = fileIO.rename(src, dst);
+
+        assertThat(renamed).isTrue();
+        ArgumentCaptor<UploadPartCopyRequest> captor =
+                ArgumentCaptor.forClass(UploadPartCopyRequest.class);
+        verify(client, atMost((int) maxPartCount)).uploadPartCopy(captor.capture());
+        // No part number exceeds the 10,000 cap.
+        for (UploadPartCopyRequest request : captor.getAllValues()) {
+            assertThat(request.getPartNumber()).isBetween(1, (int) maxPartCount);
+        }
+        // Every non-tail part is a multiple of the 8 MiB minimum and at least 5 MiB.
+        List<UploadPartCopyRequest> parts = captor.getAllValues();
+        for (int i = 0; i < parts.size() - 1; i++) {
+            assertThat(parts.get(i).getPartSize()).isGreaterThanOrEqualTo(5L * 1024 * 1024);
+            assertThat(parts.get(i).getPartSize() % minPartSize).isZero();
+        }
+        // Parts together cover exactly the object length.
+        long copied =
+                captor.getAllValues().stream().mapToLong(UploadPartCopyRequest::getPartSize).sum();
+        assertThat(copied).isEqualTo(contentLength);
+    }
+
+    private static long optimal(long contentLength) {
+        return OSSFileIO.optimalPartSize(
+                contentLength, 8L * 1024 * 1024, 5L * 1024 * 1024 * 1024, 10_000);
+    }
+
+    private static long partCount(long contentLength, long partSize) {
+        return (contentLength + partSize - 1) / partSize;
     }
 }


### PR DESCRIPTION
### Purpose
The current implementaion of the oss migration only support the same bucket. So you can't do a migration of a hive table from the bucket `a` to a paimon table at the  bucket `b`.  The limitation is due to the `AliyunOssFileSystem`'s `rename` implementation. It hard codes the source and target bucket to the same one. But the offical [document](https://www.alibabacloud.com/help/zh/oss/developer-reference/copyobject?spm=a2c63.p38356.0.i6#reference-mvx-xxc-5db) of the aliyun oss doesn't have this limitation. 

So this pr is to overload the `rename` function to support the cross bucket data movement. 

### Tests

`OSSFileIOTest`'s mock test cases passed. And I test this by the real aliyun AK.