### PR TITLE
[core] Avoid retaining rejected cache pages

### DIFF
--- a/paimon-common/src/main/java/org/apache/paimon/io/cache/Cache.java
+++ b/paimon-common/src/main/java/org/apache/paimon/io/cache/Cache.java
@@ -27,10 +27,13 @@ import java.util.function.Function;
 
 /** Cache interface in Paimon. */
 public interface Cache {
+
     @Nullable
     CacheValue get(CacheKey key, Function<CacheKey, CacheValue> supplier);
 
     void put(CacheKey key, CacheValue value);
+
+    boolean contains(CacheKey key);
 
     void invalidate(CacheKey key);
 

--- a/paimon-common/src/main/java/org/apache/paimon/io/cache/CacheManager.java
+++ b/paimon-common/src/main/java/org/apache/paimon/io/cache/CacheManager.java
@@ -102,6 +102,14 @@ public class CacheManager implements AutoCloseable {
         return checkNotNull(value, "Cache result for key(%s) is null", key).segment;
     }
 
+    public boolean contains(CacheKey key) {
+        if (key.isIndex()) {
+            return indexCache.contains(key);
+        } else {
+            return dataCache.contains(key);
+        }
+    }
+
     public void invalidPage(CacheKey key) {
         if (key.isIndex()) {
             indexCache.invalidate(key);

--- a/paimon-common/src/main/java/org/apache/paimon/io/cache/CaffeineCache.java
+++ b/paimon-common/src/main/java/org/apache/paimon/io/cache/CaffeineCache.java
@@ -48,6 +48,11 @@ public class CaffeineCache implements Cache {
     }
 
     @Override
+    public boolean contains(CacheKey key) {
+        return this.cache.policy().getIfPresentQuietly(key) != null;
+    }
+
+    @Override
     public void invalidate(CacheKey key) {
         this.cache.invalidate(key);
     }

--- a/paimon-common/src/main/java/org/apache/paimon/sst/BlockCache.java
+++ b/paimon-common/src/main/java/org/apache/paimon/sst/BlockCache.java
@@ -79,7 +79,9 @@ public class BlockCache implements Closeable {
                             },
                             blocks::remove);
             container = new SegmentContainer(segment);
-            blocks.put(cacheKey, container);
+            if (cacheManager.contains(cacheKey)) {
+                blocks.put(cacheKey, container);
+            }
         }
         return container.access();
     }

--- a/paimon-common/src/test/java/org/apache/paimon/io/cache/CacheManagerTest.java
+++ b/paimon-common/src/test/java/org/apache/paimon/io/cache/CacheManagerTest.java
@@ -18,8 +18,10 @@
 
 package org.apache.paimon.io.cache;
 
+import org.apache.paimon.fs.ByteArraySeekableStream;
 import org.apache.paimon.memory.MemorySegment;
 import org.apache.paimon.options.MemorySize;
+import org.apache.paimon.sst.BlockCache;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
@@ -29,6 +31,7 @@ import java.io.File;
 import java.io.RandomAccessFile;
 import java.nio.file.Path;
 import java.util.Arrays;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -65,6 +68,38 @@ public class CacheManagerTest {
                 assertThat(segment.getHeapMemory()).isEqualTo(value);
             }
         }
+    }
+
+    @Test
+    void testRejectedPageNotRetainedByBlockCache() throws Exception {
+        int pageSize = 1024;
+        int hotPages = 64;
+        int totalPages = 10_000;
+        byte[] data = new byte[pageSize * totalPages];
+        org.apache.paimon.fs.Path file = new org.apache.paimon.fs.Path("file");
+        AtomicInteger invalidatedPages = new AtomicInteger();
+        CacheManager cacheManager =
+                new CacheManager(MemorySize.ofKibiBytes(64), 0) {
+                    @Override
+                    public void invalidPage(CacheKey key) {
+                        invalidatedPages.incrementAndGet();
+                        super.invalidPage(key);
+                    }
+                };
+        BlockCache blockCache =
+                new BlockCache(file, new ByteArraySeekableStream(data), cacheManager);
+
+        for (int round = 0; round < 100; round++) {
+            for (int page = 0; page < hotPages; page++) {
+                blockCache.getBlock(page * pageSize, pageSize, bytes -> bytes, false);
+            }
+        }
+        for (int page = hotPages; page < totalPages; page++) {
+            blockCache.getBlock(page * pageSize, pageSize, bytes -> bytes, false);
+        }
+
+        blockCache.close();
+        assertThat(invalidatedPages).hasValue(hotPages);
     }
 
     @Test


### PR DESCRIPTION
### Purpose

#8857 changes the default Guava cache to Caffeine cache.

However, Caffeine has a feature, where a newly put value might not be admitted into the cache (see [github issue](https://github.com/ben-manes/caffeine/issues/289)).

In `BlockCache`, we maintain another variable `blocks` and it should be synced with Caffeine cache. Due to the above feature, when new value is not admitted, this value will still be kept in `blocks` and consumes memory. This PR fixes the issue.

This is only a temporary fix. Our goal should be removing the variable `blocks` and maintain everything in cache.

### Tests

* `CacheManagerTest`