### PR TITLE
[spark] Close the commit and release the cached RDD in remove_unexisting_files

### DIFF
--- a/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/procedure/SparkRemoveUnexistingFiles.scala
+++ b/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/procedure/SparkRemoveUnexistingFiles.scala
@@ -85,26 +85,26 @@ case class SparkRemoveUnexistingFiles(
       .repartition(1)
       .cache()
 
-    if (!dryRun) {
-      pathAndMessage.foreachPartition {
-        iter =>
-          {
-            val serializer = new CommitMessageSerializer()
-            val messages = new util.ArrayList[CommitMessage]()
-            iter.foreach {
-              case (_, bytes) => messages.add(serializer.deserialize(serializer.getVersion, bytes))
-            }
-            val commit = table.newCommit(UUID.randomUUID().toString)
-            try {
-              commit.commit(Long.MaxValue, messages)
-            } finally {
-              commit.close()
-            }
-          }
-      }
-    }
-
     try {
+      if (!dryRun) {
+        pathAndMessage.foreachPartition {
+          iter =>
+            {
+              val serializer = new CommitMessageSerializer()
+              val messages = new util.ArrayList[CommitMessage]()
+              iter.foreach {
+                case (_, bytes) =>
+                  messages.add(serializer.deserialize(serializer.getVersion, bytes))
+              }
+              val commit = table.newCommit(UUID.randomUUID().toString)
+              try {
+                commit.commit(messages)
+              } finally {
+                commit.close()
+              }
+            }
+        }
+      }
       pathAndMessage.flatMap { case (paths, _) => paths }.collect()
     } finally {
       pathAndMessage.unpersist()

--- a/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/procedure/SparkRemoveUnexistingFiles.scala
+++ b/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/procedure/SparkRemoveUnexistingFiles.scala
@@ -27,7 +27,6 @@ import org.apache.paimon.table.FileStoreTable
 import org.apache.paimon.table.sink.{CommitMessage, CommitMessageImpl, CommitMessageSerializer}
 
 import org.apache.spark.internal.Logging
-import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.{PaimonSparkSession, SparkSession}
 import org.apache.spark.sql.catalyst.SQLConfHelper
 
@@ -44,10 +43,10 @@ case class SparkRemoveUnexistingFiles(
   extends SQLConfHelper
   with Logging {
 
-  private def buildRDD(): RDD[String] = {
+  private def execute(): Array[String] = {
     val binaryPartitions = table.newScan().listPartitions()
     if (binaryPartitions.isEmpty) {
-      return spark.sparkContext.emptyRDD[String]
+      return Array.empty[String]
     }
 
     val realParallelism = Math.min(binaryPartitions.size(), parallelism)
@@ -96,15 +95,20 @@ case class SparkRemoveUnexistingFiles(
               case (_, bytes) => messages.add(serializer.deserialize(serializer.getVersion, bytes))
             }
             val commit = table.newCommit(UUID.randomUUID().toString)
-            commit.commit(Long.MaxValue, messages)
+            try {
+              commit.commit(Long.MaxValue, messages)
+            } finally {
+              commit.close()
+            }
           }
       }
     }
 
-    pathAndMessage.mapPartitions(
-      iter => {
-        iter.flatMap { case (paths, _) => paths }
-      })
+    try {
+      pathAndMessage.flatMap { case (paths, _) => paths }.collect()
+    } finally {
+      pathAndMessage.unpersist()
+    }
   }
 }
 
@@ -129,6 +133,6 @@ object SparkRemoveUnexistingFiles extends SQLConfHelper {
       table.isInstanceOf[FileStoreTable],
       s"Only FileStoreTable supports remove-unexsiting-files action. The table type is '${table.getClass.getName}'.")
     val fileStoreTable = table.asInstanceOf[FileStoreTable]
-    SparkRemoveUnexistingFiles(fileStoreTable, dryRun, parallelism, spark).buildRDD().collect()
+    SparkRemoveUnexistingFiles(fileStoreTable, dryRun, parallelism, spark).execute()
   }
 }


### PR DESCRIPTION
### Purpose

`SparkRemoveUnexistingFiles` creates a `TableCommit` on the executor inside `foreachPartition` but never closes it. `TableCommitImpl.close()` shuts down the underlying commit and the `maintainExecutor` thread pool, so every invocation of the procedure leaks a thread pool on a long-lived executor. Other call sites such as `PaimonPartitionManagement` already wrap the commit in try/finally.

The intermediate RDD is also cached and never unpersisted. `buildRDD()` returned a child of the cached RDD to the caller, so the cache could only be released after the caller finished, which never happened. This change turns it into `execute()`, which collects the result inside the method and unpersists the cache in a `finally` block.

Behaviour of the procedure is unchanged; only resource lifecycle is affected.

### Tests
