### PR TITLE
[common] Default missing variant shredding fields to the unshredded index

### DIFF
--- a/paimon-common/src/main/java/org/apache/paimon/data/variant/BaseVariantReader.java
+++ b/paimon-common/src/main/java/org/apache/paimon/data/variant/BaseVariantReader.java
@@ -195,9 +195,12 @@ public class BaseVariantReader {
             List<DataField> targetFields = targetType.getFields();
             this.fieldInputIndices = new int[targetFields.size()];
             for (int i = 0; i < targetFields.size(); i++) {
+                // A target field may live in the untyped value under partial shredding;
+                // Map.get returns null for it and unboxing would NPE.
                 fieldInputIndices[i] =
                         schema.objectSchemaMap != null
-                                ? schema.objectSchemaMap.get(targetFields.get(i).name())
+                                ? schema.objectSchemaMap.getOrDefault(
+                                        targetFields.get(i).name(), -1)
                                 : -1;
             }
 

--- a/paimon-common/src/test/java/org/apache/paimon/data/variant/BaseVariantReaderTest.java
+++ b/paimon-common/src/test/java/org/apache/paimon/data/variant/BaseVariantReaderTest.java
@@ -1,0 +1,66 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.data.variant;
+
+import org.apache.paimon.data.BinaryString;
+import org.apache.paimon.data.GenericRow;
+import org.apache.paimon.data.InternalRow;
+import org.apache.paimon.types.DataType;
+import org.apache.paimon.types.DataTypes;
+import org.apache.paimon.types.RowType;
+
+import org.junit.jupiter.api.Test;
+
+import java.time.ZoneOffset;
+
+import static org.apache.paimon.data.variant.PaimonShreddingUtils.buildVariantSchema;
+import static org.apache.paimon.data.variant.PaimonShreddingUtils.castShredded;
+import static org.apache.paimon.data.variant.PaimonShreddingUtils.variantShreddingSchema;
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Test for {@link BaseVariantReader}. */
+public class BaseVariantReaderTest {
+
+    @Test
+    void testRowReaderWithUnshreddedTargetField() {
+        VariantCastArgs castArgs = new VariantCastArgs(true, ZoneOffset.UTC);
+
+        // The file shreds only field "a" of the object, so a target asking for "b" as well
+        // has to pick "b" up from the untyped value.
+        RowType shreddedType = RowType.of(new DataType[] {DataTypes.INT()}, new String[] {"a"});
+        VariantSchema schema = buildVariantSchema(variantShreddingSchema(shreddedType));
+        assertThat(schema.objectSchemaMap).containsKey("a").doesNotContainKey("b");
+
+        RowType targetType =
+                RowType.of(
+                        new DataType[] {DataTypes.INT(), DataTypes.STRING()},
+                        new String[] {"a", "b"});
+        BaseVariantReader reader = BaseVariantReader.create(schema, targetType, castArgs, false);
+
+        InternalRow shredded =
+                castShredded(GenericVariant.fromJson("{\"a\": 1, \"b\": \"hello\"}"), schema);
+        assertThat(reader.read(shredded, shredded.getBinary(schema.topLevelMetadataIdx)))
+                .isEqualTo(GenericRow.of(1, BinaryString.fromString("hello")));
+
+        // "b" absent from both the shredded object and the untyped value reads back as null.
+        shredded = castShredded(GenericVariant.fromJson("{\"a\": 27}"), schema);
+        assertThat(reader.read(shredded, shredded.getBinary(schema.topLevelMetadataIdx)))
+                .isEqualTo(GenericRow.of(27, null));
+    }
+}


### PR DESCRIPTION
### Purpose

close #9615

`BaseVariantReader.RowReader`'s constructor unboxed a map lookup straight into an `int`:

```java
fieldInputIndices[i] =
        schema.objectSchemaMap != null
                ? schema.objectSchemaMap.get(targetFields.get(i).name())
                : -1;
```

`objectSchemaMap` holds only the fields the file actually shredded, so reading a struct whose fields are not all shredded threw a `NullPointerException` while the reader was being built, taking the whole scan with it. Shredding is inferred per data file by default, so the same query can work on one file and fail on the next.

`getOrDefault(name, -1)` is all it takes, because -1 is the convention the rest of the class already speaks. The field's own comment says "or -1 if it doesn't exist in object `typed_value`", `VariantSchema` documents the same thing for its indices, and `readFromTyped` carries the branch that reads such a field out of the untyped value:

```java
} else if (unshreddedObject != null) {
    ...
    GenericVariant unshreddedField = unshreddedObject.getFieldByKey(fieldName);
```

Since the constructor could never produce -1, that branch and the `needUnshreddedObject` flag guarding it were both dead code. This makes them reachable, which is the behavior the class was written for.

I checked the other lookups in `org.apache.paimon.data.variant` while I was there: they all take the result as an `Integer` and null-check it, or go through `containsKey`, so this was the only site.

### Tests

`BaseVariantReaderTest.testRowReaderWithUnshreddedTargetField` builds a shredding schema covering only field `a`, asks for `struct<a int, b string>`, and reads a row back. `b` is asserted to come through as `"hello"`, which is only reachable through the unshredded branch, so the test covers the revived path rather than just the absence of the crash. A second case reads `{"a": 27}`, where the file has no untyped value at all, and expects `b` to be null.

Against the unfixed reader the test fails with a `NullPointerException` out of `BaseVariantReader.create`.

`mvn -pl paimon-common -Dtest=BaseVariantReaderTest test` on JDK 8: 1 test, 0 failures. `spotless:check` and `checkstyle:check` on paimon-common are clean.
