### PR TITLE
[common] Do not drop a partition on contradictory partition-key equals

### DIFF
--- a/paimon-common/src/main/java/org/apache/paimon/predicate/OnlyPartitionKeyEqualVisitor.java
+++ b/paimon-common/src/main/java/org/apache/paimon/predicate/OnlyPartitionKeyEqualVisitor.java
@@ -32,6 +32,7 @@ public class OnlyPartitionKeyEqualVisitor implements FunctionVisitor<Boolean> {
     private final List<String> partitionKeys;
 
     private final Map<String, String> partitions;
+    private boolean contradiction = false;
 
     public OnlyPartitionKeyEqualVisitor(List<String> partitionKeys) {
         this.partitionKeys = partitionKeys;
@@ -111,7 +112,13 @@ public class OnlyPartitionKeyEqualVisitor implements FunctionVisitor<Boolean> {
     public Boolean visitEqual(FieldRef fieldRef, Object literal) {
         boolean contains = partitionKeys.contains(fieldRef.name());
         if (contains) {
-            partitions.put(fieldRef.name(), literal.toString());
+            String value = literal.toString();
+            String existing = partitions.put(fieldRef.name(), value);
+            if (existing != null && !existing.equals(value)) {
+                // Contradictory condition on the same key (pt = 'a' AND pt = 'b'):
+                // no partition can match, so the delete must not drop anything.
+                contradiction = true;
+            }
             return true;
         }
         return false;
@@ -134,6 +141,12 @@ public class OnlyPartitionKeyEqualVisitor implements FunctionVisitor<Boolean> {
 
     @Override
     public Boolean visitAnd(List<Boolean> children) {
+        if (contradiction) {
+            // Two equals on the same partition key carried different literals, so the
+            // conjunction matches nothing; dropping the partition would delete rows
+            // the predicate never selected.
+            return false;
+        }
         return children.stream().reduce((first, second) -> first && second).get();
     }
 

--- a/paimon-common/src/test/java/org/apache/paimon/predicate/OnlyPartitionKeyEqualVisitorTest.java
+++ b/paimon-common/src/test/java/org/apache/paimon/predicate/OnlyPartitionKeyEqualVisitorTest.java
@@ -1,0 +1,92 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.predicate;
+
+import org.apache.paimon.data.BinaryString;
+import org.apache.paimon.types.DataTypes;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.Collections;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Test for {@link OnlyPartitionKeyEqualVisitor}. */
+public class OnlyPartitionKeyEqualVisitorTest {
+
+    @Test
+    public void testContradictoryPartitionKeysNotDroppable() {
+        OnlyPartitionKeyEqualVisitor visitor =
+                new OnlyPartitionKeyEqualVisitor(Arrays.asList("pt", "dt"));
+
+        // pt = 'a' AND pt = 'b': no partition matches; must not be treated as a
+        // partition drop (the old last-write-wins map made it drop partition pt='b').
+        Predicate p1 =
+                new LeafPredicate(
+                        Equal.INSTANCE,
+                        DataTypes.STRING(),
+                        0,
+                        "pt",
+                        Collections.singletonList(BinaryString.fromString("a")));
+        Predicate p2 =
+                new LeafPredicate(
+                        Equal.INSTANCE,
+                        DataTypes.STRING(),
+                        0,
+                        "pt",
+                        Collections.singletonList(BinaryString.fromString("b")));
+        Predicate contradiction = PredicateBuilder.and(Arrays.asList(p1, p2));
+        assertThat(contradiction.visit(visitor)).isFalse();
+    }
+
+    @Test
+    public void testDistinctPartitionKeysDroppable() {
+        OnlyPartitionKeyEqualVisitor visitor =
+                new OnlyPartitionKeyEqualVisitor(Arrays.asList("pt", "dt"));
+        Predicate p1 =
+                new LeafPredicate(
+                        Equal.INSTANCE,
+                        DataTypes.STRING(),
+                        0,
+                        "pt",
+                        Collections.singletonList(BinaryString.fromString("a")));
+        Predicate p2 =
+                new LeafPredicate(
+                        Equal.INSTANCE,
+                        DataTypes.STRING(),
+                        1,
+                        "dt",
+                        Collections.singletonList(BinaryString.fromString("2024")));
+        Predicate combined = PredicateBuilder.and(Arrays.asList(p1, p2));
+        assertThat(combined.visit(visitor)).isTrue();
+        assertThat(visitor.partitions()).containsEntry("pt", "a").containsEntry("dt", "2024");
+    }
+
+    @Test
+    public void testNonPartitionKeyNotDroppable() {
+        OnlyPartitionKeyEqualVisitor visitor =
+                new OnlyPartitionKeyEqualVisitor(Collections.singletonList("pt"));
+        Predicate px =
+                new LeafPredicate(
+                        Equal.INSTANCE, DataTypes.INT(), 2, "x", Collections.singletonList(1));
+        assertThat(px.visit(visitor)).isFalse();
+        assertThat(visitor.partitions()).isEmpty();
+    }
+}


### PR DESCRIPTION
### Purpose

close #9631

`OnlyPartitionKeyEqualVisitor` decides whether a DELETE can be turned into a partition drop, and it collects the equality literals into a `Map<String, String>` keyed by partition key. Two equals on the same key overwrite each other, so `pt = 'a' AND pt = 'b'` reported "droppable" with `partitions()` returning `{pt=b}`: the Flink sink would drop that partition for a predicate that matches no row.

`visitEqual` now notices when a key already carries a different literal, and `visitAnd` reports non-droppable in that case. The delete then goes down the normal row-level path, which is what every other predicate shape this visitor does not understand already gets.

Worth stating plainly, because it changes how you may want to prioritize this: I could not construct a SQL statement that reaches it. Calcite folds `pt = 'a' AND pt = 'b'` to FALSE before `applyDeleteFilters` sees it, and `PredicateBuilder.and` does not merge equality predicates on its own. So the protection exists today, but it lives in the planner rather than here, and it does not cover a caller that builds the predicate directly or a future engine binding. Given the consequence is deleting a partition, keeping the decision honest inside the visitor seemed worth the six lines.

### Tests

`OnlyPartitionKeyEqualVisitorTest` covers the three shapes: two conflicting equals on one key report non-droppable, equals on two different keys stay droppable and produce both partition values, and an equal on a non-partition column is not droppable and contributes nothing.

Against the unfixed visitor the first of those fails, reporting droppable.

`mvn -pl paimon-common -Dtest=OnlyPartitionKeyEqualVisitorTest,DeletePushDownVisitorTest test` on JDK 8: 4 tests, 0 failures. `spotless:check` and `checkstyle:check` on paimon-common are clean.
