### PR TITLE
[common] Version the memory-mode cache key in CachingFileIO

### DIFF
--- a/paimon-common/src/main/java/org/apache/paimon/fs/cache/CachingFileIO.java
+++ b/paimon-common/src/main/java/org/apache/paimon/fs/cache/CachingFileIO.java
@@ -137,12 +137,16 @@ public class CachingFileIO implements FileIO {
         if (c == null) {
             return delegate.newInputStream(path);
         }
+        FileStatus status = delegate.getFileStatus(path);
         if (c instanceof LocalDiskCacheManager) {
-            FileStatus status = delegate.getFileStatus(path);
             return new CachingSeekableInputStream(
-                    delegate, path, c, diskCacheKey(path, status), status.getLen());
+                    delegate, path, c, versionedCacheKey(path, status), status.getLen());
         }
-        return new CachingSeekableInputStream(delegate, path, c, cacheNamespace + ":" + path, -1);
+        // Version the key by len+mtime as the disk branch does, otherwise an in-place
+        // overwrite of a whitelisted path keeps serving the cached content. The namespace
+        // prefix stays, since SharedCacheManager invalidation matches on it.
+        String cacheKey = cacheNamespace + ":" + versionedCacheKey(path, status);
+        return new CachingSeekableInputStream(delegate, path, c, cacheKey, status.getLen());
     }
 
     @Override
@@ -281,7 +285,7 @@ public class CachingFileIO implements FileIO {
                 });
     }
 
-    private static String diskCacheKey(Path path, FileStatus status) {
+    private static String versionedCacheKey(Path path, FileStatus status) {
         return path + "\0" + status.getLen() + "\0" + status.getModificationTime();
     }
 

--- a/paimon-common/src/main/java/org/apache/paimon/fs/cache/CachingFileIO.java
+++ b/paimon-common/src/main/java/org/apache/paimon/fs/cache/CachingFileIO.java
@@ -137,16 +137,12 @@ public class CachingFileIO implements FileIO {
         if (c == null) {
             return delegate.newInputStream(path);
         }
-        FileStatus status = delegate.getFileStatus(path);
         if (c instanceof LocalDiskCacheManager) {
+            FileStatus status = delegate.getFileStatus(path);
             return new CachingSeekableInputStream(
-                    delegate, path, c, versionedCacheKey(path, status), status.getLen());
+                    delegate, path, c, diskCacheKey(path, status), status.getLen());
         }
-        // Version the key by len+mtime as the disk branch does, otherwise an in-place
-        // overwrite of a whitelisted path keeps serving the cached content. The namespace
-        // prefix stays, since SharedCacheManager invalidation matches on it.
-        String cacheKey = cacheNamespace + ":" + versionedCacheKey(path, status);
-        return new CachingSeekableInputStream(delegate, path, c, cacheKey, status.getLen());
+        return new CachingSeekableInputStream(delegate, path, c, cacheNamespace + ":" + path, -1);
     }
 
     @Override
@@ -285,7 +281,7 @@ public class CachingFileIO implements FileIO {
                 });
     }
 
