### PR TITLE
[core][spark] Maintain num files and total file size on snapshots

### DIFF
--- a/docs/docs/concepts/system-tables.mdx
+++ b/docs/docs/concepts/system-tables.mdx
@@ -76,11 +76,14 @@ costs nothing extra, and they cover data files only: changelog files, index file
 vectors are not counted.
 
 Both columns are nullable, and `NULL` means unknown rather than zero. It appears for snapshots
-written before these columns existed, and for commits that could not derive the values from the
-previous snapshot, such as metadata repair operations that replace the manifest layout wholesale.
-Once a snapshot reports unknown, the snapshots committed after it report unknown as well, until the
-values are recomputed. Fall back to scanning the manifests when you read `NULL`; never read it as
-zero.
+written before these columns existed, and once a snapshot reports unknown the snapshots committed
+after it report unknown as well, because there is no baseline to fold the next commit onto. Fall
+back to scanning the manifests when you read `NULL`; never read it as zero.
+
+Run the `compact_manifest` procedure to recover the values on such a table. It rewrites the whole
+manifest set anyway, so it folds the counters from the compacted manifests and commits them, after
+which the incremental chain continues on its own. The procedure commits a snapshot for this even
+when the manifests themselves need no merging.
 
 ### Schemas Table
 

--- a/docs/docs/concepts/system-tables.mdx
+++ b/docs/docs/concepts/system-tables.mdx
@@ -70,6 +70,18 @@ logical rows to a table with one [dedicated BLOB column](../multimodal-table/blo
 adds `N` records to the regular data files and `N` records to the BLOB files, so
 `delta_record_count` increases by `2 * N`. Use `COUNT(*)` when you need the logical row count.
 
+`num_files` and `total_file_size_in_bytes` describe the live data files of the snapshot. They are
+folded incrementally at commit time from the files the commit adds and removes, so reading them
+costs nothing extra, and they cover data files only: changelog files, index files and deletion
+vectors are not counted.
+
+Both columns are nullable, and `NULL` means unknown rather than zero. It appears for snapshots
+written before these columns existed, and for commits that could not derive the values from the
+previous snapshot, such as metadata repair operations that replace the manifest layout wholesale.
+Once a snapshot reports unknown, the snapshots committed after it report unknown as well, until the
+values are recomputed. Fall back to scanning the manifests when you read `NULL`; never read it as
+zero.
+
 ### Schemas Table
 
 You can query the historical schemas of the table through schemas table.

--- a/paimon-api/src/main/java/org/apache/paimon/Snapshot.java
+++ b/paimon-api/src/main/java/org/apache/paimon/Snapshot.java
@@ -73,6 +73,8 @@ public class Snapshot implements Serializable {
     protected static final String FIELD_PROPERTIES = "properties";
     protected static final String FIELD_NEXT_ROW_ID = "nextRowId";
     protected static final String FIELD_OPERATION = "operation";
+    protected static final String FIELD_NUM_FILES = "numFiles";
+    protected static final String FIELD_TOTAL_FILE_SIZE_IN_BYTES = "totalFileSizeInBytes";
 
     // version of snapshot
     @JsonProperty(FIELD_VERSION)
@@ -203,6 +205,19 @@ public class Snapshot implements Serializable {
     @Nullable
     protected final Operation operation;
 
+    // number of live data files in this snapshot, null when it could not be derived incrementally
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    @JsonProperty(FIELD_NUM_FILES)
+    @Nullable
+    protected final Long numFiles;
+
+    // total size of live data files in this snapshot, null when it could not be derived
+    // incrementally
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    @JsonProperty(FIELD_TOTAL_FILE_SIZE_IN_BYTES)
+    @Nullable
+    protected final Long totalFileSizeInBytes;
+
     public Snapshot(
             long id,
             long schemaId,
@@ -227,6 +242,58 @@ public class Snapshot implements Serializable {
             @Nullable Long nextRowId,
             @Nullable Operation operation) {
         this(
+                id,
+                schemaId,
+                baseManifestList,
+                baseManifestListSize,
+                deltaManifestList,
+                deltaManifestListSize,
+                changelogManifestList,
+                changelogManifestListSize,
+                indexManifest,
+                commitUser,
+                writerVersion,
+                commitIdentifier,
+                commitKind,
+                timeMillis,
+                totalRecordCount,
+                deltaRecordCount,
+                changelogRecordCount,
+                watermark,
+                statistics,
+                properties,
+                nextRowId,
+                operation,
+                null,
+                null);
+    }
+
+    public Snapshot(
+            long id,
+            long schemaId,
+            String baseManifestList,
+            @Nullable Long baseManifestListSize,
+            String deltaManifestList,
+            @Nullable Long deltaManifestListSize,
+            @Nullable String changelogManifestList,
+            @Nullable Long changelogManifestListSize,
+            @Nullable String indexManifest,
+            String commitUser,
+            @Nullable String writerVersion,
+            long commitIdentifier,
+            CommitKind commitKind,
+            long timeMillis,
+            long totalRecordCount,
+            long deltaRecordCount,
+            @Nullable Long changelogRecordCount,
+            @Nullable Long watermark,
+            @Nullable String statistics,
+            @Nullable Map<String, String> properties,
+            @Nullable Long nextRowId,
+            @Nullable Operation operation,
+            @Nullable Long numFiles,
+            @Nullable Long totalFileSizeInBytes) {
+        this(
                 CURRENT_VERSION,
                 UUID.randomUUID().toString(),
                 id,
@@ -250,7 +317,67 @@ public class Snapshot implements Serializable {
                 statistics,
                 properties,
                 nextRowId,
-                operation);
+                operation,
+                numFiles,
+                totalFileSizeInBytes);
+    }
+
+    /**
+     * Kept so that callers written before {@link #numFiles()} and {@link #totalFileSizeInBytes()}
+     * existed keep compiling; both are left unknown.
+     */
+    public Snapshot(
+            int version,
+            @Nullable String uuid,
+            long id,
+            long schemaId,
+            String baseManifestList,
+            @Nullable Long baseManifestListSize,
+            String deltaManifestList,
+            @Nullable Long deltaManifestListSize,
+            @Nullable String changelogManifestList,
+            @Nullable Long changelogManifestListSize,
+            @Nullable String indexManifest,
+            String commitUser,
+            @Nullable String writerVersion,
+            long commitIdentifier,
+            CommitKind commitKind,
+            long timeMillis,
+            long totalRecordCount,
+            long deltaRecordCount,
+            @Nullable Long changelogRecordCount,
+            @Nullable Long watermark,
+            @Nullable String statistics,
+            @Nullable Map<String, String> properties,
+            @Nullable Long nextRowId,
+            @Nullable Operation operation) {
+        this(
+                version,
+                uuid,
+                id,
+                schemaId,
+                baseManifestList,
+                baseManifestListSize,
+                deltaManifestList,
+                deltaManifestListSize,
+                changelogManifestList,
+                changelogManifestListSize,
+                indexManifest,
+                commitUser,
+                writerVersion,
+                commitIdentifier,
+                commitKind,
+                timeMillis,
+                totalRecordCount,
+                deltaRecordCount,
+                changelogRecordCount,
+                watermark,
+                statistics,
+                properties,
+                nextRowId,
+                operation,
+                null,
+                null);
     }
 
     @JsonCreator
@@ -279,7 +406,9 @@ public class Snapshot implements Serializable {
             @JsonProperty(FIELD_STATISTICS) @Nullable String statistics,
             @JsonProperty(FIELD_PROPERTIES) @Nullable Map<String, String> properties,
             @JsonProperty(FIELD_NEXT_ROW_ID) @Nullable Long nextRowId,
-            @JsonProperty(FIELD_OPERATION) @Nullable Operation operation) {
+            @JsonProperty(FIELD_OPERATION) @Nullable Operation operation,
+            @JsonProperty(FIELD_NUM_FILES) @Nullable Long numFiles,
+            @JsonProperty(FIELD_TOTAL_FILE_SIZE_IN_BYTES) @Nullable Long totalFileSizeInBytes) {
         this.version = version;
         this.uuid = uuid;
         this.id = id;
@@ -304,6 +433,8 @@ public class Snapshot implements Serializable {
         this.properties = properties;
         this.nextRowId = nextRowId;
         this.operation = operation;
+        this.numFiles = numFiles;
+        this.totalFileSizeInBytes = totalFileSizeInBytes;
     }
 
     @JsonGetter(FIELD_VERSION)
@@ -439,6 +570,29 @@ public class Snapshot implements Serializable {
         return operation;
     }
 
+    /**
+     * Number of live data files in this snapshot, maintained incrementally at commit time.
+     *
+     * <p>Returns null when the value is unknown: snapshots written before this field existed, and
+     * commits whose previous snapshot had no value to derive from. Callers must fall back to
+     * scanning manifests instead of treating null as zero.
+     */
+    @JsonGetter(FIELD_NUM_FILES)
+    @Nullable
+    public Long numFiles() {
+        return numFiles;
+    }
+
+    /**
+     * Total size in bytes of the live data files in this snapshot, maintained incrementally at
+     * commit time. Null has the same meaning as in {@link #numFiles()}.
+     */
+    @JsonGetter(FIELD_TOTAL_FILE_SIZE_IN_BYTES)
+    @Nullable
+    public Long totalFileSizeInBytes() {
+        return totalFileSizeInBytes;
+    }
+
     public String toJson() {
         return JsonSerdeUtil.toJson(this);
     }
@@ -469,7 +623,9 @@ public class Snapshot implements Serializable {
                 statistics,
                 properties,
                 nextRowId,
-                operation);
+                operation,
+                numFiles,
+                totalFileSizeInBytes);
     }
 
     @Override
@@ -504,7 +660,9 @@ public class Snapshot implements Serializable {
                 && Objects.equals(statistics, that.statistics)
                 && Objects.equals(properties, that.properties)
                 && Objects.equals(nextRowId, that.nextRowId)
-                && operation == that.operation;
+                && operation == that.operation
+                && Objects.equals(numFiles, that.numFiles)
+                && Objects.equals(totalFileSizeInBytes, that.totalFileSizeInBytes);
     }
 
     /** Type of changes in this snapshot. */

--- a/paimon-core/src/main/java/org/apache/paimon/Changelog.java
+++ b/paimon-core/src/main/java/org/apache/paimon/Changelog.java
@@ -66,7 +66,9 @@ public class Changelog extends Snapshot {
                 snapshot.statistics(),
                 snapshot.properties,
                 snapshot.nextRowId,
-                snapshot.operation);
+                snapshot.operation,
+                snapshot.numFiles,
+                snapshot.totalFileSizeInBytes);
     }
 
     @JsonCreator
@@ -95,7 +97,9 @@ public class Changelog extends Snapshot {
             @JsonProperty(FIELD_STATISTICS) @Nullable String statistics,
             @JsonProperty(FIELD_PROPERTIES) Map<String, String> properties,
             @JsonProperty(FIELD_NEXT_ROW_ID) @Nullable Long nextRowId,
-            @JsonProperty(FIELD_OPERATION) @Nullable Operation operation) {
+            @JsonProperty(FIELD_OPERATION) @Nullable Operation operation,
+            @JsonProperty(FIELD_NUM_FILES) @Nullable Long numFiles,
+            @JsonProperty(FIELD_TOTAL_FILE_SIZE_IN_BYTES) @Nullable Long totalFileSizeInBytes) {
         super(
                 version,
                 uuid,
@@ -120,7 +124,9 @@ public class Changelog extends Snapshot {
                 statistics,
                 properties,
                 nextRowId,
-                operation);
+                operation,
+                numFiles,
+                totalFileSizeInBytes);
     }
 
     public static Changelog fromJson(String json) {

--- a/paimon-core/src/main/java/org/apache/paimon/operation/FileStoreCommitImpl.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/FileStoreCommitImpl.java
@@ -1412,6 +1412,17 @@ public class FileStoreCommitImpl implements FileStoreCommit {
             Pair<String, Long> deltaManifestList,
             @Nullable String indexManifest,
             @Nullable Long nextRowId) {
+        // The manifest layout is replaced wholesale and callers may drop files along with it, so
+        // the file statistics cannot be carried over from the previous snapshot. Recompute them
+        // from the manifests actually being committed: this reads every entry, which is acceptable
+        // because this path only serves metadata repair, never regular commits.
+        List<ManifestFileMeta> committedManifests = new ArrayList<>();
+        committedManifests.addAll(
+                manifestList.read(baseManifestList.getLeft(), baseManifestList.getRight()));
+        committedManifests.addAll(
+                manifestList.read(deltaManifestList.getLeft(), deltaManifestList.getRight()));
+        FileStats fileStats = computeFileStats(committedManifests);
+
         Snapshot newSnapshot =
                 new Snapshot(
                         latest.id() + 1,
@@ -1437,10 +1448,8 @@ public class FileStoreCommitImpl implements FileStoreCommit {
                         latest.properties(),
                         nextRowId,
                         null,
-                        // the manifest layout is rewritten wholesale here, so the incremental file
-                        // statistics cannot be carried over; leave them unknown
-                        null,
-                        null);
+                        fileStats.numFiles,
+                        fileStats.totalFileSizeInBytes);
 
         return commitSnapshotImpl(latest, newSnapshot, emptyList());
     }
@@ -1646,13 +1655,28 @@ public class FileStoreCommitImpl implements FileStoreCommit {
                         manifestCompactionOptions(options, mergeBeforeManifests, partitionType),
                         ioManager);
 
-        if (new HashSet<>(mergeBeforeManifests).equals(new HashSet<>(mergeAfterManifests))) {
+        boolean statsUnknown =
+                latestSnapshot.numFiles() == null || latestSnapshot.totalFileSizeInBytes() == null;
+        if (new HashSet<>(mergeBeforeManifests).equals(new HashSet<>(mergeAfterManifests))
+                && !statsUnknown) {
             // no need to commit this snapshot, because no compact were happened
             return true;
         }
 
         Pair<String, Long> baseManifestList = manifestList.write(mergeAfterManifests);
         Pair<String, Long> deltaManifestList = manifestList.write(emptyList());
+
+        // Manifest compaction only rewrites metadata, so known statistics carry over untouched.
+        // When they are unknown - a table whose snapshots predate the fields, or one that went
+        // through a metadata repair - this is the place to seed them: the manifest set has just
+        // been rewritten, and the compacted form is the cheapest one to fold.
+        Long numFiles = latestSnapshot.numFiles();
+        Long totalFileSizeInBytes = latestSnapshot.totalFileSizeInBytes();
+        if (statsUnknown) {
+            FileStats fileStats = computeFileStats(mergeAfterManifests);
+            numFiles = fileStats.numFiles;
+            totalFileSizeInBytes = fileStats.totalFileSizeInBytes;
+        }
 
         // prepare snapshot file
         Snapshot newSnapshot =
@@ -1679,9 +1703,8 @@ public class FileStoreCommitImpl implements FileStoreCommit {
                         latestSnapshot.properties(),
                         latestSnapshot.nextRowId(),
                         null,
-                        // manifest compaction only rewrites metadata, the data files are untouched
-                        latestSnapshot.numFiles(),
-                        latestSnapshot.totalFileSizeInBytes());
+                        numFiles,
+                        totalFileSizeInBytes);
 
         return commitSnapshotImpl(latestSnapshot, newSnapshot, emptyList());
     }
@@ -1698,6 +1721,39 @@ public class FileStoreCommitImpl implements FileStoreCommit {
                     CoreOptions.MANIFEST_FULL_COMPACTION_FILE_SIZE, MemorySize.ofBytes(1));
         }
         return new CoreOptions(compactOptions);
