### PR TITLE
[common] Overflow-safe URI length check in VideoFrameDescriptor

### DIFF
--- a/paimon-common/src/main/java/org/apache/paimon/data/VideoFrameDescriptor.java
+++ b/paimon-common/src/main/java/org/apache/paimon/data/VideoFrameDescriptor.java
@@ -109,8 +109,16 @@ public class VideoFrameDescriptor extends BlobDescriptor {
             throw invalidPayload("missing magic header");
         }
         int uriLength = buffer.getInt();
-        if (uriLength < 0 || buffer.remaining() < uriLength + 3 * Long.BYTES) {
-            throw invalidPayload("invalid URI length: " + uriLength);
+        if (uriLength < 0) {
+            throw invalidPayload("negative URI length: " + uriLength);
+        }
+        if (uriLength > buffer.remaining()) {
+            throw invalidPayload("URI length exceeds data size");
+        }
+        // subtraction rather than uriLength + 3 * Long.BYTES, which wraps negative for a
+        // uriLength near Integer.MAX_VALUE
+        if (buffer.remaining() - uriLength < 3 * Long.BYTES) {
+            throw invalidPayload("missing offset/length/frame index");
         }
 
         byte[] uriBytes = new byte[uriLength];

--- a/paimon-common/src/main/java/org/apache/paimon/data/VideoFrameDescriptor.java
+++ b/paimon-common/src/main/java/org/apache/paimon/data/VideoFrameDescriptor.java
@@ -109,14 +109,14 @@ public class VideoFrameDescriptor extends BlobDescriptor {
             throw invalidPayload("missing magic header");
         }
         int uriLength = buffer.getInt();
+        // checked by comparison and subtraction: uriLength + 3 * Long.BYTES wraps negative
+        // for a uriLength near Integer.MAX_VALUE
         if (uriLength < 0) {
             throw invalidPayload("negative URI length: " + uriLength);
         }
         if (uriLength > buffer.remaining()) {
             throw invalidPayload("URI length exceeds data size");
         }
-        // subtraction rather than uriLength + 3 * Long.BYTES, which wraps negative for a
-        // uriLength near Integer.MAX_VALUE
         if (buffer.remaining() - uriLength < 3 * Long.BYTES) {
             throw invalidPayload("missing offset/length/frame index");
         }

--- a/paimon-common/src/test/java/org/apache/paimon/data/VideoFrameDescriptorTest.java
+++ b/paimon-common/src/test/java/org/apache/paimon/data/VideoFrameDescriptorTest.java
@@ -92,8 +92,8 @@ public class VideoFrameDescriptorTest {
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessageContaining("non-negative");
 
-        // A uriLength near Integer.MAX_VALUE: uriLength + 3 * Long.BYTES wrapped negative,
-        // so the length check passed and deserialize went on to allocate ~2GB.
+        // The old check let this through because uriLength + 3 * Long.BYTES wrapped
+        // negative, and deserialize went on to allocate ~2GB.
         byte[] hostileUriLength = descriptor.serialize();
         ByteBuffer.wrap(hostileUriLength)
                 .order(ByteOrder.LITTLE_ENDIAN)

--- a/paimon-common/src/test/java/org/apache/paimon/data/VideoFrameDescriptorTest.java
+++ b/paimon-common/src/test/java/org/apache/paimon/data/VideoFrameDescriptorTest.java
@@ -22,6 +22,8 @@ import org.apache.paimon.utils.IOUtils;
 
 import org.junit.jupiter.api.Test;
 
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 
@@ -89,6 +91,30 @@ public class VideoFrameDescriptorTest {
         assertThatThrownBy(() -> new VideoFrameDescriptor("file:/video.mp4", 0, 9, -1))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessageContaining("non-negative");
+
+        // A uriLength near Integer.MAX_VALUE: uriLength + 3 * Long.BYTES wrapped negative,
+        // so the length check passed and deserialize went on to allocate ~2GB.
+        byte[] hostileUriLength = descriptor.serialize();
+        ByteBuffer.wrap(hostileUriLength)
+                .order(ByteOrder.LITTLE_ENDIAN)
+                .putInt(Byte.BYTES + Long.BYTES, Integer.MAX_VALUE - 23);
+        assertThatThrownBy(() -> VideoFrameDescriptor.deserialize(hostileUriLength))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("URI length exceeds data size");
+
+        byte[] negativeUriLength = descriptor.serialize();
+        ByteBuffer.wrap(negativeUriLength)
+                .order(ByteOrder.LITTLE_ENDIAN)
+                .putInt(Byte.BYTES + Long.BYTES, -1);
+        assertThatThrownBy(() -> VideoFrameDescriptor.deserialize(negativeUriLength))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("negative URI length");
+
+        byte[] truncated =
+                Arrays.copyOf(descriptor.serialize(), descriptor.serialize().length - Long.BYTES);
+        assertThatThrownBy(() -> VideoFrameDescriptor.deserialize(truncated))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("missing offset/length/frame index");
     }
 
     private static byte[] fromHex(String hex) {


### PR DESCRIPTION
### Purpose

close #9617

`VideoFrameDescriptor.deserialize` validated the URI length by adding first:

```java
if (uriLength < 0 || buffer.remaining() < uriLength + 3 * Long.BYTES) {
    throw invalidPayload("invalid URI length: " + uriLength);
}
```

For a `uriLength` near `Integer.MAX_VALUE` the addition wraps negative, the comparison against `buffer.remaining()` is then false, and control reaches `new byte[uriLength]`. A crafted descriptor therefore ends in `OutOfMemoryError` from a 2GB allocation instead of the `IllegalArgumentException` every other malformed case here produces. The bytes can come from the query: `descriptor_to_string` and `descriptor_to_presigned_url` take `BINARY` arguments.

The sibling `BlobDescriptor.deserialize`, which dispatches here by magic number, already validates by subtraction and reports each case separately, so this takes the same three checks:

```java
if (uriLength < 0) {
    throw invalidPayload("negative URI length: " + uriLength);
}
if (uriLength > buffer.remaining()) {
    throw invalidPayload("URI length exceeds data size");
}
if (buffer.remaining() - uriLength < 3 * Long.BYTES) {
    throw invalidPayload("missing offset/length/frame index");
}
```

`buffer.remaining()` is non-negative and `uriLength` is known non-negative by the time the subtraction runs, so nothing here can wrap. Three longs rather than the sibling's two, since a video frame descriptor also carries the frame index.

### Tests

`VideoFrameDescriptorTest.testRejectInvalidPayload` gains a case that serializes a valid descriptor and overwrites its URI length field with `Integer.MAX_VALUE - 23`, the smallest value whose old `+ 24` wrapped, then asserts the rejection message. Building the payload from `serialize()` keeps the test off the version and magic byte layout.

Against the unfixed code that case fails with `OutOfMemoryError: Java heap space`, from the allocation the check was supposed to prevent.

`mvn -pl paimon-common -Dtest=VideoFrameDescriptorTest,BlobDescriptorTest test` on JDK 8: 12 tests, 0 failures. `spotless:check` and `checkstyle:check` on paimon-common are clean.
