### PR TITLE
[common] Order decimal z-values through the signed long transform

### DIFF
--- a/paimon-common/src/main/java/org/apache/paimon/sort/zorder/ZIndexer.java
+++ b/paimon-common/src/main/java/org/apache/paimon/sort/zorder/ZIndexer.java
@@ -51,6 +51,7 @@ import org.apache.paimon.types.VariantType;
 import org.apache.paimon.types.VectorType;
 
 import java.io.Serializable;
+import java.math.BigInteger;
 import java.nio.ByteBuffer;
 import java.util.Arrays;
 import java.util.LinkedHashSet;
@@ -144,6 +145,12 @@ public class ZIndexer implements Serializable {
 
     /** Type Visitor to generate function map from row column to z-index. */
     public static class TypeVisitor implements DataTypeVisitor<ZProcessFunction>, Serializable {
+
+        // Clamp bounds for the unscaled value of a non-compact decimal: clamping keeps the
+        // ordering non-decreasing where narrowing to a long would wrap. The lower bound stops
+        // one above Long.MIN_VALUE, whose z-value is the all-zero null sentinel.
+        private static final BigInteger MIN_UNSCALED = BigInteger.valueOf(Long.MIN_VALUE + 1);
+        private static final BigInteger MAX_UNSCALED = BigInteger.valueOf(Long.MAX_VALUE);
 
         private final int fieldIndex;
         private final int varTypeSize;
@@ -241,13 +248,23 @@ public class ZIndexer implements Serializable {
                     InternalRow.createFieldGetter(decimalType, fieldIndex);
             return (row, reuse) -> {
                 Object o = fieldGetter.getFieldOrNull(row);
-                return o == null
-                        ? NULL_BYTES
-                        : ZOrderByteUtils.byteTruncateOrFill(
-                                        ((Decimal) o).toUnscaledBytes(),
-                                        PRIMITIVE_BUFFER_SIZE,
-                                        reuse)
-                                .array();
+                if (o == null) {
+                    return NULL_BYTES;
+                }
+                Decimal decimal = (Decimal) o;
+                // toUnscaledBytes is a variable-length two's-complement array, which is not
+                // order-preserving under the unsigned comparison a z-value gets. Map the
+                // unscaled value through the same sign-flipped long transform as BIGINT,
+                // clamped into the long range for the decimals that do not fit it.
+                long unscaled =
+                        decimal.isCompact()
+                                ? decimal.toUnscaledLong()
+                                : decimal.toBigDecimal()
+                                        .unscaledValue()
+                                        .max(MIN_UNSCALED)
+                                        .min(MAX_UNSCALED)
+                                        .longValue();
+                return ZOrderByteUtils.longToOrderedBytes(unscaled, reuse).array();
             };
         }
 

--- a/paimon-common/src/main/java/org/apache/paimon/sort/zorder/ZIndexer.java
+++ b/paimon-common/src/main/java/org/apache/paimon/sort/zorder/ZIndexer.java
@@ -77,7 +77,7 @@ public class ZIndexer implements Serializable {
     public ZIndexer(RowType rowType, List<String> orderColumns, int varTypeSize) {
         List<String> fields = rowType.getFieldNames();
         fieldsIndex = new int[orderColumns.size()];
-        int varTypeCount = 0;
+        int total = 0;
         for (int i = 0; i < fieldsIndex.length; i++) {
             int index = fields.indexOf(orderColumns.get(i));
             if (index == -1) {
@@ -88,15 +88,10 @@ public class ZIndexer implements Serializable {
                                 + fields);
             }
             fieldsIndex[i] = index;
-
-            if (isVarType(rowType.getFieldTypes().get(index))) {
-                varTypeCount++;
-            }
+            total += zBytes(rowType.getFieldTypes().get(index), varTypeSize);
         }
         this.functionSet = constructFunctionMap(rowType.getFields(), varTypeSize);
-        this.totalBytes =
-                PRIMITIVE_BUFFER_SIZE * (this.fieldsIndex.length - varTypeCount)
-                        + varTypeSize * varTypeCount;
+        this.totalBytes = total;
     }
 
     private static boolean isVarType(DataType dataType) {
@@ -104,6 +99,26 @@ public class ZIndexer implements Serializable {
                 || dataType instanceof VarCharType
                 || dataType instanceof BinaryType
                 || dataType instanceof VarBinaryType;
+    }
+
+    /**
+     * Bytes the z-value reserves for a column. A DECIMAL gets a width that holds any unscaled value
+     * of its precision, so it keeps full ordering resolution; 8 bytes cannot, and projecting into
+     * them collapses ordinary wide-decimal values to one key.
+     */
+    private static int zBytes(DataType type, int varTypeSize) {
+        if (isVarType(type)) {
+            return varTypeSize;
+        }
+        if (type instanceof DecimalType) {
+            return decimalBytes(((DecimalType) type).getPrecision());
+        }
+        return PRIMITIVE_BUFFER_SIZE;
+    }
+
+    /** Two's-complement byte width that holds any unscaled value with {@code precision} digits. */
+    private static int decimalBytes(int precision) {
+        return BigInteger.TEN.pow(precision).bitLength() / 8 + 1;
     }
 
     public void open() {
@@ -139,8 +154,7 @@ public class ZIndexer implements Serializable {
     public static RowProcessor zmapColumnToCalculator(DataField field, int index, int varTypeSize) {
         DataType type = field.type();
         return new RowProcessor(
-                type.accept(new TypeVisitor(index, varTypeSize)),
-                isVarType(type) ? varTypeSize : PRIMITIVE_BUFFER_SIZE);
+                type.accept(new TypeVisitor(index, varTypeSize)), zBytes(type, varTypeSize));
     }
 
     /** Type Visitor to generate function map from row column to z-index. */
@@ -240,31 +254,37 @@ public class ZIndexer implements Serializable {
         public ZProcessFunction visit(DecimalType decimalType) {
             final InternalRow.FieldGetter fieldGetter =
                     InternalRow.createFieldGetter(decimalType, fieldIndex);
-            // An unscaled value of a DECIMAL(p, s) is up to p digits wide, past what a long holds
-            // for p > 18. Right-shift it into the signed-long range by a per-column amount before
-            // the long transform: an arithmetic shift by a fixed width is a monotonic projection
-            // that keeps the high-order bits, so separated values keep distinct z-keys instead of
-            // saturating to one bound the way clamping did. The widest magnitude for the column is
-            // below 10^p, so shifting off (bitLength(10^p) - 63) bits leaves at most 63, which fits
-            // a long without reaching Long.MIN_VALUE (whose z-value is the null sentinel). Compact
-            // decimals (p <= 18) always fit, so the shift is 0.
-            final int unscaledShift =
-                    Math.max(0, BigInteger.TEN.pow(decimalType.getPrecision()).bitLength() - 63);
+            // Encode the unscaled value as a fixed-width, sign-flipped big-endian two's complement.
+            // The width holds any value of this precision, so the encoding is order-preserving
+            // under the unsigned comparison a z-value gets and keeps full resolution: small
+            // separated values, their negatives, and values past the long range all get distinct
+            // keys. An 8-byte projection cannot, since one wide-decimal column exceeds 64 bits and
+            // every value below the shift collapses to a single key.
+            final int width = decimalBytes(decimalType.getPrecision());
+            final byte[] nullBytes = new byte[width];
             return (row, reuse) -> {
                 Object o = fieldGetter.getFieldOrNull(row);
                 if (o == null) {
-                    return NULL_BYTES;
+                    return nullBytes;
                 }
                 Decimal decimal = (Decimal) o;
-                long unscaled =
+                BigInteger unscaled =
                         decimal.isCompact()
-                                ? decimal.toUnscaledLong() >> unscaledShift
-                                : decimal.toBigDecimal()
-                                        .unscaledValue()
-                                        .shiftRight(unscaledShift)
-                                        .longValue();
-                return ZOrderByteUtils.longToOrderedBytes(unscaled, reuse).array();
+                                ? BigInteger.valueOf(decimal.toUnscaledLong())
+                                : decimal.toBigDecimal().unscaledValue();
+                return orderedDecimalBytes(unscaled, width, reuse);
             };
+        }
+
+        private static byte[] orderedDecimalBytes(
+                BigInteger unscaled, int width, ByteBuffer reuse) {
+            byte[] buffer = ZOrderByteUtils.reuse(reuse, width).array();
+            Arrays.fill(buffer, 0, width, unscaled.signum() < 0 ? (byte) 0xFF : (byte) 0x00);
+            byte[] magnitude = unscaled.toByteArray();
+            System.arraycopy(magnitude, 0, buffer, width - magnitude.length, magnitude.length);
+            // Flip the sign bit so signed order becomes unsigned lexicographic order.
+            buffer[0] ^= (byte) 0x80;
+            return buffer;
         }
 
         @Override

--- a/paimon-common/src/main/java/org/apache/paimon/sort/zorder/ZIndexer.java
+++ b/paimon-common/src/main/java/org/apache/paimon/sort/zorder/ZIndexer.java
@@ -146,12 +146,6 @@ public class ZIndexer implements Serializable {
     /** Type Visitor to generate function map from row column to z-index. */
     public static class TypeVisitor implements DataTypeVisitor<ZProcessFunction>, Serializable {
 
-        // Clamp bounds for the unscaled value of a non-compact decimal: clamping keeps the
-        // ordering non-decreasing where narrowing to a long would wrap. The lower bound stops
-        // one above Long.MIN_VALUE, whose z-value is the all-zero null sentinel.
-        private static final BigInteger MIN_UNSCALED = BigInteger.valueOf(Long.MIN_VALUE + 1);
-        private static final BigInteger MAX_UNSCALED = BigInteger.valueOf(Long.MAX_VALUE);
-
         private final int fieldIndex;
         private final int varTypeSize;
 
@@ -246,23 +240,28 @@ public class ZIndexer implements Serializable {
         public ZProcessFunction visit(DecimalType decimalType) {
             final InternalRow.FieldGetter fieldGetter =
                     InternalRow.createFieldGetter(decimalType, fieldIndex);
+            // An unscaled value of a DECIMAL(p, s) is up to p digits wide, past what a long holds
+            // for p > 18. Right-shift it into the signed-long range by a per-column amount before
+            // the long transform: an arithmetic shift by a fixed width is a monotonic projection
+            // that keeps the high-order bits, so separated values keep distinct z-keys instead of
+            // saturating to one bound the way clamping did. The widest magnitude for the column is
+            // below 10^p, so shifting off (bitLength(10^p) - 63) bits leaves at most 63, which fits
+            // a long without reaching Long.MIN_VALUE (whose z-value is the null sentinel). Compact
+            // decimals (p <= 18) always fit, so the shift is 0.
+            final int unscaledShift =
+                    Math.max(0, BigInteger.TEN.pow(decimalType.getPrecision()).bitLength() - 63);
             return (row, reuse) -> {
                 Object o = fieldGetter.getFieldOrNull(row);
                 if (o == null) {
                     return NULL_BYTES;
                 }
                 Decimal decimal = (Decimal) o;
-                // toUnscaledBytes is a variable-length two's-complement array, which is not
-                // order-preserving under the unsigned comparison a z-value gets. Map the
-                // unscaled value through the same sign-flipped long transform as BIGINT,
-                // clamped into the long range for the decimals that do not fit it.
                 long unscaled =
                         decimal.isCompact()
-                                ? decimal.toUnscaledLong()
+                                ? decimal.toUnscaledLong() >> unscaledShift
                                 : decimal.toBigDecimal()
                                         .unscaledValue()
-                                        .max(MIN_UNSCALED)
-                                        .min(MAX_UNSCALED)
+                                        .shiftRight(unscaledShift)
                                         .longValue();
                 return ZOrderByteUtils.longToOrderedBytes(unscaled, reuse).array();
             };

--- a/paimon-common/src/test/java/org/apache/paimon/sort/zorder/TestZOrderByteUtil.java
+++ b/paimon-common/src/test/java/org/apache/paimon/sort/zorder/TestZOrderByteUtil.java
@@ -18,14 +18,18 @@
 
 package org.apache.paimon.sort.zorder;
 
+import org.apache.paimon.data.Decimal;
 import org.apache.paimon.data.GenericRow;
+import org.apache.paimon.types.DataField;
 import org.apache.paimon.types.DataType;
 import org.apache.paimon.types.DataTypes;
+import org.apache.paimon.types.DecimalType;
 import org.apache.paimon.types.RowType;
 
 import org.junit.Test;
 import org.testcontainers.shaded.com.google.common.primitives.UnsignedBytes;
 
+import java.math.BigDecimal;
 import java.nio.ByteBuffer;
 import java.util.Arrays;
 import java.util.Comparator;
@@ -92,6 +96,71 @@ public class TestZOrderByteUtil {
             substringIndex++;
         }
         return result.toString();
+    }
+
+    /** Decimal z-values must order by value and stay distinct from the null sentinel. */
+    @Test
+    public void testZIndexerDecimalOrdering() {
+        RowType rowType =
+                new RowType(
+                        Arrays.asList(
+                                new DataField(0, "a", new DecimalType(20, 2)),
+                                new DataField(1, "b", new DecimalType(20, 2))));
+        ZIndexer indexer = new ZIndexer(rowType, Arrays.asList("a", "b"));
+        indexer.open();
+
+        // Two rows whose decimal z-values must order by value: (-1, 0) then (0, 1).
+        // Old code fed minimal two's-complement arrays into unsigned comparison,
+        // making -1 > 1 and 0 collide with the null sentinel.
+        GenericRow row1 = new GenericRow(2);
+        row1.setField(0, Decimal.fromBigDecimal(new BigDecimal("-1.00"), 20, 2));
+        row1.setField(1, Decimal.fromBigDecimal(new BigDecimal("0.00"), 20, 2));
+        GenericRow row2 = new GenericRow(2);
+        row2.setField(0, Decimal.fromBigDecimal(new BigDecimal("0.00"), 20, 2));
+        row2.setField(1, Decimal.fromBigDecimal(new BigDecimal("1.00"), 20, 2));
+
+        byte[] z1 = Arrays.copyOf(indexer.index(row1), 16);
+        byte[] z2 = Arrays.copyOf(indexer.index(row2), 16);
+        // Interleaved bits: column a dominates the high bits of the first 8 bytes.
+        assertThat(compareUnsigned(z1, z2)).isLessThan(0);
+
+        GenericRow rowNull = new GenericRow(2);
+        rowNull.setField(0, null);
+        rowNull.setField(1, null);
+        byte[] zNull = Arrays.copyOf(indexer.index(rowNull), 16);
+        // The null sentinel (all-zero bytes) sorts below every real value.
+        assertThat(compareUnsigned(zNull, z1)).isLessThan(0);
+        assertThat(compareUnsigned(zNull, z2)).isLessThan(0);
+
+        // An unscaled value that does not fit in a long clamps to the top of the range:
+        // 2^63 narrowed to a long would be Long.MIN_VALUE and sink to the bottom instead.
+        GenericRow big = new GenericRow(2);
+        big.setField(0, Decimal.fromBigDecimal(new BigDecimal("92233720368547758.08"), 20, 2));
+        big.setField(1, Decimal.fromBigDecimal(new BigDecimal("0.00"), 20, 2));
+        byte[] zBig = Arrays.copyOf(indexer.index(big), 16);
+        assertThat(compareUnsigned(zBig, z2)).isGreaterThan(0);
+
+        // Clamping stops at Long.MIN_VALUE + 1, because Long.MIN_VALUE itself encodes to the
+        // all-zero null sentinel.
+        Decimal minUnscaled =
+                Decimal.fromBigDecimal(new BigDecimal("-92233720368547758.08"), 20, 2);
+        GenericRow negativeBig = new GenericRow(2);
+        negativeBig.setField(0, minUnscaled);
+        negativeBig.setField(1, minUnscaled);
+        byte[] zNegativeBig = Arrays.copyOf(indexer.index(negativeBig), 16);
+        assertThat(compareUnsigned(zNull, zNegativeBig)).isLessThan(0);
+        assertThat(compareUnsigned(zNegativeBig, z1)).isLessThan(0);
+    }
+
+    private static int compareUnsigned(byte[] left, byte[] right) {
+        for (int i = 0; i < left.length && i < right.length; i++) {
+            int a = left[i] & 0xFF;
+            int b = right[i] & 0xFF;
+            if (a != b) {
+                return Integer.compare(a, b);
+            }
+        }
+        return Integer.compare(left.length, right.length);
     }
 
     /**

--- a/paimon-common/src/test/java/org/apache/paimon/sort/zorder/TestZOrderByteUtil.java
+++ b/paimon-common/src/test/java/org/apache/paimon/sort/zorder/TestZOrderByteUtil.java
@@ -132,16 +132,16 @@ public class TestZOrderByteUtil {
         assertThat(compareUnsigned(zNull, z1)).isLessThan(0);
         assertThat(compareUnsigned(zNull, z2)).isLessThan(0);
 
-        // An unscaled value that does not fit in a long clamps to the top of the range:
-        // 2^63 narrowed to a long would be Long.MIN_VALUE and sink to the bottom instead.
+        // An unscaled value too wide for a long is shifted into range, not narrowed: it stays a
+        // large positive key above the small positives instead of wrapping to Long.MIN_VALUE.
         GenericRow big = new GenericRow(2);
         big.setField(0, Decimal.fromBigDecimal(new BigDecimal("92233720368547758.08"), 20, 2));
         big.setField(1, Decimal.fromBigDecimal(new BigDecimal("0.00"), 20, 2));
         byte[] zBig = Arrays.copyOf(indexer.index(big), 16);
         assertThat(compareUnsigned(zBig, z2)).isGreaterThan(0);
 
-        // Clamping stops at Long.MIN_VALUE + 1, because Long.MIN_VALUE itself encodes to the
-        // all-zero null sentinel.
+        // Its negative counterpart shifts to a large negative key: below the small negatives, but
+        // still above the all-zero null sentinel.
         Decimal minUnscaled =
                 Decimal.fromBigDecimal(new BigDecimal("-92233720368547758.08"), 20, 2);
         GenericRow negativeBig = new GenericRow(2);
@@ -150,6 +150,45 @@ public class TestZOrderByteUtil {
         byte[] zNegativeBig = Arrays.copyOf(indexer.index(negativeBig), 16);
         assertThat(compareUnsigned(zNull, zNegativeBig)).isLessThan(0);
         assertThat(compareUnsigned(zNegativeBig, z1)).isLessThan(0);
+    }
+
+    /**
+     * High-precision decimals whose unscaled value exceeds the long range must still cluster:
+     * separated values keep distinct, correctly ordered z-keys rather than saturating to one bound.
+     */
+    @Test
+    public void testZIndexerHighPrecisionDecimalClustering() {
+        RowType rowType =
+                new RowType(
+                        Arrays.asList(
+                                new DataField(0, "a", new DecimalType(38, 18)),
+                                new DataField(1, "b", new DecimalType(38, 18))));
+        ZIndexer indexer = new ZIndexer(rowType, Arrays.asList("a", "b"));
+        indexer.open();
+
+        // Unscaled 10^19, 2*10^19 and 9*10^19 all exceed Long.MAX_VALUE; clamping collapsed them
+        // to one key, so the decimal column stopped clustering across its whole ordinary range.
+        byte[] z10 = highPrecisionKey(indexer, "10");
+        byte[] z20 = highPrecisionKey(indexer, "20");
+        byte[] z90 = highPrecisionKey(indexer, "90");
+        assertThat(compareUnsigned(z10, z20)).isLessThan(0);
+        assertThat(compareUnsigned(z20, z90)).isLessThan(0);
+
+        // Negatives past the long range stay ordered among themselves and below the positives.
+        byte[] zNeg90 = highPrecisionKey(indexer, "-90");
+        byte[] zNeg10 = highPrecisionKey(indexer, "-10");
+        assertThat(compareUnsigned(zNeg90, zNeg10)).isLessThan(0);
+        assertThat(compareUnsigned(zNeg10, z10)).isLessThan(0);
+
+        byte[] zNull = Arrays.copyOf(indexer.index(new GenericRow(2)), 16);
+        assertThat(compareUnsigned(zNull, zNeg90)).isLessThan(0);
+    }
+
+    private static byte[] highPrecisionKey(ZIndexer indexer, String value) {
+        GenericRow row = new GenericRow(2);
+        row.setField(0, Decimal.fromBigDecimal(new BigDecimal(value), 38, 18));
+        row.setField(1, Decimal.fromBigDecimal(new BigDecimal("0"), 38, 18));
+        return Arrays.copyOf(indexer.index(row), 16);
     }
 
     private static int compareUnsigned(byte[] left, byte[] right) {

--- a/paimon-common/src/test/java/org/apache/paimon/sort/zorder/TestZOrderByteUtil.java
+++ b/paimon-common/src/test/java/org/apache/paimon/sort/zorder/TestZOrderByteUtil.java
@@ -33,6 +33,7 @@ import java.math.BigDecimal;
 import java.nio.ByteBuffer;
 import java.util.Arrays;
 import java.util.Comparator;
+import java.util.List;
 import java.util.Random;
 
 import static org.apache.paimon.utils.RandomUtil.randomBytes;
@@ -119,42 +120,42 @@ public class TestZOrderByteUtil {
         row2.setField(0, Decimal.fromBigDecimal(new BigDecimal("0.00"), 20, 2));
         row2.setField(1, Decimal.fromBigDecimal(new BigDecimal("1.00"), 20, 2));
 
-        byte[] z1 = Arrays.copyOf(indexer.index(row1), 16);
-        byte[] z2 = Arrays.copyOf(indexer.index(row2), 16);
-        // Interleaved bits: column a dominates the high bits of the first 8 bytes.
+        byte[] z1 = Arrays.copyOf(indexer.index(row1), indexer.size());
+        byte[] z2 = Arrays.copyOf(indexer.index(row2), indexer.size());
+        // Interleaved bits: column a dominates the high bits of the z-value.
         assertThat(compareUnsigned(z1, z2)).isLessThan(0);
 
         GenericRow rowNull = new GenericRow(2);
         rowNull.setField(0, null);
         rowNull.setField(1, null);
-        byte[] zNull = Arrays.copyOf(indexer.index(rowNull), 16);
+        byte[] zNull = Arrays.copyOf(indexer.index(rowNull), indexer.size());
         // The null sentinel (all-zero bytes) sorts below every real value.
         assertThat(compareUnsigned(zNull, z1)).isLessThan(0);
         assertThat(compareUnsigned(zNull, z2)).isLessThan(0);
 
-        // An unscaled value too wide for a long is shifted into range, not narrowed: it stays a
-        // large positive key above the small positives instead of wrapping to Long.MIN_VALUE.
+        // A large magnitude still orders correctly against the small positives: the fixed-width
+        // encoding holds the whole unscaled value rather than projecting it into 8 bytes.
         GenericRow big = new GenericRow(2);
         big.setField(0, Decimal.fromBigDecimal(new BigDecimal("92233720368547758.08"), 20, 2));
         big.setField(1, Decimal.fromBigDecimal(new BigDecimal("0.00"), 20, 2));
-        byte[] zBig = Arrays.copyOf(indexer.index(big), 16);
+        byte[] zBig = Arrays.copyOf(indexer.index(big), indexer.size());
         assertThat(compareUnsigned(zBig, z2)).isGreaterThan(0);
 
-        // Its negative counterpart shifts to a large negative key: below the small negatives, but
-        // still above the all-zero null sentinel.
+        // Its negative counterpart orders below the small negatives, but still above the null
+        // sentinel.
         Decimal minUnscaled =
                 Decimal.fromBigDecimal(new BigDecimal("-92233720368547758.08"), 20, 2);
         GenericRow negativeBig = new GenericRow(2);
         negativeBig.setField(0, minUnscaled);
         negativeBig.setField(1, minUnscaled);
-        byte[] zNegativeBig = Arrays.copyOf(indexer.index(negativeBig), 16);
+        byte[] zNegativeBig = Arrays.copyOf(indexer.index(negativeBig), indexer.size());
         assertThat(compareUnsigned(zNull, zNegativeBig)).isLessThan(0);
         assertThat(compareUnsigned(zNegativeBig, z1)).isLessThan(0);
     }
 
     /**
-     * High-precision decimals whose unscaled value exceeds the long range must still cluster:
-     * separated values keep distinct, correctly ordered z-keys rather than saturating to one bound.
+     * High-precision decimals must keep full clustering resolution: ordinary small values, their
+     * negatives, and values past the long range all get distinct, correctly ordered z-keys.
      */
     @Test
     public void testZIndexerHighPrecisionDecimalClustering() {
@@ -166,29 +167,44 @@ public class TestZOrderByteUtil {
         ZIndexer indexer = new ZIndexer(rowType, Arrays.asList("a", "b"));
         indexer.open();
 
-        // Unscaled 10^19, 2*10^19 and 9*10^19 all exceed Long.MAX_VALUE; clamping collapsed them
-        // to one key, so the decimal column stopped clustering across its whole ordinary range.
-        byte[] z10 = highPrecisionKey(indexer, "10");
-        byte[] z20 = highPrecisionKey(indexer, "20");
-        byte[] z90 = highPrecisionKey(indexer, "90");
-        assertThat(compareUnsigned(z10, z20)).isLessThan(0);
-        assertThat(compareUnsigned(z20, z90)).isLessThan(0);
+        // Strictly ascending values, including small ones well below an 8-byte projection's
+        // overflow point (which collapsed 0..18 to a single key), sub-unit fractions, negatives,
+        // and a value past Long.MAX_VALUE. Each must get a strictly greater z-key than the last.
+        List<String> ascending =
+                Arrays.asList(
+                        "-90",
+                        "-10",
+                        "-2",
+                        "-1",
+                        "0",
+                        "0.001",
+                        "0.002",
+                        "1",
+                        "2",
+                        "3",
+                        "10",
+                        "20",
+                        "90",
+                        "12345678901234567890.123456789012345678");
+        byte[] previous = null;
+        for (String value : ascending) {
+            byte[] key = highPrecisionKey(indexer, value);
+            if (previous != null) {
+                assertThat(compareUnsigned(previous, key)).isLessThan(0);
+            }
+            previous = key;
+        }
 
-        // Negatives past the long range stay ordered among themselves and below the positives.
-        byte[] zNeg90 = highPrecisionKey(indexer, "-90");
-        byte[] zNeg10 = highPrecisionKey(indexer, "-10");
-        assertThat(compareUnsigned(zNeg90, zNeg10)).isLessThan(0);
-        assertThat(compareUnsigned(zNeg10, z10)).isLessThan(0);
-
-        byte[] zNull = Arrays.copyOf(indexer.index(new GenericRow(2)), 16);
-        assertThat(compareUnsigned(zNull, zNeg90)).isLessThan(0);
+        // Null sorts below every real value.
+        byte[] zNull = Arrays.copyOf(indexer.index(new GenericRow(2)), indexer.size());
+        assertThat(compareUnsigned(zNull, highPrecisionKey(indexer, "-90"))).isLessThan(0);
     }
 
     private static byte[] highPrecisionKey(ZIndexer indexer, String value) {
         GenericRow row = new GenericRow(2);
         row.setField(0, Decimal.fromBigDecimal(new BigDecimal(value), 38, 18));
         row.setField(1, Decimal.fromBigDecimal(new BigDecimal("0"), 38, 18));
-        return Arrays.copyOf(indexer.index(row), 16);
+        return Arrays.copyOf(indexer.index(row), indexer.size());
     }
 
     private static int compareUnsigned(byte[] left, byte[] right) {


### PR DESCRIPTION
### Purpose

close #9625

`ZIndexer`'s DECIMAL branch fed `Decimal.toUnscaledBytes()`, a minimal two's-complement array, into the fixed 8-byte z-value buffer through `byteTruncateOrFill`. That call left-aligns and zero-pads, and z-values are compared unsigned, so the encoding was not order-preserving. On DECIMAL(20,2), `-1.00` sorted above `1.00`, the longer `100.00` sorted below `1.00`, and `0.00` became eight zero bytes, which is the all-zero null sentinel.

Decimals now get a fixed-width, sign-flipped big-endian two's-complement encoding of the unscaled value. The width is sized to the column's precision (8 bytes for precision up to 18, up to 16 for DECIMAL(38, x)), enough to hold any value the precision allows. That makes the key order-preserving under the unsigned comparison a z-value gets, and it keeps full resolution: small separated values, their negatives, and values past the long range all get distinct keys. A decimal column reserves that width in the z-value instead of a flat 8 bytes.

This only changes the transient sort key used while clustering, so nothing on disk changes format.

An earlier revision narrowed the unscaled value into a single long, first by clamping to the long bounds and then by a precision-based right shift. Both preserved order but lost resolution: a shift wide enough to fit the DECIMAL(38, 18) range maps every value below about 18.44 to one key, so a price or rate column on that schema stops contributing clustering information while still paying the rewrite cost. The fixed-width encoding avoids that.

### Tests

`TestZOrderByteUtil.testZIndexerDecimalOrdering` builds a two-column DECIMAL(20, 2) `ZIndexer` and checks ordering by value, separation from the null sentinel, and a large magnitude against small positives and negatives.

`TestZOrderByteUtil.testZIndexerHighPrecisionDecimalClustering` walks a strictly ascending DECIMAL(38, 18) sequence covering negatives, sub-unit fractions, small integers, and a value past `Long.MAX_VALUE`, and asserts each z-key is strictly greater than the previous one, with null below all. It fails against the earlier shift revision, where the small values shared a single key.

`mvn -pl paimon-common -Dtest=TestZOrderByteUtil test` on JDK 11: 16 tests, 0 failures.