### PR TITLE
[common] Close the file-index stream when reader construction fails

### DIFF
--- a/paimon-common/src/main/java/org/apache/paimon/fileindex/FileIndexFormat.java
+++ b/paimon-common/src/main/java/org/apache/paimon/fileindex/FileIndexFormat.java
@@ -318,7 +318,10 @@ public final class FileIndexFormat {
                         }
                     }
                 }
-            } catch (IOException e) {
+            } catch (IOException | RuntimeException e) {
+                // Callers wrap the constructor in try-with-resources on the stream,
+                // but a throwing constructor never assigns the resource, so both
+                // checked and unchecked validation failures must close here.
                 IOUtils.closeQuietly(seekableInputStream);
                 throw new RuntimeException(
                         "Exception happens while construct file index reader.", e);

--- a/paimon-common/src/main/java/org/apache/paimon/fileindex/FileIndexPredicate.java
+++ b/paimon-common/src/main/java/org/apache/paimon/fileindex/FileIndexPredicate.java
@@ -32,7 +32,6 @@ import org.apache.paimon.predicate.PredicateVisitor;
 import org.apache.paimon.predicate.SortValue;
 import org.apache.paimon.predicate.TopN;
 import org.apache.paimon.types.RowType;
-import org.apache.paimon.utils.IOUtils;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -69,14 +68,9 @@ public class FileIndexPredicate implements Closeable {
     }
 
     public FileIndexPredicate(SeekableInputStream inputStream, RowType fileRowType) {
-        try {
-            this.reader = FileIndexFormat.createReader(inputStream, fileRowType);
-        } catch (RuntimeException e) {
-            // nothing else holds a reference to inputStream yet, so this is the only chance to
-            // release it: createReader rejects a file whose magic or version does not match.
-            IOUtils.closeQuietly(inputStream);
-            throw e;
-        }
+        // createReader itself closes the stream when the header fails validation, so
+        // there is no stream to release here anymore.
+        this.reader = FileIndexFormat.createReader(inputStream, fileRowType);
     }
 
     public FileIndexResult evaluate(@Nullable Predicate predicate) {

--- a/paimon-common/src/test/java/org/apache/paimon/fileindex/FileIndexFormatFormatTest.java
+++ b/paimon-common/src/test/java/org/apache/paimon/fileindex/FileIndexFormatFormatTest.java
@@ -20,6 +20,7 @@ package org.apache.paimon.fileindex;
 
 import org.apache.paimon.fileindex.empty.EmptyFileIndexReader;
 import org.apache.paimon.fs.ByteArraySeekableStream;
+import org.apache.paimon.fs.SeekableInputStream;
 import org.apache.paimon.types.DataTypes;
 import org.apache.paimon.types.RowType;
 
@@ -35,6 +36,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Random;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 import static org.apache.paimon.utils.RandomUtil.randomBytes;
 import static org.apache.paimon.utils.RandomUtil.randomString;
@@ -44,6 +46,29 @@ import static org.assertj.core.api.Assertions.tuple;
 public class FileIndexFormatFormatTest {
 
     private static final Random RANDOM = new Random();
+
+    @Test
+    public void testCreateReaderClosesStreamOnBadMagic() {
+        byte[] notIndexFile = "this is definitely not a file index".getBytes();
+        AtomicBoolean closed = new AtomicBoolean();
+        SeekableInputStream counting =
+                new ByteArraySeekableStream(notIndexFile) {
+                    @Override
+                    public void close() throws IOException {
+                        closed.set(true);
+                        super.close();
+                    }
+                };
+        Throwable thrown =
+                Assertions.catchThrowable(
+                        () -> FileIndexFormat.createReader(counting, RowType.builder().build()));
+        // A throwing constructor never assigns the caller's try-with-resources resource,
+        // so closing the stream is the constructor's job.
+        Assertions.assertThat(closed.get()).isTrue();
+        Assertions.assertThat(thrown)
+                .isInstanceOf(RuntimeException.class)
+                .hasRootCauseMessage("This file is not file index file.");
+    }
 
     @Test
     public void testWriteRead() throws IOException {

--- a/paimon-common/src/test/java/org/apache/paimon/fileindex/FileIndexPredicateCloseTest.java
+++ b/paimon-common/src/test/java/org/apache/paimon/fileindex/FileIndexPredicateCloseTest.java
@@ -47,7 +47,8 @@ public class FileIndexPredicateCloseTest {
 
         assertThatThrownBy(() -> new FileIndexPredicate(tracking(notAnIndexFile, closed), ROW_TYPE))
                 .isInstanceOf(RuntimeException.class)
-                .hasMessageContaining("not file index file");
+                .hasMessageContaining("Exception happens while construct file index reader.")
+                .hasRootCauseMessage("This file is not file index file.");
 
         assertThat(closed).hasValue(1);
     }


### PR DESCRIPTION
### Purpose

close #9635

`FileIndexFormat.Reader`'s constructor closed the stream it was handed only for an `IOException`, while a header it does not recognize is reported with `throw new RuntimeException("This file is not file index file.")`. Every call site opens the stream inside the try-with-resources head:

```java
try (FileIndexFormat.Reader indexReader =
        FileIndexFormat.createReader(fileIO.newInputStream(...), schemaInfo.fileSchema)) {
```

A constructor that throws never assigns that resource, so the stream stays open. #9462 fixed this for `FileIndexPredicate` by catching `RuntimeException` at the call site; `FileIndexProcessor` and `FileIndexesTable` still leak, one per failed read, and `FileIndexProcessor` runs per data file during compaction and `rewrite-file-index`.

The `catch` in the constructor now covers `RuntimeException` too, which is where the stream reference lives, so all three call sites are covered and the next one does not have to remember. The call-site workaround in `FileIndexPredicate` goes away with it.

One behavior change worth knowing about: a bad magic or version now arrives wrapped, `RuntimeException("Exception happens while construct file index reader.")` with the original as its cause, rather than bare. `FileIndexesTable.fileIndexReadException` tests `getCause() instanceof IOException` and is unaffected; the only place that asserted the old message was `FileIndexPredicateCloseTest`, updated here.

### Tests

`FileIndexFormatFormatTest.testCreateReaderClosesStreamOnBadMagic` hands `createReader` a stream over bytes that are not an index file, with `close()` instrumented, and asserts the stream was closed before it asserts anything about the exception. Ordering it that way matters: the close is what the fix is about, and asserting the message first would let a change that only wraps the exception pass.

`FileIndexPredicateCloseTest` keeps covering the same thing one layer up, with its message expectation updated.

Against the unfixed constructor the new test fails on the close assertion.

`mvn -pl paimon-common -Dtest=FileIndexFormatFormatTest,FileIndexPredicateCloseTest test` on JDK 8: 5 tests, 0 failures. `spotless:check` and `checkstyle:check` on paimon-common are clean.
