### PR TITLE
[core] Fix default NOT IN composition in file index reader

### DIFF
--- a/paimon-common/src/main/java/org/apache/paimon/fileindex/FileIndexReader.java
+++ b/paimon-common/src/main/java/org/apache/paimon/fileindex/FileIndexReader.java
@@ -132,7 +132,7 @@ public abstract class FileIndexReader implements FunctionVisitor<FileIndexResult
             fileIndexResult =
                     fileIndexResult == null
                             ? visitNotEqual(fieldRef, key)
-                            : fileIndexResult.or(visitNotEqual(fieldRef, key));
+                            : fileIndexResult.and(visitNotEqual(fieldRef, key));
         }
         return fileIndexResult;
     }

--- a/paimon-common/src/test/java/org/apache/paimon/fileindex/FileIndexReaderTest.java
+++ b/paimon-common/src/test/java/org/apache/paimon/fileindex/FileIndexReaderTest.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.fileindex;
+
+import org.apache.paimon.fileindex.bitmap.BitmapIndexResult;
+import org.apache.paimon.predicate.FieldRef;
+import org.apache.paimon.types.IntType;
+import org.apache.paimon.utils.RoaringBitmap32;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Tests for default predicate composition in {@link FileIndexReader}. */
+public class FileIndexReaderTest {
+
+    @Test
+    public void testNotInCombinesNotEqualResultsWithAnd() {
+        FieldRef fieldRef = new FieldRef(0, "a", new IntType());
+        FileIndexReader reader =
+                new FileIndexReader() {
+                    @Override
+                    public FileIndexResult visitNotEqual(FieldRef fieldRef, Object literal) {
+                        return new BitmapIndexResult(
+                                () ->
+                                        ((Integer) literal) == 1
+                                                ? RoaringBitmap32.bitmapOf(0, 2)
+                                                : RoaringBitmap32.bitmapOf(0, 1));
+                    }
+                };
+
+        FileIndexResult result = reader.visitNotIn(fieldRef, Arrays.asList(1, 2));
+
+        assertThat(((BitmapIndexResult) result).get()).isEqualTo(RoaringBitmap32.bitmapOf(0));
+    }
+}


### PR DESCRIPTION
### Purpose
The default FileIndexReader implementation incorrectly combines
multiple NOT EQUAL results with OR when evaluating NOT IN.

Use AND to match SQL semantics:
 `a NOT IN (1, 2) = a != 1 AND a != 2`

### Tests
 FileIndexReaderTest#testNotInCombinesNotEqualResultsWithAnd