### PR TITLE
[common] Keep escaped characters in StringToMapCastRule entry splitting

### DIFF
--- a/paimon-common/src/main/java/org/apache/paimon/casting/StringToMapCastRule.java
+++ b/paimon-common/src/main/java/org/apache/paimon/casting/StringToMapCastRule.java
@@ -181,7 +181,10 @@ class StringToMapCastRule extends AbstractCastRule<BinaryString, InternalMap> {
 
         for (char c : content.toCharArray()) {
             if (escaped) {
+                // an escaped character is taken literally: it must survive in the
+                // entry instead of being dropped together with its backslash
                 escaped = false;
+                current.append(c);
                 continue;
             } else if (c == '\\') {
                 escaped = true;

--- a/paimon-common/src/test/java/org/apache/paimon/casting/CastExecutorTest.java
+++ b/paimon-common/src/test/java/org/apache/paimon/casting/CastExecutorTest.java
@@ -982,6 +982,31 @@ public class CastExecutorTest {
         assertThat(result).containsExactly("1", "abc");
     }
 
+    @Test
+    public void testSplitMapEntriesWithEscapes() {
+        // the escaped separator must survive as a literal instead of vanishing
+        assertThat(StringToMapCastRule.INSTANCE.splitMapEntries("a\\,b, c"))
+                .containsExactly("a,b", "c");
+        // an escaped backslash yields one literal backslash
+        assertThat(StringToMapCastRule.INSTANCE.splitMapEntries("x\\\\y, z"))
+                .containsExactly("x\\y", "z");
+        // an escaped quote is a literal and does not toggle quote state
+        assertThat(StringToMapCastRule.INSTANCE.splitMapEntries("\"q\\\"z, w\""))
+                .containsExactly("q\"z, w");
+    }
+
+    @Test
+    public void testStringToMapPreservesEscapedCharacters() {
+        Map<Object, Object> expected = new HashMap<>();
+        expected.put(BinaryString.fromString("a,b"), BinaryString.fromString("v\\1"));
+        compareCastResult(
+                CastExecutors.resolve(
+                        VarCharType.STRING_TYPE,
+                        new MapType(DataTypes.STRING(), DataTypes.STRING())),
+                BinaryString.fromString("{a\\,b -> v\\\\1}"),
+                new GenericMap(expected));
+    }
+
     @SuppressWarnings("rawtypes")
     private void compareCastResult(CastExecutor<?, ?> cast, Object input, Object output) {
         assertThat(((CastExecutor) cast).cast(input)).isEqualTo(output);


### PR DESCRIPTION
### Purpose

close #9619

`StringToMapCastRule.splitMapEntries` used the escape marker to stop a separator from splitting an entry, then threw away the character it was protecting:

```java
if (escaped) {
    escaped = false;
    continue;          // the escaped character
} else if (c == '\\') {
    escaped = true;
    continue;          // and its backslash
}
```

So `{a\,b -> v}` produced the key `ab` rather than `a,b`. A MAP column default value written that way is silently stored as something other than what the DDL said, with no error anywhere.

Appending the escaped character is all this needs. It also lines the backslash up with the quote handling a few lines below it, which already keeps the content and drops only the marker, so `{"a,b" -> v}` has always produced `a,b`. After this both escape mechanisms in this rule behave the same way.

Two things I deliberately left out. `ENTRY_PATTERN` splits key from value after the entry has been unescaped, so `\->` inside a key still cannot be protected; making that work means moving the key/value split into the escape-aware scan, which is a larger change than this bug needs. And `StringToArrayCastRule` and `StringToRowCastRule` run the same loop but append every character, so backslashes and quotes survive into their elements while the map rule strips both. Bringing the three into agreement is worth doing, but it changes parsed output for array and row, so it does not belong in a bug fix.

### Tests

`CastExecutorTest.testSplitMapEntriesWithEscapes` covers the three cases the loop distinguishes: an escaped separator stays inside the entry as a literal comma, `\\` collapses to one backslash, and an escaped quote is a literal that does not toggle quote state (so a comma inside the quoted section still does not split).

`CastExecutorTest.testStringToMapPreservesEscapedCharacters` runs the whole STRING to MAP cast and asserts the parsed key and value, which is the level a default value goes through.

Both fail against the unfixed rule, with the escaped characters missing from the expected strings.

`mvn -pl paimon-common -Dtest=CastExecutorTest test` on JDK 8: 40 tests, 0 failures. `spotless:check` and `checkstyle:check` on paimon-common are clean.
