### PR TITLE
[core] Delete the files of a compaction task whose result is discarded

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/append/AppendCompactTask.java
+++ b/paimon-core/src/main/java/org/apache/paimon/append/AppendCompactTask.java
@@ -84,10 +84,11 @@ public class AppendCompactTask {
                             partition);
             compactAfter.addAll(
                     write.compactRewrite(
-                            partition,
-                            UNAWARE_BUCKET,
-                            dvIndexFileMaintainer::getDeletionVector,
-                            compactBefore));
+                                    partition,
+                                    UNAWARE_BUCKET,
+                                    dvIndexFileMaintainer::getDeletionVector,
+                                    compactBefore)
+                            .after());
 
             compactBefore.forEach(
                     f -> dvIndexFileMaintainer.notifyRemovedDeletionVector(f.fileName()));
@@ -101,7 +102,7 @@ public class AppendCompactTask {
             }
         } else {
             compactAfter.addAll(
-                    write.compactRewrite(partition, UNAWARE_BUCKET, null, compactBefore));
+                    write.compactRewrite(partition, UNAWARE_BUCKET, null, compactBefore).after());
         }
 
         CompactIncrement compactIncrement =

--- a/paimon-core/src/main/java/org/apache/paimon/append/BucketedAppendCompactManager.java
+++ b/paimon-core/src/main/java/org/apache/paimon/append/BucketedAppendCompactManager.java
@@ -46,8 +46,6 @@ import java.util.PriorityQueue;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 
-import static java.util.Collections.emptyList;
-
 /** Compact manager for {@link AppendOnlyFileStore}. */
 public class BucketedAppendCompactManager extends CompactFutureManager {
 
@@ -115,15 +113,15 @@ public class BucketedAppendCompactManager extends CompactFutureManager {
             LOG.debug("Submit full compaction with these files {}", toCompact);
         }
 
-        taskFuture =
-                executor.submit(
-                        new FullCompactTask(
-                                dvMaintainer,
-                                toCompact,
-                                compactionFileSize,
-                                forceRewriteAllFiles,
-                                rewriter,
-                                metricsReporter));
+        submitTask(
+                executor,
+                new FullCompactTask(
+                        dvMaintainer,
+                        toCompact,
+                        compactionFileSize,
+                        forceRewriteAllFiles,
+                        rewriter,
+                        metricsReporter));
         recordCompactionsQueuedRequest();
         compacting = new ArrayList<>(toCompact);
         toCompact.clear();
@@ -147,10 +145,9 @@ public class BucketedAppendCompactManager extends CompactFutureManager {
                 LOG.debug("Submit normal compaction with these files {}", compacting);
             }
 
-            taskFuture =
-                    executor.submit(
-                            new AutoCompactTask(
-                                    dvMaintainer, compacting, rewriter, metricsReporter));
+            submitTask(
+                    executor,
+                    new AutoCompactTask(dvMaintainer, compacting, rewriter, metricsReporter));
             recordCompactionsQueuedRequest();
         }
     }
@@ -281,7 +278,7 @@ public class BucketedAppendCompactManager extends CompactFutureManager {
             // do compaction
             if (dvMaintainer != null) {
                 // if deletion vector enables, always trigger compaction.
-                return compact(dvMaintainer, toCompact, rewriter);
+                return compact(this, dvMaintainer, toCompact, rewriter);
             } else {
                 // compute small files
                 int big = 0;
@@ -295,9 +292,9 @@ public class BucketedAppendCompactManager extends CompactFutureManager {
                 }
                 if (forceRewriteAllFiles
                         || (small > big && toCompact.size() >= FULL_COMPACT_MIN_FILE)) {
-                    return compact(null, toCompact, rewriter);
+                    return compact(this, null, toCompact, rewriter);
                 } else {
-                    return result(emptyList(), emptyList());
+                    return new CompactResult();
                 }
             }
         }
@@ -334,17 +331,20 @@ public class BucketedAppendCompactManager extends CompactFutureManager {
 
         @Override
         protected CompactResult doCompact() throws Exception {
-            return compact(dvMaintainer, toCompact, rewriter);
+            return compact(this, dvMaintainer, toCompact, rewriter);
         }
     }
 
     private static CompactResult compact(
+            CompactTask task,
             @Nullable BucketedDvMaintainer dvMaintainer,
             List<DataFileMeta> toCompact,
             CompactRewriter rewriter)
             throws Exception {
-        List<DataFileMeta> rewrite = rewriter.rewrite(toCompact);
-        CompactResult result = result(toCompact, rewrite);
+        CompactResult result = rewriter.rewrite(toCompact);
+        // The files exist from here on, so hand them to the task before doing anything that can
+        // still fail: from now on the task is what keeps them reachable.
+        task.trackNewFiles(result);
         if (dvMaintainer != null) {
             toCompact.forEach(f -> dvMaintainer.removeDeletionVectorOf(f.fileName()));
             result.setDeletionFile(CompactDeletionFile.generateFiles(dvMaintainer));
@@ -352,12 +352,16 @@ public class BucketedAppendCompactManager extends CompactFutureManager {
         return result;
     }
 
-    private static CompactResult result(List<DataFileMeta> before, List<DataFileMeta> after) {
-        return new CompactResult(before, after);
-    }
-
     /** Compact rewriter for append-only table. */
     public interface CompactRewriter {
-        List<DataFileMeta> rewrite(List<DataFileMeta> compactBefore) throws Exception;
+
+        /**
+         * Rewrites the given files.
+         *
+         * <p>The returned result carries the handles to delete the files it has written, so that
+         * they can still be cleaned up if the compaction is cancelled before its result is
+         * committed.
+         */
+        CompactResult rewrite(List<DataFileMeta> compactBefore) throws Exception;
     }
 }

--- a/paimon-core/src/main/java/org/apache/paimon/append/DedicatedFormatRollingFileWriter.java
+++ b/paimon-core/src/main/java/org/apache/paimon/append/DedicatedFormatRollingFileWriter.java
@@ -444,6 +444,15 @@ public class DedicatedFormatRollingFileWriter
         }
     }
 
