### PR TITLE
[core] Preserve timestamp values on changelog retraction records

### DIFF
--- a/docs/docs/primary-key-table/changelog-producer.md
+++ b/docs/docs/primary-key-table/changelog-producer.md
@@ -103,6 +103,24 @@ changelog for the same record. It also supports `changelog-producer.ignore-updat
 records and `changelog-producer.ignore-delete` to exclude DELETE (-D) records from changelog files. These options are
 useful when downstream consumers only need the latest state (e.g. upsert sinks) and do not require retraction.
 
+By setting `'changelog-producer.preserve-sequence-on-retract'` to a comma-separated list of column names,
+retraction records (`-U`, `-D`) will take those columns' values from the incoming event instead of the
+stored row. This is useful when delete or update events carry an event timestamp that downstream consumers
+need, such as external systems like Cassandra that rely on `WRITETIME` for conflict resolution.
+This option is only supported by the `lookup` changelog producer.
+
+```sql
+CREATE TABLE my_table (
+    id INT PRIMARY KEY NOT ENFORCED,
+    data STRING,
+    event_ts BIGINT
+) WITH (
+    'changelog-producer' = 'lookup',
+    'sequence.field' = 'event_ts',
+    'changelog-producer.preserve-sequence-on-retract' = 'event_ts'
+);
+```
+
 (Note: Please increase `'execution.checkpointing.max-concurrent-checkpoints'` Flink configuration, this is very
 important for performance).
 

--- a/docs/docs/primary-key-table/changelog-producer.md
+++ b/docs/docs/primary-key-table/changelog-producer.md
@@ -103,7 +103,7 @@ changelog for the same record. It also supports `changelog-producer.ignore-updat
 records and `changelog-producer.ignore-delete` to exclude DELETE (-D) records from changelog files. These options are
 useful when downstream consumers only need the latest state (e.g. upsert sinks) and do not require retraction.
 
-By setting `'changelog-producer.preserve-sequence-on-retract'` to a comma-separated list of column names,
+By setting `'changelog-producer.preserve-field-on-retract'` to a comma-separated list of column names,
 retraction records (`-U`, `-D`) will take those columns' values from the incoming event instead of the
 stored row. This is useful when delete or update events carry an event timestamp that downstream consumers
 need, such as external systems like Cassandra that rely on `WRITETIME` for conflict resolution.
