### PR TITLE
[common] Normalize row-id IN literals inside Range.toRanges

### DIFF
--- a/paimon-common/src/main/java/org/apache/paimon/predicate/RowIdPredicateVisitor.java
+++ b/paimon-common/src/main/java/org/apache/paimon/predicate/RowIdPredicateVisitor.java
@@ -61,9 +61,14 @@ public class RowIdPredicateVisitor implements PredicateVisitor<Optional<List<Ran
                 return Optional.of(Range.toRanges(rowIds));
             } else if (function instanceof Between) {
                 List<Object> literals = predicate.literals();
-                return Optional.of(
-                        Collections.singletonList(
-                                new Range((Long) literals.get(0), (Long) literals.get(1))));
+                long from = (Long) literals.get(0);
+                long to = (Long) literals.get(1);
+                // BETWEEN with inverted bounds (SQL allows BETWEEN 10 AND 5) is empty.
+                if (from > to) {
+                    // Mutable: the Or union path accumulates into the returned list.
+                    return Optional.of(new ArrayList<>());
+                }
+                return Optional.of(Collections.singletonList(new Range(from, to)));
             }
         }
         return Optional.empty();

--- a/paimon-common/src/main/java/org/apache/paimon/utils/Range.java
+++ b/paimon-common/src/main/java/org/apache/paimon/utils/Range.java
@@ -121,7 +121,8 @@ public class Range implements Serializable {
 
     public static List<Range> sortAndMergeOverlap(List<Range> ranges, boolean adjacent) {
         if (ranges == null || ranges.isEmpty()) {
-            return Collections.emptyList();
+            // Mutable: callers accumulate into the result across children.
+            return new ArrayList<>();
         }
 
         if (ranges.size() == 1) {
@@ -184,9 +185,18 @@ public class Range implements Serializable {
         return result;
     }
 
+    /**
+     * Groups row ids into ascending ranges, merging consecutive ids. The ids may arrive in any
+     * order and may repeat; both are normalized here, since the returned list has to be sorted and
+     * non-overlapping for {@link #and(List, List)} to intersect it correctly.
+     */
     public static List<Range> toRanges(Iterable<Long> ids) {
+        List<Long> sorted = new ArrayList<>();
+        ids.forEach(sorted::add);
+        Collections.sort(sorted);
+
         List<Range> ranges = new ArrayList<>();
-        Iterator<Long> iterator = ids.iterator();
+        Iterator<Long> iterator = sorted.iterator();
 
         if (!iterator.hasNext()) {
             return ranges;
@@ -197,6 +207,9 @@ public class Range implements Serializable {
 
         while (iterator.hasNext()) {
             long current = iterator.next();
+            if (current == rangeEnd) {
+                continue;
+            }
             if (current != rangeEnd + 1) {
                 // Save the current range and start a new one
                 ranges.add(new Range(rangeStart, rangeEnd));

--- a/paimon-common/src/test/java/org/apache/paimon/predicate/RowIdPredicateVisitorTest.java
+++ b/paimon-common/src/test/java/org/apache/paimon/predicate/RowIdPredicateVisitorTest.java
@@ -26,6 +26,7 @@ import org.apache.paimon.utils.Range;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -80,6 +81,53 @@ public class RowIdPredicateVisitorTest {
         // Test unrecognized predicate (should return empty)
         Predicate unrecognized = builder.greaterThan(0, 10);
         assertThat(unrecognized.visit(visitor)).isEmpty();
+    }
+
+    @Test
+    public void testUnsortedInLiteralsIntersectCorrectly() {
+        // IN literals in descending engine order: unsorted input to Range.and's
+        // two-pointer intersection silently drops rows (e.g. only [5,5] instead of
+        // [1,2] and [5,6]).
+        // >20 literals so PredicateBuilder keeps a real In leaf (smaller INs become
+        // an OR of equals): descending 25..5 exercises the In branch unsorted.
+        List<Object> descending = new ArrayList<>();
+        for (long v = 25; v >= 5; v--) {
+            descending.add(v);
+        }
+        Predicate inUnsorted = builder.in(rowIdIndex, descending);
+        Predicate between1To6 = builder.between(rowIdIndex, 1L, 6L);
+        Predicate and = PredicateBuilder.and(inUnsorted, between1To6);
+        Optional<List<Range>> result = and.visit(visitor);
+        assertThat(result).isPresent();
+        assertThat(result.get()).containsExactly(new Range(5, 6));
+
+        // Duplicates in the IN list must not produce overlapping ranges.
+        List<Object> duplicates = new ArrayList<>();
+        for (int i = 0; i < 21; i++) {
+            duplicates.add(15L);
+        }
+        Predicate inDuplicates = builder.in(rowIdIndex, duplicates);
+        Predicate between10To20 = builder.between(rowIdIndex, 10L, 20L);
+        Optional<List<Range>> dedup =
+                PredicateBuilder.and(inDuplicates, between10To20).visit(visitor);
+        assertThat(dedup).isPresent();
+        assertThat(dedup.get()).containsExactly(new Range(15, 15));
+    }
+
+    @Test
+    public void testInvertedBetweenIsEmpty() {
+        // SQL allows BETWEEN 10 AND 5; it matches nothing and must not fabricate an
+        // inverted Range that breaks the from <= to invariant.
+        Predicate inverted = builder.between(rowIdIndex, 10L, 5L);
+        Optional<List<Range>> result = inverted.visit(visitor);
+        assertThat(result).isPresent();
+        assertThat(result.get()).isEmpty();
+
+        // Inverted BETWEEN under OR must not break the union accumulation.
+        Predicate equal7 = builder.equal(rowIdIndex, 7L);
+        Optional<List<Range>> orResult = PredicateBuilder.or(inverted, equal7).visit(visitor);
+        assertThat(orResult).isPresent();
+        assertThat(orResult.get()).containsExactly(new Range(7, 7));
     }
 
     @Test

--- a/paimon-core/src/test/java/org/apache/paimon/table/DataEvolutionTableTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/table/DataEvolutionTableTest.java
@@ -602,6 +602,62 @@ public class DataEvolutionTableTest extends DataEvolutionTestBase {
     }
 
     @Test
+    public void testDescendingRowIdInIntersectBetweenReadsCorrectRows() throws Exception {
+        // Table-level regression: a descending _ROW_ID IN list intersected with a BETWEEN used to
+        // drop ranges (Range.toRanges/Range.and need ascending, deduped input), and the dropped
+        // ranges are rows that are never read. This is the TableRead equivalent of
+        // RowIdPredicateVisitorTest#testUnsortedInLiteralsIntersectCorrectly.
+        write(30); // one batch per column group; row id i <-> f0 == i
+        Schema schema = schemaDefault();
+        PredicateBuilder pb = new PredicateBuilder(rowTypeWithRowId(schema));
+        int rowIdIndex = schema.rowType().getFieldCount();
+
+        // IN (25,24,...,5) is 21 descending literals (> 20, so PredicateBuilder keeps a real In
+        // leaf) intersected with BETWEEN 3 AND 8 -> {5,6,7,8}.
+        Predicate filter =
+                PredicateBuilder.and(
+                        pb.in(rowIdIndex, descendingRowIds(25L, 5L)),
+                        pb.between(rowIdIndex, 3L, 8L));
+        assertThat(readF0WithFilter(filter)).isEqualTo(Arrays.asList(5, 6, 7, 8));
+    }
+
+    @Test
+    public void testEmptyRowIdIntersectionUnderOrReadsOtherBranch() throws Exception {
+        // The empty branch (disjoint IN ∩ BETWEEN) has to yield a mutable empty range list so the
+        // Or union can accumulate the other branch into it; before the fix this threw
+        // UnsupportedOperationException while planning the scan.
+        write(30);
+        Schema schema = schemaDefault();
+        PredicateBuilder pb = new PredicateBuilder(rowTypeWithRowId(schema));
+        int rowIdIndex = schema.rowType().getFieldCount();
+
+        Predicate emptyIntersection =
+                PredicateBuilder.and(
+                        pb.in(rowIdIndex, descendingRowIds(25L, 5L)),
+                        pb.between(rowIdIndex, 100L, 110L)); // disjoint from the IN -> empty
+        Predicate filter = PredicateBuilder.or(emptyIntersection, pb.between(rowIdIndex, 10L, 12L));
+        assertThat(readF0WithFilter(filter)).isEqualTo(Arrays.asList(10, 11, 12));
+    }
+
+    private List<Integer> readF0WithFilter(Predicate filter) throws Exception {
+        ReadBuilder rb = getTableDefault().newReadBuilder().withFilter(filter);
+        List<Integer> f0 = new ArrayList<>();
+        try (RecordReader<InternalRow> reader = rb.newRead().createReader(rb.newScan().plan())) {
+            reader.forEachRemaining(r -> f0.add(r.getInt(0)));
+        }
+        Collections.sort(f0);
+        return f0;
+    }
+
+    private static List<Object> descendingRowIds(long hi, long lo) {
+        List<Object> ids = new ArrayList<>();
+        for (long v = hi; v >= lo; v--) {
+            ids.add(v);
+        }
+        return ids;
+    }
+
+    @Test
     public void testLimitPushDownWithoutFilter() throws Exception {
         createTableDefault();
         Schema schema = schemaDefault();


### PR DESCRIPTION
### Purpose

close #9629

`Range.toRanges` compresses row ids with a linear scan that merges consecutive values, so it only works on ascending, deduplicated input, and `Range.and` intersects with two forward-moving pointers, so it needs the same. Nothing established either precondition: `RowIdPredicateVisitor` passed the IN literals through in whatever order the engine produced them. A descending `_ROW_ID IN (...)` list intersected with a `BETWEEN` therefore lost most of its ranges, and since `DataEvolutionBatchScan.withFilter` feeds the result to `withRowRanges`, the dropped ranges are rows that are never read.

The precondition now lives in `toRanges`, which sorts its own copy and skips repeated ids, and says so in its javadoc. That is where it belongs: the signature is `Iterable<Long>`, so no caller could guess the requirement, and the method has one production caller to keep in step.

Two more problems in the same extraction path, both reachable and both fixed here:

`BETWEEN 10 AND 5` is legal SQL that matches nothing, but the visitor built `new Range(10, 5)` and broke the `from <= to` invariant the constructor asserts. It now yields no range.

`Range.sortAndMergeOverlap` returned `Collections.emptyList()` for empty input while the visitor's OR branch accumulates into the list it gets back, so the next child's `addAll` threw `UnsupportedOperationException`. It now returns a mutable list. `(_ROW_ID BETWEEN 1 AND 5 AND _ROW_ID BETWEEN 10 AND 20) OR _ROW_ID = 100` reaches that, and the inverted-BETWEEN fix above makes empty children easier to produce, which is why the two go together.

### Tests

`RowIdPredicateVisitorTest.testUnsortedInLiteralsIntersectCorrectly` builds a descending 21-literal IN list (long enough that `PredicateBuilder` keeps a real `In` leaf), intersects it with `BETWEEN 1 AND 6`, and asserts the single expected range; a second case feeds 21 copies of one literal and asserts one range rather than overlapping duplicates.

`RowIdPredicateVisitorTest.testInvertedBetweenIsEmpty` asserts the inverted bounds produce no range, then puts that inverted BETWEEN on the left of an OR to cover the accumulation path.

Against the unfixed visitor both tests fail.

`mvn -pl paimon-common -Dtest=RowIdPredicateVisitorTest,RangeTest,RowRangeIndexTest test` on JDK 8: 43 tests, 0 failures. `spotless:check` and `checkstyle:check` on paimon-common are clean.
