### PR TITLE
[common] Do not zero the HeapBytesVector buffer on reset

### DIFF
--- a/paimon-common/src/main/java/org/apache/paimon/data/columnar/heap/HeapBytesVector.java
+++ b/paimon-common/src/main/java/org/apache/paimon/data/columnar/heap/HeapBytesVector.java
@@ -74,8 +74,6 @@ public class HeapBytesVector extends AbstractHeapVector implements WritableBytes
         }
 
         // We don't reset buffer to avoid unnecessary copy.
-        Arrays.fill(buffer, (byte) 0);
-
         this.bytesAppended = 0;
     }
 

--- a/paimon-common/src/test/java/org/apache/paimon/data/columnar/heap/HeapBytesVectorReserveBytesTest.java
+++ b/paimon-common/src/test/java/org/apache/paimon/data/columnar/heap/HeapBytesVectorReserveBytesTest.java
@@ -179,4 +179,20 @@ class HeapBytesVectorReserveBytesTest {
         assertThat(bytes.len).isEqualTo(2);
         assertThat(vector.buffer[0]).isEqualTo((byte) 10);
     }
+
+    @Test
+    void testResetDoesNotWipeBuffer() {
+        HeapBytesVector vector = new HeapBytesVector(4);
+        byte[] data = new byte[] {1, 2, 3};
+        vector.putByteArray(0, data, 0, data.length);
+
+        vector.reset();
+
+        // reset() deliberately leaves the data buffer untouched: wiping it costs
+        // O(buffer size) per batch in the vectorized reader hot path, and reads are
+        // always bounded by the start/length offsets, which reset() does clear
+        assertThat(vector.buffer[0]).isEqualTo((byte) 1);
+        assertThat(vector.start[0]).isZero();
+        assertThat(vector.length[0]).isZero();
+    }
 }

--- a/paimon-format/src/main/java/org/apache/paimon/format/parquet/reader/VectorizedDeltaByteArrayReader.java
+++ b/paimon-format/src/main/java/org/apache/paimon/format/parquet/reader/VectorizedDeltaByteArrayReader.java
@@ -93,11 +93,11 @@ public class VectorizedDeltaByteArrayReader extends VectorizedReaderBase
 
             c.putByteArray(rowId + i, bytes, offset, length);
             // Keep the value we just assembled rather than a view over the output vector's
-            // buffer. The record reader resets that vector between batches, and reset() zeroes
-            // the buffer, so a view into it would hand NUL bytes to the next value's prefix
-            // whenever a page spans more than one batch. skipBinary avoids the same hazard by
-            // alternating two vectors; here the array is already a fresh copy, so wrapping it
-            // costs nothing.
+            // buffer. The record reader reuses that vector across batches, rewriting it
+            // from offset 0, so a view into it would hand the next batch's bytes to the
+            // next value's prefix whenever a page spans more than one batch. skipBinary
+            // avoids the same hazard by alternating two vectors; here the array is
+            // already a fresh copy, so wrapping it costs nothing.
             previous = ByteBuffer.wrap(bytes);
             currentRow++;
         }

--- a/paimon-format/src/test/java/org/apache/paimon/format/parquet/reader/DeltaByteArrayEncodingTest.java
+++ b/paimon-format/src/test/java/org/apache/paimon/format/parquet/reader/DeltaByteArrayEncodingTest.java
@@ -103,6 +103,23 @@ public class DeltaByteArrayEncodingTest {
     }
 
     /**
+     * skipBinary alternates two vectors and leaves {@code previous} pointing into the buffer of
+     * whichever one it wrote last, so after an odd number of skipped values the next skip call
+     * starts by resetting that very vector. The prefix of the following value is copied out of it.
+     */
+    @Test
+    public void skippingAnOddNumberOfValuesKeepsThePrefix() throws Exception {
+        String[] vals = new String[] {"aaaa", "aaab", "aaac", "aaad"};
+        Utils.writeData(writer, vals);
+        reader.initFromPage(vals.length, writer.getBytes().toInputStream());
+
+        reader.skipBinary(1);
+        reader.skipBinary(1);
+
+        assertArrayEquals(vals[2].getBytes(), reader.readBinary(0).getBytes());
+    }
+
+    /**
      * The record reader resets the vector between batches, so a page that spans two batches has to
      * survive that reset. Every other case here reads a whole page into one vector without a reset,
      * which is why none of them exercises this.


### PR DESCRIPTION
### Purpose

close #9643

`HeapBytesVector.reset()` zeroed its data buffer, one line under the comment saying it does not:

```java
// We don't reset buffer to avoid unnecessary copy.
Arrays.fill(buffer, (byte) 0);
```

Beyond costing O(buffer size) per batch on the vectorized read path, it silently corrupts values. `VectorizedDeltaByteArrayReader.skipBinary` alternates two vectors and leaves `previous` pointing at the buffer of whichever one it wrote last, so after an odd number of skipped values `previous` points into `tempBinaryValVector` and the next `skipBinary` call opens by resetting that same vector. The prefix it then copies out of `previous` is all zeros, and the value that follows the skipped range comes back with NUL bytes in front.

Removing the fill is safe: every read goes through `getBytes(i)`, bounded by the `start` and `length` arrays that `reset()` still clears, and null positions have length 0. Nothing in the repo reads the buffer directly except the two Parquet readers and `ColumnVectorUtils`, and since #9275 `readValues` keeps its own copy rather than a view into the vector.

The comment in `VectorizedDeltaByteArrayReader` that explained the copy in terms of "reset() zeroes the buffer" is updated to say what is actually true now: the vector is rewritten across batches, so a view into it cannot be kept.

### Tests

`DeltaByteArrayEncodingTest.skippingAnOddNumberOfValuesKeepsThePrefix` writes four values sharing a prefix, calls `skipBinary(1)` twice so the second call resets the vector `previous` points into, and reads the next value.

Against the unfixed `HeapBytesVector` it fails with `array contents differ at index [0], expected: <97> but was: <0>`, which is the prefix that was zeroed. The existing `randomStringsWithSkip` and `randomStringsWithSkipN` never reach it, since they skip once.

`HeapBytesVectorReserveBytesTest.testResetDoesNotWipeBuffer` pins the vector's own behavior.

`mvn -pl paimon-common,paimon-format -Dtest=HeapBytesVectorReserveBytesTest,DeltaByteArrayEncodingTest test` on JDK 8: 13 and 8 tests, 0 failures. `spotless:check` and `checkstyle:check` on both modules are clean. The red run needs the pre-fix paimon-common installed, since the two modules do not share a reactor for this.