+    }
+
+    /**
+     * Folds the live data file count and total size out of a manifest set by reading every entry.
+     *
+     * <p>This is the expensive way to obtain what {@link Snapshot#numFiles()} and {@link
+     * Snapshot#totalFileSizeInBytes()} normally maintain incrementally, so it belongs to
+     * maintenance operations only and must never run on the regular commit path.
+     */
+    private FileStats computeFileStats(List<ManifestFileMeta> manifests) {
+        long numFiles = 0L;
+        long totalFileSizeInBytes = 0L;
+        for (ManifestFileMeta manifest : manifests) {
+            for (ManifestEntry entry :
+                    manifestFile.read(manifest.fileName(), manifest.fileSize())) {
+                long sign = entry.kind() == FileKind.ADD ? 1L : -1L;
+                numFiles += sign;
+                totalFileSizeInBytes += sign * entry.file().fileSize();
+            }
+        }
+        return new FileStats(numFiles, totalFileSizeInBytes);
+    }
+
+    /** Live data file count and total size of a snapshot. */
+    private static class FileStats {
+
+        private final long numFiles;
+        private final long totalFileSizeInBytes;
+
+        private FileStats(long numFiles, long totalFileSizeInBytes) {
+            this.numFiles = numFiles;
+            this.totalFileSizeInBytes = totalFileSizeInBytes;
+        }
     }
 
     private boolean commitSnapshotImpl(

--- a/paimon-core/src/main/java/org/apache/paimon/operation/FileStoreCommitImpl.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/FileStoreCommitImpl.java
@@ -1107,9 +1107,16 @@ public class FileStoreCommitImpl implements FileStoreCommit {
         long nextRowIdStart = firstRowIdStart;
         try {
             long previousTotalRecordCount = 0L;
+            // A brand new table starts from an empty file set. An existing snapshot that carries no
+            // file statistics (written before the fields existed, or by a commit that could not
+            // derive them) breaks the chain, and the new snapshot stays unknown as well.
+            Long previousNumFiles = 0L;
+            Long previousTotalFileSizeInBytes = 0L;
             Long currentWatermark = watermark;
             if (latestSnapshot != null) {
                 previousTotalRecordCount = latestSnapshot.totalRecordCount();
+                previousNumFiles = latestSnapshot.numFiles();
+                previousTotalFileSizeInBytes = latestSnapshot.totalFileSizeInBytes();
                 // read all previous manifest files
                 mergeBeforeManifests = manifestList.readDataManifests(latestSnapshot);
                 Long latestWatermark = latestSnapshot.watermark();
@@ -1127,6 +1134,9 @@ public class FileStoreCommitImpl implements FileStoreCommit {
                 mergeBeforeManifests = emptyList();
                 mergeAfterManifests = emptyList();
                 oldIndexManifest = null;
+                // the previous file set is dropped entirely, so the counters restart from zero
+                previousNumFiles = 0L;
+                previousTotalFileSizeInBytes = 0L;
             } else {
                 ManifestMergeReuse manifestMergeReuse =
                         tryReuseManifestMergeResult(retryResult, mergeBeforeManifests);
@@ -1174,6 +1184,21 @@ public class FileStoreCommitImpl implements FileStoreCommit {
 
             // write new delta files into manifest files
             deltaPartitionEntries = new ArrayList<>(PartitionEntry.merge(deltaFiles));
+
+            // reuse the per-partition fold above: its counts are already signed by file kind, so
+            // summing them gives the table level delta without walking deltaFiles again
+            long deltaNumFiles = 0L;
+            long deltaFileSizeInBytes = 0L;
+            for (PartitionEntry entry : deltaPartitionEntries) {
+                deltaNumFiles += entry.fileCount();
+                deltaFileSizeInBytes += entry.fileSizeInBytes();
+            }
+            Long numFiles = previousNumFiles == null ? null : previousNumFiles + deltaNumFiles;
+            Long totalFileSizeInBytes =
+                    previousTotalFileSizeInBytes == null
+                            ? null
+                            : previousTotalFileSizeInBytes + deltaFileSizeInBytes;
+
             deltaManifestList = manifestList.write(manifestFile.write(deltaFiles));
 
             // write changelog into manifest files
@@ -1241,7 +1266,9 @@ public class FileStoreCommitImpl implements FileStoreCommit {
                             // if empty properties, just set to null
                             properties.isEmpty() ? null : properties,
                             nextRowIdStart,
-                            operation);
+                            operation,
+                            numFiles,
+                            totalFileSizeInBytes);
         } catch (Throwable e) {
             // fails when preparing for commit, we should clean up
             commitCleaner.cleanUpReuseTmpManifests(
@@ -1409,6 +1436,10 @@ public class FileStoreCommitImpl implements FileStoreCommit {
                         // if empty properties, just set to null
                         latest.properties(),
                         nextRowId,
+                        null,
+                        // the manifest layout is rewritten wholesale here, so the incremental file
+                        // statistics cannot be carried over; leave them unknown
+                        null,
                         null);
 
         return commitSnapshotImpl(latest, newSnapshot, emptyList());
@@ -1495,7 +1526,10 @@ public class FileStoreCommitImpl implements FileStoreCommit {
                         targetSnapshot.statistics(),
                         targetSnapshot.properties(),
                         nextRowId,
-                        null);
+                        null,
+                        // the live file set is restored to the target snapshot's
+                        targetSnapshot.numFiles(),
+                        targetSnapshot.totalFileSizeInBytes());
 
         // The rollback is an overwrite from the previous latest to the target, so the base files,
         // delta files and index changes describe the transition the callbacks need. These are
@@ -1644,7 +1678,10 @@ public class FileStoreCommitImpl implements FileStoreCommit {
                         latestSnapshot.statistics(),
                         latestSnapshot.properties(),
                         latestSnapshot.nextRowId(),
-                        null);
+                        null,
+                        // manifest compaction only rewrites metadata, the data files are untouched
+                        latestSnapshot.numFiles(),
+                        latestSnapshot.totalFileSizeInBytes());
 
         return commitSnapshotImpl(latestSnapshot, newSnapshot, emptyList());
     }

--- a/paimon-core/src/main/java/org/apache/paimon/table/system/SnapshotsTable.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/system/SnapshotsTable.java
@@ -111,7 +111,9 @@ public class SnapshotsTable implements ReadonlyTable {
                             new DataField(13, "next_row_id", new BigIntType(true)),
                             new DataField(14, "operation", SerializationUtils.newStringType(true)),
                             new DataField(
-                                    15, "writer_version", SerializationUtils.newStringType(true))));
+                                    15, "writer_version", SerializationUtils.newStringType(true)),
+                            new DataField(16, "num_files", new BigIntType(true)),
+                            new DataField(17, "total_file_size_in_bytes", new BigIntType(true))));
 
     private final FileIO fileIO;
     private final Path location;