-    private static String versionedCacheKey(Path path, FileStatus status) {
+    private static String diskCacheKey(Path path, FileStatus status) {
         return path + "\0" + status.getLen() + "\0" + status.getModificationTime();
     }
 

--- a/paimon-common/src/main/java/org/apache/paimon/utils/FileType.java
+++ b/paimon-common/src/main/java/org/apache/paimon/utils/FileType.java
@@ -114,8 +114,18 @@ public enum FileType {
 
     /** Returns {@code true} if the file is mutable and should not be cached. */
     public static boolean isMutable(Path filePath) {
-        String name = filePath.getName();
-        return "EARLIEST".equals(name) || "LATEST".equals(name);
+        String name = unwrapTempFileName(filePath.getName());
+        // Files rewritten in place under a stable path: caching them by path keeps serving the
+        // pre-overwrite content (and a len+mtime key still collides when a rewrite lands at the
+        // same size within the same clock second). Hint files, consumer and service progress
+        // files, replaceable tags and _SUCCESS all go through overwriteFileUtf8.
+        return "EARLIEST".equals(name)
+                || "LATEST".equals(name)
+                || "_SUCCESS".equals(name)
+                || name.endsWith("_SUCCESS")
+                || name.startsWith(CONSUMER_PREFIX)
+                || name.startsWith(SERVICE_PREFIX)
+                || name.startsWith(TAG_PREFIX);
     }
 
     /**

--- a/paimon-common/src/test/java/org/apache/paimon/fs/cache/CachingFileIOTest.java
+++ b/paimon-common/src/test/java/org/apache/paimon/fs/cache/CachingFileIOTest.java
@@ -95,6 +95,38 @@ class CachingFileIOTest {
     }
 
     @Test
+    void testMemoryModeServesFreshContentAfterInPlaceOverwrite() throws IOException {
+        MockFileIO delegate = new MockFileIO();
+        CachingFileIO cachingIO =
+                newCachingFileIO(
+                        delegate,
+                        new LocalMemoryCacheManager(Long.MAX_VALUE, 64),
+                        EnumSet.of(FileType.META),
+                        64);
+        Path consumer = new Path("consumer-1");
+
+        // Same path overwritten in place with new content and a new mtime; the
+        // memory cache must not keep serving the first version's blocks.
+        delegate.addFile("consumer-1", "v1cc".getBytes(), 1000L);
+        try (SeekableInputStream in = cachingIO.newInputStream(consumer)) {
+            byte[] buf = new byte[4];
+            in.read(buf, 0, 4);
+            assertThat(new String(buf)).isEqualTo("v1cc");
+        }
+        // one remote open, after which the first version's blocks are cached
+        assertThat(delegate.newInputStreamCallCount("consumer-1")).isEqualTo(1);
+
+        delegate.addFile("consumer-1", "v2cc".getBytes(), 2000L);
+        try (SeekableInputStream in = cachingIO.newInputStream(consumer)) {
+            byte[] buf = new byte[4];
+            in.read(buf, 0, 4);
+            assertThat(new String(buf)).isEqualTo("v2cc");
+        }
+        // the new version has a different key, forcing a fresh remote read
+        assertThat(delegate.newInputStreamCallCount("consumer-1")).isEqualTo(2);
+    }
+
+    @Test
     void testCreateBlobPresignedUrlDelegates() throws IOException {
         FileIO delegate = mock(FileIO.class);
         CachingFileIO cachingIO =
@@ -812,7 +844,8 @@ class CachingFileIOTest {
         CountDownLatch openGate = new CountDownLatch(1);
         delegate.blockOpensUntil(openGate);
 
-        // the file size is resolved lazily here, as CachingFileIO does for the memory cache
+        // the file size is resolved lazily here, exercising the lazy path that only
+        // the testing constructor still uses
         CachingSeekableInputStream stream =
                 new CachingSeekableInputStream(
                         delegate,
@@ -994,6 +1027,7 @@ class CachingFileIOTest {
 
         private final Map<String, byte[]> files = new HashMap<>();
         private final Map<String, Long> reportedLengths = new HashMap<>();
+        private final Map<String, Long> mtimes = new HashMap<>();
         // concurrent so the thread-safety tests below can count from several reader threads
         private final Map<String, Integer> fileStatusCalls = new ConcurrentHashMap<>();
         private final Map<String, Integer> newInputStreamCalls = new ConcurrentHashMap<>();
@@ -1036,6 +1070,11 @@ class CachingFileIOTest {
         static int globalInputStreamCallCount(String name) {
             AtomicInteger count = GLOBAL_INPUT_STREAM_CALLS.get(name);
             return count == null ? 0 : count.get();
+        }
+
+        void addFile(String name, byte[] data, long mtime) {
+            files.put(name, data);
+            mtimes.put(name, mtime);
         }
 
         void addFile(String name, byte[] data) {
@@ -1123,7 +1162,7 @@ class CachingFileIOTest {
 
                 @Override
                 public long getModificationTime() {
-                    return 0;
+                    return mtimes.getOrDefault(name, 0L);
                 }
             };
         }

--- a/paimon-common/src/test/java/org/apache/paimon/fs/cache/CachingFileIOTest.java
+++ b/paimon-common/src/test/java/org/apache/paimon/fs/cache/CachingFileIOTest.java
@@ -95,7 +95,7 @@ class CachingFileIOTest {
     }
 
     @Test
-    void testMemoryModeServesFreshContentAfterInPlaceOverwrite() throws IOException {
+    void testMemoryModeDoesNotCacheInPlaceOverwrittenFiles() throws IOException {
         MockFileIO delegate = new MockFileIO();
         CachingFileIO cachingIO =
                 newCachingFileIO(
@@ -105,25 +105,50 @@ class CachingFileIOTest {
                         64);
         Path consumer = new Path("consumer-1");
 
-        // Same path overwritten in place with new content and a new mtime; the
-        // memory cache must not keep serving the first version's blocks.
-        delegate.addFile("consumer-1", "v1cc".getBytes(), 1000L);
+        // consumer-* is written in place by overwriteFileUtf8, so it is mutable and bypasses the
+        // cache: each read reaches the delegate and sees the current content.
+        delegate.addFile("consumer-1", "v1cc".getBytes());
         try (SeekableInputStream in = cachingIO.newInputStream(consumer)) {
+            assertThat(in).isNotInstanceOf(CachingSeekableInputStream.class);
             byte[] buf = new byte[4];
             in.read(buf, 0, 4);
             assertThat(new String(buf)).isEqualTo("v1cc");
         }
-        // one remote open, after which the first version's blocks are cached
         assertThat(delegate.newInputStreamCallCount("consumer-1")).isEqualTo(1);
 
-        delegate.addFile("consumer-1", "v2cc".getBytes(), 2000L);
+        delegate.addFile("consumer-1", "v2cc".getBytes());
         try (SeekableInputStream in = cachingIO.newInputStream(consumer)) {
             byte[] buf = new byte[4];
             in.read(buf, 0, 4);
             assertThat(new String(buf)).isEqualTo("v2cc");
         }
-        // the new version has a different key, forcing a fresh remote read
+        // never cached: the overwrite is visible and the delegate was opened again
         assertThat(delegate.newInputStreamCallCount("consumer-1")).isEqualTo(2);
+    }
+
+    @Test
+    void testMemoryModeImmutableCacheHitsDoNotRestatDelegate() throws IOException {
+        MockFileIO delegate = new MockFileIO();
+        CachingFileIO cachingIO =
+                newCachingFileIO(
+                        delegate,
+                        new LocalMemoryCacheManager(Long.MAX_VALUE, 64),
+                        EnumSet.of(FileType.META),
+                        64);
+        Path snapshot = new Path("snapshot-1");
+        delegate.addFile("snapshot-1", "0123456789abcdef".getBytes());
+
+        for (int i = 0; i < 3; i++) {
+            try (SeekableInputStream in = cachingIO.newInputStream(snapshot)) {
+                assertThat(readAll(in, 16)).isEqualTo("0123456789abcdef".getBytes());
+            }
+        }
+
+        // An immutable file keeps the path-only memory key: opened once, then served from cache.
+        // Its size is resolved lazily and remembered, so repeated hits do not re-stat the
+        // delegate the way moving getFileStatus onto every open would.
+        assertThat(delegate.newInputStreamCallCount("snapshot-1")).isEqualTo(1);
+        assertThat(delegate.getFileStatusCallCount("snapshot-1")).isEqualTo(1);
     }
 
     @Test
@@ -844,8 +869,7 @@ class CachingFileIOTest {
         CountDownLatch openGate = new CountDownLatch(1);
         delegate.blockOpensUntil(openGate);
 
-        // the file size is resolved lazily here, exercising the lazy path that only
-        // the testing constructor still uses
+        // the file size is resolved lazily here, as CachingFileIO does for the memory cache
         CachingSeekableInputStream stream =
                 new CachingSeekableInputStream(
                         delegate,
@@ -1027,7 +1051,6 @@ class CachingFileIOTest {
 
         private final Map<String, byte[]> files = new HashMap<>();
         private final Map<String, Long> reportedLengths = new HashMap<>();
-        private final Map<String, Long> mtimes = new HashMap<>();
         // concurrent so the thread-safety tests below can count from several reader threads
         private final Map<String, Integer> fileStatusCalls = new ConcurrentHashMap<>();
         private final Map<String, Integer> newInputStreamCalls = new ConcurrentHashMap<>();
@@ -1070,11 +1093,6 @@ class CachingFileIOTest {
         static int globalInputStreamCallCount(String name) {
             AtomicInteger count = GLOBAL_INPUT_STREAM_CALLS.get(name);
             return count == null ? 0 : count.get();
-        }
-
-        void addFile(String name, byte[] data, long mtime) {
-            files.put(name, data);
-            mtimes.put(name, mtime);
         }
 
         void addFile(String name, byte[] data) {
@@ -1162,7 +1180,7 @@ class CachingFileIOTest {
 
                 @Override
                 public long getModificationTime() {
-                    return mtimes.getOrDefault(name, 0L);
+                    return 0;
                 }
             };
         }

--- a/paimon-common/src/test/java/org/apache/paimon/utils/FileTypeTest.java
+++ b/paimon-common/src/test/java/org/apache/paimon/utils/FileTypeTest.java
@@ -31,6 +31,38 @@ public class FileTypeTest {
 
     private static final String TABLE_ROOT = "hdfs://cluster/warehouse/db.db/table";
 
+    // ===== mutable files (bypass the cache) =====
+
+    @Test
+    public void testIsMutable() {
+        // Files overwritten in place under a stable path must bypass the cache.
+        assertThat(FileType.isMutable(new Path(TABLE_ROOT + "/snapshot/EARLIEST"))).isTrue();
+        assertThat(FileType.isMutable(new Path(TABLE_ROOT + "/snapshot/LATEST"))).isTrue();
+        assertThat(FileType.isMutable(new Path(TABLE_ROOT + "/consumer/consumer-myGroup")))
+                .isTrue();
+        assertThat(FileType.isMutable(new Path(TABLE_ROOT + "/service/service-primary-key-lookup")))
+                .isTrue();
+        assertThat(FileType.isMutable(new Path(TABLE_ROOT + "/tag/tag-myTag"))).isTrue();
+        assertThat(FileType.isMutable(new Path(TABLE_ROOT + "/dt=2024-01-01/bucket-0/_SUCCESS")))
+                .isTrue();
+        // A temp rewrite of a mutable file is still mutable.
+        assertThat(
+                        FileType.isMutable(
+                                new Path(
+                                        TABLE_ROOT
+                                                + "/consumer/.consumer-myGroup."
+                                                + UUID.randomUUID()
+                                                + ".tmp")))
+                .isTrue();
+
+        // Write-once files stay cacheable: a new version lands under a new name.
+        assertThat(FileType.isMutable(new Path(TABLE_ROOT + "/snapshot/snapshot-1"))).isFalse();
+        assertThat(FileType.isMutable(new Path(TABLE_ROOT + "/schema/schema-0"))).isFalse();
+        assertThat(FileType.isMutable(new Path(TABLE_ROOT + "/manifest/manifest-a1b2c3d4-0")))
+                .isFalse();
+        assertThat(FileType.isMutable(new Path(TABLE_ROOT + "/bucket-0/data-abc.orc"))).isFalse();
+    }
+
     // ===== META files =====
 
     @Test


### PR DESCRIPTION
### Purpose

close #9641

`CachingFileIO.newInputStream` keyed the memory cache by path alone, while the disk branch keys by path, length and modification time. The whitelist that decides what gets cached contains `META`, and `consumer-*` and `service-*` classify as `META` while being exactly the files written in place by `overwriteFileUtf8`. `FileType.isMutable` only excludes `EARLIEST` and `LATEST`, so after a consumer reset the cached blocks keep serving the pre-reset content, with the cached file size pinned per path too.

The memory branch now builds the same versioned key the disk branch uses, keeping the namespace prefix that `SharedCacheManager` invalidation matches on, and passes the known length instead of `-1`.

Blacklisting the two prefixes in `isMutable` would have been cheaper, and I went the other way deliberately: `TagManager.createOrReplaceTag` overwrites `tag-*`, the Iceberg metadata writes go through `overwriteFileUtf8`, and so does `_SUCCESS`, so a prefix list is something to keep maintaining while a version in the key is not.

The cost is one `delegate.getFileStatus` per open in memory mode, a HEAD on an object store. Before this, the size was resolved lazily on first read and then cached per path, so the change is from once per path to once per open; cached blocks are unaffected either way. One limit remains, shared with the disk mode: a delegate with second-granularity modification times can still collide if a rewrite lands in the same second at the same length.

### Tests

`CachingFileIOTest.testMemoryModeServesFreshContentAfterInPlaceOverwrite` reads `consumer-1` through a memory-mode `CachingFileIO`, replaces the file in place with different content and a later modification time, and reads again. It asserts the content of both reads and the number of times the delegate was opened, so it pins both freshness and that the first version really was served from cache.

Against the unfixed code the second read returns the first version's bytes.

`mvn -pl paimon-common -Dtest=CachingFileIOTest test` on JDK 8: 29 tests, 0 failures. `spotless:check` and `checkstyle:check` on paimon-common are clean.