+    /** Transfers ownership of abort executors for closed files to the caller. */
+    @Override
+    public List<FileWriterAbortExecutor> drainAbortExecutors() {
+        Preconditions.checkState(closed, "Cannot drain abort executors unless close all writers.");
+        List<FileWriterAbortExecutor> abortExecutors = new ArrayList<>(closedWriters);
+        closedWriters.clear();
+        return abortExecutors;
+    }
+
     /**
      * Checks if the current file should be rolled. The row cap applies even when there is no main
      * writer (all fields dedicated), so blob/vector writers roll together.

--- a/paimon-core/src/main/java/org/apache/paimon/append/cluster/BucketedAppendClusterManager.java
+++ b/paimon-core/src/main/java/org/apache/paimon/append/cluster/BucketedAppendClusterManager.java
@@ -151,7 +151,7 @@ public class BucketedAppendClusterManager extends CompactFutureManager {
                                                     file.fileName(), file.level(), file.fileSize()))
                             .collect(Collectors.joining(", ")));
         }
-        taskFuture = executor.submit(task);
+        submitTask(executor, task);
     }
 
     @Override

--- a/paimon-core/src/main/java/org/apache/paimon/compact/CompactFutureManager.java
+++ b/paimon-core/src/main/java/org/apache/paimon/compact/CompactFutureManager.java
@@ -20,9 +20,12 @@ package org.apache.paimon.compact;
 
 import org.apache.paimon.annotation.VisibleForTesting;
 
+import javax.annotation.Nullable;
+
 import java.util.Optional;
 import java.util.concurrent.CancellationException;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Future;
 
 /** Base implementation of {@link CompactManager} which runs compaction in a separate thread. */
@@ -30,12 +33,29 @@ public abstract class CompactFutureManager implements CompactManager {
 
     protected Future<CompactResult> taskFuture;
 
+    /**
+     * The task behind {@link #taskFuture}, kept so that its files can be deleted if it is
+     * cancelled.
+     */
+    @Nullable private CompactTask task;
+
+    /** Submits a compaction task and remembers it as the current one. */
+    protected void submitTask(ExecutorService executor, CompactTask task) {
+        this.task = task;
+        this.taskFuture = executor.submit(task);
+    }
+
     @Override
     public void cancelCompaction() {
-        // TODO this method may leave behind orphan files if compaction is actually finished
-        //  but some CPU work still needs to be done
         if (taskFuture != null && !taskFuture.isCancelled()) {
-            taskFuture.cancel(true);
+            boolean cancelled = taskFuture.cancel(true);
+            if (cancelled && task != null) {
+                // A cancelled future throws its result away, so the files the task has already
+                // written become unreachable: nothing else knows their names. The task deletes
+                // them itself once the interrupt reaches it, but the interrupt can just as well
+                // land after the task is done, and then this is the only cleanup left.
+                task.abortNewFiles();
+            }
         }
     }
 
@@ -55,6 +75,7 @@ public abstract class CompactFutureManager implements CompactManager {
                     return Optional.empty();
                 } finally {
                     taskFuture = null;
+                    task = null;
                 }
                 return Optional.of(result);
             }

--- a/paimon-core/src/main/java/org/apache/paimon/compact/CompactResult.java
+++ b/paimon-core/src/main/java/org/apache/paimon/compact/CompactResult.java
@@ -19,6 +19,7 @@
 package org.apache.paimon.compact;
 
 import org.apache.paimon.io.DataFileMeta;
+import org.apache.paimon.io.FileWriterAbortExecutor;
 
 import javax.annotation.Nullable;
 
