### PR TITLE
[common] Propagate checked IOException from RESTTokenFileIO#fileIO

### DIFF
--- a/paimon-common/src/main/java/org/apache/paimon/rest/RESTTokenFileIO.java
+++ b/paimon-common/src/main/java/org/apache/paimon/rest/RESTTokenFileIO.java
@@ -45,7 +45,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
-import java.io.UncheckedIOException;
 import java.time.Duration;
 import java.util.Map;
 import java.util.concurrent.Executors;
@@ -227,11 +226,7 @@ public class RESTTokenFileIO implements FileIO {
                             catalogContext.hadoopConf(),
                             catalogContext.preferIO(),
                             catalogContext.fallbackIO());
-            try {
-                fileIO = FileIO.get(path, context);
-            } catch (IOException e) {
-                throw new UncheckedIOException(e);
-            }
+            fileIO = FileIO.get(path, context);
             FILE_IO_CACHE.put(token, fileIO);
             return fileIO;
         }

--- a/paimon-common/src/test/java/org/apache/paimon/rest/RESTTokenFileIOTest.java
+++ b/paimon-common/src/test/java/org/apache/paimon/rest/RESTTokenFileIOTest.java
@@ -98,6 +98,36 @@ class RESTTokenFileIOTest {
     }
 
     @Test
+    void testFileIOCreationFailureSurfacesAsCheckedIOException() throws IOException {
+        Path tableRoot = new Path("resttoken-broken://bucket/table");
+        // the loader's access check fails, so FileIO.get cannot produce an inner FileIO
+        FileIO delegate = mock(FileIO.class);
+        when(delegate.exists(any())).thenThrow(new IOException("token fs unavailable"));
+        FileIOLoader loader = mock(FileIOLoader.class);
+        when(loader.getScheme()).thenReturn("resttoken-broken");
+        when(loader.load(any())).thenReturn(delegate);
+        RESTApi api = mock(RESTApi.class);
+        Identifier identifier = Identifier.create("db", "table");
+        // a unique token, so the static token-keyed FileIO cache cannot serve another test's
+        // delegate and the creation path actually runs
+        when(api.loadTableToken(identifier))
+                .thenReturn(
+                        new GetTableTokenResponse(
+                                Collections.singletonMap("token", UUID.randomUUID().toString()),
+                                Long.MAX_VALUE));
+        RESTTokenFileIO fileIO =
+                new RESTTokenFileIO(
+                        CatalogContext.create(new Options(), loader, null),
+                        api,
+                        identifier,
+                        tableRoot);
+
+        // FileIO operations declare IOException; failing to create the inner FileIO must
+        // surface the same way instead of bypassing callers as UncheckedIOException
+        assertThatThrownBy(() -> fileIO.exists(tableRoot)).isInstanceOf(IOException.class);
+    }
+
+    @Test
     void testTryToWriteAtomicReachesInnerOverride() throws IOException {
         Path tableRoot = new Path("oss://bucket/table");
         FileIO delegate = mock(FileIO.class);


### PR DESCRIPTION
### Purpose

close #9637

`RESTTokenFileIO.fileIO()` is declared `throws IOException` and then converted the one it gets into an unchecked wrapper:

```java
try {
    fileIO = FileIO.get(path, context);
} catch (IOException e) {
    throw new UncheckedIOException(e);
}
```

So a data token that cannot produce an inner FileIO surfaced as `UncheckedIOException` from whichever FileIO call triggered the lazy creation, past every caller written for the declared signature. Two of those live outside paimon-common and can never run as things stand:

```java
// paimon-lance LanceUtils, and the same shape in paimon-vortex VortexUtils
try {
    fileIO = ((RESTTokenFileIO) fileIO).fileIO();
} catch (IOException e) {
    throw new RuntimeException("Can't get fileIO from RESTTokenFileIO", e);
}
```

Letting the `IOException` through is all this needs. The signature does not change, so no caller has to, and the two above start reporting what they were written to report. The cache is keyed by `RESTToken`, so this path runs again on every token refresh rather than once at startup.

### Tests

`RESTTokenFileIOTest.testFileIOCreationFailureSurfacesAsCheckedIOException` builds a `RESTTokenFileIO` over a scheme no loader can serve, with a unique token so the static token-keyed cache cannot hand back another test's delegate, and asserts that `exists` fails with an `IOException`.

Against the unfixed code that assertion fails on the type: what comes out is `java.io.UncheckedIOException` wrapping an `UnsupportedSchemeException`.

`mvn -pl paimon-common -Dtest=RESTTokenFileIOTest test` on JDK 8: 5 tests, 0 failures. `spotless:check` and `checkstyle:check` on paimon-common are clean.
