### PR TITLE
[core] Preserve specialized iterator for identity mappings

### DIFF
--- a/paimon-common/src/main/java/org/apache/paimon/data/columnar/ColumnarRowIterator.java
+++ b/paimon-common/src/main/java/org/apache/paimon/data/columnar/ColumnarRowIterator.java
@@ -115,6 +115,10 @@ public class ColumnarRowIterator extends RecyclableIterator<InternalRow>
 
     public ColumnarRowIterator mapping(
             @Nullable PartitionInfo partitionInfo, @Nullable int[] indexMapping) {
+        if (partitionInfo == null && isIdentityMapping(indexMapping, row.batch().getArity())) {
+            return this;
+        }
+
         if (partitionInfo != null || indexMapping != null) {
             VectorizedColumnBatch vectorizedColumnBatch = row.batch();
             ColumnVector[] vectors = vectorizedColumnBatch.columns;
@@ -127,6 +131,19 @@ public class ColumnarRowIterator extends RecyclableIterator<InternalRow>
             return copy(vectors);
         }
         return this;
+    }
+
+    private static boolean isIdentityMapping(@Nullable int[] indexMapping, int arity) {
+        if (indexMapping == null || indexMapping.length != arity) {
+            return false;
+        }
+
+        for (int i = 0; i < indexMapping.length; i++) {
+            if (indexMapping[i] != i) {
+                return false;
+            }
+        }
+        return true;
     }
 
     public ColumnarRowIterator assignRowTracking(

--- a/paimon-common/src/test/java/org/apache/paimon/data/columnar/ColumnarRowIteratorTest.java
+++ b/paimon-common/src/test/java/org/apache/paimon/data/columnar/ColumnarRowIteratorTest.java
@@ -18,8 +18,13 @@
 
 package org.apache.paimon.data.columnar;
 
+import org.apache.paimon.data.BinaryRow;
+import org.apache.paimon.data.BinaryRowWriter;
+import org.apache.paimon.data.PartitionInfo;
 import org.apache.paimon.data.columnar.heap.HeapIntVector;
 import org.apache.paimon.fs.Path;
+import org.apache.paimon.types.DataTypes;
+import org.apache.paimon.types.RowType;
 import org.apache.paimon.utils.LongIterator;
 
 import org.junit.jupiter.api.Test;
@@ -60,6 +65,68 @@ public class ColumnarRowIteratorTest {
                 rowIterator.next();
             }
             assertThat(rowIterator.returnedPosition()).isEqualTo(positions[rowIterator.index - 1]);
+        }
+    }
+
+    @Test
+    public void testIdentityMappingPreservesSpecializedIterator() {
+        HeapIntVector firstVector = new HeapIntVector(1);
+        HeapIntVector secondVector = new HeapIntVector(1);
+        VectorizedColumnBatch batch =
+                new VectorizedColumnBatch(new ColumnVector[] {firstVector, secondVector});
+        batch.setNumRows(1);
+        ColumnarRowIterator rowIterator = new TestingSpecializedIterator(batch);
+        rowIterator.reset(0);
+
+        assertThat(rowIterator.mapping(null, new int[] {0, 1})).isSameAs(rowIterator);
+    }
+
+    @Test
+    public void testNonIdentityMappingCopiesIterator() {
+        HeapIntVector firstVector = new HeapIntVector(1);
+        HeapIntVector secondVector = new HeapIntVector(1);
+        VectorizedColumnBatch batch =
+                new VectorizedColumnBatch(new ColumnVector[] {firstVector, secondVector});
+        batch.setNumRows(1);
+        ColumnarRowIterator rowIterator = new TestingSpecializedIterator(batch);
+        rowIterator.reset(0);
+
+        ColumnarRowIterator reordered = rowIterator.mapping(null, new int[] {1, 0});
+        assertThat(reordered).isNotSameAs(rowIterator);
+        assertThat(reordered.batch().columns).containsExactly(secondVector, firstVector);
+
+        ColumnarRowIterator projected = rowIterator.mapping(null, new int[] {0});
+        assertThat(projected).isNotSameAs(rowIterator);
+        assertThat(projected.batch().columns).containsExactly(firstVector);
+    }
+
+    @Test
+    public void testPartitionMappingCopiesIterator() {
+        HeapIntVector dataVector = new HeapIntVector(1);
+        dataVector.setInt(0, 7);
+        VectorizedColumnBatch batch = new VectorizedColumnBatch(new ColumnVector[] {dataVector});
+        batch.setNumRows(1);
+        ColumnarRowIterator rowIterator = new TestingSpecializedIterator(batch);
+        rowIterator.reset(0);
+
+        BinaryRow partition = new BinaryRow(1);
+        BinaryRowWriter writer = new BinaryRowWriter(partition);
+        writer.writeInt(0, 42);
+        writer.complete();
+        PartitionInfo partitionInfo =
+                new PartitionInfo(new int[] {1, -1, 0}, RowType.of(DataTypes.INT()), partition);
+
+        ColumnarRowIterator mapped = rowIterator.mapping(partitionInfo, new int[] {0, 1});
+        assertThat(mapped).isNotSameAs(rowIterator);
+        assertThat(mapped.batch().getArity()).isEqualTo(2);
+        assertThat(mapped.batch().getInt(0, 0)).isEqualTo(7);
+        assertThat(mapped.batch().getInt(0, 1)).isEqualTo(42);
+    }
+
+    private static class TestingSpecializedIterator extends ColumnarRowIterator {
+
+        private TestingSpecializedIterator(VectorizedColumnBatch batch) {
+            super(new Path("test"), new ColumnarRow(batch), null);
         }
     }
 }


### PR DESCRIPTION
## Summary

Preserve specialized `ColumnarRowIterator` implementations when a reader applies a full identity index mapping. A no-op mapping should not replace an iterator that carries additional batch capabilities.

## Changes

- Detect exact full identity mappings (`[0, 1, ..., arity - 1]`) when no partition mapping is present.
- Return the original iterator for that no-op case.
- Keep the existing copy path for projections, reordering, missing columns, and partition mappings.

## Testing

- [x] `ColumnarRowIteratorTest` on JDK 11: 4/4
- [x] `ColumnarRowIteratorTest` on JDK 8: 4/4
- [x] Non-fast `paimon-common` verify (Spotless, Checkstyle, and RAT)
- [x] `git diff --check`