@@ -117,7 +117,7 @@ CREATE TABLE my_table (
 ) WITH (
     'changelog-producer' = 'lookup',
     'sequence.field' = 'event_ts',
-    'changelog-producer.preserve-sequence-on-retract' = 'event_ts'
+    'changelog-producer.preserve-field-on-retract' = 'event_ts'
 );
 ```
 

--- a/docs/generated/core_configuration.html
+++ b/docs/generated/core_configuration.html
@@ -225,6 +225,12 @@ under the License.
             <td>Whether to ignore update-before records in the changelog. When set to true, UPDATE_BEFORE (-U) records will not be written to changelog files. This configuration is only valid for the changelog-producer is lookup or full-compaction.</td>
         </tr>
         <tr>
+            <td><h5>changelog-producer.preserve-sequence-on-retract</h5></td>
+            <td style="word-wrap: break-word;">(none)</td>
+            <td>String</td>
+            <td>A comma-separated list of column names whose values should be taken from the incoming event rather than the stored row when producing changelog retraction records (-U, -D). This is useful when delete or update events carry their own event timestamp and you want that timestamp preserved in the changelog. Only valid when changelog-producer is lookup.</td>
+        </tr>
+        <tr>
             <td><h5>changelog-producer.row-deduplicate</h5></td>
             <td style="word-wrap: break-word;">false</td>
             <td>Boolean</td>
@@ -393,12 +399,6 @@ under the License.
             <td>When incremental size is bigger than this threshold, force a full compaction.</td>
         </tr>
         <tr>
-            <td><h5>continuous-compaction.initial-scan-mode</h5></td>
-            <td style="word-wrap: break-word;">earliest</td>
-            <td><p>Enum</p></td>
-            <td>Initial snapshot mode for dedicated streaming compaction. When set to 'earliest' (the default), compaction starts from the earliest available snapshot if no COMPACT snapshot exists; when a COMPACT snapshot exists, compaction always resumes from the snapshot after it. When set to 'latest', the latest snapshot is read in ALL mode as the initial baseline and subsequent scans start from the next snapshot. The 'latest' mode skips historical snapshot changes and should only be used when historical changelog replay is not required.<br /><br />Possible values:<ul><li>"earliest": Read snapshots from the earliest available snapshot.</li><li>"latest": Read the latest snapshot as the initial full baseline.</li></ul></td>
-        </tr>
-        <tr>
             <td><h5>compaction.max-size-amplification-percent</h5></td>
             <td style="word-wrap: break-word;">200</td>
             <td>Integer</td>
@@ -487,6 +487,12 @@ under the License.
             <td style="word-wrap: break-word;">exactly-once</td>
             <td><p>Enum</p></td>
             <td>Specify the consumer consistency mode for table.<br /><br />Possible values:<ul><li>"exactly-once": Readers consume data at snapshot granularity, and strictly ensure that the snapshot-id recorded in the consumer is the snapshot-id + 1 that all readers have exactly consumed.</li><li>"at-least-once": Each reader consumes snapshots at a different rate, and the snapshot with the slowest consumption progress among all readers will be recorded in the consumer.</li></ul></td>
+        </tr>
+        <tr>
+            <td><h5>continuous-compaction.initial-scan-mode</h5></td>
+            <td style="word-wrap: break-word;">earliest</td>
+            <td><p>Enum</p></td>
+            <td>Initial snapshot mode for dedicated streaming compaction. When set to 'earliest' (the default), compaction starts from the earliest available snapshot if no COMPACT snapshot exists; when a COMPACT snapshot exists, compaction always resumes from the snapshot after it. When set to 'latest', the latest snapshot is read in ALL mode as the initial baseline and subsequent scans start from the next snapshot. The 'latest' mode skips historical snapshot changes and should only be used when historical changelog replay is not required.<br /><br />Possible values:<ul><li>"earliest": Read snapshots from the earliest available snapshot.</li><li>"latest": Read the latest snapshot as the initial full baseline.</li></ul></td>
         </tr>
         <tr>
             <td><h5>continuous.discovery-interval</h5></td>

--- a/docs/generated/core_configuration.html
+++ b/docs/generated/core_configuration.html
@@ -225,7 +225,7 @@ under the License.
             <td>Whether to ignore update-before records in the changelog. When set to true, UPDATE_BEFORE (-U) records will not be written to changelog files. This configuration is only valid for the changelog-producer is lookup or full-compaction.</td>
         </tr>
         <tr>
-            <td><h5>changelog-producer.preserve-sequence-on-retract</h5></td>
+            <td><h5>changelog-producer.preserve-field-on-retract</h5></td>
             <td style="word-wrap: break-word;">(none)</td>
             <td>String</td>
             <td>A comma-separated list of column names whose values should be taken from the incoming event rather than the stored row when producing changelog retraction records (-U, -D). This is useful when delete or update events carry their own event timestamp and you want that timestamp preserved in the changelog. Only valid when changelog-producer is lookup.</td>

--- a/paimon-api/src/main/java/org/apache/paimon/CoreOptions.java
+++ b/paimon-api/src/main/java/org/apache/paimon/CoreOptions.java
@@ -1116,6 +1116,18 @@ public class CoreOptions implements Serializable {
                     .withDescription(
                             "Fields that are ignored for comparison while generating -U, +U changelog for the same record. This configuration is only valid for the changelog-producer.row-deduplicate is true.");
 
+    public static final ConfigOption<String> CHANGELOG_PRODUCER_PRESERVE_SEQUENCE_ON_RETRACT =
+            key("changelog-producer.preserve-sequence-on-retract")
+                    .stringType()
+                    .noDefaultValue()
+                    .withDescription(
+                            "A comma-separated list of column names whose values should be taken from the "
+                                    + "incoming event rather than the stored row when producing changelog "
+                                    + "retraction records (-U, -D). This is useful when delete or update "
+                                    + "events carry their own event timestamp and you want that timestamp "
+                                    + "preserved in the changelog. "
+                                    + "Only valid when changelog-producer is lookup.");
+
     public static final ConfigOption<Boolean> TABLE_READ_SEQUENCE_NUMBER_ENABLED =
             key("table-read.sequence-number.enabled")
                     .booleanType()
@@ -3911,6 +3923,16 @@ public class CoreOptions implements Serializable {
     public List<String> changelogRowDeduplicateIgnoreFields() {
         return options.getOptional(CHANGELOG_PRODUCER_ROW_DEDUPLICATE_IGNORE_FIELDS)
                 .map(s -> Arrays.asList(s.split(",")))
+                .orElse(Collections.emptyList());
+    }
+
+    public List<String> changelogPreserveSequenceOnRetract() {
+        return options.getOptional(CHANGELOG_PRODUCER_PRESERVE_SEQUENCE_ON_RETRACT)
+                .map(
+                        s ->
+                                Arrays.stream(s.split(","))
+                                        .map(String::trim)
+                                        .collect(Collectors.toList()))
                 .orElse(Collections.emptyList());
     }
 

--- a/paimon-api/src/main/java/org/apache/paimon/CoreOptions.java
+++ b/paimon-api/src/main/java/org/apache/paimon/CoreOptions.java
@@ -1116,8 +1116,8 @@ public class CoreOptions implements Serializable {
                     .withDescription(
                             "Fields that are ignored for comparison while generating -U, +U changelog for the same record. This configuration is only valid for the changelog-producer.row-deduplicate is true.");
 
-    public static final ConfigOption<String> CHANGELOG_PRODUCER_PRESERVE_SEQUENCE_ON_RETRACT =
-            key("changelog-producer.preserve-sequence-on-retract")
+    public static final ConfigOption<String> CHANGELOG_PRODUCER_PRESERVE_FIELD_ON_RETRACT =
+            key("changelog-producer.preserve-field-on-retract")
                     .stringType()
                     .noDefaultValue()
                     .withDescription(
@@ -3926,8 +3926,8 @@ public class CoreOptions implements Serializable {
                 .orElse(Collections.emptyList());
     }
 
-    public List<String> changelogPreserveSequenceOnRetract() {
-        return options.getOptional(CHANGELOG_PRODUCER_PRESERVE_SEQUENCE_ON_RETRACT)
+    public List<String> changelogPreserveFieldOnRetract() {
+        return options.getOptional(CHANGELOG_PRODUCER_PRESERVE_FIELD_ON_RETRACT)
                 .map(
                         s ->
                                 Arrays.stream(s.split(","))

--- a/paimon-core/src/main/java/org/apache/paimon/mergetree/compact/LookupChangelogMergeFunctionWrapper.java
+++ b/paimon-core/src/main/java/org/apache/paimon/mergetree/compact/LookupChangelogMergeFunctionWrapper.java
@@ -20,7 +20,15 @@ package org.apache.paimon.mergetree.compact;
 
 import org.apache.paimon.KeyValue;
 import org.apache.paimon.codegen.RecordEqualiser;
+import org.apache.paimon.data.BinaryString;
+import org.apache.paimon.data.Blob;
+import org.apache.paimon.data.Decimal;
+import org.apache.paimon.data.InternalArray;
+import org.apache.paimon.data.InternalMap;
 import org.apache.paimon.data.InternalRow;
+import org.apache.paimon.data.InternalVector;
+import org.apache.paimon.data.Timestamp;
+import org.apache.paimon.data.variant.Variant;
 import org.apache.paimon.deletionvectors.BucketedDvMaintainer;
 import org.apache.paimon.lookup.LookupStrategy;
 import org.apache.paimon.mergetree.lookup.FilePosition;
@@ -64,6 +72,7 @@ public class LookupChangelogMergeFunctionWrapper<T>
     private final LookupStrategy lookupStrategy;
     private final @Nullable BucketedDvMaintainer deletionVectorsMaintainer;
     private final Comparator<KeyValue> comparator;
+    @Nullable private final SequenceFieldOverwriteRow reusedOverwriteRow;
 
     public LookupChangelogMergeFunctionWrapper(
             MergeFunctionFactory<KeyValue> mergeFunctionFactory,
@@ -72,6 +81,24 @@ public class LookupChangelogMergeFunctionWrapper<T>
             LookupStrategy lookupStrategy,
             @Nullable BucketedDvMaintainer deletionVectorsMaintainer,
             @Nullable UserDefinedSeqComparator userDefinedSeqComparator) {
+        this(
+                mergeFunctionFactory,
+                lookup,
+                valueEqualiser,
+                lookupStrategy,
+                deletionVectorsMaintainer,
+                userDefinedSeqComparator,
+                null);
+    }
+
+    public LookupChangelogMergeFunctionWrapper(
+            MergeFunctionFactory<KeyValue> mergeFunctionFactory,
+            Function<InternalRow, T> lookup,
+            @Nullable RecordEqualiser valueEqualiser,
+            LookupStrategy lookupStrategy,
+            @Nullable BucketedDvMaintainer deletionVectorsMaintainer,
+            @Nullable UserDefinedSeqComparator userDefinedSeqComparator,
+            @Nullable int[] preserveFieldIndices) {
         MergeFunction<KeyValue> mergeFunction = mergeFunctionFactory.create();
         checkArgument(
                 mergeFunction instanceof LookupMergeFunction,
@@ -88,6 +115,10 @@ public class LookupChangelogMergeFunctionWrapper<T>
         this.lookupStrategy = lookupStrategy;
         this.deletionVectorsMaintainer = deletionVectorsMaintainer;
         this.comparator = createSequenceComparator(userDefinedSeqComparator);
+        this.reusedOverwriteRow =
+                preserveFieldIndices != null && preserveFieldIndices.length > 0
+                        ? new SequenceFieldOverwriteRow(preserveFieldIndices)
+                        : null;
     }
 
     @Override
@@ -152,18 +183,27 @@ public class LookupChangelogMergeFunctionWrapper<T>
             }
         } else {
             if (!after.isAdd()) {
-                reusedResult.addChangelog(replaceBefore(RowKind.DELETE, before));
+                reusedResult.addChangelog(
+                        replaceBeforeWithSequenceOverwrite(RowKind.DELETE, before, after));
             } else if (valueEqualiser == null
                     || !valueEqualiser.equals(before.value(), after.value())) {
                 reusedResult
-                        .addChangelog(replaceBefore(RowKind.UPDATE_BEFORE, before))
+                        .addChangelog(
+                                replaceBeforeWithSequenceOverwrite(
+                                        RowKind.UPDATE_BEFORE, before, after))
                         .addChangelog(replaceAfter(RowKind.UPDATE_AFTER, after));
             }
         }
     }
 
-    private KeyValue replaceBefore(RowKind valueKind, KeyValue from) {
-        return replace(reusedBefore, valueKind, from);
+    private KeyValue replaceBeforeWithSequenceOverwrite(
+            RowKind valueKind, KeyValue before, KeyValue after) {
+        if (reusedOverwriteRow != null) {
+            reusedOverwriteRow.replace(before.value(), after.value());
+            return reusedBefore.replace(
+                    before.key(), after.sequenceNumber(), valueKind, reusedOverwriteRow);
+        }
+        return replace(reusedBefore, valueKind, before);
     }
 
     private KeyValue replaceAfter(RowKind valueKind, KeyValue from) {
@@ -187,5 +227,144 @@ public class LookupChangelogMergeFunctionWrapper<T>
             }
             return Long.compare(o1.sequenceNumber(), o2.sequenceNumber());
         };
+    }
+
+    /**
+     * An {@link InternalRow} that delegates to a primary row for all fields, except for specified
+     * sequence field positions which are read from a secondary (event) row. This allows changelog
+     * before-image records to carry the incoming event's sequence field value while preserving the
+     * rest of the stored row's data.
+     */
+    static class SequenceFieldOverwriteRow implements InternalRow {
+
+        private final boolean[] isSequenceField;
+        private InternalRow primaryRow;
+        private InternalRow eventRow;
+
+        SequenceFieldOverwriteRow(int[] sequenceFieldIndices) {
+            int maxIndex = 0;
+            for (int idx : sequenceFieldIndices) {
+                maxIndex = Math.max(maxIndex, idx);
+            }
+            this.isSequenceField = new boolean[maxIndex + 1];
+            for (int idx : sequenceFieldIndices) {
+                this.isSequenceField[idx] = true;
+            }
+        }
+
+        SequenceFieldOverwriteRow replace(InternalRow primaryRow, InternalRow eventRow) {
+            this.primaryRow = primaryRow;
+            this.eventRow = eventRow;
+            return this;
+        }
+
+        private InternalRow rowFor(int pos) {
+            return pos < isSequenceField.length && isSequenceField[pos] ? eventRow : primaryRow;
+        }
+
+        @Override
+        public int getFieldCount() {
+            return primaryRow.getFieldCount();
+        }
+
+        @Override
+        public RowKind getRowKind() {
+            return primaryRow.getRowKind();
+        }
+
+        @Override
+        public void setRowKind(RowKind kind) {
+            primaryRow.setRowKind(kind);
+        }
+
+        @Override
+        public boolean isNullAt(int pos) {
+            return rowFor(pos).isNullAt(pos);
+        }
+
+        @Override
+        public boolean getBoolean(int pos) {
+            return rowFor(pos).getBoolean(pos);
+        }
+
+        @Override
+        public byte getByte(int pos) {
+            return rowFor(pos).getByte(pos);
+        }
+
+        @Override
+        public short getShort(int pos) {
+            return rowFor(pos).getShort(pos);
+        }
+
+        @Override
+        public int getInt(int pos) {
+            return rowFor(pos).getInt(pos);
+        }
+
+        @Override
+        public long getLong(int pos) {
+            return rowFor(pos).getLong(pos);
+        }
+
+        @Override
+        public float getFloat(int pos) {
+            return rowFor(pos).getFloat(pos);
+        }
+
+        @Override
+        public double getDouble(int pos) {
+            return rowFor(pos).getDouble(pos);
+        }
+
+        @Override
+        public BinaryString getString(int pos) {
+            return rowFor(pos).getString(pos);
+        }
+
+        @Override
+        public Decimal getDecimal(int pos, int precision, int scale) {
+            return rowFor(pos).getDecimal(pos, precision, scale);
+        }
+
+        @Override
+        public Timestamp getTimestamp(int pos, int precision) {
+            return rowFor(pos).getTimestamp(pos, precision);
+        }
+
+        @Override
+        public byte[] getBinary(int pos) {
+            return rowFor(pos).getBinary(pos);
+        }
+
+        @Override
+        public Variant getVariant(int pos) {
+            return rowFor(pos).getVariant(pos);
+        }
+
+        @Override
+        public Blob getBlob(int pos) {
+            return rowFor(pos).getBlob(pos);
+        }
+
+        @Override
+        public InternalArray getArray(int pos) {
+            return rowFor(pos).getArray(pos);
+        }
+
+        @Override
+        public InternalVector getVector(int pos) {
+            return rowFor(pos).getVector(pos);
+        }
+
+        @Override
+        public InternalMap getMap(int pos) {
+            return rowFor(pos).getMap(pos);
+        }
+
+        @Override
+        public InternalRow getRow(int pos, int numFields) {
+            return rowFor(pos).getRow(pos, numFields);
+        }
     }
 }

--- a/paimon-core/src/main/java/org/apache/paimon/mergetree/compact/LookupMergeTreeCompactRewriter.java
+++ b/paimon-core/src/main/java/org/apache/paimon/mergetree/compact/LookupMergeTreeCompactRewriter.java
@@ -199,14 +199,17 @@ public class LookupMergeTreeCompactRewriter<T> extends ChangelogMergeTreeRewrite
         @Nullable private final RecordEqualiser valueEqualiser;
         private final LookupStrategy lookupStrategy;
         @Nullable private final UserDefinedSeqComparator userDefinedSeqComparator;
+        @Nullable private final int[] preserveFieldIndices;
 
         public LookupMergeFunctionWrapperFactory(
                 @Nullable RecordEqualiser valueEqualiser,
                 LookupStrategy lookupStrategy,
-                @Nullable UserDefinedSeqComparator userDefinedSeqComparator) {
+                @Nullable UserDefinedSeqComparator userDefinedSeqComparator,
+                @Nullable int[] preserveFieldIndices) {
             this.valueEqualiser = valueEqualiser;
             this.lookupStrategy = lookupStrategy;
             this.userDefinedSeqComparator = userDefinedSeqComparator;
+            this.preserveFieldIndices = preserveFieldIndices;
         }
 
         @Override
@@ -227,7 +230,8 @@ public class LookupMergeTreeCompactRewriter<T> extends ChangelogMergeTreeRewrite
                     valueEqualiser,
                     lookupStrategy,
                     deletionVectorsMaintainer,
-                    userDefinedSeqComparator);
+                    userDefinedSeqComparator,
+                    preserveFieldIndices);
         }
     }
 

--- a/paimon-core/src/main/java/org/apache/paimon/mergetree/compact/MergeTreeCompactManagerFactory.java
+++ b/paimon-core/src/main/java/org/apache/paimon/mergetree/compact/MergeTreeCompactManagerFactory.java
@@ -323,7 +323,7 @@ public class MergeTreeCompactManagerFactory implements KvCompactionManagerFactor
                 } else {
                     processorFactory = PersistValueProcessor.factory(valueType);
                 }
-                List<String> preserveColumns = options.changelogPreserveSequenceOnRetract();
+                List<String> preserveColumns = options.changelogPreserveFieldOnRetract();
                 int[] preserveFieldIndices = null;
                 if (!preserveColumns.isEmpty()) {
                     List<String> fieldNames = valueType.getFieldNames();
@@ -339,7 +339,7 @@ public class MergeTreeCompactManagerFactory implements KvCompactionManagerFactor
                                                                             + "Available columns: %s",
                                                                     name,
                                                                     CoreOptions
-                                                                            .CHANGELOG_PRODUCER_PRESERVE_SEQUENCE_ON_RETRACT
+                                                                            .CHANGELOG_PRODUCER_PRESERVE_FIELD_ON_RETRACT
                                                                             .key(),
                                                                     fieldNames));
                                                 }

--- a/paimon-core/src/main/java/org/apache/paimon/mergetree/compact/MergeTreeCompactManagerFactory.java
+++ b/paimon-core/src/main/java/org/apache/paimon/mergetree/compact/MergeTreeCompactManagerFactory.java
@@ -323,11 +323,36 @@ public class MergeTreeCompactManagerFactory implements KvCompactionManagerFactor
                 } else {
                     processorFactory = PersistValueProcessor.factory(valueType);
                 }
+                List<String> preserveColumns = options.changelogPreserveSequenceOnRetract();
+                int[] preserveFieldIndices = null;
+                if (!preserveColumns.isEmpty()) {
+                    List<String> fieldNames = valueType.getFieldNames();
+                    preserveFieldIndices =
+                            preserveColumns.stream()
+                                    .mapToInt(
+                                            name -> {
+                                                int idx = fieldNames.indexOf(name);
+                                                if (idx < 0) {
+                                                    throw new IllegalArgumentException(
+                                                            String.format(
+                                                                    "Column '%s' specified in '%s' not found in value type. "
+                                                                            + "Available columns: %s",
+                                                                    name,
+                                                                    CoreOptions
+                                                                            .CHANGELOG_PRODUCER_PRESERVE_SEQUENCE_ON_RETRACT
+                                                                            .key(),
+                                                                    fieldNames));
+                                                }
+                                                return idx;
+                                            })
+                                    .toArray();
+                }
                 wrapperFactory =
                         new LookupMergeFunctionWrapperFactory<>(
                                 logDedupEqualSupplier.get(),
                                 lookupStrategy,
-                                UserDefinedSeqComparator.create(valueType, options));
+                                UserDefinedSeqComparator.create(valueType, options),
+                                preserveFieldIndices);
             }
             LookupLevels<?> lookupLevels =
                     createLookupLevels(

--- a/paimon-core/src/test/java/org/apache/paimon/mergetree/compact/LookupChangelogMergeFunctionWrapperTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/mergetree/compact/LookupChangelogMergeFunctionWrapperTest.java
@@ -558,7 +558,7 @@ public class LookupChangelogMergeFunctionWrapperTest {
     }
 
     @Test
-    public void testPreserveSequenceOnRetractDelete() {
+    public void testPreserveFieldOnRetractDelete() {
         // Schema: value has two fields: f0 (data), f1 (event_ts to preserve)
         Map<InternalRow, KeyValue> highLevel = new HashMap<>();
         RowType valueType =
@@ -603,7 +603,7 @@ public class LookupChangelogMergeFunctionWrapperTest {
     }
 
     @Test
-    public void testPreserveSequenceOnRetractUpdate() {
+    public void testPreserveFieldOnRetractUpdate() {
         // Schema: value has two fields: f0 (data), f1 (event_ts to preserve)
         Map<InternalRow, KeyValue> highLevel = new HashMap<>();
         RowType valueType =
@@ -651,7 +651,7 @@ public class LookupChangelogMergeFunctionWrapperTest {
     }
 
     @Test
-    public void testPreserveSequenceOnRetractNotConfigured() {
+    public void testPreserveFieldOnRetractNotConfigured() {
         // Verify that the old behavior is preserved when no columns are specified
         Map<InternalRow, KeyValue> highLevel = new HashMap<>();
         RowType valueType =

--- a/paimon-core/src/test/java/org/apache/paimon/mergetree/compact/LookupChangelogMergeFunctionWrapperTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/mergetree/compact/LookupChangelogMergeFunctionWrapperTest.java
@@ -556,4 +556,139 @@ public class LookupChangelogMergeFunctionWrapperTest {
         kv = result.result();
         assertThat(kv.value().getInt(0)).isEqualTo(3);
     }
+
+    @Test
+    public void testPreserveSequenceOnRetractDelete() {
+        // Schema: value has two fields: f0 (data), f1 (event_ts to preserve)
+        Map<InternalRow, KeyValue> highLevel = new HashMap<>();
+        RowType valueType =
+                RowType.builder()
+                        .fields(
+                                new DataType[] {DataTypes.INT(), DataTypes.INT()},
+                                new String[] {"f0", "f1"})
+                        .build();
+        UserDefinedSeqComparator userDefinedSeqComparator =
+                UserDefinedSeqComparator.create(
+                        valueType, CoreOptions.fromMap(ImmutableMap.of("sequence.field", "f1")));
+        assert userDefinedSeqComparator != null;
+
+        // preserve f1 (index 1) on retraction records
+        LookupChangelogMergeFunctionWrapper function =
+                new LookupChangelogMergeFunctionWrapper(
+                        LookupMergeFunction.wrap(
+                                DeduplicateMergeFunction.factory(), null, null, null),
+                        highLevel::get,
+                        null,
+                        LookupStrategy.from(false, true, false, false),
+                        null,
+                        userDefinedSeqComparator,
+                        new int[] {1});
+
+        // Delete with higher sequence field: changelog -D should carry the delete event's
+        // f1=100, not the old row's f1=50
+        highLevel.put(row(1), new KeyValue().replace(row(1), 1, INSERT, row(10, 50)).setLevel(2));
+        function.reset();
+        function.add(new KeyValue().replace(row(1), 2, DELETE, row(10, 100)).setLevel(0));
+        ChangelogResult result = function.getResult();
+        assertThat(result).isNotNull();
+        List<KeyValue> changelogs = result.changelogs();
+        assertThat(changelogs).hasSize(1);
+        assertThat(changelogs.get(0).valueKind()).isEqualTo(DELETE);
+        // f0 should come from the old row (before image data)
+        assertThat(changelogs.get(0).value().getInt(0)).isEqualTo(10);
+        // f1 (preserved column) should come from the delete event
+        assertThat(changelogs.get(0).value().getInt(1)).isEqualTo(100);
+        // system sequence number should come from the delete event
+        assertThat(changelogs.get(0).sequenceNumber()).isEqualTo(2);
+    }
+
+    @Test
+    public void testPreserveSequenceOnRetractUpdate() {
+        // Schema: value has two fields: f0 (data), f1 (event_ts to preserve)
+        Map<InternalRow, KeyValue> highLevel = new HashMap<>();
+        RowType valueType =
+                RowType.builder()
+                        .fields(
+                                new DataType[] {DataTypes.INT(), DataTypes.INT()},
+                                new String[] {"f0", "f1"})
+                        .build();
+        UserDefinedSeqComparator userDefinedSeqComparator =
+                UserDefinedSeqComparator.create(
+                        valueType, CoreOptions.fromMap(ImmutableMap.of("sequence.field", "f1")));
+        assert userDefinedSeqComparator != null;
+
+        // preserve f1 (index 1) on retraction records
+        LookupChangelogMergeFunctionWrapper function =
+                new LookupChangelogMergeFunctionWrapper(
+                        LookupMergeFunction.wrap(
+                                DeduplicateMergeFunction.factory(), null, null, null),
+                        highLevel::get,
+                        null,
+                        LookupStrategy.from(false, true, false, false),
+                        null,
+                        userDefinedSeqComparator,
+                        new int[] {1});
+
+        // Update: -U changelog should carry the new event's f1=100, not the old row's f1=50
+        function.reset();
+        function.add(new KeyValue().replace(row(1), 1, INSERT, row(10, 50)).setLevel(1));
+        function.add(new KeyValue().replace(row(1), 2, INSERT, row(20, 100)).setLevel(0));
+        ChangelogResult result = function.getResult();
+        assertThat(result).isNotNull();
+        List<KeyValue> changelogs = result.changelogs();
+        assertThat(changelogs).hasSize(2);
+
+        // -U (UPDATE_BEFORE): f0 from old row, f1 from new event
+        assertThat(changelogs.get(0).valueKind()).isEqualTo(UPDATE_BEFORE);
+        assertThat(changelogs.get(0).value().getInt(0)).isEqualTo(10);
+        assertThat(changelogs.get(0).value().getInt(1)).isEqualTo(100);
+        assertThat(changelogs.get(0).sequenceNumber()).isEqualTo(2);
+
+        // +U (UPDATE_AFTER): entirely from new event
+        assertThat(changelogs.get(1).valueKind()).isEqualTo(UPDATE_AFTER);
+        assertThat(changelogs.get(1).value().getInt(0)).isEqualTo(20);
+        assertThat(changelogs.get(1).value().getInt(1)).isEqualTo(100);
+    }
+
+    @Test
+    public void testPreserveSequenceOnRetractNotConfigured() {
+        // Verify that the old behavior is preserved when no columns are specified
+        Map<InternalRow, KeyValue> highLevel = new HashMap<>();
+        RowType valueType =
+                RowType.builder()
+                        .fields(
+                                new DataType[] {DataTypes.INT(), DataTypes.INT()},
+                                new String[] {"f0", "f1"})
+                        .build();
+        UserDefinedSeqComparator userDefinedSeqComparator =
+                UserDefinedSeqComparator.create(
+                        valueType, CoreOptions.fromMap(ImmutableMap.of("sequence.field", "f1")));
+        assert userDefinedSeqComparator != null;
+
+        // no preserve columns (null)
+        LookupChangelogMergeFunctionWrapper function =
+                new LookupChangelogMergeFunctionWrapper(
+                        LookupMergeFunction.wrap(
+                                DeduplicateMergeFunction.factory(), null, null, null),
+                        highLevel::get,
+                        null,
+                        LookupStrategy.from(false, true, false, false),
+                        null,
+                        userDefinedSeqComparator,
+                        null);
+
+        // Delete: changelog -D should use old row's values (original behavior)
+        highLevel.put(row(1), new KeyValue().replace(row(1), 1, INSERT, row(10, 50)).setLevel(2));
+        function.reset();
+        function.add(new KeyValue().replace(row(1), 2, DELETE, row(10, 100)).setLevel(0));
+        ChangelogResult result = function.getResult();
+        assertThat(result).isNotNull();
+        List<KeyValue> changelogs = result.changelogs();
+        assertThat(changelogs).hasSize(1);
+        assertThat(changelogs.get(0).valueKind()).isEqualTo(DELETE);
+        assertThat(changelogs.get(0).value().getInt(0)).isEqualTo(10);
+        // f1 should be from the OLD row (original behavior)
+        assertThat(changelogs.get(0).value().getInt(1)).isEqualTo(50);
+        assertThat(changelogs.get(0).sequenceNumber()).isEqualTo(1);
+    }
 }


### PR DESCRIPTION
### Purpose
 - Adds a new config option changelog-producer.preserve-sequence-on-retract that accepts a comma-separated list of column names whose values should be taken from the incoming event (rather than the stored row) when producing changelog retraction records (-U, -D)
  - This is useful when delete or update events carry an event timestamp that downstream consumers need — e.g., external systems like Cassandra that rely on WRITETIME for conflict resolution
  - Only supported with the lookup changelog producer
  -  This also allows alignment with FlinkCDC that emits retract events with db event timestamps. 

### Tests
- [x] Unit tests for delete retraction preserving the event's sequence field value
- [x] Unit tests for update retraction (-U) carrying the new event's sequence field value
- [x] Unit tests confirming original behavior is preserved when the option is not set

### Manual verification
- Tested out after configuration, the table correctly produces the changelog events.

```
CREATE TABLE test.test_table ( 
    id INT, 
    name STRING, 
    updated_at TIMESTAMP, 
    op_type STRING
) TBLPROPERTIES (
    'primary-key' = 'id', 
    'changelog-producer' = 'lookup', 
    'write-only' = 'false',
    'changelog-producer.preserve-field-on-retract' = 'updated_at',
    'rowkind.field' = 'op_type'
)
```

```
+-------+---+-------+--------------------------+
|rowkind|id |name   |updated_at                |
+-------+---+-------+--------------------------+
|-D     |1  |one_new|2026-09-09 15:11:45.082928|
|+U     |1  |one_new|2026-09-09 15:11:03.804031|
|-U     |1  |one    |2026-09-09 15:11:03.804031|
|+I     |1  |one    |2026-09-09 15:10:31.101137|
+-------+---+-------+--------------------------+
``` 
