### PR TITLE
[common] Skip null literals in btree global index IN predicates

### DIFF
--- a/paimon-common/src/main/java/org/apache/paimon/globalindex/btree/BTreeIndexReader.java
+++ b/paimon-common/src/main/java/org/apache/paimon/globalindex/btree/BTreeIndexReader.java
@@ -334,6 +334,11 @@ public class BTreeIndexReader implements Closeable {
                 () -> {
                     RoaringNavigableMap64 result = new RoaringNavigableMap64();
                     for (Object literal : literals) {
+                        // SQL IN treats NULL as never matching; skip it instead of
+                        // failing to serialize a null key.
+                        if (literal == null) {
+                            continue;
+                        }
                         result.or(rangeQuery(literal, literal, true, true));
                     }
                     return result;

--- a/paimon-common/src/test/java/org/apache/paimon/globalindex/btree/AbstractIndexReaderTest.java
+++ b/paimon-common/src/test/java/org/apache/paimon/globalindex/btree/AbstractIndexReaderTest.java
@@ -277,6 +277,30 @@ public abstract class AbstractIndexReaderTest {
     }
 
     @TestTemplate
+    public void testInPredicateWithNullLiteral() throws Exception {
+        FieldRef ref = new FieldRef(1, "testField", dataType);
+
+        try (GlobalIndexReader reader = prepareDataAndCreateReader()) {
+            // Mixed null literal: SQL IN never matches NULL, so the null is ignored
+            // and the remaining literals drive the result (previously NPE'd).
+            List<Object> literals =
+                    new ArrayList<>(
+                            data.get(0).getKey() == null
+                                    ? Collections.emptyList()
+                                    : Collections.singletonList(data.get(0).getKey()));
+            literals.add(null);
+            GlobalIndexResult result = reader.visitIn(ref, literals).join().get();
+            List<Object> finalLiterals = literals;
+            assertResult(result, filter(finalLiterals::contains));
+
+            // All-null list matches nothing.
+            GlobalIndexResult allNull =
+                    reader.visitIn(ref, Collections.singletonList(null)).join().get();
+            assertThat(allNull.results().isEmpty()).isTrue();
+        }
+    }
+
+    @TestTemplate
     public void testStartsWith() throws Exception {
         if (!dataType.is(DataTypeFamily.CHARACTER_STRING)) {
             return;

--- a/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/procedure/CreateGlobalIndexProcedureTest.scala
+++ b/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/procedure/CreateGlobalIndexProcedureTest.scala
@@ -448,6 +448,34 @@ class CreateGlobalIndexProcedureTest extends PaimonSparkTestBase with StreamTest
     }
   }
 
+  test("btree global index IN predicate with more than 20 literals including NULL") {
+    withTable("T") {
+      spark.sql("""
+                  |CREATE TABLE T (id INT, idx INT)
+                  |TBLPROPERTIES (
+                  |  'bucket' = '-1',
+                  |  'global-index.enabled' = 'true',
+                  |  'row-tracking.enabled' = 'true',
+                  |  'data-evolution.enabled' = 'true',
+                  |  'btree-index.records-per-range' = '2')
+                  |""".stripMargin)
+
+      spark.sql(s"INSERT INTO T VALUES ${(0 until 100).map(i => s"($i, $i)").mkString(",")}")
+      createBTreeIndex("T", "idx")
+
+      // 21 distinct non-null literals plus NULL is 22 (> 20), so PredicateBuilder keeps a real In
+      // leaf that reaches BTreeIndexReader.visitIn with a null (previously an NPE). Pin
+      // inSetConversionThreshold high so the pushed predicate stays a plain Catalyst In whose
+      // translation carries the null.
+      val inList = ((0 to 20).map(_.toString) :+ "NULL").mkString(", ")
+      withSQLConf("spark.sql.optimizer.inSetConversionThreshold" -> "100") {
+        checkAnswer(
+          sql(s"SELECT id FROM T WHERE idx IN ($inList) ORDER BY id"),
+          (0 to 20).map(Row(_)))
+      }
+    }
+  }
+
   private def createBTreeIndex(tableName: String, column: String): Unit = {
     spark
       .sql(


### PR DESCRIPTION
### Purpose

close #9623

`BTreeIndexReader.visitIn` fed every literal in the list straight into `rangeQuery`, which serializes the key and compares it, so a null literal threw a `NullPointerException` and took the scan with it. `IN` never matches NULL, so the literal should just be skipped.

Every other reader in that package already does this. `globalindex/bitmap/BitmapIndexReader` null-checks inside its own `in` loop, and its `equal`, `lessThan`, `greaterThan`, `between`, `notEqual` and `notIn` do the same. The guard therefore goes in the same place, in the leaf, and the btree reader stops being the odd one out.

The file selector is unaffected: `SortedFileMetaSelector.visitIn` already skips nulls when it decides which index files overlap, so a list of only nulls selects no file and the result is empty without any special case for it.

### Tests

`AbstractIndexReaderTest.testInPredicateWithNullLiteral` runs for every reader in that hierarchy, so `BTreeIndexReaderTest` and `LazyFilteredBTreeIndexReaderTest` both pick it up. It checks the two shapes that matter: a list mixing a real key with a null returns exactly the rows for the real key, and a list of only nulls returns an empty result.

Against the unfixed reader all 12 template instances of that test fail with a `NullPointerException`.

`mvn -pl paimon-common -Dtest=BTreeIndexReaderTest,LazyFilteredBTreeIndexReaderTest test` on JDK 8: 228 tests, 0 failures. `spotless:check` and `checkstyle:check` on paimon-common are clean.
