### PR TITLE
[common] Fix invalid DecimalType when extracting a variant decimal

### DIFF
--- a/paimon-common/src/main/java/org/apache/paimon/data/variant/VariantGet.java
+++ b/paimon-common/src/main/java/org/apache/paimon/data/variant/VariantGet.java
@@ -138,8 +138,16 @@ public class VariantGet {
                     break;
                 case DECIMAL:
                     BigDecimal decimal = v.getDecimal();
-                    int precision = decimal.precision();
+                    if (decimal.scale() < 0) {
+                        // stripTrailingZeros folds trailing zeros into a negative exponent,
+                        // and a negative scale is not a Paimon decimal
+                        decimal = decimal.setScale(0);
+                    }
                     int scale = decimal.scale();
+                    // precision() counts the digits of the unscaled value, so it is smaller than
+                    // the scale for a value below 0.1, which DecimalType rejects. The variant
+                    // writer caps both at MAX_DECIMAL16_PRECISION, so this stays in range.
+                    int precision = Math.max(decimal.precision(), scale);
                     input = Decimal.fromBigDecimal(decimal, precision, scale);
                     inputType = DataTypes.DECIMAL(precision, scale);
                     break;

--- a/paimon-common/src/test/java/org/apache/paimon/data/variant/GenericVariantTest.java
+++ b/paimon-common/src/test/java/org/apache/paimon/data/variant/GenericVariantTest.java
@@ -277,6 +277,38 @@ public class GenericVariantTest {
     }
 
     @Test
+    public void testVariantGetDecimalWithScaleAbovePrecision() {
+        // precision() counts the digits of the unscaled value, so it is below the scale for any
+        // value under 0.1. The scale 38 case is the widest the reader admits, and it is the
+        // first one here that needs a non compact Decimal.
+        String tiny = "0.00000000000000000000000000000000000001";
+        Variant variant = GenericVariant.fromJson("{\"small\": 0.05, \"tiny\": " + tiny + "}");
+        VariantCastArgs castArgs = new VariantCastArgs(false, ZoneOffset.UTC);
+
+        assertThat(variant.variantGet("$.small", DataTypes.STRING(), castArgs))
+                .isEqualTo(BinaryString.fromString("0.05"));
+        assertThat(variant.variantGet("$.small", DataTypes.DECIMAL(5, 3), castArgs))
+                .isEqualTo(Decimal.fromBigDecimal(new BigDecimal("0.050"), 5, 3));
+        assertThat(variant.variantGet("$.tiny", DataTypes.STRING(), castArgs))
+                .isEqualTo(BinaryString.fromString(tiny));
+        assertThat(variant.variantGet("$.tiny", DataTypes.DECIMAL(38, 38), castArgs))
+                .isEqualTo(Decimal.fromBigDecimal(new BigDecimal(tiny), 38, 38));
+    }
+
+    @Test
+    public void testVariantGetDecimalWithNegativeScale() {
+        // getDecimal() strips trailing zeros, which turns 100.00 into 1E+2, a negative scale
+        Variant variant = GenericVariant.fromJson("{\"round\": 100.00}");
+        VariantCastArgs castArgs = new VariantCastArgs(false, ZoneOffset.UTC);
+
+        // rescaling rather than un-stripping keeps this in step with toJson
+        assertThat(variant.variantGet("$.round", DataTypes.STRING(), castArgs))
+                .isEqualTo(BinaryString.fromString("100"));
+        assertThat(variant.variantGet("$.round", DataTypes.DECIMAL(5, 1), castArgs))
+                .isEqualTo(Decimal.fromBigDecimal(new BigDecimal("100.0"), 5, 1));
+    }
+
+    @Test
     public void testObjectFieldOrderingCompatibility() {
         String bmpKey = "\uE000";
         String supplementaryKey = new String(Character.toChars(0x10000));

--- a/paimon-common/src/test/java/org/apache/paimon/data/variant/PaimonShreddingUtilsTest.java
+++ b/paimon-common/src/test/java/org/apache/paimon/data/variant/PaimonShreddingUtilsTest.java
@@ -291,6 +291,27 @@ public class PaimonShreddingUtilsTest {
                                         })));
     }
 
+    @Test
+    public void testAssembleDecimalWithScaleAbovePrecision() {
+        // the unshredded leg extracts through VariantGet, which used to build an invalid
+        // DecimalType for a value below 0.1 or one whose trailing zeros were stripped off
+        GenericVariant v = GenericVariant.fromJson("{\"round\": 100.00, \"small\": 0.05}");
+        VariantCastArgs castArgs = new VariantCastArgs(true, ZoneOffset.UTC);
+
+        VariantSchema variantSchema = buildVariantSchema(variantShreddingSchema(RowType.of()));
+        FieldToExtract[] fieldsToExtract = {
+            buildFieldsToExtract(DataTypes.STRING(), "$.round", castArgs, variantSchema),
+            buildFieldsToExtract(DataTypes.STRING(), "$.small", castArgs, variantSchema)
+        };
+
+        assertThat(
+                        assembleVariantStruct(
+                                castShredded(v, variantSchema), variantSchema, fieldsToExtract))
+                .isEqualTo(
+                        GenericRow.of(
+                                BinaryString.fromString("100"), BinaryString.fromString("0.05")));
+    }
+
     private static void assertVariantStructEquals(
             RowType shreddedType, RowType allTypes, GenericVariant v, GenericRow expected) {
         VariantCastArgs castArgs = new VariantCastArgs(true, ZoneOffset.UTC);


### PR DESCRIPTION
### Purpose

`VariantGet` took the precision and scale straight off the `BigDecimal` that `getDecimal()` returns. `precision()` counts the unscaled digits, so it is below the scale for anything under 0.1, and the trailing-zero stripping in `getDecimal()` turns `100.00` into `1E+2`, a negative scale. `DecimalType` rejects both, so extraction threw `Decimal scale must be between 0 and the precision 1`. Reachable on Spark 4.1+ pushdown, which accepts a `string` target and any `try_variant_get`.

A negative scale is rescaled to zero and the precision widened to the scale, matching Spark's `Decimal.set(BigDecimal)`. `checkDecimal` caps both at 38 on read, so this stays in range.

Two things it does not close, both owned by open PRs:

- `InferVariantShreddingSchema` widens precision but never clamps a negative scale, so `{"round": 100.00}` still throws under `variant.inferShreddingSchema` (#9532).- `DECIMAL` to `STRING` now yields `100` unshredded and `100.00` shredded, since the shredded leaf does not strip. Spark covers that with `castDecimalToString`; Paimon's belongs in `BaseVariantReader` (#9616).

### Tests

`GenericVariantTest` for both shapes and the scale-38 boundary, `PaimonShreddingUtilsTest` for the pushdown path.

Written with Claude Code; verification is mine.