@@ -32,6 +33,13 @@ public class CompactResult {
     private final List<DataFileMeta> before;
     private final List<DataFileMeta> after;
     private final List<DataFileMeta> changelog;
+
+    /**
+     * Handles to delete the files this result is made of. They are only meaningful while the result
+     * has not been handed over to the writer: whoever throws the result away is responsible for
+     * aborting the files it describes.
+     */
+    private final List<FileWriterAbortExecutor> abortExecutors;
 
     @Nullable private CompactDeletionFile deletionFile;
 
@@ -52,6 +60,7 @@ public class CompactResult {
         this.before = new ArrayList<>(before);
         this.after = new ArrayList<>(after);
         this.changelog = new ArrayList<>(changelog);
+        this.abortExecutors = new ArrayList<>();
     }
 
     public List<DataFileMeta> before() {
@@ -64,6 +73,14 @@ public class CompactResult {
 
     public List<DataFileMeta> changelog() {
         return changelog;
+    }
+
+    public void addAbortExecutors(List<FileWriterAbortExecutor> executors) {
+        abortExecutors.addAll(executors);
+    }
+
+    public List<FileWriterAbortExecutor> abortExecutors() {
+        return abortExecutors;
     }
 
     public void setDeletionFile(@Nullable CompactDeletionFile deletionFile) {
@@ -79,6 +96,7 @@ public class CompactResult {
         before.addAll(that.before);
         after.addAll(that.after);
         changelog.addAll(that.changelog);
+        abortExecutors.addAll(that.abortExecutors);
 
         if (deletionFile != null || that.deletionFile != null) {
             throw new UnsupportedOperationException(

--- a/paimon-core/src/main/java/org/apache/paimon/compact/CompactTask.java
+++ b/paimon-core/src/main/java/org/apache/paimon/compact/CompactTask.java
@@ -19,6 +19,7 @@
 package org.apache.paimon.compact;
 
 import org.apache.paimon.io.DataFileMeta;
+import org.apache.paimon.io.FileWriterAbortExecutor;
 import org.apache.paimon.operation.metrics.CompactionMetrics;
 import org.apache.paimon.operation.metrics.MetricUtils;
 
@@ -27,6 +28,7 @@ import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nullable;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.Callable;
 
@@ -37,6 +39,13 @@ public abstract class CompactTask implements Callable<CompactResult> {
 
     @Nullable private final CompactionMetrics.Reporter metricsReporter;
     private final String bucketInfo;
+
+    /**
+     * Files this task has already written, with the handles needed to delete them again. Written by
+     * the compaction thread as parts of the task finish, read by whoever cancels the task, hence
+     * the lock.
+     */
+    private final List<FileWriterAbortExecutor> newFiles = new ArrayList<>();
 
     public CompactTask(@Nullable CompactionMetrics.Reporter metricsReporter, String bucketInfo) {
         this.metricsReporter = metricsReporter;
@@ -88,6 +97,15 @@ public abstract class CompactTask implements Callable<CompactResult> {
             if (LOG.isDebugEnabled()) {
                 LOG.debug(logMetric(startMillis, result.before(), result.after()));
             }
+
+            // Keep this check last. If we were cancelled the future drops the result on the
+            // floor, so this task is the only one that still knows about the files it wrote.
+            if (Thread.currentThread().isInterrupted()) {
+                trackNewFiles(result);
+                cleanDeletionFile(result);
+                throw new InterruptedException(
+                        "Compact task was cancelled after it had written its files.");
+            }
             return result;
         } catch (Exception e) {
             LOG.warn(
@@ -95,10 +113,68 @@ public abstract class CompactTask implements Callable<CompactResult> {
                     bucketInfo,
                     getClass().getSimpleName(),
                     e);
+            // Parts of this task that already finished have closed their writers, so nothing but
+            // this task can delete their output any more. The result is never returned now, so
+            // those files would be left behind.
+            abortNewFiles();
             throw e;
         } finally {
             MetricUtils.safeCall(this::stopTimer, LOG);
             MetricUtils.safeCall(this::decreaseCompactionsQueuedCount, LOG);
+        }
+    }
+
+    /**
+     * Takes over the files a finished part of this task has written, so that {@link
+     * #abortNewFiles()} can still delete them once the sub-result has been merged away.
+     *
+     * <p>Ownership is transferred: the handles are removed from {@code partialResult}, so a file is
+     * never tracked twice.
+     */
+    public void trackNewFiles(CompactResult partialResult) {
+        List<FileWriterAbortExecutor> executors = partialResult.abortExecutors();
+        if (executors.isEmpty()) {
+            return;
+        }
+        synchronized (newFiles) {
+            newFiles.addAll(executors);
+        }
+        executors.clear();
+    }
+
+    /**
+     * Deletes every file written by this task so far. Only call this once it is certain that the
+     * result of this task will not be committed, otherwise it deletes live data.
+     */
+    public void abortNewFiles() {
+        List<FileWriterAbortExecutor> toAbort;
+        synchronized (newFiles) {
+            if (newFiles.isEmpty()) {
+                return;
+            }
+            toAbort = new ArrayList<>(newFiles);
+            newFiles.clear();
+        }
+
+        LOG.info(
+                "Deleting {} file(s) written by a compact task whose result is discarded: {}, taskType={}",
+                toAbort.size(),
+                bucketInfo,
+                getClass().getSimpleName());
+        for (FileWriterAbortExecutor abortExecutor : toAbort) {
+            abortExecutor.abort();
+        }
+    }
+
+    private void cleanDeletionFile(CompactResult result) {
+        CompactDeletionFile deletionFile = result.deletionFile();
+        if (deletionFile == null) {
+            return;
+        }
+        try {
+            deletionFile.clean();
+        } catch (Throwable t) {
+            LOG.warn("Failed to clean the deletion file of a discarded compact task.", t);
         }
     }
 

--- a/paimon-core/src/main/java/org/apache/paimon/io/RollingFileWriter.java
+++ b/paimon-core/src/main/java/org/apache/paimon/io/RollingFileWriter.java
@@ -44,6 +44,17 @@ public interface RollingFileWriter<T, R> extends FileWriter<T, List<R>> {
 
     void writeBundle(BundleRecords records) throws IOException;
 
+    /**
+     * Transfers ownership of the abort executors for the files this writer has already closed and
+     * rolled over.
+     *
+     * <p>Once a file is rolled over its writer is dropped, so nothing but this handle can delete it
+     * any more. A caller which is going to throw away {@link #result()} - a compaction task whose
+     * result will never be committed, for instance - must drain these and abort them, otherwise the
+     * files are left behind with nothing referencing them.
+     */
+    List<FileWriterAbortExecutor> drainAbortExecutors();
+
     @VisibleForTesting
     static FileWriterContext createFileWriterContext(
             FileFormat fileFormat,

--- a/paimon-core/src/main/java/org/apache/paimon/io/RollingFileWriterImpl.java
+++ b/paimon-core/src/main/java/org/apache/paimon/io/RollingFileWriterImpl.java
@@ -192,6 +192,7 @@ public class RollingFileWriterImpl<T, R> implements RollingFileWriter<T, R> {
     }
 
     /** Transfers ownership of abort executors for closed files to the caller. */
+    @Override
     public List<FileWriterAbortExecutor> drainAbortExecutors() {
         Preconditions.checkState(closed, "Cannot drain abort executors unless close all writers.");
         List<FileWriterAbortExecutor> abortExecutors = new ArrayList<>(closedWriters);

--- a/paimon-core/src/main/java/org/apache/paimon/mergetree/compact/ChangelogMergeTreeRewriter.java
+++ b/paimon-core/src/main/java/org/apache/paimon/mergetree/compact/ChangelogMergeTreeRewriter.java
@@ -206,7 +206,14 @@ public abstract class ChangelogMergeTreeRewriter extends MergeTreeCompactRewrite
                 changelogFileWriter != null
                         ? changelogFileWriter.result()
                         : Collections.emptyList();
-        return new CompactResult(before, after, changelogFiles);
+        CompactResult result = new CompactResult(before, after, changelogFiles);
+        if (compactFileWriter != null) {
+            result.addAbortExecutors(compactFileWriter.drainAbortExecutors());
+        }
+        if (changelogFileWriter != null) {
+            result.addAbortExecutors(changelogFileWriter.drainAbortExecutors());
+        }
+        return result;
     }
 
     @Override

--- a/paimon-core/src/main/java/org/apache/paimon/mergetree/compact/FileRewriteCompactTask.java
+++ b/paimon-core/src/main/java/org/apache/paimon/mergetree/compact/FileRewriteCompactTask.java
@@ -69,6 +69,8 @@ public class FileRewriteCompactTask extends CompactTask {
 
     private void rewriteFile(DataFileMeta file, CompactResult toUpdate) throws Exception {
         List<List<SortedRun>> candidate = singletonList(singletonList(SortedRun.fromSingle(file)));
-        toUpdate.merge(rewriter.rewrite(outputLevel, dropDelete, candidate));
+        CompactResult rewriteResult = rewriter.rewrite(outputLevel, dropDelete, candidate);
+        trackNewFiles(rewriteResult);
+        toUpdate.merge(rewriteResult);
     }
 }

--- a/paimon-core/src/main/java/org/apache/paimon/mergetree/compact/MergeTreeCompactManager.java
+++ b/paimon-core/src/main/java/org/apache/paimon/mergetree/compact/MergeTreeCompactManager.java
@@ -255,7 +255,7 @@ public class MergeTreeCompactManager extends CompactFutureManager {
                                                     file.fileName(), file.level(), file.fileSize()))
                             .collect(Collectors.joining(", ")));
         }
-        taskFuture = executor.submit(task);
+        submitTask(executor, task);
         if (metricsReporter != null) {
             metricsReporter.increaseCompactionsQueuedCount();
             metricsReporter.increaseCompactionsTotalCount();

--- a/paimon-core/src/main/java/org/apache/paimon/mergetree/compact/MergeTreeCompactRewriter.java
+++ b/paimon-core/src/main/java/org/apache/paimon/mergetree/compact/MergeTreeCompactRewriter.java
@@ -112,7 +112,9 @@ public class MergeTreeCompactRewriter extends AbstractCompactRewriter {
             metricsReporter.reportSortBufferMetrics(
                     mergeSorter.sortBufferUsedBytes(), mergeSorter.sortBufferTotalBytes());
         }
-        return new CompactResult(before, after);
+        CompactResult result = new CompactResult(before, after);
+        result.addAbortExecutors(writer.drainAbortExecutors());
+        return result;
     }
 
     protected <T> RecordReader<T> readerForMergeTree(

--- a/paimon-core/src/main/java/org/apache/paimon/mergetree/compact/MergeTreeCompactTask.java
+++ b/paimon-core/src/main/java/org/apache/paimon/mergetree/compact/MergeTreeCompactTask.java
@@ -133,6 +133,7 @@ public class MergeTreeCompactTask extends CompactTask {
 
         if (file.level() != outputLevel) {
             CompactResult upgradeResult = rewriter.upgrade(outputLevel, file);
+            trackNewFiles(upgradeResult);
             toUpdate.merge(upgradeResult);
             upgradeFilesNum++;
         }
@@ -160,6 +161,9 @@ public class MergeTreeCompactTask extends CompactTask {
     private void rewriteImpl(List<List<SortedRun>> candidate, CompactResult toUpdate)
             throws Exception {
         CompactResult rewriteResult = rewriter.rewrite(outputLevel, dropDelete, candidate);
+        // Take the files over before merging: this section is finished, its writer is closed, and
+        // if a later section fails or the task is cancelled nothing else can delete them.
+        trackNewFiles(rewriteResult);
         toUpdate.merge(rewriteResult);
         candidate.clear();
     }

--- a/paimon-core/src/main/java/org/apache/paimon/mergetree/compact/clustering/ClusteringCompactManager.java
+++ b/paimon-core/src/main/java/org/apache/paimon/mergetree/compact/clustering/ClusteringCompactManager.java
@@ -184,14 +184,14 @@ public class ClusteringCompactManager extends CompactFutureManager {
         if (taskFuture != null) {
             return;
         }
-        taskFuture =
-                executor.submit(
-                        new CompactTask(metricsReporter, "") {
-                            @Override
-                            protected CompactResult doCompact() throws Exception {
-                                return compact(fullCompaction);
-                            }
-                        });
+        submitTask(
+                executor,
+                new CompactTask(metricsReporter, "") {
+                    @Override
+                    protected CompactResult doCompact() throws Exception {
+                        return compact(fullCompaction);
+                    }
+                });
     }
 
     private CompactResult compact(boolean fullCompaction) throws Exception {

--- a/paimon-core/src/main/java/org/apache/paimon/operation/BaseAppendFileStoreWrite.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/BaseAppendFileStoreWrite.java
@@ -23,6 +23,7 @@ import org.apache.paimon.CoreOptions;
 import org.apache.paimon.append.AppendOnlyWriter;
 import org.apache.paimon.append.cluster.Sorter;
 import org.apache.paimon.compact.CompactManager;
+import org.apache.paimon.compact.CompactResult;
 import org.apache.paimon.data.BinaryRow;
 import org.apache.paimon.data.BlobConsumer;
 import org.apache.paimon.data.InternalRow;
@@ -58,7 +59,6 @@ import org.slf4j.LoggerFactory;
 import javax.annotation.Nullable;
 
 import java.io.IOException;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -269,14 +269,21 @@ public abstract class BaseAppendFileStoreWrite extends MemoryFileStoreWrite<Inte
             ExecutorService compactExecutor,
             @Nullable BucketedDvMaintainer dvMaintainer);
 
-    public List<DataFileMeta> compactRewrite(
+    /**
+     * Rewrites the given files into new ones.
+     *
+     * <p>The result also carries the handles needed to delete the files it has written: a caller
+     * whose result may end up being thrown away - an asynchronous compaction task that can be
+     * cancelled - needs those to clean up after itself.
+     */
+    public CompactResult compactRewrite(
             BinaryRow partition,
             int bucket,
             @Nullable Function<String, DeletionVector> dvFactory,
             List<DataFileMeta> toCompact)
             throws Exception {
         if (toCompact.isEmpty()) {
-            return Collections.emptyList();
+            return new CompactResult();
         }
         Exception collectedExceptions = null;
         RowDataRollingFileWriter rewriter =
@@ -305,7 +312,9 @@ public abstract class BaseAppendFileStoreWrite extends MemoryFileStoreWrite<Inte
         if (collectedExceptions != null) {
             throw collectedExceptions;
         }
-        return rewriter.result();
+        CompactResult result = new CompactResult(toCompact, rewriter.result());
+        result.addAbortExecutors(rewriter.drainAbortExecutors());
+        return result;
     }
 
     public List<DataFileMeta> clusterRewrite(

--- a/paimon-core/src/test/java/org/apache/paimon/append/AppendCompactTaskTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/append/AppendCompactTaskTest.java
@@ -22,6 +22,7 @@ import org.apache.paimon.CoreOptions;
 import org.apache.paimon.TestAppendFileStore;
 import org.apache.paimon.TestKeyValueGenerator;
 import org.apache.paimon.compact.CompactManager;
+import org.apache.paimon.compact.CompactResult;
 import org.apache.paimon.data.BinaryRow;
 import org.apache.paimon.data.InternalRow;
 import org.apache.paimon.deletionvectors.BucketedDvMaintainer;
@@ -157,13 +158,13 @@ public class AppendCompactTaskTest {
         }
 
         @Override
-        public List<DataFileMeta> compactRewrite(
+        public CompactResult compactRewrite(
                 BinaryRow partition,
                 int bucket,
                 @Nullable Function<String, DeletionVector> dvFactory,
                 List<DataFileMeta> toCompact)
                 throws Exception {
-            return Collections.emptyList();
+            return new CompactResult();
         }
 
         @Override

--- a/paimon-core/src/test/java/org/apache/paimon/append/AppendOnlyWriterTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/append/AppendOnlyWriterTest.java
@@ -19,6 +19,7 @@
 package org.apache.paimon.append;
 
 import org.apache.paimon.CoreOptions;
+import org.apache.paimon.compact.CompactResult;
 import org.apache.paimon.compact.NoopCompactManager;
 import org.apache.paimon.compression.CompressOptions;
 import org.apache.paimon.data.BinaryRow;
@@ -192,7 +193,7 @@ public class AppendOnlyWriterTest {
                                 true,
                                 true,
                                 Collections.emptyList(),
-                                compactBefore -> Collections.emptyList(),
+                                compactBefore -> new CompactResult(),
                                 options)
                         .getKey();
 
@@ -1228,8 +1229,10 @@ public class AppendOnlyWriterTest {
                 compactBefore -> {
                     latch.await();
                     return compactBefore.isEmpty()
-                            ? Collections.emptyList()
-                            : Collections.singletonList(generateCompactAfter(compactBefore));
+                            ? new CompactResult()
+                            : new CompactResult(
+                                    compactBefore,
+                                    Collections.singletonList(generateCompactAfter(compactBefore)));
                 },
                 options);
     }
@@ -1248,7 +1251,7 @@ public class AppendOnlyWriterTest {
                         false,
                         true,
                         Collections.emptyList(),
-                        compactBefore -> Collections.emptyList(),
+                        compactBefore -> new CompactResult(),
                         options)
                 .getKey();
     }

--- a/paimon-core/src/test/java/org/apache/paimon/append/FullCompactTaskTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/append/FullCompactTaskTest.java
@@ -152,7 +152,7 @@ public class FullCompactTaskTest {
                     compactAfter.add(newFile(minSeq, file.maxSequenceNumber()));
                 }
             }
-            return compactAfter;
+            return new CompactResult(compactBefore, compactAfter);
         };
     }
 }

--- a/paimon-core/src/test/java/org/apache/paimon/compact/CompactTaskCancelTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/compact/CompactTaskCancelTest.java
@@ -1,0 +1,239 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.compact;
+
+import org.apache.paimon.fs.Path;
+import org.apache.paimon.fs.local.LocalFileIO;
+import org.apache.paimon.io.DataFileMeta;
+import org.apache.paimon.io.FileWriterAbortExecutor;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.IOException;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Optional;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Tests that a {@link CompactTask} whose result is thrown away does not leave the files it has
+ * already written behind.
+ */
+public class CompactTaskCancelTest {
+
+    @TempDir java.nio.file.Path tempDir;
+
+    private LocalFileIO fileIO;
+    private ExecutorService executor;
+
+    @BeforeEach
+    public void before() {
+        fileIO = LocalFileIO.create();
+        executor = Executors.newSingleThreadExecutor();
+    }
+
+    @AfterEach
+    public void after() {
+        executor.shutdownNow();
+        // a test may leave the flag set on the main thread
+        Thread.interrupted();
+    }
+
+    /**
+     * A section that has been rewritten has closed its writer, so its files can only be reached
+     * through the result of the whole task. When a later section fails that result is never
+     * returned, and the earlier files used to be leaked.
+     */
+    @Test
+    public void testFilesOfFinishedPartsAreDeletedWhenALaterPartFails() throws Exception {
+        Path first = writeFile("first");
+        Path second = writeFile("second");
+
+        CompactTask task =
+                new CompactTask(null, "") {
+                    @Override
+                    protected CompactResult doCompact() {
+                        CompactResult result = new CompactResult();
+                        for (Path finished : new Path[] {first, second}) {
+                            CompactResult part = finishPart(finished);
+                            trackNewFiles(part);
+                            result.merge(part);
+                        }
+                        throw new RuntimeException("rewriting the third section failed");
+                    }
+                };
+
+        assertThatThrownBy(task::call).hasMessageContaining("third section");
+
+        assertThat(fileIO.exists(first)).isFalse();
+        assertThat(fileIO.exists(second)).isFalse();
+    }
+
+    /**
+     * The interrupt of a cancellation can arrive after the task has written everything. The future
+     * then drops the result, so the task itself has to clean up.
+     */
+    @Test
+    public void testFilesAreDeletedWhenCancelledAfterWriting() throws Exception {
+        Path written = writeFile("written");
+
+        CompactTask task =
+                new CompactTask(null, "") {
+                    @Override
+                    protected CompactResult doCompact() {
+                        CompactResult result = new CompactResult();
+                        result.merge(finishPart(written));
+                        // the cancellation lands here, once all the files are on disk
+                        Thread.currentThread().interrupt();
+                        return result;
+                    }
+                };
+
+        assertThatThrownBy(task::call).isInstanceOf(InterruptedException.class);
+
+        assertThat(fileIO.exists(written)).isFalse();
+    }
+
+    /** A task which completes normally keeps its files - they are about to be committed. */
+    @Test
+    public void testFilesAreKeptWhenTaskSucceeds() throws Exception {
+        Path written = writeFile("written");
+
+        CompactTask task =
+                new CompactTask(null, "") {
+                    @Override
+                    protected CompactResult doCompact() {
+                        CompactResult result = new CompactResult();
+                        result.merge(finishPart(written));
+                        return result;
+                    }
+                };
+
+        assertThat(task.call()).isNotNull();
+        assertThat(fileIO.exists(written)).isTrue();
+    }
+
+    /**
+     * Covers the case the {@code cancelCompaction} TODO described: the task is done writing but
+     * still busy, so the interrupt never reaches a point where the task can react to it. Only the
+     * manager can clean up then.
+     */
+    @Test
+    @Timeout(30)
+    public void testCancelCompactionDeletesFilesOfAnUnresponsiveTask() throws Exception {
+        Path written = writeFile("written");
+
+        CountDownLatch tracked = new CountDownLatch(1);
+        CountDownLatch release = new CountDownLatch(1);
+
+        CompactTask task =
+                new CompactTask(null, "") {
+                    @Override
+                    protected CompactResult doCompact() {
+                        CompactResult result = new CompactResult();
+                        CompactResult part = finishPart(written);
+                        trackNewFiles(part);
+                        result.merge(part);
+                        tracked.countDown();
+                        // busy with work that does not observe interrupts
+                        boolean released = false;
+                        while (!released) {
+                            try {
+                                released = release.await(1, TimeUnit.SECONDS);
+                            } catch (InterruptedException ignored) {
+                                // deliberately swallowed
+                            }
+                        }
+                        return result;
+                    }
+                };
+
+        TestCompactManager manager = new TestCompactManager();
+        manager.submit(executor, task);
+        assertThat(tracked.await(30, TimeUnit.SECONDS)).isTrue();
+
+        manager.cancelCompaction();
+
+        assertThat(fileIO.exists(written)).isFalse();
+        release.countDown();
+    }
+
+    /** Builds the result of one finished part of a task, and hands its files to the task. */
+    private CompactResult finishPart(Path file) {
+        CompactResult part = new CompactResult();
+        part.addAbortExecutors(
+                Collections.singletonList(new FileWriterAbortExecutor(fileIO, file)));
+        return part;
+    }
+
+    private Path writeFile(String name) throws IOException {
+        Path path = new Path(tempDir.toUri().toString(), name);
+        fileIO.tryToWriteAtomic(path, "some compacted data");
+        assertThat(fileIO.exists(path)).isTrue();
+        return path;
+    }
+
+    private static class TestCompactManager extends CompactFutureManager {
+
+        void submit(ExecutorService executor, CompactTask task) {
+            submitTask(executor, task);
+        }
+
+        @Override
+        public boolean shouldWaitForLatestCompaction() {
+            return false;
+        }
+
+        @Override
+        public boolean shouldWaitForPreparingCheckpoint() {
+            return false;
+        }
+
+        @Override
+        public void addNewFile(DataFileMeta file) {}
+
+        @Override
+        public Collection<DataFileMeta> allFiles() {
+            return Collections.emptyList();
+        }
+
+        @Override
+        public void triggerCompaction(boolean fullCompaction) {}
+
+        @Override
+        public Optional<CompactResult> getCompactionResult(boolean blocking)
+                throws ExecutionException, InterruptedException {
+            return innerGetCompactionResult(blocking);
+        }
+
+        @Override
+        public void close() {}
+    }
+}

--- a/paimon-core/src/test/java/org/apache/paimon/mergetree/compact/CompactOrphanFileTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/mergetree/compact/CompactOrphanFileTest.java
@@ -1,0 +1,390 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.mergetree.compact;
+
+import org.apache.paimon.CoreOptions;
+import org.apache.paimon.KeyValue;
+import org.apache.paimon.compact.CompactResult;
+import org.apache.paimon.data.GenericRow;
+import org.apache.paimon.data.InternalRow;
+import org.apache.paimon.deletionvectors.DeletionVector;
+import org.apache.paimon.format.FileFormat;
+import org.apache.paimon.fs.FileStatus;
+import org.apache.paimon.fs.Path;
+import org.apache.paimon.fs.local.LocalFileIO;
+import org.apache.paimon.io.DataFileMeta;
+import org.apache.paimon.io.KeyValueFileReaderFactory;
+import org.apache.paimon.io.KeyValueFileWriterFactory;
+import org.apache.paimon.io.RollingFileWriter;
+import org.apache.paimon.manifest.FileSource;
+import org.apache.paimon.mergetree.Levels;
+import org.apache.paimon.mergetree.MergeSorter;
+import org.apache.paimon.mergetree.SortedRun;
+import org.apache.paimon.options.MemorySize;
+import org.apache.paimon.options.Options;
+import org.apache.paimon.schema.KeyValueFieldsExtractor;
+import org.apache.paimon.schema.SchemaManager;
+import org.apache.paimon.schema.TableSchema;
+import org.apache.paimon.table.SchemaEvolutionTableTestBase;
+import org.apache.paimon.types.DataField;
+import org.apache.paimon.types.IntType;
+import org.apache.paimon.types.RowKind;
+import org.apache.paimon.types.RowType;
+import org.apache.paimon.utils.FileStorePathFactory;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+import static java.util.Collections.singletonList;
+import static org.apache.paimon.utils.FileStorePathFactoryTest.createNonPartFactory;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * A compaction task writes real files before its result reaches the writer. These tests run a real
+ * merge tree compaction, break it half way through, and check that the files the finished part has
+ * already written to the bucket directory do not survive as orphans.
+ */
+public class CompactOrphanFileTest {
+
+    @TempDir java.nio.file.Path tempDir;
+
+    private final LocalFileIO fileIO = LocalFileIO.create();
+    private final RowType keyType =
+            new RowType(singletonList(new DataField(0, "k", new IntType())));
+    private final RowType valueType =
+            new RowType(singletonList(new DataField(1, "v", new IntType())));
+
+    private CoreOptions options;
+    private Comparator<InternalRow> comparator;
+    private KeyValueFileReaderFactory readerFactory;
+    private KeyValueFileWriterFactory writerFactory;
+    private Path bucketDir;
+    private ExecutorService executor;
+    private long sequenceNumber = 0;
+
+    @BeforeEach
+    public void before() throws IOException {
+        Path root = new Path(tempDir.toString());
+        FileStorePathFactory pathFactory = createNonPartFactory(root);
+        comparator = Comparator.comparingInt(o -> o.getInt(0));
+        executor = Executors.newSingleThreadExecutor();
+
+        Options conf = new Options();
+        conf.set(CoreOptions.TARGET_FILE_SIZE, MemorySize.ofMebiBytes(1));
+        options = new CoreOptions(conf);
+
+        FileFormat avro = FileFormat.fromIdentifier("avro", new Options());
+        SchemaManager schemaManager = testingSchemaManager(root);
+        KeyValueFileReaderFactory.Builder readerBuilder =
+                KeyValueFileReaderFactory.builder(
+                        fileIO,
+                        schemaManager,
+                        schemaManager.schema(0),
+                        keyType,
+                        valueType,
+                        ignore -> avro,
+                        pathFactory,
+                        new TestKeyValueFieldsExtractor(),
+                        new CoreOptions(new HashMap<>()));
+        readerFactory =
+                readerBuilder.build(
+                        org.apache.paimon.data.BinaryRow.EMPTY_ROW,
+                        0,
+                        DeletionVector.emptyFactory());
+
+        Function<String, FileStorePathFactory> pathFactoryMap = k -> pathFactory;
+        writerFactory =
+                KeyValueFileWriterFactory.builder(
+                                fileIO,
+                                0,
+                                keyType,
+                                valueType,
+                                avro,
+                                pathFactoryMap,
+                                options.targetFileSize(true))
+                        .build(org.apache.paimon.data.BinaryRow.EMPTY_ROW, 0, options);
+
+        bucketDir = writerFactory.pathFactory(0).newPath().getParent();
+        fileIO.mkdirs(bucketDir);
+    }
+
+    @AfterEach
+    public void after() {
+        executor.shutdownNow();
+    }
+
+    /**
+     * The compaction is cancelled while it is still running. Everything the sections it already
+     * rewrote wrote to the bucket directory is only reachable through the result of the task, which
+     * the cancelled future drops.
+     */
+    @Test
+    @Timeout(60)
+    public void testCancelledCompactionLeavesNoOrphanFile() throws Exception {
+        List<DataFileMeta> inputs = writeInputFiles();
+
+        CountDownLatch reachedSecondRewrite = new CountDownLatch(1);
+        CountDownLatch neverReleased = new CountDownLatch(1);
+        BreakingRewriter rewriter =
+                new BreakingRewriter(
+                        realRewriter(),
+                        2,
+                        () -> {
+                            reachedSecondRewrite.countDown();
+                            neverReleased.await();
+                        });
+
+        MergeTreeCompactManager manager = createCompactManager(inputs, rewriter);
+        manager.triggerCompaction(true);
+        assertThat(reachedSecondRewrite.await(60, TimeUnit.SECONDS)).isTrue();
+
+        // the first section has been rewritten by now, its files are on disk
+        assertThat(orphanFiles(inputs)).isNotEmpty();
+
+        manager.cancelCompaction();
+
+        assertThat(orphanFiles(inputs)).isEmpty();
+    }
+
+    /**
+     * The same files are left behind when a later section of the same task fails: the task never
+     * returns the result that names them.
+     */
+    @Test
+    @Timeout(60)
+    public void testFailedCompactionLeavesNoOrphanFile() throws Exception {
+        List<DataFileMeta> inputs = writeInputFiles();
+
+        BreakingRewriter rewriter =
+                new BreakingRewriter(
+                        realRewriter(),
+                        2,
+                        () -> {
+                            throw new IOException("rewriting the second section failed");
+                        });
+
+        MergeTreeCompactManager manager = createCompactManager(inputs, rewriter);
+        manager.triggerCompaction(true);
+
+        assertThatThrownBy(() -> manager.getCompactionResult(true))
+                .hasRootCauseMessage("rewriting the second section failed");
+
+        assertThat(orphanFiles(inputs)).isEmpty();
+    }
+
+    /** A compaction that runs to the end keeps its files - they are about to be committed. */
+    @Test
+    @Timeout(60)
+    public void testSuccessfulCompactionKeepsItsFiles() throws Exception {
+        List<DataFileMeta> inputs = writeInputFiles();
+
+        MergeTreeCompactManager manager = createCompactManager(inputs, realRewriter());
+        manager.triggerCompaction(true);
+
+        CompactResult result = manager.getCompactionResult(true).orElseThrow(AssertionError::new);
+        assertThat(result.after()).isNotEmpty();
+
+        Set<String> onDisk = filesOnDisk();
+        for (DataFileMeta file : result.after()) {
+            assertThat(onDisk).contains(file.fileName());
+        }
+    }
+
+    /**
+     * Five level 0 files: two overlapping small ones, one large one on its own, then two more
+     * overlapping small ones. {@link MergeTreeCompactTask} rewrites the first pair, upgrades the
+     * large file in between, and rewrites the last pair - two separate rewrites in one task.
+     */
+    private List<DataFileMeta> writeInputFiles() throws Exception {
+        List<DataFileMeta> files = new ArrayList<>();
+        files.add(writeFile(1, 10));
+        files.add(writeFile(5, 15));
+        files.add(writeFile(100, 700));
+        files.add(writeFile(2000, 2010));
+        files.add(writeFile(2005, 2015));
+        return files;
+    }
+
+    /** Between the small files and the large one, so the large one is upgraded, not rewritten. */
+    private long compactionFileSize(List<DataFileMeta> inputs) {
+        long large = inputs.get(2).fileSize();
+        long smallest =
+                inputs.stream()
+                        .mapToLong(DataFileMeta::fileSize)
+                        .min()
+                        .orElseThrow(AssertionError::new);
+        assertThat(large).isGreaterThan(smallest * 2);
+        return (large + smallest) / 2;
+    }
+
+    private MergeTreeCompactManager createCompactManager(
+            List<DataFileMeta> inputs, CompactRewriter rewriter) {
+        return new MergeTreeCompactManager(
+                executor,
+                new Levels(comparator, inputs, options.numLevels()),
+                new UniversalCompaction(
+                        options.maxSizeAmplificationPercent(),
+                        options.sortedRunSizeRatio(),
+                        options.numSortedRunCompactionTrigger(),
+                        null,
+                        null),
+                comparator,
+                compactionFileSize(inputs),
+                options.numSortedRunStopTrigger(),
+                rewriter,
+                null,
+                null,
+                false,
+                false,
+                null,
+                false,
+                false,
+                "");
+    }
+
+    private MergeTreeCompactRewriter realRewriter() {
+        return new MergeTreeCompactRewriter(
+                readerFactory,
+                writerFactory,
+                comparator,
+                null,
+                DeduplicateMergeFunction.factory(),
+                new MergeSorter(options, keyType, valueType, null));
+    }
+
+    private DataFileMeta writeFile(int minKey, int maxKey) throws Exception {
+        RollingFileWriter<KeyValue, DataFileMeta> writer =
+                writerFactory.createRollingMergeTreeFileWriter(0, FileSource.APPEND);
+        for (int k = minKey; k <= maxKey; k++) {
+            writer.write(
+                    new KeyValue()
+                            .replace(
+                                    GenericRow.of(k),
+                                    sequenceNumber++,
+                                    RowKind.INSERT,
+                                    GenericRow.of(k)));
+        }
+        writer.close();
+        List<DataFileMeta> result = writer.result();
+        assertThat(result).hasSize(1);
+        return result.get(0);
+    }
+
+    private Set<String> filesOnDisk() throws IOException {
+        FileStatus[] statuses = fileIO.listStatus(bucketDir);
+        return Arrays.stream(statuses).map(s -> s.getPath().getName()).collect(Collectors.toSet());
+    }
+
+    /** Files present in the bucket directory that nothing refers to any more. */
+    private Set<String> orphanFiles(List<DataFileMeta> inputs) throws IOException {
+        Set<String> orphans = new HashSet<>(filesOnDisk());
+        inputs.forEach(f -> orphans.remove(f.fileName()));
+        return orphans;
+    }
+
+    private SchemaManager testingSchemaManager(Path path) {
+        TableSchema schema =
+                new TableSchema(
+                        0,
+                        new ArrayList<>(),
+                        -1,
+                        new ArrayList<>(),
+                        new ArrayList<>(),
+                        new HashMap<>(),
+                        "");
+        Map<Long, TableSchema> schemas = new HashMap<>();
+        schemas.put(schema.id(), schema);
+        return new SchemaEvolutionTableTestBase.TestingSchemaManager(path, schemas);
+    }
+
+    private class TestKeyValueFieldsExtractor implements KeyValueFieldsExtractor {
+
+        private static final long serialVersionUID = 1L;
+
+        @Override
+        public List<DataField> keyFields(TableSchema schema) {
+            return keyType.getFields();
+        }
+
+        @Override
+        public List<DataField> valueFields(TableSchema schema) {
+            return valueType.getFields();
+        }
+    }
+
+    /** Runs a real rewriter, but breaks on the n-th call to {@link #rewrite}. */
+    private static class BreakingRewriter implements CompactRewriter {
+
+        private final CompactRewriter delegate;
+        private final int breakOnCall;
+        private final Break onBreak;
+
+        private int calls = 0;
+
+        private BreakingRewriter(CompactRewriter delegate, int breakOnCall, Break onBreak) {
+            this.delegate = delegate;
+            this.breakOnCall = breakOnCall;
+            this.onBreak = onBreak;
+        }
+
+        @Override
+        public CompactResult rewrite(
+                int outputLevel, boolean dropDelete, List<List<SortedRun>> sections)
+                throws Exception {
+            if (++calls == breakOnCall) {
+                onBreak.run();
+            }
+            return delegate.rewrite(outputLevel, dropDelete, sections);
+        }
+
+        @Override
+        public CompactResult upgrade(int outputLevel, DataFileMeta file) throws Exception {
+            return delegate.upgrade(outputLevel, file);
+        }
+
+        @Override
+        public void close() throws IOException {
+            delegate.close();
+        }
+
+        interface Break {
+            void run() throws Exception;
+        }
+    }
+}


### PR DESCRIPTION
### Purpose

A compaction task writes its output files before its `CompactResult` reaches the writer, and that
result is the only thing that knows their names. Two paths throw it away and leave the files
behind:

- **The task is cancelled.** `CompactFutureManager#cancelCompaction` interrupts the thread and the
  future drops the result, so nothing deletes what was already written. This is the case the TODO
  in that method described:

  ```java
  // TODO this method may leave behind orphan files if compaction is actually finished
  //  but some CPU work still needs to be done
  ```

- **A part of a merge tree compaction fails.** `MergeTreeCompactTask` calls the rewriter more than
  once per task: a large, non overlapping file sitting between two groups of overlapping sections
  flushes the accumulated candidates and is then upgraded on its own. The groups that already
  finished have closed their writers, so their files can only be reached through the result of the
  whole task, which is never returned now.

`RollingFileWriterImpl` already aborts the file it is writing when the write itself fails, so what
leaks is the output of *earlier completed* rewrite calls, not the in flight one. Those files stay
in the bucket directory, referenced by nothing, until an orphan file clean runs.

`CompactResult` now carries the `FileWriterAbortExecutor`s of the files it describes, and
`CompactTask` takes them over as each part of it finishes. A task deletes them itself when it fails
or when it notices it was cancelled; `cancelCompaction` deletes them for a task that never gets far
enough to observe the interrupt.

Two related leaks are out of scope here: the remote lookup files created by
`LookupMergeTreeCompactRewriter#notifyRewriteCompactAfter`, and the unaware bucket dedicated
compaction job, which has its own lifecycle and never goes through `CompactFutureManager`.

Internal signature changes: `RollingFileWriter` gains `drainAbortExecutors()`, and
`BucketedAppendCompactManager.CompactRewriter#rewrite` and `BaseAppendFileStoreWrite#compactRewrite`
return `CompactResult` instead of `List<DataFileMeta>`. No public API or format change.

### Tests

`CompactOrphanFileTest` reproduces the leak end to end on a real merge tree, with real files in a
real bucket directory. Five level 0 files are laid out so that a single `MergeTreeCompactTask` makes
two separate rewrite calls:

| level 0 file | key range | role |
|---|---|---|
| 1 | `[1, 10]` | small, overlaps the next one |
| 2 | `[5, 15]` | small, closes the first section (2 sorted runs) |
| 3 | `[100, 700]` | large, its own section, flushes the accumulated candidates and is then upgraded |
| 4 | `[2000, 2010]` | small, overlaps the next one |
| 5 | `[2005, 2015]` | small, closes the last section (2 sorted runs) |

The second rewrite call is then broken, once by cancelling the compaction and once by throwing, and
the test asserts that the bucket directory holds nothing beyond the five input files.

**Before this change** (the same test run against the parent commit):

```
CompactOrphanFileTest.testCancelledCompactionLeavesNoOrphanFile  <<< FAILURE!
Expecting empty but was: ["data-853a7215-e4de-492c-907c-3600d783fc99-6.parquet"]

CompactOrphanFileTest.testFailedCompactionLeavesNoOrphanFile  <<< FAILURE!
Expecting empty but was: ["data-8a2661d2-a0b1-4f00-a313-01b3d64da1e4-6.parquet"]

Tests run: 3, Failures: 2, Errors: 0, Skipped: 0
```

Each leaked file is the real output of the first rewrite call, left in the bucket directory with
nothing referencing it.

**After this change:**

```
Tests run: 3, Failures: 0, Errors: 0, Skipped: 0
```

The third case is the control: a compaction that runs to the end must keep its files, so the test
does not pass simply by deleting everything.

`CompactTaskCancelTest` covers the `CompactTask` bookkeeping directly, including that a task which
succeeds keeps its files.

Existing suites: 291 tests across the compaction, append, merge tree, lookup and clustering
packages of `paimon-core` pass, and `paimon-flink-common`, `paimon-flink-cdc` and
`paimon-spark-common` still compile.
