### PR TITLE
[python] Remove duplicate BLOB validation during table creation

### DIFF
--- a/paimon-python/pypaimon/schema/schema_manager.py
+++ b/paimon-python/pypaimon/schema/schema_manager.py
@@ -661,12 +661,6 @@ class SchemaManager:
                 comment=schema.comment,
             )
 
-            _validate_blob_fields(
-                schema.fields,
-                schema.options,
-                schema.primary_keys,
-                schema.partition_keys,
-            )
             table_schema = TableSchema.from_schema(schema_id=0, schema=schema)
             success = self.commit(table_schema)
             if success:


### PR DESCRIPTION
### Purpose

Closes #9703.

`SchemaManager.create_table()` validates BLOB fields and then calls `commit()`, which repeats the same validation. Remove the first call and keep validation in `commit()` before schema persistence. `TableSchema.from_schema()` preserves all four validation inputs, and table creation, schema changes, and direct commits remain covered.

If both general options and BLOB settings are invalid, `_validate_options()` now reports its error first.

### Tests

Ran from `paimon-python` on the updated branch:

```shell
python -m pytest pypaimon/tests/schema_manager_test.py pypaimon/tests/column_directive_utils_test.py -q
# 40 passed
python -m flake8 --config=dev/cfg.ini pypaimon/schema/schema_manager.py
```

`git diff --check` also passed.
