### PR TITLE
[python] Invalidate commit retry cache after overwrite

### DIFF
--- a/paimon-python/pypaimon/tests/overwrite_commit_conflict_test.py
+++ b/paimon-python/pypaimon/tests/overwrite_commit_conflict_test.py
@@ -276,15 +276,17 @@ class OverwriteCommitConflictTest(unittest.TestCase):
         self.assertEqual([], incr_results)
         self.assertEqual(full_scans['n'], 1)
 
-    def test_incremental_merge_across_non_append_snapshot(self):
-        self._assert_merge_equals_full_scan(self._overwrite_target)
+    def test_full_scan_across_empty_delta_overwrite_snapshot(self):
+        self._assert_merge_equals_full_scan(
+            self._overwrite_target, hide_overwrite_delta=True)
 
     def test_incremental_merge_across_compact_snapshot(self):
         self._assert_merge_equals_full_scan(self._compact_target)
 
-    def _assert_merge_equals_full_scan(self, concurrent_fn):
-        # A non-APPEND snapshot (OVERWRITE/COMPACT, delta = ADD+DELETE) lands
-        # between retries; the merged base must still equal a fresh full scan.
+    def _assert_merge_equals_full_scan(self, concurrent_fn,
+                                       hide_overwrite_delta=False):
+        # A non-APPEND snapshot lands between retries; the conflict base must
+        # still equal a fresh full scan.
         K = 2
 
         wb = self.table.new_batch_write_builder().overwrite({'f0': 1})
@@ -297,6 +299,18 @@ class OverwriteCommitConflictTest(unittest.TestCase):
         captured = []
         orig_check = fsc.conflict_detection.check_conflicts
         orig_full = fsc.commit_scanner.read_all_entries_from_changed_partitions
+
+        if hide_overwrite_delta:
+            orig_read_delta = fsc.commit_scanner.manifest_list_manager.read_delta
+
+            def read_delta(snapshot):
+                # Row-id reassignment replaces the base manifests in an
+                # OVERWRITE snapshot while deliberately writing an empty delta.
+                if snapshot.commit_kind == "OVERWRITE":
+                    return []
+                return orig_read_delta(snapshot)
+
+            fsc.commit_scanner.manifest_list_manager.read_delta = read_delta
 
         def spy_check(latest_snapshot, base_entries, delta_entries, *a, **k):
             captured.append((latest_snapshot, list(base_entries), list(delta_entries)))
@@ -315,6 +329,14 @@ class OverwriteCommitConflictTest(unittest.TestCase):
             return orig_cas(base_snapshot_uuid, snapshot, statistics)
 
         fsc.snapshot_commit.commit = patched_cas
+
+        if hide_overwrite_delta:
+            with self.assertRaisesRegex(
+                    RuntimeError, "File deletion conflicts detected"):
+                c.commit(messages)
+            c.close()
+            self.assertEqual(cas['fails'], 1)
+            return
 
         c.commit(messages)
         c.close()

--- a/paimon-python/pypaimon/write/commit/commit_scanner.py
+++ b/paimon-python/pypaimon/write/commit/commit_scanner.py
@@ -134,8 +134,8 @@ class CommitScanner:
                                  index_entries=None) -> Optional[List[ManifestEntry]]:
         """Delta entries (incl. DELETEs) in ``(from_snapshot, to_snapshot]``,
         changed-partition filtered, so a retry can reuse the prior base and read
-        only the changes since. Returns None on a missing snapshot (caller then
-        full-scans). Mirrors Java ``CommitScanner#readIncrementalChanges``.
+        only the changes since. Returns None on a missing or OVERWRITE snapshot
+        (caller then full-scans). Mirrors Java conflict detection behavior.
         """
         snapshot_manager = self.table.snapshot_manager()
         partition_filter = self._build_partition_filter_from_changes(
@@ -144,6 +144,8 @@ class CommitScanner:
         for snapshot_id in range(from_snapshot.id + 1, to_snapshot.id + 1):
             snapshot = snapshot_manager.get_snapshot_by_id(snapshot_id)
             if snapshot is None:
+                return None
+            if snapshot.commit_kind == "OVERWRITE":
                 return None
             entries.extend(
                 self.read_incremental_raw_entries_from_changed_partitions(


### PR DESCRIPTION
### Purpose

Fix a PyPaimon correctness issue in conflict detection during commit retries.

A failed commit attempt caches the base manifest entries and normally merges only later delta entries. However, an OVERWRITE may replace the base manifest list while publishing an empty delta manifest list, as row-id reassignment does. Reusing the cached base then hides the replacement and can allow stale row-id update files to commit.

Return None from the incremental scan when the retry interval contains an OVERWRITE, so the existing caller performs a full scan. This matches the Java conflict detection behavior.

### Tests

Added a regression that forces a CAS failure, commits an OVERWRITE whose replacement is hidden from the delta scan, and verifies the retry detects the file deletion conflict.

Before the fix, the regression committed with a stale conflict base and failed by showing different file identifiers from a fresh full scan. After the fix it passes.

Validated:

- overwrite_commit_conflict_test: 5 passed
- file_store_commit_test, partition_predicate_test, and conflict_detection_test: 88 passed
- flake8, py_compile, and git diff --check passed