### PR TITLE
[common] Support all TIMESTAMP precisions in the numeric string cast

### DIFF
--- a/paimon-common/src/main/java/org/apache/paimon/utils/BinaryStringUtils.java
+++ b/paimon-common/src/main/java/org/apache/paimon/utils/BinaryStringUtils.java
@@ -321,31 +321,25 @@ public class BinaryStringUtils {
         return DateTimeUtils.parseTimestampData(input.toString(), precision, timeZone);
     }
 
+    private static final long[] POW10 = {1L, 10L, 100L, 1_000L, 10_000L, 100_000L, 1_000_000L};
+
     // Helper method to convert epoch to Timestamp with the provided precision.
     private static Timestamp fromMillisToTimestamp(long epoch, int precision) {
-        // Calculate milliseconds and nanoseconds from epoch based on precision
+        if (precision < 0 || precision > 9) {
+            throw new RuntimeException("Unsupported precision: " + precision);
+        }
+
+        // epoch counts units of 10^-precision seconds, so one unit is 10^(3 - precision)
+        // milliseconds: seconds at precision 0, millis at 3, micros at 6, nanos at 9.
         long millis;
         int nanosOfMillis;
-
-        switch (precision) {
-            case 0: // seconds
-                millis = epoch * 1000;
-                nanosOfMillis = 0;
-                break;
-            case 3: // milliseconds
-                millis = epoch;
-                nanosOfMillis = 0;
-                break;
-            case 6: // microseconds
-                millis = epoch / 1000;
-                nanosOfMillis = (int) ((epoch % 1000) * 1000);
-                break;
-            case 9: // nanoseconds
-                millis = epoch / 1_000_000;
-                nanosOfMillis = (int) (epoch % 1_000_000);
-                break;
-            default:
-                throw new RuntimeException("Unsupported precision: " + precision);
+        if (precision > 3) {
+            long divisor = POW10[precision - 3];
+            millis = epoch / divisor;
+            nanosOfMillis = (int) ((epoch % divisor) * 1_000_000L / divisor);
+        } else {
+            millis = epoch * POW10[3 - precision];
+            nanosOfMillis = 0;
         }
 
         // If nanoseconds is negative, remove a millisecond

--- a/paimon-common/src/test/java/org/apache/paimon/utils/BinaryStringUtilsTest.java
+++ b/paimon-common/src/test/java/org/apache/paimon/utils/BinaryStringUtilsTest.java
@@ -52,7 +52,19 @@ class BinaryStringUtilsTest {
         // One second and one nanosecond before epoch in nanoseconds
         // The negative nanosecond gets flipped and the milliseconds decremented
         "-1000000001, 9, -1001, 999999",
-        "-86400123456, 6, -86400124, 544000"
+        "-86400123456, 6, -86400124, 544000",
+        // Intermediate precisions scale the unit by ten per step from the anchors.
+        "36000000, 4, 3600000, 0", // one hour in 0.1 ms units
+        "360000000, 5, 3600000, 0", // one hour in 0.01 ms units
+        "36000000000, 7, 3600000, 0", // one hour in 100 ns units
+        "360000000000, 8, 3600000, 0", // one hour in 10 ns units
+        "36000, 1, 3600000, 0", // one hour in 0.1 s units
+        "360000, 2, 3600000, 0", // one hour in 0.01 s units
+        // A remainder below one millisecond becomes nanos-of-millisecond
+        "17000000001, 5, 170000000, 10000", // one 0.01 ms unit past the millisecond
+        "170000000012, 8, 1700000, 120", // twelve 10 ns units past the millisecond
+        // Negative epoch: the nanos-of-millisecond offset stays positive
+        "-1700000001, 7, -170001, 999900"
     })
     void testToTimestamp(String input, int precision, long expectedMillis, int expectedNanos) {
         BinaryString binaryInput = BinaryString.fromString(input);
@@ -63,7 +75,7 @@ class BinaryStringUtilsTest {
     }
 
     @ParameterizedTest
-    @ValueSource(ints = {1, 2, 4, 5, 7, 8, 10, -1})
+    @ValueSource(ints = {10, -1})
     void testInvalidPrecisions(int precision) {
         BinaryString input = BinaryString.fromString("1609459200");
 


### PR DESCRIPTION
### Purpose

close #9621

`BinaryStringUtils.fromMillisToTimestamp` implemented the numeric-string to TIMESTAMP conversion as a `switch` over precisions 0, 3, 6 and 9, and threw `RuntimeException("Unsupported precision: N")` for everything else. `TimestampType` allows 0 through 9, so `CAST('1700000000' AS TIMESTAMP(4))` failed on a perfectly legal column type while the same string worked at precision 3.

The four implemented cases are one formula sampled at four points: the value counts units of 10^-precision seconds, so a unit is 10^(3 - precision) milliseconds. Writing that formula covers all ten precisions, and it produces exactly what the four cases produced. At precision 6 the old code computed `epoch / 1000` and `(epoch % 1000) * 1000`; the formula gives `divisor = 1000`, `epoch / 1000` and `(epoch % 1000) * 1_000_000 / 1000`, which is the same value. Precisions 0, 3 and 9 line up the same way, so the four cases are gone rather than left beside the general path.

The remainder is scaled before it is divided, so no digit the string carried is lost: `"170000000012"` at precision 8 gives 1700000 ms plus 120 ns. The existing negative-nanos correction below the branch is unchanged and still does the borrow, so `"-1700000001"` at precision 7 gives -170001 ms plus 999900 ns rather than a negative offset. Out-of-range precisions still throw the same message, now checked once against 0..9 instead of falling out of a `switch`.

### Tests

`BinaryStringUtilsTest.testToTimestamp` gains nine rows: one hour expressed in each of the six previously rejected units, two cases where the remainder lands below a millisecond and has to come back as nanos-of-millisecond (precision 5 and precision 8), and a negative epoch at precision 7. `testInvalidPrecisions` drops 1, 2, 4, 5, 7 and 8, keeping 10 and -1.

Against the unfixed code nine of those rows error with `RuntimeException: Unsupported precision`.

`mvn -pl paimon-common -Dtest=BinaryStringUtilsTest test` on JDK 8: 31 tests, 0 failures. `spotless:check` and `checkstyle:check` on paimon-common are clean.