@@ -346,7 +348,9 @@ public class SnapshotsTable implements ReadonlyTable {
                     snapshot.operation() == null
                             ? null
                             : BinaryString.fromString(snapshot.operation().toString()),
-                    BinaryString.fromString(snapshot.writerVersion()));
+                    BinaryString.fromString(snapshot.writerVersion()),
+                    snapshot.numFiles(),
+                    snapshot.totalFileSizeInBytes());
         }
     }
 }

--- a/paimon-core/src/main/java/org/apache/paimon/tag/Tag.java
+++ b/paimon-core/src/main/java/org/apache/paimon/tag/Tag.java
@@ -83,6 +83,8 @@ public class Tag extends Snapshot {
             @JsonProperty(FIELD_PROPERTIES) Map<String, String> properties,
             @JsonProperty(FIELD_NEXT_ROW_ID) @Nullable Long nextRowId,
             @JsonProperty(FIELD_OPERATION) @Nullable Operation operation,
+            @JsonProperty(FIELD_NUM_FILES) @Nullable Long numFiles,
+            @JsonProperty(FIELD_TOTAL_FILE_SIZE_IN_BYTES) @Nullable Long totalFileSizeInBytes,
             @JsonProperty(FIELD_TAG_CREATE_TIME) @Nullable LocalDateTime tagCreateTime,
             @JsonProperty(FIELD_TAG_TIME_RETAINED) @Nullable Duration tagTimeRetained) {
         super(
@@ -109,7 +111,9 @@ public class Tag extends Snapshot {
                 statistics,
                 properties,
                 nextRowId,
-                operation);
+                operation,
+                numFiles,
+                totalFileSizeInBytes);
         this.tagCreateTime = tagCreateTime;
         this.tagTimeRetained = tagTimeRetained;
     }
