### PR TITLE
[core] Fall back to renaming when multipart upload is unavailable

### DIFF
--- a/paimon-filesystems/paimon-jindo/src/main/java/org/apache/paimon/jindo/JindoFileIO.java
+++ b/paimon-filesystems/paimon-jindo/src/main/java/org/apache/paimon/jindo/JindoFileIO.java
@@ -35,6 +35,7 @@ import com.aliyun.jindodata.common.JindoHadoopSystem;
 import com.aliyun.jindodata.dls.JindoDlsFileSystem;
 import com.aliyun.jindodata.oss.JindoOssFileSystem;
 import com.aliyun.jindodata.oss.auth.SimpleCredentialsProvider;
+import com.aliyun.jindodata.store.JindoMpuStore;
 import com.aliyun.oss.OSSClient;
 import com.aliyun.oss.OSSClientBuilder;
 import org.apache.hadoop.conf.Configuration;
@@ -214,8 +215,15 @@ public class JindoFileIO extends HadoopCompliantFileIO implements HadoopOptionsP
         org.apache.hadoop.fs.Path hadoopPath = path(path);
         Pair<JindoHadoopSystem, String> pair = getFileSystemPair(hadoopPath, false);
         JindoHadoopSystem fs = pair.getKey();
+        JindoMpuStore mpuStore = fs.getMpuStore(hadoopPath);
+        if (mpuStore == null) {
+            LOG.debug(
+                    "Jindo multipart upload is unavailable for {}, falling back to rename commit.",
+                    path);
+            return super.newTwoPhaseOutputStream(path, overwrite);
+        }
         return new JindoTwoPhaseOutputStream(
-                new JindoMultiPartUpload(fs, hadoopPath), hadoopPath, path);
+                new JindoMultiPartUpload(mpuStore, fs.getWorkingDirectory()), hadoopPath, path);
     }
 
     @Override

--- a/paimon-filesystems/paimon-jindo/src/main/java/org/apache/paimon/jindo/JindoMultiPartUpload.java
+++ b/paimon-filesystems/paimon-jindo/src/main/java/org/apache/paimon/jindo/JindoMultiPartUpload.java
@@ -42,8 +42,12 @@ public class JindoMultiPartUpload
     private final Path workingDirectory;
 
     public JindoMultiPartUpload(JindoHadoopSystem fs, Path filePath) {
-        this.workingDirectory = fs.getWorkingDirectory();
-        this.mpuStore = fs.getMpuStore(filePath);
+        this(fs.getMpuStore(filePath), fs.getWorkingDirectory());
+    }
+
+    JindoMultiPartUpload(JindoMpuStore mpuStore, Path workingDirectory) {
+        this.workingDirectory = workingDirectory;
+        this.mpuStore = mpuStore;
     }
 
     @Override

--- a/paimon-filesystems/paimon-jindo/src/test/java/org/apache/paimon/jindo/JindoFileIOTest.java
+++ b/paimon-filesystems/paimon-jindo/src/test/java/org/apache/paimon/jindo/JindoFileIOTest.java
@@ -21,11 +21,16 @@ package org.apache.paimon.jindo;
 import org.apache.paimon.catalog.CatalogContext;
 import org.apache.paimon.data.BlobDescriptor;
 import org.apache.paimon.fs.Path;
+import org.apache.paimon.fs.RenamingTwoPhaseOutputStream;
+import org.apache.paimon.fs.TwoPhaseOutputStream;
 import org.apache.paimon.options.Options;
+import org.apache.paimon.utils.Pair;
 
+import com.aliyun.jindodata.common.JindoHadoopSystem;
 import com.aliyun.oss.HttpMethod;
 import com.aliyun.oss.OSSClient;
 import com.aliyun.oss.model.ObjectMetadata;
+import org.apache.hadoop.fs.FSDataOutputStream;
 import org.junit.jupiter.api.Test;
 
 import java.net.URI;
@@ -120,6 +125,47 @@ public class JindoFileIOTest {
 
         fileIO.close();
         verify(client).shutdown();
+    }
+
+    @Test
+    public void testFallbackToRenamingWhenMultipartUploadUnsupported() throws Exception {
+        JindoHadoopSystem fs = mock(JindoHadoopSystem.class);
+        org.apache.hadoop.fs.Path hadoopPath = mock(org.apache.hadoop.fs.Path.class);
+        when(fs.exists(any())).thenReturn(false);
+        when(fs.getMpuStore(any())).thenReturn(null);
+        when(fs.create(any(), eq(false))).thenReturn(mock(FSDataOutputStream.class));
+
+        JindoFileIO fileIO = new TestingJindoFileIO(fs, hadoopPath);
+        TwoPhaseOutputStream stream =
+                fileIO.newTwoPhaseOutputStream(
+                        new Path("oss://bucket.cn-hangzhou.oss-dls.aliyuncs.com/table/file"),
+                        false);
+
+        assertThat(stream).isInstanceOf(RenamingTwoPhaseOutputStream.class);
+        stream.close();
+        verify(fs).getMpuStore(hadoopPath);
+    }
+
+    private static class TestingJindoFileIO extends JindoFileIO {
+
+        private final JindoHadoopSystem fs;
+        private final org.apache.hadoop.fs.Path hadoopPath;
+
+        private TestingJindoFileIO(JindoHadoopSystem fs, org.apache.hadoop.fs.Path hadoopPath) {
+            this.fs = fs;
+            this.hadoopPath = hadoopPath;
+        }
+
+        @Override
+        protected org.apache.hadoop.fs.Path path(Path path) {
+            return hadoopPath;
+        }
+
+        @Override
+        protected Pair<JindoHadoopSystem, String> getFileSystemPair(
+                org.apache.hadoop.fs.Path path, boolean enableCache) {
+            return Pair.of(fs, "dls");
+        }
     }
 
     private static String sha256Hex(byte[] bytes) throws Exception {


### PR DESCRIPTION
### Purpose

Jindo returns `null` from `getMpuStore` when the filesystem does not support multipart uploads, such as OSS-HDFS. The existing two-phase write path then dereferences the missing store.

Fall back to FileIO's rename-based two-phase output stream when MPU is unavailable. Filesystems supporting MPU continue using the multipart path with the already resolved store.

### Tests

- `mvn -pl paimon-filesystems/paimon-jindo -Pspark3 spotless:apply`
- `mvn -pl paimon-filesystems/paimon-jindo -am -Pspark3,fast-build -DfailIfNoTests=false -DwildcardSuites=none -Dtest=JindoFileIOTest test`
  - Tests run: 5, Failures: 0, Errors: 0