### PR TITLE
[python] Batch BTree point reads by data block

### DIFF
--- a/paimon-python/pypaimon/globalindex/btree/btree_index_reader.py
+++ b/paimon-python/pypaimon/globalindex/btree/btree_index_reader.py
@@ -225,9 +225,11 @@ class BTreeIndexReader:
 
     def visit_in(self, literals: List[object]) -> Optional[GlobalIndexResult]:
         result = RoaringBitmap64()
-        for literal in literals:
-            range_result = self._range_query(literal, literal, True, True)
-            result = RoaringBitmap64.or_(result, range_result)
+        keys = [self.key_serializer.serialize(literal)
+                for literal in literals if literal is not None]
+        for entry in self.reader.read_many(keys):
+            for row_id in _deserialize_row_ids(entry.value):
+                result.add(row_id)
         return GlobalIndexResult.create(result)
 
     def visit_not_in(self, literals: List[object]) -> Optional[GlobalIndexResult]:

--- a/paimon-python/pypaimon/globalindex/btree/sst_file_reader.py
+++ b/paimon-python/pypaimon/globalindex/btree/sst_file_reader.py
@@ -173,6 +173,27 @@ class SstFileReader:
             read_block,
             self.index_block.iterator())
 
+    def read_many(self, keys):
+        """Return exact matches while reading each selected data block once."""
+        blocks = {}
+        for key in dict.fromkeys(keys):
+            index_iterator = self.index_block.iterator()
+            index_iterator.seek_to(key)
+            if not index_iterator.has_next():
+                continue
+            entry = index_iterator.__next__()
+            handle = SstFileIterator._parse_block_handle(entry.value)
+            blocks.setdefault((handle.offset, handle.size), []).append(key)
+
+        result = []
+        for (offset, size), block_keys in blocks.items():
+            block = self._read_block(BlockHandle(offset, size))
+            for key in block_keys:
+                iterator = block.iterator()
+                if iterator.seek_to(key):
+                    result.append(iterator.__next__())
+        return result
+
     def close(self) -> None:
         """Close the reader and release resources."""
         # No resources to release in this implementation

--- a/paimon-python/pypaimon/tests/global_index_test.py
+++ b/paimon-python/pypaimon/tests/global_index_test.py
@@ -27,9 +27,17 @@ from pypaimon.common.options.core_options import CoreOptions, GlobalIndexSearchM
 from pypaimon.common.options.options import Options
 from pypaimon.common.predicate import Predicate
 from pypaimon.common.predicate_builder import PredicateBuilder
-from pypaimon.globalindex.global_index_meta import GlobalIndexMeta
+from pypaimon.filesystem.local_file_io import LocalFileIO
+from pypaimon.globalindex.btree.btree_index_reader import BTreeIndexReader
+from pypaimon.globalindex.btree.btree_index_writer import BTreeIndexWriter
+from pypaimon.globalindex.btree.sst_file_reader import SstFileReader
 from pypaimon.globalindex.global_index_evaluator import GlobalIndexEvaluation
+from pypaimon.globalindex.global_index_meta import (
+    GlobalIndexIOMeta,
+    GlobalIndexMeta,
+)
 from pypaimon.globalindex.global_index_result import GlobalIndexResult
+from pypaimon.globalindex.key_serializer import LongSerializer
 from pypaimon.index.index_file_meta import IndexFileMeta
 from pypaimon.index.index_file_handler import IndexFileHandler
 from pypaimon.schema.data_types import AtomicType, DataField
@@ -79,6 +87,41 @@ class GlobalIndexTest(unittest.TestCase):
             result = result.and_(other)
 
         self.assertEqual(result.results().cardinality(), 10001)
+
+    def test_btree_in_reads_shared_data_block_once(self):
+        with tempfile.TemporaryDirectory() as directory:
+            file_io = LocalFileIO.create()
+            serializer = LongSerializer()
+            writer = BTreeIndexWriter(file_io, directory, serializer)
+            for value in range(128):
+                writer.write(value, value)
+            entry = writer.finish()[0]
+            path = "%s/%s" % (directory, entry.file_name)
+            reader = BTreeIndexReader(
+                serializer,
+                file_io,
+                directory,
+                GlobalIndexIOMeta(
+                    entry.file_name,
+                    file_io.get_file_size(path),
+                    entry.meta,
+                ),
+            )
+            reads = []
+            original = SstFileReader._read_from
+
+            def tracked(instance, offset, length):
+                reads.append((offset, length))
+                return original(instance, offset, length)
+
+            try:
+                with patch.object(SstFileReader, "_read_from", new=tracked):
+                    result = reader.visit_in([1, 2, 3, 3, 127, 999])
+            finally:
+                reader.close()
+
+            self.assertEqual([1, 2, 3, 127], result.results().to_list())
+            self.assertEqual(1, len(reads))
 
 
 class _CoverageOptions:


### PR DESCRIPTION
### Purpose

Avoid reading the same BTree SST data block once per literal for batched `IN` predicates.

### Changes

- Group serialized point keys by their selected SST data block.
- Read each selected block once and resolve its keys in memory.
- Deduplicate repeated literals without retaining a cross-query cache.

### Tests

- Added a regression test proving four keys in one data block issue one data-block read.
- `102 passed` across global-index, BTree thread-safety, and vector-filter tests.
- Flake8 and `git diff --check` pass.