@@ -151,6 +155,8 @@ public class Tag extends Snapshot {
                 snapshot.properties(),
                 snapshot.nextRowId(),
                 snapshot.operation(),
+                snapshot.numFiles(),
+                snapshot.totalFileSizeInBytes(),
                 tagCreateTime,
                 tagTimeRetained);
     }
@@ -180,7 +186,9 @@ public class Tag extends Snapshot {
                 statistics,
                 properties,
                 nextRowId,
-                operation);
+                operation,
+                numFiles,
+                totalFileSizeInBytes);
     }
 
     @Override

--- a/paimon-core/src/test/java/org/apache/paimon/table/SnapshotFileStatsTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/table/SnapshotFileStatsTest.java
@@ -181,8 +181,12 @@ public class SnapshotFileStatsTest extends TableTestBase {
         assertThat(readRows(table))
                 .containsExactlyInAnyOrder("1:a", "2:b", "10:n0", "11:n1", "12:n2");
 
-        // a full scan still answers the question the statistics would have answered
+        // a full scan still answers the question the statistics would have answered, and
+        // compacting the manifests is what brings the counters back
         assertThat(scannedNumFiles(table)).isGreaterThan(0L);
+        compactManifests(table);
+        table = reload("legacy_write");
+        assertStatsMatchManifests(table);
     }
 
     @Test
@@ -309,19 +313,70 @@ public class SnapshotFileStatsTest extends TableTestBase {
     }
 
     @Test
