### PR TITLE
[common] Run the z-order sign flip at the width of the bit pattern

### DIFF
--- a/paimon-common/src/main/java/org/apache/paimon/sort/zorder/ZOrderByteUtils.java
+++ b/paimon-common/src/main/java/org/apache/paimon/sort/zorder/ZOrderByteUtils.java
@@ -108,8 +108,10 @@ public class ZOrderByteUtils {
      */
     public static ByteBuffer floatToOrderedBytes(float val, ByteBuffer reuse) {
         ByteBuffer bytes = reuse(reuse, PRIMITIVE_BUFFER_SIZE);
+        // Widening to double is exact and order-preserving, so the double bit pattern can
+        // carry the float: flip the sign bit, and invert the rest for negatives.
         long lval = Double.doubleToLongBits(val);
-        lval ^= ((lval >> (Integer.SIZE - 1)) | Long.MIN_VALUE);
+        lval ^= ((lval >> (Long.SIZE - 1)) | Long.MIN_VALUE);
         bytes.putLong(lval);
         return bytes;
     }
@@ -120,7 +122,7 @@ public class ZOrderByteUtils {
     public static ByteBuffer doubleToOrderedBytes(double val, ByteBuffer reuse) {
         ByteBuffer bytes = reuse(reuse, PRIMITIVE_BUFFER_SIZE);
         long lval = Double.doubleToLongBits(val);
-        lval ^= ((lval >> (Integer.SIZE - 1)) | Long.MIN_VALUE);
+        lval ^= ((lval >> (Long.SIZE - 1)) | Long.MIN_VALUE);
         bytes.putLong(lval);
         return bytes;
     }

--- a/paimon-common/src/test/java/org/apache/paimon/sort/zorder/TestZOrderByteUtil.java
+++ b/paimon-common/src/test/java/org/apache/paimon/sort/zorder/TestZOrderByteUtil.java
@@ -95,6 +95,82 @@ public class TestZOrderByteUtil {
     }
 
     /**
+     * Ordered-bytes transforms must preserve value order across negatives for floats and doubles.
+     */
+    @Test
+    public void testFloatDoubleNegativeOrdering() {
+        float[] floats = {
+            -Float.MAX_VALUE,
+            -2.5f,
+            -1f,
+            -Float.MIN_VALUE,
+            0f,
+            Float.MIN_VALUE,
+            1f,
+            2.5f,
+            Float.MAX_VALUE
+        };
+        long prevF =
+                ZOrderByteUtils.floatToOrderedBytes(floats[0], ByteBuffer.allocate(8)).getLong(0);
+        for (int i = 1; i < floats.length; i++) {
+            long cur =
+                    ZOrderByteUtils.floatToOrderedBytes(floats[i], ByteBuffer.allocate(8))
+                            .getLong(0);
+            assertThat(Long.compareUnsigned(prevF, cur)).isLessThan(0);
+            prevF = cur;
+        }
+
+        double[] doubles = {
+            -Double.MAX_VALUE,
+            -2.5d,
+            -1d,
+            -Double.MIN_VALUE,
+            0d,
+            Double.MIN_VALUE,
+            1d,
+            2.5d,
+            Double.MAX_VALUE
+        };
+        long prevD =
+                ZOrderByteUtils.doubleToOrderedBytes(doubles[0], ByteBuffer.allocate(8)).getLong(0);
+        for (int i = 1; i < doubles.length; i++) {
+            long cur =
+                    ZOrderByteUtils.doubleToOrderedBytes(doubles[i], ByteBuffer.allocate(8))
+                            .getLong(0);
+            assertThat(Long.compareUnsigned(prevD, cur)).isLessThan(0);
+            prevD = cur;
+        }
+
+        // Dense walk of adjacent negative bit patterns: value strictly decreases, so
+        // the transformed unsigned value must strictly decrease too. The old shift-31
+        // flip inverts order for a fraction of adjacent negative pairs.
+        for (int i = 1; i < 1000; i++) {
+            int bits = 0xC0400000 + i; // starting at -3.0f, descending values
+            long prev =
+                    ZOrderByteUtils.floatToOrderedBytes(
+                                    Float.intBitsToFloat(bits - 1), ByteBuffer.allocate(8))
+                            .getLong(0);
+            long cur =
+                    ZOrderByteUtils.floatToOrderedBytes(
+                                    Float.intBitsToFloat(bits), ByteBuffer.allocate(8))
+                            .getLong(0);
+            assertThat(Long.compareUnsigned(prev, cur)).isGreaterThan(0);
+        }
+        for (int i = 0; i < 1000; i++) {
+            long bits = 0xC004000000000000L + i; // just below -2.5d, descending values
+            double v = Double.longBitsToDouble(bits);
+            long cur = ZOrderByteUtils.doubleToOrderedBytes(v, ByteBuffer.allocate(8)).getLong(0);
+            if (i > 0) {
+                long prev =
+                        ZOrderByteUtils.doubleToOrderedBytes(
+                                        Double.longBitsToDouble(bits - 1), ByteBuffer.allocate(8))
+                                .getLong(0);
+                assertThat(Long.compareUnsigned(prev, cur)).isGreaterThan(0);
+            }
+        }
+    }
+
+    /**
      * Compares the result of a string based interleaving algorithm implemented above versus the
      * binary bit-shifting algorithm used in ZOrderByteUtils. Either both algorithms are identically
      * wrong or are both identically correct.


### PR DESCRIPTION
### Purpose

close #9627

`ZOrderByteUtils.doubleToOrderedBytes` built its sign-magnitude mask from a 31-bit shift of a 64-bit value:

```java
long lval = Double.doubleToLongBits(val);
lval ^= ((lval >> (Integer.SIZE - 1)) | Long.MIN_VALUE);
```

The shift is meant to be a sign extension, all ones for a negative pattern and all zeros for a positive one. At 31 it instead copies bits 31 through 61 into the low half of the mask, so any value bit lining up with a set bit there gets inverted. Negatives lose most of their ordering: `-2.5` encodes to `0x3ffbffff80080000` while the strictly smaller `-2.5000000000000004` encodes to `0x3ffbffff80080001`. Positives are affected wherever two values differ at one of those positions: `2.5` encodes to `0xc004000080080000` and the larger `2.5000000002328306` to `0xc004000080000000`. `floatToOrderedBytes` widens to double and ran the same line, so both types were wrong.

Both now shift by `Long.SIZE - 1`. The same transform is written correctly in `SortUtil`, where `putFloatNormalizedKey` shifts an `int` by `Integer.SIZE - 1` and `putDoubleNormalizedKey` shifts a `long` by `Long.SIZE - 1`; the z-order copy had kept the int-sized constant on a long.

The float path keeps widening to double instead of encoding the 32-bit pattern into half the buffer. Widening is exact and order-preserving, and it keeps all eight bytes carrying information, which matters because `interleaveBits` consumes bytes most-significant first and Spark truncates the interleaved output to a maximum size.

Nothing on disk changes, since a z-value only exists while sorting.

### Tests

`TestZOrderByteUtil.testFloatDoubleNegativeOrdering` walks an ascending array from `-MAX_VALUE` to `MAX_VALUE` for both types and asserts the encodings ascend with it. It then walks a thousand adjacent bit patterns descending from `-3.0f` and from just below `-2.5d`, asserting each encoding is strictly lower than the one before, which is where the old mask fails: the arrays on their own are too sparse to catch it.

The existing `testFloatOrdering` and `testDoubleOrdering` only used `random.nextFloat()` and `random.nextDouble()`, both in [0, 1), which is why this survived.

`mvn -pl paimon-common -Dtest=TestZOrderByteUtil test` on JDK 8: 15 tests, 0 failures. `spotless:check` and `checkstyle:check` on paimon-common are clean.
