### PR TITLE
[ci][python] Fix Python 3.6 CI after Bullseye EOL

### DIFF
--- a/.github/workflows/paimon-python-checks.yml
+++ b/.github/workflows/paimon-python-checks.yml
@@ -69,6 +69,12 @@ jobs:
       - name: Install system dependencies
         shell: bash
         run: |
+          if [[ "${{ matrix.python-version }}" == "3.6.15" ]]; then
+            # The Python 3.6 image uses EOL Debian Bullseye.
+            sed -i '/security.debian.org\/debian-security/d' /etc/apt/sources.list
+            sed -i 's|deb.debian.org/debian|archive.debian.org/debian|g' /etc/apt/sources.list
+            echo 'Acquire::Check-Valid-Until "false";' > /etc/apt/apt.conf.d/99archive
+          fi
           apt-get update && apt-get install -y \
             build-essential \
             git \


### PR DESCRIPTION
### Purpose

The `python:3.6.15-slim` image uses Debian 11 Bullseye. Bullseye reached end of LTS on August 31, 2026, so its frozen security metadata has expired and every Python 3.6 job now fails during `apt-get update` before tests run.

### Changes

- Use the Debian archive for the Python 3.6 job.
- Remove the expired Bullseye security source and disable `Valid-Until` checks for the archive.
- Leave every other Python job unchanged.

### Tests

- Verified the Bullseye and Bullseye Updates archive endpoints.
- Verified the source rewrite.
- `git diff --check`.