-    public void testManifestCompactionOnLegacyTableStaysUnknown() throws Exception {
+    public void testManifestCompactionSeedsLegacyTable() throws Exception {
         FileStoreTable table = createTable("manifest_compact_legacy", false);
         for (int i = 0; i < 6; i++) {
             write(table, row(i, "v" + i));
         }
+        long expectedFiles = scannedNumFiles(table);
 
         table = degradeToLegacy("manifest_compact_legacy");
+        assertThat(latest(table).numFiles()).isNull();
+
+        // manifest compaction rewrites the whole manifest set anyway, so it seeds the counters
         compactManifests(table);
         table = reload("manifest_compact_legacy");
 
-        assertThat(latest(table).numFiles()).isNull();
+        assertThat(latest(table).numFiles()).isEqualTo(expectedFiles);
+        assertStatsMatchManifests(table);
         assertThat(readRows(table))
                 .containsExactlyInAnyOrder("0:v0", "1:v1", "2:v2", "3:v3", "4:v4", "5:v5");
+
+        // once seeded, the incremental chain picks up again
+        write(table, row(9, "z"));
+        assertStatsMatchManifests(table);
+    }
+
+    @Test
+    public void testManifestCompactionSeedsEvenWhenNothingToMerge() throws Exception {
+        // a legacy table small enough that the manifests need no merging must still get seeded,
+        // otherwise compact_manifest would be an unreliable way to recover the counters
+        FileStoreTable table = createTable("manifest_compact_noop", false);
+        write(table, row(1, "a"));
+        long expectedFiles = scannedNumFiles(table);
+
+        table = degradeToLegacy("manifest_compact_noop");
+        long snapshotsBefore = latest(table).id();
+
+        compactManifests(table);
+        table = reload("manifest_compact_noop");
+
+        assertThat(latest(table).id()).isGreaterThan(snapshotsBefore);
+        assertThat(latest(table).numFiles()).isEqualTo(expectedFiles);
+        assertStatsMatchManifests(table);
+
+        // and a second run is a no-op now that the counters are known
+        long seededId = latest(table).id();
+        compactManifests(table);
+        table = reload("manifest_compact_noop");
+        assertThat(latest(table).id()).isEqualTo(seededId);
+    }
+
+    @Test
+    public void testManifestCompactionSeedsLegacyPrimaryKeyTable() throws Exception {
+        FileStoreTable table = createTable("manifest_compact_legacy_pk", true);
+        for (int i = 0; i < 8; i++) {
+            write(table, row(i % 3, "v" + i));
+        }
+        long expectedFiles = scannedNumFiles(table);
+
+        table = degradeToLegacy("manifest_compact_legacy_pk");
+        compactManifests(table);
+        table = reload("manifest_compact_legacy_pk");
+
+        // deletion entries left behind by compaction must cancel their adds, not be counted
+        assertThat(latest(table).numFiles()).isEqualTo(expectedFiles);
+        assertStatsMatchManifests(table);
     }
 
     @Test
@@ -353,26 +408,25 @@ public class SnapshotFileStatsTest extends TableTestBase {
     }
 
     @Test
-    public void testReplaceManifestListReportsUnknown() throws Exception {
+    public void testReplaceManifestListRecomputes() throws Exception {
         FileStoreTable table = createTable("replace_manifests", false);
         write(table, row(1, "a"), row(2, "b"));
         write(table, row(3, "c"));
         List<String> before = readRows(table);
-        assertThat(latest(table).numFiles()).isNotNull();
+        Long filesBefore = latest(table).numFiles();
+        assertThat(filesBefore).isNotNull();
 
         replaceManifestListWithSameLayout(table);
         table = reload("replace_manifests");
 
-        // this path swaps the manifest layout wholesale, so the counters cannot be carried over.
-        // Reporting unknown is the only honest answer; reporting the previous numbers would be
-        // wrong for callers such as RemoveUnexistingManifestsAction, which drops files.
-        assertThat(latest(table).numFiles()).isNull();
-        assertThat(latest(table).totalFileSizeInBytes()).isNull();
+        // the layout was replaced with an equivalent one, so recomputing lands on the same numbers
+        assertStatsMatchManifests(table);
+        assertThat(latest(table).numFiles()).isEqualTo(filesBefore);
 
-        // the data itself is untouched, and the table keeps taking writes
+        // the data itself is untouched, and the chain continues from the recomputed values
         assertThat(readRows(table)).containsExactlyInAnyOrderElementsOf(before);
         write(table, row(4, "d"));
-        assertThat(latest(table).numFiles()).isNull();
+        assertStatsMatchManifests(table);
         assertThat(readRows(table)).containsExactlyInAnyOrder("1:a", "2:b", "3:c", "4:d");
     }
 
@@ -413,16 +467,16 @@ public class SnapshotFileStatsTest extends TableTestBase {
         }
         table = reload("replace_manifests_drop");
 
-        // the live file set really did shrink, so carrying the previous counters over would have
-        // published a number that is simply wrong; unknown is the correct answer
+        // the live file set really did shrink; carrying the previous counters over would have
+        // published a number that no longer matches it, so the values are recomputed instead
         long filesAfter = scannedNumFiles(table);
         assertThat(filesAfter).isLessThan(filesBefore);
-        assertThat(latest(table).numFiles()).isNull();
-        assertThat(latest(table).totalFileSizeInBytes()).isNull();
+        assertThat(latest(table).numFiles()).isEqualTo(filesAfter);
+        assertStatsMatchManifests(table);
 
-        // and the table stays usable afterwards
+        // and the table stays usable afterwards, with the chain continuing from the new values
         write(table, row(4, "d"));
-        assertThat(latest(table).numFiles()).isNull();
+        assertStatsMatchManifests(table);
         assertThat(readRows(table)).contains("4:d");
     }
 

--- a/paimon-core/src/test/java/org/apache/paimon/table/SnapshotFileStatsTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/table/SnapshotFileStatsTest.java
@@ -1,0 +1,627 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.table;
+
+import org.apache.paimon.CoreOptions;
+import org.apache.paimon.Snapshot;
+import org.apache.paimon.catalog.Identifier;
+import org.apache.paimon.data.BinaryString;
+import org.apache.paimon.data.GenericRow;
+import org.apache.paimon.data.InternalRow;
+import org.apache.paimon.fs.Path;
+import org.apache.paimon.manifest.ManifestFileMeta;
+import org.apache.paimon.manifest.ManifestList;
+import org.apache.paimon.manifest.PartitionEntry;
+import org.apache.paimon.operation.FileStoreCommitImpl;
+import org.apache.paimon.options.ExpireConfig;
+import org.apache.paimon.schema.Schema;
+import org.apache.paimon.table.sink.BatchTableCommit;
+import org.apache.paimon.table.sink.BatchTableWrite;
+import org.apache.paimon.table.sink.BatchWriteBuilder;
+import org.apache.paimon.table.sink.TableCommitImpl;
+import org.apache.paimon.tag.Tag;
+import org.apache.paimon.types.DataTypes;
+import org.apache.paimon.utils.Pair;
+import org.apache.paimon.utils.SnapshotManager;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+
+/**
+ * Tests for {@link Snapshot#numFiles()} and {@link Snapshot#totalFileSizeInBytes()}, which are
+ * folded incrementally at commit time.
+ *
+ * <p>Two things are checked: the values agree with a full manifest scan whenever they are present,
+ * and tables whose snapshots predate the fields keep reading and writing exactly as before, with
+ * the values reported as unknown rather than as a wrong number.
+ */
+public class SnapshotFileStatsTest extends TableTestBase {
+
+    private static final String commitUser = "test-commit-user";
+
+    // ------------------------------------------------------------------------------------------
+    // the statistics agree with a full manifest scan
+    // ------------------------------------------------------------------------------------------
+
+    @Test
+    public void testAppendTable() throws Exception {
+        FileStoreTable table = createTable("append_table", false);
+
+        write(table, row(1, "a"), row(2, "b"));
+        assertStatsMatchManifests(table);
+
+        write(table, row(3, "c"));
+        assertStatsMatchManifests(table);
+
+        write(table, row(4, "d"), row(5, "e"), row(6, "f"));
+        assertStatsMatchManifests(table);
+
+        assertThat(latest(table).numFiles()).isGreaterThan(0L);
+    }
+
+    @Test
+    public void testPrimaryKeyTableAcrossCompaction() throws Exception {
+        FileStoreTable table = createTable("pk_table", true);
+
+        // enough commits to trigger compaction, which deletes files as well as adding them
+        for (int i = 0; i < 12; i++) {
+            write(table, row(i % 3, "v" + i));
+            assertStatsMatchManifests(table);
+        }
+
+        // guard the premise: without a COMPACT snapshot this test only covers appends
+        assertThat(commitKindCount(table, Snapshot.CommitKind.COMPACT)).isGreaterThan(0);
+    }
+
+    @Test
+    public void testOverwrite() throws Exception {
+        FileStoreTable table = createTable("overwrite_table", false);
+
+        write(table, row(1, "a"), row(2, "b"));
+        assertThat(latest(table).numFiles()).isGreaterThan(0L);
+
+        overwrite(table, row(9, "z"));
+        assertStatsMatchManifests(table);
+    }
+
+    @Test
+    public void testStatsSurviveTagAndRollback() throws Exception {
+        FileStoreTable table = createTable("tag_rollback", false);
+
+        write(table, row(1, "a"));
+        long targetId = latest(table).id();
+        Long targetNumFiles = latest(table).numFiles();
+        table.createTag("t1");
+
+        write(table, row(2, "b"));
+        assertStatsMatchManifests(table);
+
+        // a tag carries the statistics of the snapshot it was taken from
+        Tag tag = table.tagManager().get("t1").orElseThrow(IllegalStateException::new);
+        assertThat(tag.numFiles()).isEqualTo(targetNumFiles);
+
+        // rolling back restores the target snapshot's file set, so its statistics come along
+        table.rollbackTo(targetId);
+        table = reload("tag_rollback");
+        assertStatsMatchManifests(table);
+    }
+
+    // ------------------------------------------------------------------------------------------
+    // tables written before these fields existed
+    // ------------------------------------------------------------------------------------------
+
+    @Test
+    public void testLegacySnapshotOmitsTheFieldsEntirely() throws Exception {
+        FileStoreTable table = createTable("legacy_json", false);
+        write(table, row(1, "a"));
+
+        String json = legacyJsonOf(latest(table));
+        assertThat(json).doesNotContain("numFiles").doesNotContain("totalFileSizeInBytes");
+
+        Snapshot parsed = Snapshot.fromJson(json);
+        assertThat(parsed.numFiles()).isNull();
+        assertThat(parsed.totalFileSizeInBytes()).isNull();
+    }
+
+    @Test
+    public void testReadLegacyTable() throws Exception {
+        FileStoreTable table = createTable("legacy_read", false);
+        write(table, row(1, "a"), row(2, "b"));
+        write(table, row(3, "c"));
+        List<String> before = readRows(table);
+
+        table = degradeToLegacy("legacy_read");
+
+        assertThat(latest(table).numFiles()).isNull();
+        assertThat(latest(table).totalFileSizeInBytes()).isNull();
+        assertThat(readRows(table)).containsExactlyInAnyOrderElementsOf(before);
+    }
+
+    @Test
+    public void testWriteToLegacyTableStaysUnknownAndNeverWrong() throws Exception {
+        FileStoreTable table = createTable("legacy_write", false);
+        write(table, row(1, "a"), row(2, "b"));
+
+        table = degradeToLegacy("legacy_write");
+
+        // writing on top of a snapshot without statistics must succeed, and must report unknown
+        // rather than a count derived from a zero baseline
+        for (int i = 0; i < 3; i++) {
+            write(table, row(10 + i, "n" + i));
+            Snapshot snapshot = latest(table);
+            assertThat(snapshot.numFiles())
+                    .as("snapshot %s must stay unknown once the chain is broken", snapshot.id())
+                    .isNull();
+            assertThat(snapshot.totalFileSizeInBytes()).isNull();
+        }
+
+        assertThat(readRows(table))
+                .containsExactlyInAnyOrder("1:a", "2:b", "10:n0", "11:n1", "12:n2");
+
+        // a full scan still answers the question the statistics would have answered
+        assertThat(scannedNumFiles(table)).isGreaterThan(0L);
+    }
+
+    @Test
+    public void testLegacyPrimaryKeyTableCompactsAndReadsCorrectly() throws Exception {
+        FileStoreTable table = createTable("legacy_pk", true);
+        for (int i = 0; i < 4; i++) {
+            write(table, row(i % 2, "v" + i));
+        }
+
+        table = degradeToLegacy("legacy_pk");
+
+        for (int i = 4; i < 16; i++) {
+            write(table, row(i % 2, "v" + i));
+            assertThat(latest(table).numFiles()).isNull();
+        }
+
+        assertThat(commitKindCount(table, Snapshot.CommitKind.COMPACT)).isGreaterThan(0);
+        // the merge engine still resolves to the last value written per key
+        assertThat(readRows(table)).containsExactlyInAnyOrder("0:v14", "1:v15");
+    }
+
+    @Test
+    public void testOverwriteLegacyTable() throws Exception {
+        FileStoreTable table = createTable("legacy_overwrite", false);
+        write(table, row(1, "a"), row(2, "b"));
+
+        table = degradeToLegacy("legacy_overwrite");
+
+        overwrite(table, row(9, "z"));
+        assertThat(latest(table).numFiles()).isNull();
+        assertThat(readRows(table)).containsExactly("9:z");
+    }
+
+    @Test
+    public void testTagAndRollbackOnLegacyTable() throws Exception {
+        FileStoreTable table = createTable("legacy_tag", false);
+        write(table, row(1, "a"));
+        write(table, row(2, "b"));
+
+        table = degradeToLegacy("legacy_tag");
+        long targetId = table.snapshotManager().earliestSnapshotId();
+
+        assertThatCode(() -> reload("legacy_tag").createTag("legacy_t1"))
+                .doesNotThrowAnyException();
+        Tag tag = table.tagManager().get("legacy_t1").orElseThrow(IllegalStateException::new);
+        assertThat(tag.numFiles()).isNull();
+        assertThat(tag.totalFileSizeInBytes()).isNull();
+
+        table.rollbackTo(targetId);
+        table = reload("legacy_tag");
+        assertThat(latest(table).numFiles()).isNull();
+        assertThat(readRows(table)).containsExactly("1:a");
+    }
+
+    @Test
+    public void testSnapshotsSystemTableOnLegacyTable() throws Exception {
+        FileStoreTable table = createTable("legacy_sys", false);
+        write(table, row(1, "a"));
+        write(table, row(2, "b"));
+
+        // a table that still carries the statistics reports them in the two new columns
+        Table systemTable = catalog.getTable(identifier("legacy_sys$snapshots"));
+        List<InternalRow> rows = read(systemTable);
+        assertThat(rows).hasSize(2);
+        for (InternalRow row : rows) {
+            assertThat(row.isNullAt(16)).isFalse();
+            assertThat(row.isNullAt(17)).isFalse();
+        }
+
+        degradeToLegacy("legacy_sys");
+
+        // after degrading, the same query must still work and report the columns as null
+        systemTable = catalog.getTable(identifier("legacy_sys$snapshots"));
+        rows = read(systemTable);
+        assertThat(rows).hasSize(2);
+        for (InternalRow row : rows) {
+            assertThat(row.isNullAt(16)).isTrue();
+            assertThat(row.isNullAt(17)).isTrue();
+        }
+    }
+
+    @Test
+    public void testMixedLegacyAndCurrentSnapshotsAreReadable() throws Exception {
+        FileStoreTable table = createTable("legacy_mixed", false);
+        write(table, row(1, "a"));
+        write(table, row(2, "b"));
+
+        // degrade only the first snapshot, as an upgraded table looks: old snapshots without the
+        // fields still in the retained history, newer ones with them
+        degradeSnapshot("legacy_mixed", table.snapshotManager().earliestSnapshotId());
+        table = reload("legacy_mixed");
+
+        SnapshotManager manager = table.snapshotManager();
+        assertThat(manager.snapshot(manager.earliestSnapshotId()).numFiles()).isNull();
+        assertThat(manager.snapshot(manager.latestSnapshotId()).numFiles()).isNotNull();
+
+        // time travel into the degraded part of the history keeps working
+        assertThat(
+                        readRows(
+                                table.copy(
+                                        java.util.Collections.singletonMap(
+                                                CoreOptions.SCAN_SNAPSHOT_ID.key(),
+                                                String.valueOf(manager.earliestSnapshotId())))))
+                .containsExactly("1:a");
+        assertThat(readRows(table)).containsExactlyInAnyOrder("1:a", "2:b");
+    }
+
+    @Test
+    public void testManifestCompactionKeepsStats() throws Exception {
+        FileStoreTable table = createTable("manifest_compact", false);
+        for (int i = 0; i < 6; i++) {
+            write(table, row(i, "v" + i));
+        }
+        Long filesBefore = latest(table).numFiles();
+        Long sizeBefore = latest(table).totalFileSizeInBytes();
+
+        compactManifests(table);
+        table = reload("manifest_compact");
+
+        // compacting manifests only rewrites metadata, so the data file statistics carry over
+        assertThat(latest(table).numFiles()).isEqualTo(filesBefore);
+        assertThat(latest(table).totalFileSizeInBytes()).isEqualTo(sizeBefore);
+        assertStatsMatchManifests(table);
+    }
+
+    @Test
+    public void testManifestCompactionOnLegacyTableStaysUnknown() throws Exception {
+        FileStoreTable table = createTable("manifest_compact_legacy", false);
+        for (int i = 0; i < 6; i++) {
+            write(table, row(i, "v" + i));
+        }
+
+        table = degradeToLegacy("manifest_compact_legacy");
+        compactManifests(table);
+        table = reload("manifest_compact_legacy");
+
+        assertThat(latest(table).numFiles()).isNull();
+        assertThat(readRows(table))
+                .containsExactlyInAnyOrder("0:v0", "1:v1", "2:v2", "3:v3", "4:v4", "5:v5");
+    }
+
+    @Test
+    public void testExpireSnapshotsOnLegacyTable() throws Exception {
+        FileStoreTable table = createTable("legacy_expire", false);
+        for (int i = 0; i < 5; i++) {
+            write(table, row(i, "v" + i));
+        }
+
+        table = degradeToLegacy("legacy_expire");
+        table.newExpireSnapshots()
+                .config(
+                        ExpireConfig.builder()
+                                .snapshotMaxDeletes(Integer.MAX_VALUE)
+                                .snapshotRetainMax(2)
+                                .snapshotRetainMin(1)
+                                .build())
+                .expire();
+        table = reload("legacy_expire");
+
+        assertThat(latest(table).numFiles()).isNull();
+        assertThat(readRows(table))
+                .containsExactlyInAnyOrder("0:v0", "1:v1", "2:v2", "3:v3", "4:v4");
+
+        // writing after expiration on a legacy table still works
+        write(table, row(9, "z"));
+        assertThat(latest(table).numFiles()).isNull();
+        assertThat(readRows(table)).hasSize(6);
+    }
+
+    @Test
+    public void testReplaceManifestListReportsUnknown() throws Exception {
+        FileStoreTable table = createTable("replace_manifests", false);
+        write(table, row(1, "a"), row(2, "b"));
+        write(table, row(3, "c"));
+        List<String> before = readRows(table);
+        assertThat(latest(table).numFiles()).isNotNull();
+
+        replaceManifestListWithSameLayout(table);
+        table = reload("replace_manifests");
+
+        // this path swaps the manifest layout wholesale, so the counters cannot be carried over.
+        // Reporting unknown is the only honest answer; reporting the previous numbers would be
+        // wrong for callers such as RemoveUnexistingManifestsAction, which drops files.
+        assertThat(latest(table).numFiles()).isNull();
+        assertThat(latest(table).totalFileSizeInBytes()).isNull();
+
+        // the data itself is untouched, and the table keeps taking writes
+        assertThat(readRows(table)).containsExactlyInAnyOrderElementsOf(before);
+        write(table, row(4, "d"));
+        assertThat(latest(table).numFiles()).isNull();
+        assertThat(readRows(table)).containsExactlyInAnyOrder("1:a", "2:b", "3:c", "4:d");
+    }
+
+    @Test
+    public void testReplaceManifestListThatDropsFiles() throws Exception {
+        // keep every commit in its own manifest so one of them can be dropped below
+        FileStoreTable table =
+                createTable(
+                        "replace_manifests_drop",
+                        false,
+                        CoreOptions.MANIFEST_MERGE_MIN_COUNT.key(),
+                        "100");
+        write(table, row(1, "a"));
+        write(table, row(2, "b"));
+        write(table, row(3, "c"));
+
+        long filesBefore = latest(table).numFiles();
+        ManifestList manifestList = table.store().manifestListFactory().create();
+        List<ManifestFileMeta> manifests = manifestList.readDataManifests(latest(table));
+        assertThat(manifests.size()).isGreaterThan(1);
+
+        // drop one manifest, the way a repair operation removes manifests whose files are gone
+        Snapshot latest = latest(table);
+        List<ManifestFileMeta> kept = new ArrayList<>(manifests.subList(1, manifests.size()));
+        Pair<String, Long> base = manifestList.write(kept);
+        Pair<String, Long> delta = manifestList.write(Collections.emptyList());
+        try (FileStoreCommitImpl commit =
+                (FileStoreCommitImpl) table.store().newCommit(commitUser, table)) {
+            assertThat(
+                            commit.replaceManifestList(
+                                    latest,
+                                    latest.totalRecordCount(),
+                                    base,
+                                    delta,
+                                    latest.indexManifest(),
+                                    latest.nextRowId()))
+                    .isTrue();
+        }
+        table = reload("replace_manifests_drop");
+
+        // the live file set really did shrink, so carrying the previous counters over would have
+        // published a number that is simply wrong; unknown is the correct answer
+        long filesAfter = scannedNumFiles(table);
+        assertThat(filesAfter).isLessThan(filesBefore);
+        assertThat(latest(table).numFiles()).isNull();
+        assertThat(latest(table).totalFileSizeInBytes()).isNull();
+
+        // and the table stays usable afterwards
+        write(table, row(4, "d"));
+        assertThat(latest(table).numFiles()).isNull();
+        assertThat(readRows(table)).contains("4:d");
+    }
+
+    @Test
+    public void testUnknownJsonFieldsAreIgnored() {
+        // an older reader must tolerate a snapshot written by a newer writer; the same mechanism
+        // that lets it ignore numFiles is exercised here with an unknown field
+        Snapshot parsed =
+                Snapshot.fromJson(
+                        "{\n"
+                                + "  \"version\" : 3,\n"
+                                + "  \"id\" : 5,\n"
+                                + "  \"schemaId\" : 0,\n"
+                                + "  \"baseManifestList\" : \"base\",\n"
+                                + "  \"deltaManifestList\" : \"delta\",\n"
+                                + "  \"commitUser\" : \"user\",\n"
+                                + "  \"commitIdentifier\" : 0,\n"
+                                + "  \"commitKind\" : \"APPEND\",\n"
+                                + "  \"timeMillis\" : 1000,\n"
+                                + "  \"totalRecordCount\" : 10,\n"
+                                + "  \"deltaRecordCount\" : 10,\n"
+                                + "  \"numFiles\" : 7,\n"
+                                + "  \"totalFileSizeInBytes\" : 4096,\n"
+                                + "  \"someFieldFromTheFuture\" : \"whatever\"\n"
+                                + "}");
+        assertThat(parsed.numFiles()).isEqualTo(7L);
+        assertThat(parsed.totalFileSizeInBytes()).isEqualTo(4096L);
+    }
+
+    // ------------------------------------------------------------------------------------------
+    // helpers
+    // ------------------------------------------------------------------------------------------
+
+    private FileStoreTable createTable(String name, boolean primaryKey, String... options)
+            throws Exception {
+        Schema.Builder builder =
+                Schema.newBuilder()
+                        .column("k", DataTypes.INT())
+                        .column("v", DataTypes.STRING())
+                        .option(CoreOptions.BUCKET.key(), "1");
+        for (int i = 0; i < options.length; i += 2) {
+            builder.option(options[i], options[i + 1]);
+        }
+        if (primaryKey) {
+            builder.primaryKey("k");
+        } else {
+            builder.option(CoreOptions.BUCKET_KEY.key(), "k");
+        }
+        Identifier identifier = identifier(name);
+        catalog.createTable(identifier, builder.build(), false);
+        return (FileStoreTable) catalog.getTable(identifier);
+    }
+
+    private FileStoreTable reload(String name) throws Exception {
+        return (FileStoreTable) catalog.getTable(identifier(name));
+    }
+
+    private static GenericRow row(int k, String v) {
+        return GenericRow.of(k, BinaryString.fromString(v));
+    }
+
+    /**
+     * Rewrites the snapshot with exactly the manifest layout it already has, which is the shape
+     * metadata-repair operations commit through {@code replaceManifestList}.
+     */
+    private void replaceManifestListWithSameLayout(FileStoreTable table) throws Exception {
+        Snapshot latest = latest(table);
+        ManifestList manifestList = table.store().manifestListFactory().create();
+        Pair<String, Long> base = manifestList.write(manifestList.readDataManifests(latest));
+        Pair<String, Long> delta = manifestList.write(Collections.emptyList());
+        try (FileStoreCommitImpl commit =
+                (FileStoreCommitImpl) table.store().newCommit(commitUser, table)) {
+            assertThat(
+                            commit.replaceManifestList(
+                                    latest,
+                                    latest.totalRecordCount(),
+                                    base,
+                                    delta,
+                                    latest.indexManifest(),
+                                    latest.nextRowId()))
+                    .isTrue();
+        }
+    }
+
+    private void compactManifests(FileStoreTable table) throws Exception {
+        try (TableCommitImpl commit = table.newCommit(commitUser)) {
+            commit.compactManifests();
+        }
+    }
+
+    private void overwrite(FileStoreTable table, GenericRow... rows) throws Exception {
+        BatchWriteBuilder writeBuilder = table.newBatchWriteBuilder().withOverwrite();
+        try (BatchTableWrite write = writeBuilder.newWrite();
+                BatchTableCommit commit = writeBuilder.newCommit()) {
+            for (GenericRow row : rows) {
+                write.write(row);
+            }
+            commit.commit(write.prepareCommit());
+        }
+    }
+
+    private List<String> readRows(Table table) throws Exception {
+        return read(table).stream()
+                .map(row -> row.getInt(0) + ":" + row.getString(1))
+                .collect(Collectors.toList());
+    }
+
+    private static Snapshot latest(FileStoreTable table) {
+        Snapshot snapshot = table.snapshotManager().latestSnapshot();
+        assertThat(snapshot).isNotNull();
+        return snapshot;
+    }
+
+    private static long scannedNumFiles(FileStoreTable table) {
+        return table.newScan().listPartitionEntries().stream()
+                .mapToLong(PartitionEntry::fileCount)
+                .sum();
+    }
+
+    private void assertStatsMatchManifests(FileStoreTable table) {
+        Snapshot snapshot = latest(table);
+        List<PartitionEntry> entries = table.newScan().listPartitionEntries();
+        long expectedFiles = entries.stream().mapToLong(PartitionEntry::fileCount).sum();
+        long expectedSize = entries.stream().mapToLong(PartitionEntry::fileSizeInBytes).sum();
+
+        assertThat(snapshot.numFiles())
+                .as("num files of snapshot %s", snapshot.id())
+                .isEqualTo(expectedFiles);
+        assertThat(snapshot.totalFileSizeInBytes())
+                .as("total file size of snapshot %s", snapshot.id())
+                .isEqualTo(expectedSize);
+    }
+
+    private int commitKindCount(FileStoreTable table, Snapshot.CommitKind kind) {
+        SnapshotManager manager = table.snapshotManager();
+        int count = 0;
+        for (long id = manager.earliestSnapshotId(); id <= manager.latestSnapshotId(); id++) {
+            if (manager.snapshot(id).commitKind() == kind) {
+                count++;
+            }
+        }
+        return count;
+    }
+
+    /** Rewrites every snapshot file the way a Paimon without these fields would have written it. */
+    private FileStoreTable degradeToLegacy(String name) throws Exception {
+        FileStoreTable table = reload(name);
+        SnapshotManager manager = table.snapshotManager();
+        List<Long> ids = new ArrayList<>();
+        for (long id = manager.earliestSnapshotId(); id <= manager.latestSnapshotId(); id++) {
+            ids.add(id);
+        }
+        for (long id : ids) {
+            degradeSnapshot(name, id);
+        }
+        return reload(name);
+    }
+
+    private void degradeSnapshot(String name, long snapshotId) throws Exception {
+        FileStoreTable table = reload(name);
+        Path path = table.snapshotManager().snapshotPath(snapshotId);
+        Snapshot snapshot = Snapshot.fromJson(table.fileIO().readFileUtf8(path));
+        table.fileIO().overwriteFileUtf8(path, legacyJsonOf(snapshot));
+        // the snapshot object and the table itself are cached, drop both so the rewritten file is
+        // the one that gets read back
+        table.snapshotManager().invalidateCache();
+        catalog.invalidateTable(identifier(name));
+    }
+
+    /**
+     * Serializes through the constructor that predates the two fields, so the payload looks exactly
+     * like one written by an older version: the keys are absent, not null.
+     */
+    private static String legacyJsonOf(Snapshot s) {
+        return new Snapshot(
+                        s.version(),
+                        s.uuid(),
+                        s.id(),
+                        s.schemaId(),
+                        s.baseManifestList(),
+                        s.baseManifestListSize(),
+                        s.deltaManifestList(),
+                        s.deltaManifestListSize(),
+                        s.changelogManifestList(),
+                        s.changelogManifestListSize(),
+                        s.indexManifest(),
+                        s.commitUser(),
+                        s.writerVersion(),
+                        s.commitIdentifier(),
+                        s.commitKind(),
+                        s.timeMillis(),
+                        s.totalRecordCount(),
+                        s.deltaRecordCount(),
+                        s.changelogRecordCount(),
+                        s.watermark(),
+                        s.statistics(),
+                        s.properties(),
+                        s.nextRowId(),
+                        s.operation())
+                .toJson();
+    }
+}

--- a/paimon-core/src/test/java/org/apache/paimon/table/system/SnapshotsTableTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/table/system/SnapshotsTableTest.java
@@ -162,7 +162,9 @@ public class SnapshotsTableTest extends TableTestBase {
                             snapshot.operation() == null
                                     ? null
                                     : BinaryString.fromString(snapshot.operation().toString()),
-                            BinaryString.fromString(snapshot.writerVersion())));
+                            BinaryString.fromString(snapshot.writerVersion()),
+                            snapshot.numFiles(),
+                            snapshot.totalFileSizeInBytes()));
         }
 
         return expectedRow;

