### PR TITLE
[common] Range-check the digit guard in DateTimeUtils

### DIFF
--- a/paimon-common/src/main/java/org/apache/paimon/utils/DateTimeUtils.java
+++ b/paimon-common/src/main/java/org/apache/paimon/utils/DateTimeUtils.java
@@ -349,15 +349,22 @@ public class DateTimeUtils {
                 + milli;
     }
 
+    /**
+     * Whether the string is a non-negative decimal integer that fits in an {@code int}. Callers
+     * hand the string straight to {@link Integer#parseInt}, so the range matters as much as the
+     * characters.
+     */
     private static boolean isInteger(String s) {
-        boolean isInt = s.length() > 0;
+        if (s.isEmpty() || s.length() > 10) {
+            return false;
+        }
         for (int i = 0; i < s.length(); i++) {
             if (s.charAt(i) < '0' || s.charAt(i) > '9') {
-                isInt = false;
-                break;
+                return false;
             }
         }
-        return isInt;
+        // ten digits still reach past Integer.MAX_VALUE
+        return s.length() < 10 || Long.parseLong(s) <= Integer.MAX_VALUE;
     }
 
     private static boolean isIllegalDate(int y, int m, int d) {

--- a/paimon-common/src/main/java/org/apache/paimon/utils/DateTimeUtils.java
+++ b/paimon-common/src/main/java/org/apache/paimon/utils/DateTimeUtils.java
@@ -355,16 +355,25 @@ public class DateTimeUtils {
      * characters.
      */
     private static boolean isInteger(String s) {
-        if (s.isEmpty() || s.length() > 10) {
+        if (s.isEmpty()) {
             return false;
         }
+        // Accumulate with overflow checking rather than a digit-count limit: a zero-padded
+        // component such as "00000002024" is still in range, so what matters is the value, not
+        // how many characters it took to write. Bailing out the moment the running value passes
+        // Integer.MAX_VALUE keeps the accumulator itself from overflowing a long.
+        long value = 0;
         for (int i = 0; i < s.length(); i++) {
-            if (s.charAt(i) < '0' || s.charAt(i) > '9') {
+            char c = s.charAt(i);
+            if (c < '0' || c > '9') {
+                return false;
+            }
+            value = value * 10 + (c - '0');
+            if (value > Integer.MAX_VALUE) {
                 return false;
             }
         }
-        // ten digits still reach past Integer.MAX_VALUE
-        return s.length() < 10 || Long.parseLong(s) <= Integer.MAX_VALUE;
+        return true;
     }
 
     private static boolean isIllegalDate(int y, int m, int d) {

--- a/paimon-common/src/test/java/org/apache/paimon/utils/DateTimeUtilsTest.java
+++ b/paimon-common/src/test/java/org/apache/paimon/utils/DateTimeUtilsTest.java
@@ -34,6 +34,24 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 public class DateTimeUtilsTest {
 
     @Test
+    public void testParseDateAndTimeOverflowReturnsNull() {
+        // A component too large for an int is an invalid date or time, not a crash: the
+        // contract of parseDate/parseTime is null for unparseable input. 2147483648 is
+        // Integer.MAX_VALUE + 1, the smallest ten-digit value that does not fit.
+        assertThat(DateTimeUtils.parseDate("2147483648-01-01")).isNull();
+        assertThat(DateTimeUtils.parseDate("2147483647-01-01"))
+                .isNull(); // in range, but not a year
+        assertThat(DateTimeUtils.parseDate("99999999999-01-01")).isNull();
+        assertThat(DateTimeUtils.parseDate("2024-99999999999-01")).isNull();
+        assertThat(DateTimeUtils.parseDate("2024-01-99999999999")).isNull();
+        assertThat(DateTimeUtils.parseTime("99999999999:00:00")).isNull();
+
+        // Sanity: valid values still parse.
+        assertThat(DateTimeUtils.parseDate("2024-01-15")).isNotNull();
+        assertThat(DateTimeUtils.parseTime("12:30:00")).isNotNull();
+    }
+
+    @Test
     public void testFormatLocalDateTime() {
         LocalDateTime time = LocalDateTime.of(2023, 8, 30, 12, 30, 59, 999_999_999);
         String[] expectations = new String[10];

--- a/paimon-common/src/test/java/org/apache/paimon/utils/DateTimeUtilsTest.java
+++ b/paimon-common/src/test/java/org/apache/paimon/utils/DateTimeUtilsTest.java
@@ -49,6 +49,14 @@ public class DateTimeUtilsTest {
         // Sanity: valid values still parse.
         assertThat(DateTimeUtils.parseDate("2024-01-15")).isNotNull();
         assertThat(DateTimeUtils.parseTime("12:30:00")).isNotNull();
+
+        // Zero-padded components whose value still fits an int must keep parsing: the range
+        // guard has to judge the value, not the digit count, or previously accepted padded
+        // dates/times would silently turn into NULL.
+        assertThat(DateTimeUtils.parseDate("00000002024-01-15"))
+                .isEqualTo(DateTimeUtils.parseDate("2024-01-15"));
+        assertThat(DateTimeUtils.parseTime("00000000012:30:00"))
+                .isEqualTo(DateTimeUtils.parseTime("12:30:00"));
     }
 
     @Test


### PR DESCRIPTION
### Purpose

close #9648

`DateTimeUtils.parseDate` and `parseTime` return null for input they cannot parse, and they guard every `Integer.parseInt` with `isInteger`. That guard only checked the characters:

```java
private static boolean isInteger(String s) {
    boolean isInt = s.length() > 0;
    for (int i = 0; i < s.length(); i++) {
        if (s.charAt(i) < '0' || s.charAt(i) > '9') {
            isInt = false;
            break;
        }
    }
    return isInt;
}
```

A component of eleven digits therefore passed it and `Integer.parseInt` threw `NumberFormatException`, escaping a method whose every other failure path returns null. `parseDate("2147483648-01-01")` and `parseTime("2147483648:00:00")` both do it.

The guard now also checks the range, which is enough because it sits in front of each of the eleven `parseInt` calls in those two methods. Nothing else changes: no signature, no local variable type, no arithmetic.

Callers see the difference as an exception type. Through the casts, `NumberFormatException` becomes the `DateTimeException` that `BinaryStringUtils.toDate` raises for any unparseable string, which is what a caller already gets for `"99999-01-01"` (rejected by `isIllegalDate`) or `"not-a-date"`. The Hive `PaimonTimeObjectInspector.convert` passes the `Integer` through, so a TIME column holding such a value writes NULL rather than failing, matching what it already does for other invalid times.

### Tests

`DateTimeUtilsTest.testParseDateAndTimeOverflowReturnsNull` covers a too-large year, month, day and hour, and the two boundary cases: `2147483648` is the smallest ten-digit value that does not fit an `int`, and `2147483647` does fit but is still not a valid year, so both have to come back null through different branches. Valid values are asserted alongside them.

Against the unfixed guard the test errors with `NumberFormatException: For input string: "2147483648"`.

`mvn -pl paimon-common -Dtest=DateTimeUtilsTest test` on JDK 8: 12 tests, 0 failures. `spotless:check` and `checkstyle:check` on paimon-common are clean.