--- a/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/commands/PaimonAnalyzeTableColumnCommand.scala
+++ b/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/commands/PaimonAnalyzeTableColumnCommand.scala
@@ -59,12 +59,18 @@ case class PaimonAnalyzeTableColumnCommand(
     }
 
     // compute stats
-    val totalSize = table
-      .newScan()
-      .listPartitionEntries()
-      .asScala
-      .map(_.fileSizeInBytes())
-      .sum
+    // Prefer the total file size maintained incrementally on the snapshot. It is unknown for
+    // snapshots written before the field existed, or when a commit could not derive it, in which
+    // case fall back to folding the partition entries out of the manifests.
+    val totalSize = Option(currentSnapshot.totalFileSizeInBytes())
+      .map(_.longValue())
+      .getOrElse(
+        table
+          .newScan()
+          .listPartitionEntries()
+          .asScala
+          .map(_.fileSizeInBytes())
+          .sum)
     val (mergedRecordCount, colStats) =
       PaimonStatsUtils.computeColumnStats(sparkSession, relation, attributes)
 


### PR DESCRIPTION
### Purpose

Paimon cannot answer "how many data files does this table have, and how large are they" without folding every manifest entry.

Two places pay for it today:

- `ANALYZE TABLE` calls `listPartitionEntries()` and sums `fileSizeInBytes` over the whole manifest set purely to obtain one number, then uses it to *estimate* the merged size as `totalSize * mergedRecordCount / totalRecordCount` (`PaimonAnalyzeTableColumnCommand.scala:62-73`).
- Append compaction planning calls `partitionEntries()` on every discovery round — `AppendTableCompact.java:115`, `CombinedAppendCompactSource.java:181`, `MultiTableAppendCompactReadOperator.java:110` — which in combined mode is one full manifest scan per table per round.

The commit path already computes this information and then throws it away. `FileStoreCommitImpl` builds `PartitionEntry.merge(deltaFiles)` on every commit, whose counts are already signed by file kind, hands the result to the catalog as partition statistics, and drops it for every catalog that does not implement partition reporting — `AbstractCatalog.commitSnapshot` throws `UnsupportedOperationException`, and `RenamingSnapshotCommit.commit` ignores the argument.

Summing those per-partition entries gives the table level delta, so a snapshot can carry the running totals:

- `numFiles` — live data files
- `totalFileSizeInBytes` — their total size

Both are derived as `previous + delta`. This adds no IO and no second pass over the delta entries; it reuses a fold that already runs.

Deriving the totals costs nothing when it works and is skipped when it does not, so the values are advisory. `null` means unknown, never zero, and readers fall back to scanning — `PaimonAnalyzeTableColumnCommand` shows the intended shape:

```scala
val totalSize = Option(currentSnapshot.totalFileSizeInBytes())
  .map(_.longValue())
  .getOrElse(table.newScan().listPartitionEntries().asScala.map(_.fileSizeInBytes()).sum)
```

Unknown arises for snapshots written before the fields existed, and for any commit whose predecessor was unknown. Two paths recompute instead of propagating it:

- `replaceManifestList` replaces the manifest layout wholesale and its callers may drop files with it — `RemoveUnexistingManifestsAction` does exactly that — so inheriting the previous counters would publish a number that no longer matches the live file set. It folds the manifests it is about to commit instead.
- Manifest compaction seeds unknown counters from the compacted manifest set. It rewrites the whole manifest set anyway and the compacted form is the cheapest one to fold, which makes `compact_manifest` the way to recover the counters on an upgraded table; the incremental chain continues on its own afterwards. To keep that reliable the procedure commits a snapshot when the counters are unknown even if no manifests need merging, and returns early exactly as before once they are known.

The two-field, fold-at-commit, advisory-and-degradable shape follows Delta Lake's version checksum file, which maintains the equivalent counters per commit and falls back rather than failing when it cannot.

### Benefits

Delivered here:

- `ANALYZE TABLE` no longer scans the manifest set for the table size, and the value it feeds into the merged-size calculation is exact rather than a scan result summed on the spot.
- `sys.snapshots` gains `num_files` and `total_file_size_in_bytes`, so "which commit blew up the file count" is answerable by query, for any retained snapshot, without starting a job and without scanning manifests. Commit metrics cannot answer this: they are per-commit deltas held in a running writer's memory, carry no snapshot identity, and are absent entirely for tables written by Spark batch jobs or procedures.

Enabled next, not part of this PR:

- Compaction planning and cost-based optimization can read the counters instead of scanning, with the fallback above keeping them correct on tables that have not been seeded.
- The same fold extends naturally to a file size histogram and to deletion vector counts, which would let compaction decisions move from a file count threshold to a distribution.

### Compatibility

Existing tables are unaffected. The fields are nullable and serialized only when present, so snapshots written before this change stay byte-identical, and the constructors that predate the fields are kept so no caller needs to change. Reads, writes, compaction, overwrite, tags, rollback, snapshot expiration and the `sys.snapshots` query all keep working on such tables, with the two columns reported as `NULL`.

### Tests

`SnapshotFileStatsTest`, 20 cases:

- Five assert the values against a full manifest scan across appends, primary key compaction, overwrite, tag and rollback, and manifest compaction.
- Eleven cover tables rewritten into the pre-change snapshot format — read, write, primary key compaction, overwrite, tag, rollback, snapshot expiration, the `sys.snapshots` columns, mixed old/new history with time travel, and unknown JSON fields. The central one asserts that writing on top of an unknown baseline keeps reporting unknown rather than restarting from zero, which is the failure mode that would publish a plausible but wrong file count.
- The rest cover the recompute paths, including one that drops a manifest and must follow the shrink instead of reporting the stale count, and seeding a legacy table whose manifests need no merging at all.

`RemoveUnexistingManifestsActionITCase` and `CompactManifestProcedureITCase` exercise the same paths through Flink.

Full run: 293 paimon-core cases and 9 paimon-flink cases, no failures. `paimon-spark-common` compiles.

### Documentation

`docs/docs/concepts/system-tables.mdx` documents the two columns, what `NULL` means, how it propagates, and that `compact_manifest` recovers the values.
