### PR TITLE
[docs] Restructure primary-key table documentation and diagrams

### DIFF
--- a/docs/docs/primary-key-table/blob-storage.md
+++ b/docs/docs/primary-key-table/blob-storage.md
@@ -29,13 +29,18 @@ Unlike the positional BLOB files used by append tables, managed BLOB payloads ha
 sorting, deduplication, and compaction can therefore reorder or remove rows without rewriting the surviving payload
 bytes.
 
-This mode stores:
+Three pieces of storage work together:
 
-- a serialized `BlobDescriptor` for each scalar value, non-null array element, or non-null map value;
-- the payload in an immutable `.managed.blob` pack; and
-- one `.blobref` sidecar for every data file, containing the exact managed packs referenced by that file.
+| Piece | Contents | Lifecycle |
+| --- | --- | --- |
+| Data file | A `BlobDescriptor` for each non-null scalar, array element, or map value | Rows and descriptors are merged by the table's merge engine |
+| `.managed.blob` pack | Immutable payload bytes, potentially shared by several rows and files | Surviving descriptors continue to reference the same bytes |
+| `.blobref` sidecar | Exact set of managed packs referenced by one data file | Owned by that data file and replaced with compacted output |
 
 For general BLOB concepts and read options, see [BLOB Storage](../multimodal-table/blob).
+Before adopting managed storage, check [Requirements and Limitations](#requirements-and-limitations)
+and [Garbage Collection](#garbage-collection). The sections below cover table creation, merge-engine
+behavior, and the payload lifecycle.
 
 The append-only `video-frame-field` mode is deliberately separate from primary-key managed BLOB
 storage. It writes self-contained `.video` packs containing complete encoded videos and embedded
@@ -48,7 +53,7 @@ Use `blob-field` to mark scalar, array, or map fields whose payloads should be s
 `blob-descriptor-field` and `blob-view-field` are inline forms: their serialized descriptor or view metadata stays in
 the normal data file and is not materialized into a managed BLOB file.
 
-The following example accepts both a scalar value and an ordered array of values:
+The following Flink SQL example accepts scalar, array, and map values:
 
 ```sql
 CREATE TABLE media (
@@ -74,6 +79,8 @@ Reads return the payload bytes by default; the existing `blob-as-descriptor` rea
 A `blob-descriptor-field` is written inline to the normal data file and does not participate in managed storage or its
 reference sidecars.
 
+### Copy Payloads from Another Table
+
 When descriptor-backed BLOBs are copied to another table, the target normally rebuilds a `FileIO` from its catalog
 context. For a managed `blob-field`, this is a copy flow: the target writes the payload into its own BLOB storage and
 does not retain the source descriptor. If the source table uses table-scoped credentials, configure
@@ -92,6 +99,8 @@ accessed with static configuration; `source-table` is for table-scoped `FileIO` 
 The source table must belong to the same catalog. A branch suffix is supported. Target tables without a catalog loader,
 including external tables in REST catalogs, are not supported. When this option is set, it takes precedence over other
 `blob-descriptor.*` options; remove it before switching back to descriptor-specific filesystem configuration.
+
+### Arrays, Maps, and Pack Size
 
 `ARRAY<BLOB>` is externalized element by element. Every non-null `Blob` element is copied into managed storage, while
 array order, a null array, and null elements are preserved. An empty array writes no payload. `ARRAY<BLOB>` uses
@@ -234,6 +243,11 @@ rules are applied. An update later discarded by partial-update or sequence rules
 payload pack. A delete record does not write a new payload. The merge engine determines the logical final row during
 reads and compaction. Each data file's `.blobref` sidecar records managed packs referenced by non-retract key-values in
 that file, which may include intermediate partial-update payloads before compaction.
+
+The example below uses `deduplicate`. A newer descriptor for key `7` replaces its old descriptor;
+the payload for unchanged key `11` remains shared with the input files.
+
+![Compaction replaces input data files and their reference sidecars while reusing the managed BLOB packs for surviving rows.](/img/primary-key-blob-lifecycle.svg)
 
 Compaction preserves descriptors for surviving values and creates new `.blobref` sidecars from the compacted output.
 It does not copy the referenced payload bytes into new `.managed.blob` packs. This keeps ordinary compaction cost

--- a/docs/docs/primary-key-table/chain-table.mdx
+++ b/docs/docs/primary-key-table/chain-table.mdx
@@ -27,24 +27,21 @@ import TabItem from '@theme/TabItem';
 
 # Chain Table
 
-Chain table is a new capability for primary key tables that transforms how you process incremental data.
-Imagine a scenario where you periodically store a full snapshot of data (for example, once a day), even 
-though only a small portion changes between snapshots. ODS binlog dump is a typical example of this pattern.
+A chain table reconstructs a full dataset from a snapshot branch and subsequent changes in a
+delta branch. Use it when periodic batch jobs produce a full view even though only a small
+fraction of rows changes between runs, such as an ODS binlog dump.
 
-Taking a daily binlog dump job as an example. A batch job merges yesterday's full dataset with today's
-incremental changes to produce a new full dataset. This approach has two clear drawbacks:
-* Full computation: Merge operation includes all data, and it will involve shuffle, which results in poor performance.
-* Full storage: Store a full set of data every day, and the changed data usually accounts for a very small proportion.
+Instead of rewriting the full dataset every day, write the daily changes to the delta branch.
+Reads can merge a snapshot with later deltas; periodic compaction materializes a new full view
+in the snapshot branch.
 
-Paimon addresses this problem by directly consuming only the changed data and performing merge-on-read. 
-In this way, full computation and storage are turned into incremental mode:
-* Incremental computation: The offline ETL daily job only needs to consume the changed data of the current day and do not require merging all data.
-* Incremental Storage: Only store the changed data each day, and asynchronously compact it periodically (e.g., weekly) to build a global chain table within the lifecycle.
-  ![](/img/chain-table.png)
+![A full query merges the latest snapshot with later daily deltas; chain compaction writes a new full partition.](/img/primary-key-chain-table.svg)
 
-Based on the regular table, chain table introduces snapshot and delta branches to represent full and incremental 
-data respectively. When writing, you specify the branch to write full or incremental data. When reading, paimon 
-automatically chooses the appropriate strategy based on the read mode, such as full, incremental, or hybrid.
+Start with [Enable Chain Table](#enable-chain-table), then [Write Data](#write-data) and
+[Read Data](#read-data). [Streaming Read](#streaming-read) and [Lookup Join](#lookup-join) have
+additional requirements; review them separately from batch reads. Use
+[Chain Table Compaction](#chain-table-compaction) and [Partition Expiration](#partition-expiration)
+to manage the retained history.
 
 ## Enable Chain Table
 
@@ -164,7 +161,18 @@ insert overwrite `default`.`t$branch_delta` partition (date = '20250811')
 
 ## Read Data
 
-You can query chain table in full, incremental, or hybrid mode.
+Choose the read path according to the result you need:
+
+| Read path | Result | Follow-up behavior |
+| --- | --- | --- |
+| [Full query](#full-query) on the main table | A full partition, directly or reconstructed from an anchor and later deltas | Batch result for the requested partition |
+| [Incremental query](#incremental-query) on the delta branch | Changes stored in the selected delta partition | Does not reconstruct the full state |
+| [Hybrid query](#hybrid-query) | Explicit combination of full and incremental results | `UNION ALL` can include the same row from both paths |
+| [Streaming read](#streaming-read) | Initial load followed by new delta-branch commits | Snapshot-branch writes are not consumed after initial load |
+| [Lookup join](#lookup-join) | Lookup against the supported chain-table read path | Has additional engine and startup restrictions |
+
+The batch examples below query full, incremental, and hybrid results. Review the dedicated
+streaming and lookup sections before using those paths.
 
 ### Full Query
 

--- a/docs/docs/primary-key-table/changelog-producer.md
+++ b/docs/docs/primary-key-table/changelog-producer.md
@@ -24,122 +24,128 @@ under the License.
 
 # Changelog Producer
 
-Streaming write can continuously produce the latest changes for streaming read.
+The `changelog-producer` option controls the changes available to streaming readers. It is
+separate from the [merge engine](./merge-engine/), which defines the table's logical rows, and
+from the [table mode](./table-mode), which determines how those rows are stored and read.
 
-By specifying the `changelog-producer` table property when creating the table, users can choose the pattern of changes produced from table files.
+A full changelog includes the old row needed to retract an update. For example, changing an
+amount from `4` to `5` requires a downstream sum to subtract `4` and add `5`. An upsert containing
+only `5` requires the consumer to remember the previous value.
 
-:::info
+## Choose a Producer
 
-`changelog-producer` may significantly reduce compaction performance, please do not enable it unless necessary.
+| Producer | Where old values come from | When changes are available | Use when |
+| --- | --- | --- | --- |
+| `none` (default) | Consumer state, if needed | Incremental snapshot reads | The consumer accepts upserts or can normalize them |
+| `input` | Complete changelog supplied by the source | Committed input changelog files | The upstream already supplies the required before/after records |
+| `lookup` | Lookup of existing rows during compaction | After lookup compaction is committed | The input has no before images and consumers need complete changes |
+| `full-compaction` | Difference between full-compaction results | After a full compaction is committed | Consumers can wait for periodic full compactions |
 
-:::
+The diagram follows one existing key whose value changes from `4` to `5`. `-U` is
+`UPDATE_BEFORE`, and `+U` is `UPDATE_AFTER`.
+
+![For an update from 4 to 5, none leaves old-state reconstruction to the consumer; input, lookup, and full-compaction obtain the before image at different stages.](/img/primary-key-changelog-producers.svg)
+
+Deletion-vector tables support `none`, `input`, and `lookup`; they do not support the
+`full-compaction` producer.
+
+Producing extra changelog files adds work and storage. Choose the least expensive producer that
+satisfies the consumer's contract. Check merge-engine restrictions as well:
+[Partial Update](./merge-engine/partial-update), [Aggregation](./merge-engine/aggregation), and
+[First Row](./merge-engine/first-row). [Managed BLOB storage](./blob-storage#requirements-and-limitations)
+requires `none`.
 
 ## None
 
-By default, no extra changelog producer will be applied to the writer of table. Paimon source can only see the merged changes across snapshots, like what keys are removed and what are the new values of some keys.
+With `changelog-producer = none`, the writer creates no separate full changelog. Incremental
+reads expose changes without complete before images; they are not an audit log of every input
+record. A downstream upsert sink can replace its stored value by key.
 
-However, these merged changes cannot form a complete changelog, because we can't read the old values of the keys directly from them. Merged changes require the consumers to "remember" the values of each key and to rewrite the values without seeing the old ones. Some consumers, however, need the old values to ensure correctness or efficiency.
+Flink can add a stateful normalize operator when downstream processing needs old values. The
+state and checkpoint cost depend on the number of keys and the workload. Do not remove this
+operator with `scan.remove-normalize` unless the downstream computation remains correct without
+before images.
 
-Consider a consumer which calculates the sum on some grouping keys (might not be equal to the primary keys). If the consumer only sees a new value `5`, it cannot determine what values should be added to the summing result. For example, if the old value is `4`, it should add `1` to the result. But if the old value is `6`, it should in turn subtract `1` from the result. Old values are important for these types of consumers.
-
-To conclude, `none` changelog producers are best suited for consumers such as a database system. Flink also has a 
-built-in "normalize" operator which persists the values of each key in states. As one can easily tell, this operator
-will be very costly and should be avoided. (You can force removing "normalize" operator via `'scan.remove-normalize'`.)
-
-![](/img/changelog-producer-none.png)
+[Nullable primary keys](./#nullable-primary-keys) cannot be exposed as a Flink SQL primary-key
+constraint, so Flink cannot normalize an updating stream from such a table. Use a suitable full
+changelog producer for that case.
 
 ## Input
 
-By specifying `'changelog-producer' = 'input'`, Paimon writers rely on their inputs as a source of complete changelog. All input records will be saved in separated changelog files and will be given to the consumers by Paimon sources.
+```sql
+'changelog-producer' = 'input'
+```
 
-`input` changelog producer can be used when Paimon writers' inputs are complete changelog, such as from a database CDC, or generated by Flink stateful computation.
+Paimon saves the incoming records in separate changelog files and forwards them to streaming
+readers. It does not reconstruct missing before images or convert partial input rows into the
+final merged row.
 
-![](/img/changelog-producer-input.png)
+Use this producer with a complete upstream changelog, such as suitable database CDC output or
+Flink stateful computation. Verify that the source actually supplies the old values required by
+your consumer.
 
 ## Lookup
 
-If your input can't produce a complete changelog but you still want to get rid of the costly normalized operator, you
-may consider using the `'lookup'` changelog producer.
+```sql
+'changelog-producer' = 'lookup'
+```
 
-By specifying `'changelog-producer' = 'lookup'`, Paimon will generate changelog through `'lookup'` during compaction (You can also enable [Async Compaction](./compaction#asynchronous-compaction)). By default, lookup compaction is performed before committing written data unless disabled by `write-only` property.
+Lookup compaction reads the existing value for a key, applies the incoming changes, and generates
+the resulting changelog. By default, writers wait for lookup compaction before committing, unless
+writer compaction is disabled with `write-only`. [Asynchronous Compaction](./compaction#asynchronous-compaction)
+can improve write throughput at the cost of later changelog availability.
 
-![](/img/changelog-producer-lookup.png)
+Lookup uses memory and local disk caches:
 
-Lookup will cache data on the memory and local disk, you can use the following options to tune performance:
+| Option | Default | Purpose |
+| --- | --- | --- |
+| `lookup.cache-file-retention` | `1 h` | Retain cached files; expired files may need to be fetched and indexed again |
+| `lookup.cache-max-disk-size` | Unlimited | Bound local disk usage |
+| `lookup.cache-max-memory-size` | `256 mb` | Bound in-memory cache usage |
 
-<table class="table table-bordered">
-    <thead>
-    <tr>
-      <th class="text-left" style="width: 20%">Option</th>
-      <th class="text-left" style="width: 5%">Default</th>
-      <th class="text-left" style="width: 10%">Type</th>
-      <th class="text-left" style="width: 60%">Description</th>
-    </tr>
-    </thead>
-    <tbody>
-    <tr>
-        <td><h5>lookup.cache-file-retention</h5></td>
-        <td style="word-wrap: break-word;">1 h</td>
-        <td>Duration</td>
-        <td>The cached files retention time for lookup. After the file expires, if there is a need for access, it will be re-read from the DFS to build an index on the local disk.</td>
-    </tr>
-    <tr>
-        <td><h5>lookup.cache-max-disk-size</h5></td>
-        <td style="word-wrap: break-word;">unlimited</td>
-        <td>MemorySize</td>
-        <td>Max disk size for lookup cache, you can use this option to limit the use of local disks.</td>
-    </tr>
-    <tr>
-        <td><h5>lookup.cache-max-memory-size</h5></td>
-        <td style="word-wrap: break-word;">256 mb</td>
-        <td>MemorySize</td>
-        <td>Max memory size for lookup cache.</td>
-    </tr>
-    </tbody>
-</table>
+In Flink, `execution.checkpointing.max-concurrent-checkpoints` can also affect throughput when
+checkpoint completion waits for compaction. Tune it with checkpoint duration and resource usage.
 
-Lookup changelog-producer supports `changelog-producer.row-deduplicate` to avoid generating -U, +U
-changelog for the same record. It also supports `changelog-producer.ignore-update-before` to exclude UPDATE_BEFORE (-U)
-records and `changelog-producer.ignore-delete` to exclude DELETE (-D) records from changelog files. These options are
-useful when downstream consumers only need the latest state (e.g. upsert sinks) and do not require retraction.
-
-(Note: Please increase `'execution.checkpointing.max-concurrent-checkpoints'` Flink configuration, this is very
-important for performance).
+`lookup` is incompatible with `full-compaction.delta-commits`. For periodic full compaction with
+changelog generation, use `full-compaction` instead.
 
 ## Full Compaction
 
-You can also consider using 'full-compaction' changelog producer to generate changelog, and is more suitable for scenarios
-with large latency (For example, 30 minutes).
+```sql
+'changelog-producer' = 'full-compaction'
+```
 
-1. By specifying `'changelog-producer' = 'full-compaction'`, Paimon will compare the results between full compactions and
-produce the differences as changelog. The latency of changelog is affected by the frequency of full compactions.
-2. By specifying `full-compaction.delta-commits` table property, full compaction will be constantly triggered after delta
-commits (checkpoints). This is set to 1 by default, so each checkpoint will have a full compression and generate a
-changelog.
+Paimon compares successive full-compaction results and emits their differences. Intermediate
+updates between those results may be collapsed; this is a changelog of table-state changes,
+not a copy of every source event.
 
-Generally speaking, the cost and consumption of full compaction are high, so we recommend using `'lookup'` changelog
-producer.
+`full-compaction.delta-commits` controls the number of delta commits between synchronous full
+compactions. In Flink streaming writes with this producer, the interval defaults to one checkpoint
+when it is not explicitly configured. Increase the interval when the consumer can tolerate a
+longer delay and full compaction is too expensive.
 
-![](/img/changelog-producer-full-compaction.png)
+For example, consumers with a latency budget of tens of minutes may use periodic full compaction.
+For lower-latency generated changelogs, evaluate `lookup`.
 
-:::info
+## Filter Generated Changes
 
-Full compaction changelog producer can produce complete changelog for any type of source. However it is not as
-efficient as the input changelog producer and the latency to produce changelog might be high.
+The `lookup` and `full-compaction` producers support:
 
-:::
+| Option | Effect |
+| --- | --- |
+| `changelog-producer.row-deduplicate` | Avoid an update pair when the old and new rows are equal |
+| `changelog-producer.ignore-update-before` | Omit `UPDATE_BEFORE` (`-U`) records |
+| `changelog-producer.ignore-delete` | Omit `DELETE` (`-D`) records |
 
-Full-compaction changelog-producer supports `changelog-producer.row-deduplicate` to avoid generating -U, +U
-changelog for the same record. It also supports `changelog-producer.ignore-update-before` and
-`changelog-producer.ignore-delete` to filter out -U and -D records from changelog files respectively.
+Dropping before images or deletes changes the consumer contract. Enable these filters only when
+the consumer can handle the resulting stream; downstream retracting aggregations need those
+records to remain correct.
 
 ## Changelog Merging
 
-For `input`, `lookup`, `full-compaction` 'changelog-producer'.
+For `input`, `lookup`, and `full-compaction`, short Flink checkpoint intervals combined with many
+buckets can produce numerous small changelog files.
 
-If Flink's checkpoint interval is short (for example, 30 seconds) and the number of buckets is large, each snapshot may
-produce lots of small changelog files. Too many files may put a burden on the distributed storage cluster.
-
-In order to compact small changelog files into large ones, you can set the table option `precommit-compact = true`.
-Default value of this option is false, if true, it will add a compact coordinator and worker operator after the writer
-operator, which copies changelog files into large ones.
+Set `precommit-compact = true` to merge them before commit. This adds a compaction coordinator
+and worker after the writer. The default is `false`. This file-consolidation step is distinct
+from choosing how the changelog records are generated.

--- a/docs/docs/primary-key-table/compaction.md
+++ b/docs/docs/primary-key-table/compaction.md
@@ -105,21 +105,33 @@ select a full compaction as data accumulates. To request one regularly:
 ## Lookup Compaction
 
 Paimon uses lookup compaction for the `lookup` changelog producer, the `first-row` merge engine,
-and tables with deletion vectors. It reconciles Level-0 records with existing rows.
+and tables with deletion vectors. It can also be enabled explicitly with `force-lookup = true`.
+Lookup compaction reconciles Level-0 records with existing rows and promotes them to higher
+levels, making processed rows or generated changelogs available to readers.
+
+The following options control forced Level-0 promotion for these lookup scenarios. Ordinary
+MOR tables can merge Level-0 data during reads and do not enable this strategy by default.
+Non-lookup tables can opt into immediate forced promotion separately with
+`compaction.force-up-level-0 = true`.
 
 | Option | Behavior |
 | --- | --- |
-| `lookup-compact = radical` (default) | Force new Level-0 files into higher levels at compaction triggers |
-| `lookup-compact = gentle` | Use the universal strategy with a configurable forced-compaction interval |
-| `lookup-compact.max-interval` | Number of compaction-selection attempts without universal compaction work before forcing Level-0 compaction; only used in `gentle` mode |
+| `lookup-compact = radical` (default) | Immediately select Level-0 files for promotion when the universal strategy selects no compaction work |
+| `lookup-compact = gentle` | Allow the universal strategy to select work, with forced Level-0 promotion after the effective interval |
+| `lookup-compact.max-interval` | Control the forced-promotion interval in `gentle` mode; count only compaction-selection attempts where the universal strategy selects no work |
 
-To defer forced Level-0 compaction, use `gentle` together with an explicit
-`lookup-compact.max-interval`. The interval has no default value; leaving it unset still forces
-Level-0 compaction immediately when the universal strategy selects no work. It counts selection
-attempts, not elapsed time.
+Setting `lookup-compact = gentle` alone already defers forced Level-0 promotion. When
+`lookup-compact.max-interval` is unset, its effective runtime default is
+`2 * num-sorted-run.compaction-trigger`: **10** with the default trigger of **5**. An explicitly
+configured interval is clamped to at least `num-sorted-run.compaction-trigger`; for example,
+configuring `3` with a trigger of `5` gives an effective interval of `5`.
 
-Deferring compaction can reduce resource use, but pending files can reduce freshness. Choose the
-interval together with `lookup-wait` and the visibility requirements of your table mode.
+The interval counts selection attempts, not elapsed time or commits. The universal strategy can
+still select compaction work before this interval is reached.
+
+Gentle mode can reduce compaction frequency, but pending Level-0 files can delay the visibility
+of DV/`first-row` data and lookup changelogs. Choose the interval together with `lookup-wait` and
+the [visibility requirements](#asynchronous-compaction) of your table mode.
 
 ## Compaction Options
 

--- a/docs/docs/primary-key-table/compaction.md
+++ b/docs/docs/primary-key-table/compaction.md
@@ -24,172 +24,122 @@ under the License.
 
 # Compaction
 
-When more and more records are written into the LSM tree, the number of sorted runs will increase. Because querying an
-LSM tree requires all sorted runs to be combined, too many sorted runs will result in a poor query performance, or even
-out of memory.
+Compaction combines sorted runs and applies the [merge engine](./merge-engine/) to records with
+the same key. It reduces file and merge overhead for reads, while consuming CPU and storage I/O
+on the write side. Paimon's default strategy selects runs using a universal compaction policy.
 
-To limit the number of sorted runs, we have to merge several sorted runs into one big sorted run once in a while. This
-procedure is called compaction.
+![Compaction merges several overlapping sorted runs into a new run, while old files remain available to retained snapshots.](/img/primary-key-compaction.svg)
 
-However, compaction is a resource intensive procedure which consumes a certain amount of CPU time and disk IO, so too 
-frequent compaction may in turn result in slower writes. It is a trade-off between query and write performance. Paimon
-currently adopts a compaction strategy similar to Rocksdb's [universal compaction](https://github.com/facebook/rocksdb/wiki/Universal-Compaction).
+Depending on the table options, compaction also generates a
+[changelog](./changelog-producer), maintains [deletion vectors](./table-mode#merge-on-write) and
+[indexes](./global-index#maintenance-and-coverage), or applies record-level expiration.
+Compaction itself does not mean that old files are immediately deleted: snapshot, tag, and
+partition retention have separate lifecycles. See [Maintenance](../maintenance/).
 
-Compaction solves:
+## Choose a Compaction Strategy
 
-1. Reduce Level 0 files to avoid poor query performance.
-2. Produce changelog via [changelog-producer](./changelog-producer).
-3. Produce deletion vectors for [MOW mode](./table-mode#merge-on-write).
-4. Snapshot Expiration, Tag Expiration, Partitions Expiration.
-
-Limitation:
-
-- There can only be one job working on the same partition's compaction, otherwise it will cause conflicts and one side will throw an exception failure.
-
-Writing performance is almost always affected by compaction, so its tuning is crucial.
+| Need | Configuration or operation | Trade-off |
+| --- | --- | --- |
+| Control overlapping runs | Default background compaction and sorted-run thresholds | Lower thresholds spend more write resources to reduce read work |
+| Fresh lookup changelogs or MOW rows | Lookup compaction with the default wait behavior | Commit latency includes required compaction work |
+| Favor write throughput | [Asynchronous Compaction](#asynchronous-compaction) | More pending files and potentially older query results |
+| Isolate compaction resources or coordinate writers | [Dedicated compaction job](#dedicated-compaction-job) | Requires a separately operated job |
+| Refresh a read-optimized view | `compaction.optimization-interval` | Freshness follows completed full compactions |
+| Fully merge every N delta commits | `full-compaction.delta-commits` | Synchronous full compaction increases write amplification |
 
 ## Asynchronous Compaction
 
-Compaction is inherently asynchronous, but if you want it to be completely asynchronous without blocking writes,
-expecting a mode for maximum writing throughput, the compaction can be done slowly and not in a hurry.
-You can use the following strategies for your table:
+Writers normally run compaction in background threads. They can still wait when too many sorted
+runs accumulate, or when lookup compaction is needed before a commit.
 
-```shell
+The following table options illustrate a configuration that relaxes those waits:
+
+```properties
 num-sorted-run.stop-trigger = 2147483647
 sort-spill-threshold = 10
 lookup-wait = false
 ```
 
-This configuration will generate more files during peak write periods and gradually merge them for optimal read
-performance during low write periods.
+This effectively removes the sorted-run write-stall limit and allows pending work to accumulate.
+It is a throughput-oriented example, not a default recommendation. Size the spill storage and
+monitor file counts, compaction backlog, and read latency before using it.
+
+By default, MOW and `first-row` batch reads exclude pending Level-0 data until lookup compaction
+publishes it. MOW batch readers can opt into merging pending data with
+`deletion-vectors.merge-on-read`; see [MOW visibility](./table-mode#merge-on-write).
+For `changelog-producer = lookup`, generated changelogs are also delayed. A compactor that cannot
+keep up with sustained input will keep falling behind; relaxing waits does not add capacity.
 
 ## Dedicated compaction job
 
-In general, if you expect multiple jobs to be written to the same table, you need to separate the compaction. You can
-use [dedicated compaction job](../maintenance/dedicated-compaction#dedicated-compaction-job).
+Set `write-only = true` on ingest writers and run a
+[dedicated compaction job](../maintenance/dedicated-compaction#dedicated-compaction-job) when
+compaction needs separate resources or multiple writers need a single compaction owner.
+Avoid overlapping compaction jobs for the same partition, which can cause commit conflicts.
+
+This does not lift [dynamic-bucket](./data-distribution#dynamic-bucket) restrictions on concurrent
+writers to the same partition.
 
 ## Record-Level expire
 
-In compaction, you can configure record-Level expire time to expire records, you should configure:
+Configure `record-level.expire-time` for the retention duration and `record-level.time-field` for
+the field used to evaluate each record's age.
 
-1. `'record-level.expire-time'`: time retain for records.
-2. `'record-level.time-field'`: time field for record level expire.
-
-Expiration happens in compaction, and there is no strong guarantee to expire records in time.
-You can trigger a full compaction manually to expire records which were not expired in time.
+Expiration happens when compaction processes the records, so it has no strict wall-clock deadline.
+A manual full compaction can process records that ordinary compaction has not reached. This is
+separate from expiring snapshots or entire partitions.
 
 ## Full Compaction
 
-Paimon Compaction uses [Universal-Compaction](https://github.com/facebook/rocksdb/wiki/Universal-Compaction).
-By default, when there is too much incremental data, Full Compaction will be automatically performed. You don't usually
-have to worry about it.
+Full compaction merges all runs of a bucket into its highest level. The default strategy can
+select a full compaction as data accumulates. To request one regularly:
 
-Paimon also provides a configuration that allows for regular execution of Full Compaction.
+| Option | Scheduling | Use |
+| --- | --- | --- |
+| `compaction.optimization-interval` | Time-based optimization compaction | Keep the [read-optimized table](../concepts/system-tables#read-optimized-table) reasonably fresh |
+| `full-compaction.delta-commits` | Synchronous compaction after a number of delta commits | COW behavior or periodic full-compaction changelogs |
 
-1. 'compaction.optimization-interval': Implying how often to perform an optimization full compaction, this
-    configuration is used to ensure the query timeliness of the read-optimized system table.
-2. 'full-compaction.delta-commits': Full compaction will be constantly triggered after delta commits. Its disadvantage
-    is that it can only perform compaction synchronously, which will affect writing efficiency.
+`full-compaction.delta-commits` is incompatible with `changelog-producer = lookup`. See
+[Full Compaction Changelogs](./changelog-producer#full-compaction) for producer-specific defaults.
 
 ## Lookup Compaction
 
-When primary key table is configured with `lookup` [changelog producer](./changelog-producer) 
-or `first-row` [merge-engine](./merge-engine/)
-or has enabled `deletion vectors` for [MOW mode](./table-mode#merge-on-write), Paimon will
-use a radical compaction strategy to force compacting level 0 files to higher levels for every compaction trigger.
+Paimon uses lookup compaction for the `lookup` changelog producer, the `first-row` merge engine,
+and tables with deletion vectors. It reconciles Level-0 records with existing rows.
 
-Paimon also provides configurations to optimize the frequency of this compaction.
+| Option | Behavior |
+| --- | --- |
+| `lookup-compact = radical` (default) | Force new Level-0 files into higher levels at compaction triggers |
+| `lookup-compact = gentle` | Use the universal strategy with a configurable forced-compaction interval |
+| `lookup-compact.max-interval` | Number of compaction-selection attempts without universal compaction work before forcing Level-0 compaction; only used in `gentle` mode |
 
-1. 'lookup-compact': compact mode used for lookup compaction. Possible values: `radical`, will use
-   `ForceUpLevel0Compaction` strategy to radically compact new files; `gentle`, will use `UniversalCompaction` strategy
-   to gently compact new files;
-2. 'lookup-compact.max-interval': The max interval for a forced L0 lookup compaction to be triggered in `gentle` mode.
-   This option is only valid when `lookup-compact` mode is `gentle`.
+To defer forced Level-0 compaction, use `gentle` together with an explicit
+`lookup-compact.max-interval`. The interval has no default value; leaving it unset still forces
+Level-0 compaction immediately when the universal strategy selects no work. It counts selection
+attempts, not elapsed time.
 
-By configuring 'lookup-compact' as `gentle`, new files in L0 will not be compacted immediately, this may greatly
-reduce the overall resource usage at the expense of worse data freshness in certain cases.
+Deferring compaction can reduce resource use, but pending files can reduce freshness. Choose the
+interval together with `lookup-wait` and the visibility requirements of your table mode.
 
 ## Compaction Options
 
 ### Number of Sorted Runs to Pause Writing
 
-When the number of sorted runs is small, Paimon writers will perform compaction asynchronously in separated threads, so
-records can be continuously written into the table. However, to avoid unbounded growth of sorted runs, writers will
-pause writing when the number of sorted runs hits the threshold. The following table property determines
-the threshold.
+`num-sorted-run.stop-trigger` limits the backlog at which writers wait for compaction. If unset,
+it defaults to `num-sorted-run.compaction-trigger + 3`.
 
-<table class="table table-bordered">
-    <thead>
-    <tr>
-      <th class="text-left" style="width: 20%">Option</th>
-      <th class="text-left" style="width: 5%">Required</th>
-      <th class="text-left" style="width: 5%">Default</th>
-      <th class="text-left" style="width: 10%">Type</th>
-      <th class="text-left" style="width: 60%">Description</th>
-    </tr>
-    </thead>
-    <tbody>
-    <tr>
-      <td><h5>num-sorted-run.stop-trigger</h5></td>
-      <td>No</td>
-      <td style="word-wrap: break-word;">(none)</td>
-      <td>Integer</td>
-      <td>The number of sorted runs that trigger the stopping of writes, the default value is 'num-sorted-run.compaction-trigger' + 3.</td>
-    </tr>
-    </tbody>
-</table>
-
-Write stalls will become less frequent when `num-sorted-run.stop-trigger` becomes larger, thus improving writing
-performance. However, if this value becomes too large, more memory and CPU time will be needed when querying the
-table. If you are concerned about the OOM problem, please configure the following option.
-Its value depends on your memory size.
-
-<table class="table table-bordered">
-    <thead>
-    <tr>
-      <th class="text-left" style="width: 20%">Option</th>
-      <th class="text-left" style="width: 5%">Required</th>
-      <th class="text-left" style="width: 5%">Default</th>
-      <th class="text-left" style="width: 10%">Type</th>
-      <th class="text-left" style="width: 60%">Description</th>
-    </tr>
-    </thead>
-    <tbody>
-    <tr>
-      <td><h5>sort-spill-threshold</h5></td>
-      <td>No</td>
-      <td style="word-wrap: break-word;">(none)</td>
-      <td>Integer</td>
-      <td>If the maximum number of sort readers exceeds this value, a spill will be attempted. This prevents too many readers from consuming too much memory and causing OOM.</td>
-    </tr>
-    </tbody>
-</table>
+Increasing the limit can reduce write stalls but leaves more overlapping runs for readers. Use
+`sort-spill-threshold` to allow merge readers to spill when their number exceeds the configured
+threshold. This option has no explicit configured default; spilling trades memory pressure for
+local disk I/O. Size it for the available memory and disk resources.
 
 ### Number of Sorted Runs to Trigger Compaction
 
-Paimon uses [LSM tree](./#lsm-trees) which supports a large number of updates. LSM organizes files in several [sorted runs](./#sorted-runs). When querying records from an LSM tree, all sorted runs must be combined to produce a complete view of all records.
+`num-sorted-run.compaction-trigger` defaults to `5`. Each Level-0 file counts as one sorted run;
+each occupied higher level counts as one run.
 
-One can easily see that too many sorted runs will result in poor query performance. To keep the number of sorted runs in a reasonable range, Paimon writers will automatically perform [compactions](./compaction). The following table property determines the minimum number of sorted runs to trigger a compaction.
+A larger value usually makes compaction less frequent and leaves more merge work for reads.
+A smaller value spends more write resources keeping reads efficient. Tune it alongside the
+stop threshold, rather than increasing either threshold to hide a persistent compaction backlog.
 
-<table class="table table-bordered">
-    <thead>
-    <tr>
-      <th class="text-left" style="width: 20%">Option</th>
-      <th class="text-left" style="width: 5%">Required</th>
-      <th class="text-left" style="width: 5%">Default</th>
-      <th class="text-left" style="width: 10%">Type</th>
-      <th class="text-left" style="width: 60%">Description</th>
-    </tr>
-    </thead>
-    <tbody>
-    <tr>
-      <td><h5>num-sorted-run.compaction-trigger</h5></td>
-      <td>No</td>
-      <td style="word-wrap: break-word;">5</td>
-      <td>Integer</td>
-      <td>The sorted run number to trigger compaction. Includes level0 files (one file one sorted run) and high-level runs (one level one sorted run).</td>
-    </tr>
-    </tbody>
-</table>
-
-Compaction will become less frequent when `num-sorted-run.compaction-trigger` becomes larger, thus improving writing performance. However, if this value becomes too large, more memory and CPU time will be needed when querying the table. This is a trade-off between writing and query performance.
+For the complete option reference, see [Configurations](../maintenance/configurations#coreoptions).

--- a/docs/docs/primary-key-table/data-distribution.md
+++ b/docs/docs/primary-key-table/data-distribution.md
@@ -24,51 +24,74 @@ under the License.
 
 # Data Distribution
 
-A bucket is the smallest storage unit for reads and writes, each bucket directory contains an [LSM tree](./#lsm-trees).
+Buckets divide the data inside a table or partition into independent LSM trees. Choose a bucket
+mode based on how keys arrive, whether updates move between partitions, and how many writers
+must ingest concurrently. For the file layout, see [Buckets and LSM Trees](./#bucket).
+
+## Choose a Bucket Mode
+
+| Mode | `bucket` | Assignment | Planning consideration |
+| --- | --- | --- | --- |
+| Fixed | Positive integer | Hash the bucket key into a fixed number of buckets | Predictable layout; resizing requires an explicit rescale operation |
+| Dynamic (default) | `-1` | Maintain a key-to-bucket index and grow buckets | Index memory and single-writer constraints |
+| Postpone | `-2` | Stage data, then assign real buckets | Batch/compaction workflow and per-partition sizing |
+
+If the primary key excludes a partition column that can change, read
+[Cross Partitions Upsert](#cross-partitions-upsert) before choosing a mode.
 
 ## Fixed Bucket
 
-Configure a bucket greater than 0, using Fixed Bucket mode, according to `Math.abs(key_hashcode % numBuckets)` to compute
-the bucket of record.
+Set `bucket` to a positive integer. Paimon calculates the bucket using
+`Math.abs(key_hashcode % numBuckets)`.
 
-Rescaling buckets can only be done through offline processes, see [Rescale Bucket](../maintenance/rescale-bucket).
-A too large number of buckets leads to too many small files, and a too small number of buckets leads to poor write performance.
+For primary-key tables, `bucket-key` defaults to the primary key excluding partition columns.
+An explicit bucket key must be a subset of the primary key and must not contain partition columns.
+For example, with primary key `(dt, order_id)` and partition key `dt`, `order_id` is the default
+bucket key.
+
+### Bucket Sizing
+
+Too many buckets create small files; too few can concentrate writes and leave overlapping ranges
+that are expensive to read. For MOR workloads, 200 MB–1 GB per bucket is an initial sizing guide,
+not a limit. Measure skew, throughput, and read plans to select the actual count. A batch scan can
+split one bucket into independent key ranges, so bucket count is not a hard read-parallelism cap.
+
+To change an existing layout, use the offline [Rescale Bucket](../maintenance/rescale-bucket)
+workflow.
 
 ## Dynamic Bucket
 
-Default mode for primary key table, or configure `'bucket' = '-1'`.
+Dynamic buckets are the default for primary-key tables (`bucket = -1`). Paimon maintains an index
+that maps keys to buckets. Existing keys return to their assigned buckets; new keys can be
+assigned to new buckets as the table grows. The layout therefore depends on the arrival of keys.
+Do not configure `bucket-key` in this mode.
 
-The keys that arrive first will fall into the old buckets, and the new keys will fall into the new buckets, the
-distribution of buckets and keys depends on the order in which the data arrives. Paimon maintains an index to determine
-which key corresponds to which bucket.
+| Option | Purpose |
+| --- | --- |
+| `dynamic-bucket.target-row-num` | Target row count per bucket |
+| `dynamic-bucket.initial-buckets` | Initial bucket count |
+| `dynamic-bucket.max-buckets` | Maximum bucket count |
 
-Paimon will automatically expand the number of buckets.
+:::warning Concurrent writers
 
-- Option1: `'dynamic-bucket.target-row-num'`: controls the target row number for one bucket.
-- Option2: `'dynamic-bucket.initial-buckets'`: controls the number of initialized bucket.
-- Option3: `'dynamic-bucket.max-buckets'`: controls the number of max buckets.
-
-:::info
-
-Dynamic Bucket only support single write job. Please do not start multiple jobs to write to the same partition
-(this can lead to duplicate data). Even if you enable `'write-only'` and start a dedicated compaction job, it won't work.
+Only one job may write to a given partition in dynamic-bucket mode. Concurrent writers can assign
+the same key independently and create duplicates. `write-only` with a dedicated compaction job
+does not remove this restriction.
 
 :::
 
-When your updates do not cross partitions (no partitions, or primary keys contain all partition fields), Dynamic
-Bucket mode uses HASH index to maintain mapping from key to bucket, it requires more memory than fixed bucket mode.
-
-Performance:
-
-1. Generally speaking, there is no performance loss, but there will be some additional memory consumption, **100 million**
-   entries in a partition takes up **1 GB** more memory, partitions that are no longer active do not take up memory.
-2. For tables with low update rates, this mode is recommended to significantly improve performance.
+When updates stay within a partition, Paimon uses a hash index for bucket assignment. Budget
+additional memory for active partitions: 100 million entries in a partition require roughly 1 GB
+of index memory. Inactive partitions do not retain this in-memory index. Evaluate this cost
+against the benefit of growing buckets automatically, particularly when most arriving keys are new.
 
 ## Postpone Bucket
 
 Postpone bucket mode is configured by `'bucket' = '-2'`.
-This mode aims to solve the difficulty to determine a fixed number of buckets
-and support different buckets for different partitions.
+Use it to defer bucket sizing and allow different partitions to have different bucket counts.
+The write path and visibility depend on the engine and `postpone.batch-write-fixed-bucket`.
+
+### Spark Batch Write
 
 By default, `postpone.batch-write-fixed-bucket` is `true`. The fixed-bucket flow uses Spark's
 DataSource V1 write path, even when `spark.paimon.write.use-v2-write` is enabled. Unless direct
@@ -105,6 +128,8 @@ Previously committed bucket `-2` files are not included in the calculation, read
 deleted by an append or rescale. They remain available to merge-on-read and regular postpone
 compaction. `INSERT OVERWRITE` still follows its normal replacement semantics.
 
+### Compaction-Based Assignment
+
 When `postpone.batch-write-fixed-bucket` is `false`,
 records are first stored in the `bucket-postpone` directory of each partition
 and are not available to readers.
@@ -125,32 +150,35 @@ See `rescale` [procedure](../flink/procedures).
 
 ## Cross Partitions Upsert
 
-When you need cross partition upsert (primary keys not contain all partition fields), recommend using the '-1' bucket.
-Key Dynamic mode directly maintains the mapping of keys to partition and bucket, uses local disks, and initializes 
-indexes by reading all existing keys in the table when starting stream write job. Different merge engines have different behaviors:
+An update crosses partitions when a key's partition value changes and the primary key does not
+include all partition fields. Dynamic buckets (`bucket = -1`) maintain a mapping from each key
+to its partition and bucket, using local disk. Starting a streaming writer initializes this index
+by reading existing keys.
 
-1. Deduplicate: Delete data from the old partition and insert new data into the new partition.
-2. PartialUpdate & Aggregation: Insert new data into the old partition.
-3. FirstRow: Ignore new data if there is old value.
+| Merge engine | Existing key arrives with a different partition value |
+| --- | --- |
+| `deduplicate` | Delete the row in the old partition and insert it in the new partition |
+| `partial-update` or `aggregation` | Apply the update in the old partition |
+| `first-row` | Keep the existing row and ignore the incoming row |
 
-Performance: For tables with a large amount of data, there will be a significant loss in performance. Moreover,
-initialization takes a long time.
+The index can add substantial startup and storage costs for large tables. If updates only need
+to match recent data, `cross-partition-upsert.index-ttl` limits the history retained in the index
+and considered during initialization. Choose a TTL that covers the required update history;
+expiring an entry means it can no longer locate an older row through that index.
 
-If your upsert does not rely on too old data, you can consider configuring index TTL to reduce Index and initialization time:
-- `'cross-partition-upsert.index-ttl'`: The TTL in local index and initialization, this can avoid maintaining too many
-  indexes and lead to worse and worse performance.
-
-You can also use Cross Partitions Upsert with bucket (N > 0) or bucket (-2), in these modes, there is no global index to
-ensure that your data undergoes reasonable deduplication, so relying on your input to have a complete changelog can
-ensure the uniqueness of the data.
+Fixed and postpone buckets do not maintain this cross-partition mapping. Their inputs must
+supply a complete changelog, including the retraction of the old partition's row, to preserve
+uniqueness across partition moves.
 
 ## Pick Partition Fields
 
-The following three types of fields may be defined as partition fields in the warehouse:
+| Candidate | Guidance |
+| --- | --- |
+| Immutable creation time | Usually a good fit: it can be included in the primary key without moving an entity between partitions |
+| Mutable event time | Moving an entity requires a before image for the old partition and an after image for the new one, or a cross-partition index |
+| CDC operation timestamp (`op_ts`) | Usually a poor entity partition key: each change has a new timestamp, which may not identify the old row's partition |
 
-- Creation Time (Recommended): The creation time is generally immutable, so you can confidently treat it as a partition field
-  and add it to the primary key.
-- Event Time: Event time is a field in the original table. For CDC data, such as tables synchronized from MySQL
-  CDC or Changelogs generated by Paimon, they are all complete CDC data, including `UPDATE_BEFORE` records, even
-  if you declare the primary key containing partition field, you can achieve the unique effect (require `'changelog-producer'='input'`).
-- CDC op_ts: It cannot be defined as a partition field, unable to know previous record timestamp. So you need to use cross partition upsert, it will consume more resources.
+For complete CDC input, a primary key containing the partition field can retract the old
+partition's row and insert the new one. Use `changelog-producer = input` when streaming readers
+must receive those input before/after records; this producer does not create a missing before
+image. See [Changelog Producer](./changelog-producer#input).

--- a/docs/docs/primary-key-table/global-index.mdx
+++ b/docs/docs/primary-key-table/global-index.mdx
@@ -37,82 +37,31 @@ Primary-key indexes differ from indexes created with `create_global_index`. A re
 independently for a Data Evolution table. A primary-key index follows the write and compaction
 lifecycle of a primary-key table and addresses rows inside its compact data files.
 
+For a first setup, choose an index family below, check [Requirements](#requirements), and follow
+[Create a Table](#create-a-table). Before using search results in production, review
+[Maintenance and Coverage](#maintenance-and-coverage): the default Vector and Full Text search
+modes omit files without active index coverage.
+
 ## Choose an Index
 
-<Tabs groupId="primary-key-index-family">
+| Index family | Use for | Query path |
+| --- | --- | --- |
+| [BTree](../multimodal-table/global-index/btree) | Selective scalar equality, `IN`, ranges, and null checks | Ordinary batch predicates |
+| [Bitmap](../multimodal-table/global-index/bitmap) | Indexed values such as enum-like dimensions | Ordinary batch predicates |
+| [Multivalue](../multimodal-table/global-index/multivalue) | Element membership in `ARRAY` columns | Supported array predicates |
+| [FM](../multimodal-table/global-index/fm) | Exact substring matches on character columns | A predicate converted to Paimon's `CONTAINS` |
+| [Vector](../multimodal-table/global-index/vector) | Approximate nearest neighbors in `VECTOR<FLOAT>` columns | [Vector Search](#vector-search) |
+| Full Text | Ranked text search on character columns | [Full-Text Search](#full-text-search) |
 
-<TabItem value="btree" label="BTree">
+Scalar and array indexes are used after the connector converts the query expression to a
+supported Paimon predicate. BTree and Bitmap support equality, comparisons, null checks, complement
+predicates, and supported string predicates. Multivalue supports `ARRAY_CONTAINS`, `ARRAYS_OVERLAP`,
+and `ARRAY_CONTAINS_ALL`; null arrays and empty arrays produce no element postings, and array null
+checks use the ordinary scan path.
 
-Use BTree for selective scalar predicates such as equality, `IN`, comparisons, ranges, and null
-checks. Normal Flink, Spark, and Java batch scans apply it automatically; no index-specific query
-API is required.
-
-See [BTree Index](../multimodal-table/global-index/btree) for the built-in format and supported
-data types.
-
-</TabItem>
-
-<TabItem value="bitmap" label="Bitmap">
-
-Use Bitmap for enum-like dimensions, tags, and other columns where compressed bitmaps can evaluate
-equality, `IN`, null checks, complement predicates, and supported string predicates efficiently.
-Normal batch scans apply it automatically.
-
-See [Bitmap Index](../multimodal-table/global-index/bitmap) for predicate and format details.
-
-</TabItem>
-
-<TabItem value="multivalue" label="Multivalue">
-
-Use Multivalue for element-membership predicates on an `ARRAY` column. It stores one compressed
-bitmap posting list per distinct non-null element and accelerates Paimon Core `ARRAY_CONTAINS`,
-`ARRAYS_OVERLAP`, and `ARRAY_CONTAINS_ALL` predicates. Null arrays, empty arrays, and null elements
-produce no membership posting; array null checks fall back to the ordinary data path.
-
-The Core predicate and index pushdown are available independently of SQL connectors. A connector
-uses this index after it translates its array-membership expression to the corresponding Paimon
-predicate.
-
-For an append-only or Data Evolution table whose Multivalue index is built independently, see
-[Global Multivalue Index](../multimodal-table/global-index/multivalue).
-
-</TabItem>
-
-<TabItem value="vector" label="Vector">
-
-Use Vector for approximate nearest-neighbor (ANN) Top-K search on embeddings that are updated with
-the primary-key table. The index implementation and distance metric are configured per field, and
-search is exposed through Spark SQL, a Flink procedure, and the Java API.
-
-For an append-only or Data Evolution table whose vector index is built independently, see
-[Global Vector Index](../multimodal-table/global-index/vector).
-
-</TabItem>
-
-<TabItem value="full-text" label="Full Text">
-
-Use Full Text for native ranked search on `CHAR`, `VARCHAR`, or `STRING` content that can be
-updated or deleted with the primary-key table. The fixed `full-text` implementation is selected
-automatically. Search is exposed through Spark SQL, a Flink procedure, and the Java API.
-
-For an append-only or Data Evolution table whose full-text index is built independently, see
-[Global Index](../multimodal-table/global-index).
-
-</TabItem>
-
-<TabItem value="fm" label="FM">
-
-Use FM for exact substring predicates on a `CHAR`, `VARCHAR`, or `STRING` column. Normal batch
-scans apply it automatically after a connector converts a literal substring expression to
-Paimon's `CONTAINS` predicate. Needles of any byte length are supported without choosing a gram
-size.
-
-For an append-only or Data Evolution table whose FM index is built independently, see
-[FM Index](../multimodal-table/global-index/fm).
-
-</TabItem>
-
-</Tabs>
+FM performs exact substring matching without a configured gram size and accepts needles of any
+byte length. Vector and Full Text expose dedicated ranked-search APIs in Spark, Flink, and Java.
+Full Text uses the fixed `full-text` implementation; Vector uses the configured ANN implementation.
 
 Different columns in one table can use different index families. One column can occur in at most
 one of `pk-vector.index.columns`, `pk-full-text.index.columns`, `pk-btree.index.columns`,
@@ -177,6 +126,58 @@ Exactly one full-text column is currently supported per table.
 </Tabs>
 
 ## Create a Table
+
+### Start with One Index
+
+This example uses a BTree index to accelerate selective filters on `amount`.
+
+<Tabs groupId="primary-key-index-quick-start">
+<TabItem value="flink-sql" label="Flink SQL">
+
+```sql
+CREATE TABLE indexed_orders (
+    id BIGINT,
+    amount DECIMAL(12, 2),
+    PRIMARY KEY (id) NOT ENFORCED
+) WITH (
+    'bucket' = '8',
+    'deletion-vectors.enabled' = 'true',
+    'pk-btree.index.columns' = 'amount'
+);
+```
+
+</TabItem>
+<TabItem value="spark-sql" label="Spark SQL">
+
+```sql
+CREATE TABLE indexed_orders (
+    id BIGINT,
+    amount DECIMAL(12, 2)
+) USING paimon
+TBLPROPERTIES (
+    'primary-key' = 'id',
+    'bucket' = '8',
+    'deletion-vectors.enabled' = 'true',
+    'pk-btree.index.columns' = 'amount'
+);
+```
+
+</TabItem>
+</Tabs>
+
+Query it with an ordinary predicate:
+
+```sql
+SELECT id, amount FROM indexed_orders WHERE amount BETWEEN 100.00 AND 200.00;
+```
+
+Indexes are built from eligible compacted data. Uncovered files selected by this batch scan
+follow the ordinary data path; see [Maintenance and Coverage](#maintenance-and-coverage).
+
+### Combine Index Families
+
+<details>
+<summary>Example: configure all six index families on different columns</summary>
 
 The following table uses all six families on different columns: Vector for `embedding`, Full Text
 for `content`, FM for `raw_text`, BTree for `amount`, Bitmap for `status`, and Multivalue for
@@ -262,6 +263,8 @@ TBLPROPERTIES (
 Duplicate, empty, unknown, unsupported, or cross-family duplicate columns are rejected during
 schema validation.
 
+</details>
+
 ### Options
 
 | Option | Default | Description |
@@ -326,21 +329,30 @@ Index construction can execute asynchronously inside the writer. A writer which 
 compaction also waits for active index maintenance; a non-blocking writer can complete maintenance
 in a later commit. Coverage can therefore be temporarily partial.
 
-Coverage behavior depends on the index family and search mode. `vector-index.search-mode` and
-`full-text-index.search-mode` default to `fast`. In `fast` mode, primary-key Vector and Full Text
-queries search only data covered by an active index group. Uncovered files are not searched, so
-partial coverage can make results incomplete.
+### Query Behavior with Partial Coverage
 
-- BTree, Bitmap, Multivalue, and FM scans always read uncovered files through the ordinary data path.
-  Partial coverage affects their acceleration, not result completeness. The original predicate and
-  deletion vectors are applied after index pruning.
-- Vector search in `full` or `detail` mode evaluates files without an active ANN group exactly and
-  merges those results with ANN candidates. In the default `fast` mode, those files are omitted.
+Coverage is separate from data visibility: first determine which data files the selected batch
+scan can read, then check which of those files have an active index group.
 
-Primary-key Full Text currently supports only `full-text-index.search-mode = fast`. It searches
-persistent archives and ignores uncovered files; `full` and `detail` are rejected because a
-merge-aware logical-row fallback is not implemented. Consequently, newly appended Level-0 rows
-become full-text searchable only after compaction publishes an eligible data file and archive.
+| Query | Indexed files | Files without an active index group |
+| --- | --- | --- |
+| BTree, Bitmap, Multivalue, or FM predicate | Prune using the index; apply predicates and deletion vectors | Read through the ordinary data path |
+| Vector, `fast` (default) | Search the ANN index | Omitted |
+| Vector, `full` or `detail` | Search the ANN index | Evaluate vectors exactly and merge the candidates |
+| Full Text, `fast` (default and only supported mode) | Search the persistent text index | Omitted |
+
+![For files visible to a batch scan, scalar indexes fall back to scanning uncovered files, Vector fast and Full Text omit them, and Vector full or detail evaluates them exactly.](/img/primary-key-index-coverage.svg)
+
+For ordinary scalar and array predicates, partial coverage affects performance rather than result
+completeness. The original predicate and deletion vectors still apply.
+
+For Vector and Full Text, `fast` can omit matching rows when coverage is incomplete. Vector's
+`full` and `detail` modes cover unindexed files with exact evaluation, but indexed files still use
+ANN search; these modes do not promise an exact global Top-K.
+
+Full Text rejects `full` and `detail` because a merge-aware logical-row fallback is not implemented.
+New Level-0 rows become full-text searchable only after compaction publishes eligible data and its
+persistent text index. A metadata-only level upgrade is not enough.
 
 ## BTree, Bitmap, Multivalue, and FM Queries
 

--- a/docs/docs/primary-key-table/index.md
+++ b/docs/docs/primary-key-table/index.md
@@ -1,5 +1,5 @@
 ---
-title: "PrimaryKey Table"
+title: "Primary-Key Table"
 sidebar_position: 2
 ---
 
@@ -22,13 +22,98 @@ specific language governing permissions and limitations
 under the License.
 -->
 
-# Overview
+<a id="overview"></a>
 
-If you define a table with primary key, you can insert, update or delete records in the table.
+# Primary-Key Tables
 
-Primary keys consist of a set of columns that contain unique values for each record. Paimon enforces data ordering by
-sorting the primary key within each bucket, allowing users to achieve high performance by applying filtering conditions
-on the primary key. See [CREATE TABLE](../flink/sql-ddl#create-table).
+A primary-key table maintains one logical row per key. Incoming records can insert, update, or
+remove that row according to the table's **merge engine**. Multiple physical versions may remain
+in data files until they are merged during reads or compaction.
+
+Use a primary-key table for CDC replication, upsert pipelines, or combining updates to the same
+entity. For data that only grows without merging by key, see [Append Table](../append-table/).
+
+## Quick Start
+
+The following Flink SQL table keeps the latest row for each `order_id`:
+
+```sql
+CREATE TABLE orders (
+    order_id BIGINT,
+    customer_id BIGINT,
+    amount DECIMAL(12, 2),
+    PRIMARY KEY (order_id) NOT ENFORCED
+) WITH (
+    'bucket' = '4'
+);
+
+INSERT INTO orders VALUES (1, 101, 12.00);
+INSERT INTO orders VALUES (1, 101, 15.00);
+
+SELECT * FROM orders;
+-- 1, 101, 15.00
+```
+
+This example uses four fixed buckets, the default `deduplicate` merge engine, and the default
+merge-on-read storage mode. Omitting `bucket` selects dynamic buckets. See
+[Data Distribution](./data-distribution) before choosing a bucket mode for your workload, and
+[Sequence Field](./sequence-rowkind#sequence-field) when updates can arrive out of order.
+
+## Design a Primary-Key Table
+
+These settings answer different questions. Choose them together, checking each feature's
+compatibility requirements.
+
+| Decision | What it controls | Read next |
+| --- | --- | --- |
+| Partition and bucket keys | Where a row is stored and how work is distributed | [Data Distribution](./data-distribution) |
+| Merge engine | How records with the same key form a logical row | [Merge Engine](./merge-engine/) |
+| Sequence and row kind | Which update takes precedence and whether it inserts or retracts | [Sequence and Row Kind](./sequence-rowkind) |
+| Table mode | Whether readers merge versions, read compacted files, or apply deletion vectors | [Table Mode](./table-mode) |
+| Changelog producer | Which changes a streaming consumer receives | [Changelog Producer](./changelog-producer) |
+
+Then tune [Compaction](./compaction) and [Query Performance](./query-performance). For specialized
+workloads, see [Primary-Key Indexes](./global-index), [PK Clustering Override](./pk-clustering-override),
+[Chain Table](./chain-table), and [BLOB Storage](./blob-storage).
+
+## Bucket
+
+A table, or each partition of a partitioned table, contains buckets. Each bucket has its own LSM
+tree of data files. Changelog files and indexes may accompany those data files, depending on the
+configuration.
+
+![A partition contains independent buckets, each with Level-0 files and higher-level sorted runs.](/img/primary-key-storage-layout.svg)
+
+In fixed-bucket mode, Paimon hashes the `bucket-key` columns to select a bucket. If `bucket-key`
+is not set, it uses the primary-key columns excluding partition columns. Dynamic and postpone
+buckets use different assignment mechanisms; see [Data Distribution](./data-distribution).
+
+Buckets distribute writes and affect read parallelism, but are not a universal one-reader limit:
+[Table Mode](./table-mode) explains when files can be read independently. Use the
+[bucket sizing guidance](./data-distribution#bucket-sizing) to balance parallelism against
+small-file overhead.
+
+## LSM Trees
+
+Paimon stores primary-key data in an LSM tree (log-structured merge-tree). Writers buffer records,
+sort them, and flush new files. Compaction merges files to reduce the work needed by future reads.
+
+### Sorted Runs
+
+A sorted run contains one or more data files. In the default primary-key layout, records in each
+file are sorted by key, and file key ranges do not overlap within the same run. Different runs
+can overlap and contain different versions of the same key.
+
+![Files have disjoint key ranges within a sorted run; key 7 occurs in two different runs.](/img/primary-key-sorted-runs.svg)
+
+A merge-on-read scan combines the relevant runs and applies the
+[merge engine](./merge-engine/) and [record ordering](./sequence-rowkind) to records with the same
+key. The result contains one logical row per key, even if several physical versions exist.
+
+Each Level-0 file is a separate sorted run; each higher level forms a run of non-overlapping
+files. [Compaction](./compaction) keeps the number of runs manageable.
+[PK Clustering Override](./pk-clustering-override) is a specialized layout that changes the physical
+sort order and resolves row versions using deletion vectors.
 
 ## Nullable Primary Keys
 
@@ -36,7 +121,7 @@ Primary key fields are `NOT NULL` by default. Set `primary-key.nullable` to `tru
 system can produce null key components:
 
 ```sql
-CREATE TABLE orders (
+CREATE TABLE nullable_orders (
     order_id BIGINT,
     payload STRING
 ) WITH (
@@ -59,31 +144,3 @@ which Flink can normalize only when the table exposes a SQL primary-key constrai
 nullable key cannot be exposed as that constraint, Paimon rejects this streaming-read combination
 instead of producing an invalid Flink plan. Insert-only streaming reads, such as tables using the
 `first-row` merge engine, are not affected.
-
-## Bucket
-
-Unpartitioned tables, or partitions in partitioned tables, are sub-divided into buckets, to provide extra structure to the data that may be used for more efficient querying.
-
-Each bucket directory contains an LSM tree and its [changelog files](./changelog-producer).
-
-The range for a bucket is determined by the hash value of one or more columns in the records. Users can specify bucketing columns by providing the [`bucket-key` option](../maintenance/configurations#coreoptions). If no `bucket-key` option is specified, the primary key (if defined) or the complete record will be used as the bucket key.
-
-A bucket is the smallest storage unit for reads and writes, so the number of buckets limits the maximum processing parallelism. This number should not be too big, though, as it will result in lots of small files and low read performance. In general, the recommended data size in each bucket is about 200MB - 1GB.
-
-Also, see [rescale bucket](../maintenance/rescale-bucket) if you want to adjust the number of buckets after a table is created.
-
-## LSM Trees
-
-Paimon adopts the LSM tree (log-structured merge-tree) as the data structure for file storage. This documentation briefly introduces the concepts about LSM trees.
-
-### Sorted Runs
-
-LSM tree organizes files into several sorted runs. A sorted run consists of one or multiple data files and each data file belongs to exactly one sorted run.
-
-Records within a data file are sorted by their primary keys. Within a sorted run, ranges of primary keys of data files never overlap.
-
-![](/img/sorted-runs.png)
-
-As you can see, different sorted runs may have overlapped primary key ranges, and may even contain the same primary key. When querying the LSM tree, all sorted runs must be combined and all records with the same primary key must be merged according to the user-specified [merge engine](./merge-engine/) and the timestamp of each record.
-
-New records written into the LSM tree will be first buffered in memory. When the memory buffer is full, all records in memory will be sorted and flushed to disk. A new sorted run is now created.

--- a/docs/docs/primary-key-table/merge-engine/aggregation.mdx
+++ b/docs/docs/primary-key-table/merge-engine/aggregation.mdx
@@ -35,7 +35,14 @@ NOTE: Always set `table.exec.sink.upsert-materialize` to `NONE` in Flink SQL Tab
 
 Sometimes users only care about aggregated results. The `aggregation` merge engine aggregates each value field with the latest data one by one under the same primary key according to the aggregate function.
 
-Each field not part of the primary keys can be given an aggregate function, specified by the `fields.<field-name>.aggregate-function` table property, otherwise it will use `last_non_null_value` aggregation as default. For example, consider the following table definition.
+For ordinary non-key fields, Paimon selects the function in this order:
+
+1. `fields.<field-name>.aggregate-function`, when configured for the field.
+2. `fields.default-aggregate-function`, when configured for the table.
+3. `last_non_null_value` otherwise.
+
+Sequence fields use `last_value`; primary-key fields are not value-aggregated.
+The following table keeps the maximum observed price and sums the sales contributions.
 
 <Tabs groupId="aggregation-merge-engine-example">
 
@@ -60,9 +67,29 @@ CREATE TABLE my_table (
 
 Field `price` will be aggregated by the `max` function, and field `sales` will be aggregated by the `sum` function. Given two input records `<1, 23.0, 15>` and `<1, 30.2, 20>`, the final result will be `<1, 30.2, 35>`.
 
+## Streaming Reads
+
+For a stream of complete aggregated rows, use the `lookup` or `full-compaction`
+[changelog producer](../changelog-producer). The `input` producer forwards the input contributions,
+which are not necessarily the aggregated result.
+
 ## Aggregation Functions
 
-Current supported aggregate functions and data types are:
+Choose each function according to the meaning of its input contributions. Replaying a contribution
+can change results such as `sum`; this engine does not deduplicate events by a separate event ID.
+Check [Retraction](#retraction) before accepting `UPDATE_BEFORE` or `DELETE` records.
+
+| Need | Functions or recipe |
+| --- | --- |
+| Numeric aggregation | [sum](#sum), [product](#product), [max](#max), [min](#min), [counting with sum](#count) |
+| Retain a value | [last_value](#last_value), [last_non_null_value](#last_non_null_value), [first_value](#first_value), [first_non_null_value](#first_non_null_value) |
+| Strings and booleans | [listagg](#listagg), [bool_and](#bool_and), [bool_or](#bool_or) |
+| Arrays and maps | [collect](#collect), [merge_map](#merge_map), [merge_map_with_keytime](#merge_map_with_keytime) |
+| Nested rows | [nested_update](#nested_update), [nested_partial_update](#nested_partial_update) |
+| Bitmap union | [rbm32](#rbm32), [rbm64](#rbm64) |
+| Approximate distinct counts | [hll_sketch](#hll_sketch), [theta_sketch](#theta_sketch) |
+
+## Numeric Functions
 
 ### sum
 
@@ -73,15 +100,32 @@ Current supported aggregate functions and data types are:
   The product function can compute product values across multiple lines.
   It supports DECIMAL, TINYINT, SMALLINT, INTEGER, BIGINT, FLOAT, and DOUBLE data types.
 
-### count
-  In scenarios where counting rows that match a specific condition is required, you can use the SUM function to achieve this. By expressing a condition as a Boolean value (TRUE or FALSE) and converting it into a numerical value, you can effectively count the rows. In this approach, TRUE is converted to 1, and FALSE is converted to 0.
+### Counting with sum {#count}
 
-  For example, if you have a table orders and want to count the number of rows that meet a specific condition, you can use the following query:
-  ```sql
-  SELECT SUM(CASE WHEN condition THEN 1 ELSE 0 END) AS count
-  FROM orders;
-  ```
+There is no `count` value for `fields.<field-name>.aggregate-function`. To count contributions,
+write `1` for a matching event and `0` for a non-matching event into a field configured with `sum`.
+For example, this Flink SQL table counts paid events per customer:
 
+```sql
+CREATE TABLE customer_counts (
+    customer_id BIGINT,
+    paid_events BIGINT,
+    PRIMARY KEY (customer_id) NOT ENFORCED
+) WITH (
+    'merge-engine' = 'aggregation',
+    'fields.paid_events.aggregate-function' = 'sum'
+);
+
+-- customer 1: matching event, non-matching event, matching event
+INSERT INTO customer_counts VALUES (1, 1), (1, 0), (1, 1);
+
+SELECT * FROM customer_counts;
+-- 1, 2
+```
+
+In a pipeline, derive the contribution with `CASE WHEN condition THEN 1 ELSE 0 END` in the input
+query. Replaying an event adds its contribution again; this is a count of contributions, not a
+count of distinct event IDs.
 
 ### max
   The max function identifies and retains the maximum value.
@@ -91,6 +135,8 @@ Current supported aggregate functions and data types are:
   The min function identifies and retains the minimum value.
   It supports BOOLEAN, CHAR, VARCHAR, BINARY, VARBINARY, DECIMAL, TINYINT, SMALLINT, INTEGER, BIGINT, FLOAT, DOUBLE, DATE, TIME, TIMESTAMP, and TIMESTAMP_LTZ data types.
 
+## Value Selection
+
 ### last_value
   The last_value function replaces the previous value with the most recently imported value.
   It supports all data types.
@@ -98,6 +144,16 @@ Current supported aggregate functions and data types are:
 ### last_non_null_value
   The last_non_null_value function replaces the previous value with the latest non-null value.
   It supports all data types.
+
+### first_value
+  The first_value function retains the first value, including null.
+  It supports all data types.
+
+### first_non_null_value
+  The first_non_null_value function selects the first non-null value in a data set.
+  It supports all data types.
+
+## Strings and Booleans
 
 ### listagg
   The listagg function concatenates multiple string values into a single string.
@@ -113,13 +169,157 @@ Current supported aggregate functions and data types are:
   The bool_or function checks if at least one value in a boolean set is true.
   It supports BOOLEAN data type.
 
-### first_value
-  The first_value function retrieves the first null value from a data set.
-  It supports all data types.
+## Collections and Nested Rows
 
-### first_non_null_value
-  The first_non_null_value function selects the first non-null value in a data set.
-  It supports all data types.
+### collect
+  The collect function collects elements into an Array. You can set `fields.<field-name>.distinct=true` to deduplicate elements.
+  It only supports ARRAY type.
+
+### merge_map
+  The merge_map function merge input maps. It only supports MAP type.
+
+### merge_map_with_keytime
+
+  The merge_map_with_keytime function merges input maps with key-level partial updates based on timestamps.
+  Each key in the map carries a string timestamp. During merging, the entry with the greater
+  timestamp in lexicographic order is retained. Use equally padded numeric strings or a consistent
+  sortable date/time format; the implementation reads this field as a string.
+  It only supports `MAP<key_type, ROW<value_field, ts_field>>` type, where the ROW must have at least 2 fields.
+
+  Use `fields.<field-name>.ts-field=<field_name_in_row>` to specify the timestamp field name in the ROW type.
+  If not specified, the last field of the ROW is used as the timestamp by default.
+
+  When merging into an existing map, a null incoming map value removes that key, and an entry
+  with a null timestamp is skipped. The first map is accepted directly when there is no existing
+  accumulator, so do not rely on the first input to remove null entries or null timestamps.
+
+  An example:
+
+  <Tabs groupId="merge-map-with-keytime-example">
+
+<TabItem value="flink" label="Flink">
+
+```sql
+  CREATE TABLE my_table (
+      biz_order_id STRING,
+      key_value_map MAP<STRING, ROW<`value` STRING, `ts` STRING>>,
+      PRIMARY KEY (biz_order_id) NOT ENFORCED
+  ) WITH (
+      'merge-engine' = 'aggregation',
+      'fields.key_value_map.aggregate-function' = 'merge_map_with_keytime',
+      'fields.key_value_map.ts-field' = 'ts'
+  );
+  ```
+
+</TabItem>
+
+</Tabs>
+
+  Given the following input records:
+
+  | biz_order_id | key_value_map |
+  |---|---|
+  | 1 | {'\{'}"product_name": ("iPhone", "100"), "color": ("Black", "100"){'\}'} |
+  | 1 | {'\{'}"product_name": ("iPad", "200"), "price": ("999", "200"){'\}'} |
+  | 1 | {'\{'}"color": ("White", "050"){'\}'} |
+
+  The final result will be:
+  `{"product_name": ("iPad", "200"), "color": ("Black", "100"), "price": ("999", "200")}`
+  Note that `color` remains "Black" because its existing timestamp "100" is greater than the incoming "050".
+
+### nested_update
+  The nested_update function collects multiple rows into one array\<row> (so-called 'nested table'). It supports ARRAY\<ROW> data types.
+
+  Use `fields.<field-name>.nested-key=pk0,pk1,...` to specify the primary keys of the nested table. If no keys, row will be appended to array\<row>.
+
+  Use `fields.<field-name>.nested-key-null-strategy=<merge|ignore|error>` to specify how rows are handled when the nested-key does not satisfy primary key semantics (e.g., primary key fields contain null values).
+
+   - `merge` (default): Merge rows even if the nested-key does not satisfy primary key semantics. This is the same behavior as when this option is not configured.
+   - `ignore`: Ignore rows whose nested-key contains null values because they do not satisfy primary key semantics.
+   - `error`: Throw an exception if the nested-key contains null values, because primary key fields must not be null.
+
+  Use `fields.<field-name>.nested-sequence-field=seq0,seq1,...` to control the update sequence of a nested table, you must configure `fields.<field-name>.nested-key` when using it.
+
+  Use `fields.<field-name>.count-limit=<Integer>` to specify the maximum number of rows in the nested table. When no nested-key, it will select data
+  sequentially up to limit; but if nested-key is specified, it cannot guarantee the correctness of the aggregation result. This option can be used to
+  avoid abnormal input.
+
+  An example:
+
+  <Tabs groupId="nested-update-example">
+
+<TabItem value="flink" label="Flink">
+
+```sql
+  -- orders table
+  CREATE TABLE orders (
+    order_id BIGINT PRIMARY KEY NOT ENFORCED,
+    user_name STRING,
+    address STRING
+  );
+
+  -- sub orders that have the same order_id
+  -- belongs to the same order
+  CREATE TABLE sub_orders (
+    order_id BIGINT,
+    sub_order_id INT,
+    product_name STRING,
+    price BIGINT,
+    PRIMARY KEY (order_id, sub_order_id) NOT ENFORCED
+  );
+
+  -- wide table
+  CREATE TABLE order_wide (
+    order_id BIGINT PRIMARY KEY NOT ENFORCED,
+    user_name STRING,
+    address STRING,
+    sub_orders ARRAY<ROW<sub_order_id BIGINT, product_name STRING, price BIGINT>>
+  ) WITH (
+    'merge-engine' = 'aggregation',
+    'fields.sub_orders.aggregate-function' = 'nested_update',
+    'fields.sub_orders.nested-key' = 'sub_order_id'
+  );
+
+  -- widen
+  INSERT INTO order_wide
+
+  SELECT
+    order_id,
+    user_name,
+    address,
+    CAST (NULL AS ARRAY<ROW<sub_order_id BIGINT, product_name STRING, price BIGINT>>)
+  FROM orders
+
+  UNION ALL
+
+  SELECT
+    order_id,
+    CAST (NULL AS STRING),
+    CAST (NULL AS STRING),
+    ARRAY[ROW(sub_order_id, product_name, price)]
+  FROM sub_orders;
+
+  -- query using UNNEST
+  SELECT order_id, user_name, address, sub_order_id, product_name, price
+  FROM order_wide, UNNEST(sub_orders) AS so(sub_order_id, product_name, price)
+  ```
+
+</TabItem>
+
+</Tabs>
+
+### nested_partial_update
+  The nested_partial_update function collects multiple rows into one array\<row\> (so-called 'nested table'). It supports
+  ARRAY\<ROW\> data types. You need to use `fields.<field-name>.nested-key=pk0,pk1,...` to specify the primary keys of the
+  nested table. The values in each row are written by partial updating some columns.
+
+  Use `fields.<field-name>.nested-key-null-strategy=<merge|ignore|error>` to specify how rows are handled when the nested-key does not satisfy primary key semantics (e.g., primary key fields contain null values).
+
+   - `merge` (default): Merge rows even if the nested-key does not satisfy primary key semantics. This is the same behavior as when this option is not configured.
+   - `ignore`: Ignore rows whose nested-key contains null values because they do not satisfy primary key semantics.
+   - `error`: Throw an exception if the nested-key contains null values, because primary key fields must not be null.
+
+## Bitmap Aggregation
 
 ### rbm32
   The rbm32 function aggregates multiple serialized 32-bit RoaringBitmap into a single RoaringBitmap.
@@ -164,7 +364,7 @@ Current supported aggregate functions and data types are:
   It supports VARBINARY data type which must be serialized 64-bit RoaringBitmap.
 
   Similar to rbm32, but supports 64-bit integers, making it suitable for scenarios with very large integer values
-  or when you need to represent sets with values beyond the 32-bit range (up to 2^31-1).
+  or when identifiers require a 64-bit representation.
 
   **Example:**
 
@@ -200,14 +400,16 @@ The `rbm32` and `rbm64` aggregators work by:
 2. Performing bitwise OR operations to merge the bitmaps
 3. Serializing the result back to VARBINARY format
 
-**Working with RoaringBitmap Functions:**
+<details>
+<summary>Preparing bitmap inputs and implementing Flink UDFs</summary>
 
 Paimon currently does not provide built-in Flink UDFs for bitmap creation. You have two options:
 
 1. Create bitmaps programmatically: in your application code and insert serialized bytes
 2. Create custom Flink UDFs: to convert raw integers to serialized bitmap format
 
-Here are examples of both approaches:
+The examples below illustrate both approaches. SQL names such as `TO_BITMAP`, `FROM_BITMAP`,
+and `BITMAP_CONTAINS` refer to user-supplied functions; they are not built-in Paimon functions.
 
 **Option 1: Programmatic Bitmap Creation (Java/Scala)**
 
@@ -221,10 +423,7 @@ byte[] serialized1 = bitmap1.serialize();
 byte[] serialized2 = bitmap2.serialize();
 byte[] serialized3 = bitmap3.serialize();
 
-INSERT INTO user_page_visits VALUES
-    (1, CAST(x'...' AS VARBINARY)),  -- serialized1 bytes
-    (2, CAST(x'...' AS VARBINARY)),  -- serialized2 bytes
-    (3, CAST(x'...' AS VARBINARY));  -- serialized3 bytes
+// Write serialized1, serialized2, and serialized3 as VARBINARY values through your writer API.
 ```
 
 **Option 2: Custom Flink UDFs**
@@ -306,165 +505,21 @@ public static class BitmapContainsUDF extends ScalarFunction {
 }
 ```
 
-### nested_update
-  The nested_update function collects multiple rows into one array\<row> (so-called 'nested table'). It supports ARRAY\<ROW> data types.
+</details>
 
-  Use `fields.<field-name>.nested-key=pk0,pk1,...` to specify the primary keys of the nested table. If no keys, row will be appended to array\<row>.
-
-  Use `fields.<field-name>.nested-key-null-strategy=<merge|ignore|error>` to specify how rows are handled when the nested-key does not satisfy primary key semantics (e.g., primary key fields contain null values).
-
-   - `merge` (default): Merge rows even if the nested-key does not satisfy primary key semantics. This is the same behavior as when this option is not configured.
-   - `ignore`: Ignore rows whose nested-key contains null values because they do not satisfy primary key semantics.
-   - `error`: Throw an exception if the nested-key contains null values, because primary key fields must not be null.
-
-  Use `fields.<field-name>.nested-sequence-field=seq0,seq1,...` to control the update sequence of a nested table, you must configure `fields.<field-name>.nested-key` when using it.
-
-  Use `fields.<field-name>.count-limit=<Integer>` to specify the maximum number of rows in the nested table. When no nested-key, it will select data
-  sequentially up to limit; but if nested-key is specified, it cannot guarantee the correctness of the aggregation result. This option can be used to
-  avoid abnormal input.
-
-  An example:
-
-  <Tabs groupId="nested-update-example">
-
-<TabItem value="flink" label="Flink">
-
-```sql
-  -- orders table
-  CREATE TABLE orders (
-    order_id BIGINT PRIMARY KEY NOT ENFORCED,
-    user_name STRING,
-    address STRING
-  );
-  
-  -- sub orders that have the same order_id 
-  -- belongs to the same order
-  CREATE TABLE sub_orders (
-    order_id BIGINT,
-    sub_order_id INT,
-    product_name STRING,
-    price BIGINT,
-    PRIMARY KEY (order_id, sub_order_id) NOT ENFORCED
-  );
-  
-  -- wide table
-  CREATE TABLE order_wide (
-    order_id BIGINT PRIMARY KEY NOT ENFORCED,
-    user_name STRING,
-    address STRING,
-    sub_orders ARRAY<ROW<sub_order_id BIGINT, product_name STRING, price BIGINT>>
-  ) WITH (
-    'merge-engine' = 'aggregation',
-    'fields.sub_orders.aggregate-function' = 'nested_update',
-    'fields.sub_orders.nested-key' = 'sub_order_id'
-  );
-  
-  -- widen
-  INSERT INTO order_wide
-  
-  SELECT 
-    order_id, 
-    user_name,
-    address, 
-    CAST (NULL AS ARRAY<ROW<sub_order_id BIGINT, product_name STRING, price BIGINT>>) 
-  FROM orders
-  
-  UNION ALL 
-    
-  SELECT 
-    order_id, 
-    CAST (NULL AS STRING), 
-    CAST (NULL AS STRING), 
-    ARRAY[ROW(sub_order_id, product_name, price)] 
-  FROM sub_orders;
-  
-  -- query using UNNEST
-  SELECT order_id, user_name, address, sub_order_id, product_name, price 
-  FROM order_wide, UNNEST(sub_orders) AS so(sub_order_id, product_name, price)
-  ```
-
-</TabItem>
-
-</Tabs>
-
-### nested_partial_update
-  The nested_partial_update function collects multiple rows into one array\<row\> (so-called 'nested table'). It supports
-  ARRAY\<ROW\> data types. You need to use `fields.<field-name>.nested-key=pk0,pk1,...` to specify the primary keys of the
-  nested table. The values in each row are written by partial updating some columns.
-
-  Use `fields.<field-name>.nested-key-null-strategy=<merge|ignore|error>` to specify how rows are handled when the nested-key does not satisfy primary key semantics (e.g., primary key fields contain null values).
-
-   - `merge` (default): Merge rows even if the nested-key does not satisfy primary key semantics. This is the same behavior as when this option is not configured.
-   - `ignore`: Ignore rows whose nested-key contains null values because they do not satisfy primary key semantics.
-   - `error`: Throw an exception if the nested-key contains null values, because primary key fields must not be null.
-
-
-### collect
-  The collect function collects elements into an Array. You can set `fields.<field-name>.distinct=true` to deduplicate elements.
-  It only supports ARRAY type.
-
-### merge_map
-  The merge_map function merge input maps. It only supports MAP type.
-
-### merge_map_with_keytime
-
-  The merge_map_with_keytime function merges input maps with key-level partial updates based on timestamps.
-  Each key in the map carries its own timestamp, and during merging, only the value with the latest timestamp for each key is retained.
-  It only supports `MAP<key_type, ROW<value_field, ts_field>>` type, where the ROW must have at least 2 fields.
-
-  Use `fields.<field-name>.ts-field=<field_name_in_row>` to specify the timestamp field name in the ROW type.
-  If not specified, the last field of the ROW is used as the timestamp by default.
-
-  When a key's value is null, the key will be removed from the map.
-  When the timestamp field is null, the entry will be skipped.
-
-  An example:
-
-  <Tabs groupId="merge-map-with-keytime-example">
-
-<TabItem value="flink" label="Flink">
-
-```sql
-  CREATE TABLE my_table (
-      biz_order_id STRING,
-      key_value_map MAP\<STRING, ROW\<`value` STRING, `ts` STRING>>,
-      PRIMARY KEY (biz_order_id) NOT ENFORCED
-  ) WITH (
-      'merge-engine' = 'aggregation',
-      'fields.key_value_map.aggregate-function' = 'merge_map_with_keytime',
-      'fields.key_value_map.ts-field' = 'ts'
-  );
-  ```
-
-</TabItem>
-
-</Tabs>
-
-  Given the following input records:
-
-  | biz_order_id | key_value_map |
-  |---|---|
-  | 1 | {'\{'}"product_name": ("iPhone", "100"), "color": ("Black", "100"){'\}'} |
-  | 1 | {'\{'}"product_name": ("iPad", "200"), "price": ("999", "200"){'\}'} |
-  | 1 | {'\{'}"color": ("White", "50"){'\}'} |
-
-  The final result will be:
-  `{"product_name": ("iPad", "200"), "color": ("Black", "100"), "price": ("999", "200")}` 
-  Note that `color` remains "Black" because its existing timestamp "100" is greater than the incoming "50".
-
-### Types of cardinality sketches
+## Types of cardinality sketches
 
  Paimon uses the [Apache DataSketches](https://datasketches.apache.org/) library of stochastic streaming algorithms to implement sketch modules. The DataSketches library includes various types of sketches, each one designed to solve a different sort of problem. Paimon supports HyperLogLog (HLL) and Theta cardinality sketches.
 
-#### HyperLogLog
+### HyperLogLog
 
- The HyperLogLog (HLL) sketch aggregator is a very compact sketch algorithm for approximate distinct counting.  You can also use the HLL aggregator to calculate a union of HLL sketches. 
+ The HyperLogLog (HLL) sketch aggregator is a very compact sketch algorithm for approximate distinct counting.  You can also use the HLL aggregator to calculate a union of HLL sketches.
 
-#### Theta
+### Theta
 
  The Theta sketch is a sketch algorithm for approximate distinct counting with set operations. Theta sketches let you count the overlap between sets, so that you can compute the union, intersection, or set difference between sketch objects.
 
-#### Choosing a sketch type
+### Choosing a sketch type
 
   HLL and Theta sketches both support approximate distinct counting; however, the HLL sketch produces more accurate results and consumes less storage space. Theta sketches are more flexible but require significantly more memory.
 
@@ -472,14 +527,19 @@ When choosing an approximation algorithm for your use case, consider the followi
 
 If your use case entails distinct counting and merging sketch objects, use the HLL sketch.
 If you need to evaluate union, intersection, or difference set operations, use the Theta sketch.
-You cannot merge HLL sketches with Theta sketches.
+You cannot merge HLL sketches with Theta sketches. Paimon's `hll_sketch` and `theta_sketch`
+aggregate functions both perform **union**. Theta intersection and difference operations require
+separate application code or UDFs; they are not operations selectable on `theta_sketch`.
 
-#### hll_sketch
+### hll_sketch
 
 The hll_sketch function aggregates multiple serialized Sketch objects into a single Sketch.
 It supports VARBINARY data type.
 
 An example:
+
+<details>
+<summary>Flink SQL and HLL UDF example</summary>
 
 <Tabs groupId="hll-sketch-example">
 
@@ -491,7 +551,7 @@ An example:
     id INT PRIMARY KEY NOT ENFORCED,
     user_id STRING
   );
-  
+
   -- agg table
   CREATE TABLE UV_AGG (
     id INT PRIMARY KEY NOT ENFORCED,
@@ -500,8 +560,8 @@ An example:
     'merge-engine' = 'aggregation',
     'fields.uv.aggregate-function' = 'hll_sketch'
   );
-  
-  -- Register the following class as a Flink function with the name "HLL_SKETCH" 
+
+  -- Register the following class as a Flink function with the name "HLL_SKETCH"
   -- for example: create TEMPORARY function HLL_SKETCH as  'HllSketchFunction';
   -- which is used to transform input to sketch bytes array:
   --
@@ -518,14 +578,14 @@ An example:
   -- Register the following class as a Flink function with the name "HLL_SKETCH_COUNT"
   -- for example: create TEMPORARY function HLL_SKETCH_COUNT as  'HllSketchCountFunction';
   -- which is used to get cardinality from sketch bytes array:
-  -- 
-  -- public static class HllSketchCountFunction extends ScalarFunction { 
+  --
+  -- public static class HllSketchCountFunction extends ScalarFunction {
   --   public Double eval(byte[] sketchBytes) {
   --     if (sketchBytes == null) {
-  --       return 0d; 
-  --     } 
-  --     return HllSketch.heapify(sketchBytes).getEstimate(); 
-  --   } 
+  --       return 0d;
+  --     }
+  --     return HllSketch.heapify(sketchBytes).getEstimate();
+  --   }
   -- }
   --
   -- Then we can get user cardinality based on the aggregated field.
@@ -536,14 +596,19 @@ An example:
 
 </Tabs>
 
+</details>
 
-#### theta_sketch
+
+### theta_sketch
   The theta_sketch function aggregates multiple serialized Sketch objects into a single Sketch.
   It supports VARBINARY data type.
 
   An example:
 
-  <Tabs groupId="theta-sketch-example">
+  <details>
+<summary>Flink SQL and Theta UDF example</summary>
+
+<Tabs groupId="theta-sketch-example">
 
 <TabItem value="flink" label="Flink">
 
@@ -553,7 +618,7 @@ An example:
     id INT PRIMARY KEY NOT ENFORCED,
     user_id STRING
   );
-  
+
   -- agg table
   CREATE TABLE UV_AGG (
     id INT PRIMARY KEY NOT ENFORCED,
@@ -562,33 +627,33 @@ An example:
     'merge-engine' = 'aggregation',
     'fields.uv.aggregate-function' = 'theta_sketch'
   );
-  
-  -- Register the following class as a Flink function with the name "THETA_SKETCH" 
+
+  -- Register the following class as a Flink function with the name "THETA_SKETCH"
   -- for example: create TEMPORARY function THETA_SKETCH as  'ThetaSketchFunction';
   -- which is used to transform input to sketch bytes array:
   --
-  -- public static class ThetaSketchFunction extends ScalarFunction {'\{'}
-  --   public byte[] eval(String user_id) {'\{'}
+  -- public static class ThetaSketchFunction extends ScalarFunction {
+  --   public byte[] eval(String user_id) {
   --     UpdateSketch updateSketch = UpdateSketch.builder().build();
   --     updateSketch.update(user_id);
   --     return updateSketch.compact().toByteArray();
-  --   {'\}'}
-  -- {'\}'}
+  --   }
+  -- }
   --
   INSERT INTO UV_AGG SELECT id, THETA_SKETCH(user_id) FROM VISITS;
 
   -- Register the following class as a Flink function with the name "THETA_SKETCH_COUNT"
   -- for example: create TEMPORARY function THETA_SKETCH_COUNT as  'ThetaSketchCountFunction';
   -- which is used to get cardinality from sketch bytes array:
-  -- 
-  -- public static class ThetaSketchCountFunction extends ScalarFunction {'\{'} 
-  --   public Double eval(byte[] sketchBytes) {'\{'}
-  --     if (sketchBytes == null) {'\{'}
-  --       return 0d; 
-  --     {'\}'} 
-  --     return Sketches.wrapCompactSketch(Memory.wrap(sketchBytes)).getEstimate(); 
-  --   {'\}'} 
-  -- {'\}'}
+  --
+  -- public static class ThetaSketchCountFunction extends ScalarFunction {
+  --   public Double eval(byte[] sketchBytes) {
+  --     if (sketchBytes == null) {
+  --       return 0d;
+  --     }
+  --     return Sketches.wrapCompactSketch(Memory.wrap(sketchBytes)).getEstimate();
+  --   }
+  -- }
   --
   -- Then we can get user cardinality based on the aggregated field.
   SELECT id, THETA_SKETCH_COUNT(UV) as uv FROM UV_AGG;
@@ -598,20 +663,26 @@ An example:
 
 </Tabs>
 
-:::info
-
-For streaming queries, `aggregation` merge engine must be used together with `lookup` or `full-compaction`
-[changelog producer](../changelog-producer). ('input' changelog producer is also supported, but only returns input records.)
-
-:::
+</details>
 
 ## Retraction
 
-Only `sum`, `product`, `collect`, `merge_map`, `nested_update`, `last_value` and `last_non_null_value` supports retraction (`UPDATE_BEFORE` and `DELETE`), others aggregate functions do not support retraction.
-If you allow some functions to ignore retraction messages, you can configure:
-`'fields.${field_name}.ignore-retract'='true'`.
+By default, `UPDATE_BEFORE` and `DELETE` retract individual field contributions. Only `sum`,
+`product`, `collect`, `merge_map`, `nested_update`, `last_value`, and `last_non_null_value` support
+this behavior. Other functions, including bitmap and sketch aggregators, reject field retractions
+unless `fields.<field-name>.ignore-retract = true` is configured.
 
-The `last_value` and `last_non_null_value` just set field to null when accept retract messages.
+### Delete the Whole Row
+
+Set `aggregation.remove-record-on-delete = true` to remove the whole row on `DELETE`, bypassing
+per-field retraction. The default is `false`. `UPDATE_BEFORE` still retracts individual fields.
+This option cannot be combined with per-field `ignore-retract`.
+
+### Field Retraction Behavior
+
+`last_value` always clears the field on retraction. `last_non_null_value` clears it only when
+the retract record's field is non-null; a null retract leaves the accumulated value unchanged.
+Neither function restores an earlier historical value.
 
 The `product` will return null for retraction message when accumulator is null.
 

--- a/docs/docs/primary-key-table/merge-engine/first-row.md
+++ b/docs/docs/primary-key-table/merge-engine/first-row.md
@@ -24,23 +24,47 @@ under the License.
 
 # First Row
 
-By specifying `'merge-engine' = 'first-row'`, users can keep the first row of the same primary key. It differs from the
-`deduplicate` merge engine that in the `first-row` merge engine, it will generate insert only changelog.
+Set `merge-engine = first-row` to keep the first row for each primary key and ignore subsequent
+rows for that key. This is useful for event or log deduplication. Unlike `deduplicate`, later
+values do not replace the retained row.
 
-:::info
+## Create a Table
 
-`first-row` merge engine only supports `none` and `lookup` changelog producer. 
-For streaming queries must be used with the `lookup` [changelog producer](../changelog-producer).
+```sql
+CREATE TABLE events (
+    event_id BIGINT,
+    payload STRING,
+    PRIMARY KEY (event_id) NOT ENFORCED
+) WITH (
+    'merge-engine' = 'first-row',
+    'changelog-producer' = 'lookup'
+);
+```
 
-:::
+Inputs `(1, 'first')` and `(1, 'later')` leave `(1, 'first')` in the table.
 
-:::info
+## Streaming Reads
 
-1. You can not specify [sequence.field](../sequence-rowkind#sequence-field).
-2. Not accept `DELETE` and `UPDATE_BEFORE` message. You can config `ignore-delete` to ignore these two kinds records.
-3. Visibility guarantee: Tables with First Row engine, the files with level 0 will only be visible after compaction.
-   So by default, compaction is synchronous, and if asynchronous is turned on, there may be delays in the data.
+The engine supports `none` and `lookup` changelog producers. Use
+[`lookup`](../changelog-producer#lookup) for streaming reads that must emit a key only once:
+lookup compaction checks existing keys and produces an insert-only changelog of newly retained
+rows. `none` does not provide the same cross-commit streaming deduplication.
 
-:::
+[Managed BLOB storage](../blob-storage#first-row-with-blob-fields) requires `none`, so it cannot
+use this lookup-changelog streaming pattern.
 
-This is of great help in replacing log deduplication in streaming computation.
+## Ordering and Deletes
+
+- User-defined [sequence fields](../sequence-rowkind#sequence-field) are not supported.
+- `DELETE` and `UPDATE_BEFORE` records are rejected by default. Set `ignore-delete = true` to
+  discard them when the source may emit retractions.
+- The retained row follows ingestion ordering, not the smallest value of a business timestamp.
+
+## Compaction and Visibility
+
+By default, batch reads expose Level-0 data only after lookup compaction. Writers wait for lookup
+compaction by default; asynchronous compaction can delay visibility. See
+[Lookup Compaction](../compaction#lookup-compaction).
+
+Do not enable deletion vectors for an ordinary `first-row` table. The
+[PK Clustering Override](../pk-clustering-override) layout is a special case with its own requirements.

--- a/docs/docs/primary-key-table/merge-engine/index.md
+++ b/docs/docs/primary-key-table/merge-engine/index.md
@@ -22,23 +22,62 @@ specific language governing permissions and limitations
 under the License.
 -->
 
-# Overview
+<a id="overview"></a>
 
-When Paimon sink receives two or more records with the same primary keys, it will merge them into one record to keep
-primary keys unique. By specifying the `merge-engine` table property, users can choose how records are merged together.
+# Merge Engines
 
-:::info
+A merge engine defines how records with the same primary key form one logical row. Set the
+`merge-engine` table option when creating a table. The choice affects the meaning of updates,
+null values, and retractions; it is separate from the [storage mode](../table-mode).
 
-Always set `table.exec.sink.upsert-materialize` to `NONE` in Flink SQL TableConfig, sink upsert-materialize may
-result in strange behavior. When the input is out of order, we recommend that you use
-[Sequence Field](../sequence-rowkind#sequence-field) to correct disorder.
+## Choose a Merge Engine
+
+| Engine | Result for the same key | Typical input | Details |
+| --- | --- | --- | --- |
+| `deduplicate` (default) | Keep the latest row; a latest retract removes it | Complete replacement rows, such as CDC updates | [Deduplicate](#deduplicate) |
+| `partial-update` | Update non-null fields; sequence groups can also explicitly set nulls | Updates to different columns of an entity | [Partial Update](./partial-update) |
+| `aggregation` | Aggregate each value field using its configured function | Contributions such as sums or maxima | [Aggregation](./aggregation) |
+| `first-row` | Keep the first row and ignore later rows for the key | Deduplicating events or logs | [First Row](./first-row) |
+
+"Latest" follows Paimon's record ordering. Configure a
+[sequence field](../sequence-rowkind#sequence-field) if arrival order does not represent the
+business order. Partial updates from independent streams can use per-column
+[sequence groups](./partial-update#sequence-group).
+
+:::info Flink SQL input ordering
+
+Set `table.exec.sink.upsert-materialize` to `NONE` in the Flink SQL TableConfig for these merge
+pipelines. The sink materializer can reorder records before Paimon receives them. Use sequence
+fields to express the required update order explicitly.
 
 :::
 
 ## Deduplicate
 
-The `deduplicate` merge engine is the default merge engine. Paimon will only keep the latest record and throw away
-other records with the same primary keys.
+`deduplicate` keeps the latest complete row. A null value in that row replaces an earlier non-null
+value; use `partial-update` if null should mean "leave this field unchanged".
 
-Specifically, if the latest record is a `DELETE` record, all records with the same primary keys will be deleted.
-You can config `ignore-delete` to ignore it.
+For example, two inputs `(1, 'open', 12.00)` and `(1, 'closed', 15.00)`, where the first column is
+the key, produce `(1, 'closed', 15.00)`.
+
+```sql
+CREATE TABLE orders (
+    order_id BIGINT,
+    status STRING,
+    amount DECIMAL(12, 2),
+    PRIMARY KEY (order_id) NOT ENFORCED
+) WITH (
+    'merge-engine' = 'deduplicate'
+);
+```
+
+If the latest record is `DELETE` or `UPDATE_BEFORE`, the logical row is removed. Set
+`ignore-delete = true` only when the pipeline should discard these retract records.
+
+## Streaming Results
+
+The merge engine defines stored table state; the
+[changelog producer](../changelog-producer) defines what streaming readers receive. For example,
+`input` forwards the original input records, which may be partial updates rather than complete
+merged rows. Check the streaming requirements on each engine's page before building a downstream
+aggregation or sink.

--- a/docs/docs/primary-key-table/merge-engine/partial-update.md
+++ b/docs/docs/primary-key-table/merge-engine/partial-update.md
@@ -3,7 +3,6 @@ title: "Partial Update"
 sidebar_position: 2
 ---
 
-
 <!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
@@ -25,262 +24,217 @@ under the License.
 
 # Partial Update
 
-By specifying `'merge-engine' = 'partial-update'`, users have the ability to update columns of a record through
-multiple updates until the record is complete. This is achieved by updating the value fields one by one, using the
-latest data under the same primary key. However, null values are not overwritten in the process.
+Set `merge-engine = partial-update` to combine updates to different columns of the same key.
+By default, non-null input values replace the corresponding fields and null input values leave
+them unchanged. [Sequence groups](#sequence-group) let independent streams order their own fields
+and explicitly replace values with null.
 
-For example, suppose Paimon receives three records:
+The Flink SQL examples below use bounded inputs. Wait for each `INSERT` job to finish before
+running the next statement, and run `SELECT` in batch mode.
 
-- `<1, 23.0, 10, NULL>`-
-- `<1, NULL, NULL, 'This is a book'>`
-- `<1, 25.2, NULL, NULL>`
+## Non-Null Updates
 
-Assuming that the first column is the primary key, the final result would be `<1, 25.2, 10, 'This is a book'>`.
+For example, a product's price, quantity, and description can arrive in separate updates:
+
+```sql
+CREATE TABLE products (
+    product_id BIGINT PRIMARY KEY NOT ENFORCED,
+    price DECIMAL(10, 2),
+    quantity INT,
+    description STRING
+) WITH (
+    'merge-engine' = 'partial-update'
+);
+
+INSERT INTO products VALUES (1, 23.00, 10, CAST(NULL AS STRING));
+INSERT INTO products VALUES (1, CAST(NULL AS DECIMAL(10, 2)), CAST(NULL AS INT), 'Book');
+INSERT INTO products VALUES (1, 25.20, CAST(NULL AS INT), CAST(NULL AS STRING));
+
+SELECT * FROM products;
+-- 1, 25.20, 10, Book
+```
+
+The second update fills in the description. The third changes only the price; its null fields
+preserve the stored quantity and description. To clear a stored value to null, use a sequence
+group with a valid version, as shown below.
 
 :::info
 
-For streaming queries, `partial-update` merge engine must be used together with `lookup` or `full-compaction`
-[changelog producer](../changelog-producer). ('input' changelog producer is also supported,
-but only returns input records.)
-
-:::
-
-:::info
-
-By default, Partial update can not accept delete records, you can choose one of the following solutions:
-
-- Configure 'ignore-delete' to ignore delete records.
-- Configure 'partial-update.remove-record-on-delete' to remove the whole row when receiving delete records.
-- Configure 'sequence-group's to retract partial columns. Also configure 'partial-update.remove-record-on-sequence-group' to remove the whole row when receiving deleted records of `specified sequence group`.
+Streaming readers that need the complete updated rows require the `lookup` or `full-compaction`
+[changelog producer](../changelog-producer). The `input` producer is also supported, but it
+returns the input changes, which may contain only partial rows.
 
 :::
 
 ## Sequence Group
 
-A sequence-field may not solve the disorder problem of partial-update tables with multiple stream updates, because
-the sequence-field may be overwritten by the latest data of another stream during multi-stream update.
+A single [sequence field](../sequence-rowkind#sequence-field) orders an entire record. When
+independent streams update different columns, give each stream its own sequence group so one
+stream's version does not determine whether the other stream's update is accepted.
 
-So we introduce sequence group mechanism for partial-update tables. It can solve:
-
-1. Disorder during multi-stream update. Each stream defines its own sequence-groups.
-2. A true partial-update, not just a non-null update.
-
-See example:
+Configure `fields.<ordering-field>.sequence-group` with the columns that the version protects.
+This example separates profile updates from score updates:
 
 ```sql
-CREATE TABLE t
-(
-    k   INT,
-    a   INT,
-    b   INT,
-    g_1 INT,
-    c   INT,
-    d   INT,
-    g_2 INT,
-    PRIMARY KEY (k) NOT ENFORCED
+CREATE TABLE profiles (
+    user_id BIGINT PRIMARY KEY NOT ENFORCED,
+    name STRING,
+    city STRING,
+    profile_version BIGINT,
+    score BIGINT,
+    score_version BIGINT
 ) WITH (
-      'merge-engine' = 'partial-update',
-      'fields.g_1.sequence-group' = 'a,b',
-      'fields.g_2.sequence-group' = 'c,d'
-      );
+    'merge-engine' = 'partial-update',
+    'fields.profile_version.sequence-group' = 'name,city',
+    'fields.score_version.sequence-group' = 'score'
+);
 
-INSERT INTO t
-VALUES (1, 1, 1, 1, 1, 1, 1);
+INSERT INTO profiles VALUES (1, 'Ada', 'London', 10, 40, 5);
 
--- g_2 is null, c, d should not be updated
-INSERT INTO t
-VALUES (1, 2, 2, 2, 2, 2, CAST(NULL AS INT));
+-- A newer profile clears city to NULL. A NULL score_version skips the score group.
+INSERT INTO profiles VALUES (1, 'Ada', CAST(NULL AS STRING), 11, 999, CAST(NULL AS BIGINT));
 
-SELECT *
-FROM t;
--- output 1, 2, 2, 2, 1, 1, 1
+-- The old profile is ignored, while the newer score is accepted.
+INSERT INTO profiles VALUES (1, 'Old', 'Paris', 9, 50, 6);
 
--- g_1 is smaller, a, b should not be updated
-INSERT INTO t
-VALUES (1, 3, 3, 1, 3, 3, 3);
-
-SELECT *
-FROM t; -- output 1, 2, 2, 2, 3, 3, 3
+SELECT * FROM profiles;
+-- 1, Ada, NULL, 11, 50, 6
 ```
 
-For `fields.<field-name>.sequence-group`, valid comparative data types include: DECIMAL, TINYINT, SMALLINT, INTEGER,
-BIGINT, FLOAT, DOUBLE, DATE, TIME, TIMESTAMP, and TIMESTAMP_LTZ.
+![Profile and score updates use independent versions: profile version 11 clears city, a null score version skips that group, and a later input updates only the score.](/img/primary-key-sequence-groups.svg)
 
-You can also configure multiple sorted fields in a `sequence-group`,
-like `fields.<field-name1>,<field-name2>.sequence-group`, multiple fields will be compared in order.
+For fields without aggregation, each group follows these rules:
 
-See example:
+| Incoming ordering value | Effect on the group |
+| --- | --- |
+| Null | Skip this group; other groups and ungrouped fields can still update |
+| Smaller than the stored value | Keep the stored ordering value and protected fields |
+| Greater than or equal to the stored value | Replace the ordering value and protected fields, including null values |
 
-```sql
-CREATE TABLE SG
-(
-    k   INT,
-    a   INT,
-    b   INT,
-    g_1 INT,
-    c   INT,
-    d   INT,
-    g_2 INT,
-    g_3 INT,
-    PRIMARY KEY (k) NOT ENFORCED
-) WITH (
-      'merge-engine' = 'partial-update',
-      'fields.g_1.sequence-group' = 'a,b',
-      'fields.g_2,g_3.sequence-group' = 'c,d'
-      );
+Fields outside sequence groups retain the default non-null update behavior. A primary-key
+column cannot be an ordering field or a protected field. Common ordering types include `DECIMAL`,
+`TINYINT`, `SMALLINT`, `INTEGER`, `BIGINT`, `FLOAT`, `DOUBLE`, `DATE`, `TIME`, `TIMESTAMP`, and
+`TIMESTAMP_LTZ`.
 
-INSERT INTO SG
-VALUES (1, 1, 1, 1, 1, 1, 1, 1);
+### Multiple Ordering Fields
 
--- g_3 is null, g_2, g_3 are not bigger, c, d should not be updated
-INSERT INTO SG
-VALUES (1, 2, 2, 2, 2, 2, 1, CAST(NULL AS INT));
+Use multiple ordering fields when one version is insufficient to break ties. For example,
+`fields.profile_version,profile_offset.sequence-group = name,city` compares `profile_version`
+first, then `profile_offset`. Both ordering columns must be present in the table schema.
 
-SELECT *
-FROM SG;
--- output 1, 2, 2, 2, 1, 1, 1, 1
+The group is skipped only when **all** its ordering fields are null. Otherwise, the tuple
+participates in comparison, with null sorting before a non-null value:
 
--- g_1 is smaller, a, b should not be updated
-INSERT INTO SG
-VALUES (1, 3, 3, 1, 3, 3, 3, 1);
-
-SELECT *
-FROM SG;
--- output 1, 2, 2, 2, 3, 3, 3, 1
-```
+| Stored tuple | Incoming tuple | Effect on non-aggregated protected fields |
+| --- | --- | --- |
+| `(1, 100)` | `(NULL, NULL)` | Skip the group |
+| `(1, 100)` | `(1, NULL)` | Keep stored fields: the incoming tuple is smaller |
+| `(1, 100)` | `(2, NULL)` | Replace fields: the first ordering value is larger |
+| `(1, 100)` | `(1, 100)` | Replace fields: equal versions are accepted |
 
 ## Aggregation For Partial Update
 
-You can specify aggregation function for the input field, all the functions in the
-[Aggregation](./aggregation) are supported.
+Set `fields.<field-name>.aggregate-function` to combine contributions to a field instead of
+replacing it. The functions listed in [Aggregation](./aggregation) are available, but every
+aggregated value field must belong to a sequence group unless its function is
+`last_non_null_value`. Primary-key fields and sequence-group ordering fields are not aggregated
+as value fields.
 
-:::info
+An aggregate changes how older records are handled: an older version can still contribute to
+an aggregated field, while non-aggregated fields in the same group keep their stored values.
+A group whose ordering fields are all null is still skipped.
 
-**Sequence-group behavior changes when aggregate functions are involved.**
+For example, profile names use replacement, while `total` accumulates contributions:
 
-Without aggregate functions, a sequence-group field acts as a **version filter**: an incoming sequence value
-that is newer than or equal to the stored value replaces the sequence fields and every protected field, including
-with NULL values. Only records with an older sequence value are ignored for the group.
+```sql
+CREATE TABLE profile_totals (
+    user_id BIGINT PRIMARY KEY NOT ENFORCED,
+    name STRING,
+    profile_version BIGINT,
+    total BIGINT,
+    event_version BIGINT
+) WITH (
+    'merge-engine' = 'partial-update',
+    'fields.profile_version.sequence-group' = 'name',
+    'fields.event_version.sequence-group' = 'total',
+    'fields.total.aggregate-function' = 'sum'
+);
 
-With aggregate functions, the sequence-group field acts as an **ordering key**: every incoming record with
-a non-NULL sequence value participates in the aggregation, regardless of whether its sequence value is
-larger or smaller than the stored one. The stored sequence value is only advanced when the incoming value
-is larger. For order-independent functions (`sum`, `product`, `max`, `min`) the ordering has no effect on
-the result; for order-dependent functions (`last_non_null_value`, `first_value`, `listagg`) the
-sequence-group value determines which record's contribution is considered "last" or "first".
+INSERT INTO profile_totals VALUES (1, 'Ada', 10, 5, 100);
 
-Records with a NULL sequence-group value are always skipped.
+-- The older name is ignored. The older total contribution still adds 3.
+INSERT INTO profile_totals VALUES (1, 'Older', 9, 3, 90);
+
+SELECT * FROM profile_totals;
+-- 1, Ada, 10, 8, 100
+
+-- Update the name; a NULL event_version skips the total contribution.
+INSERT INTO profile_totals VALUES (1, 'Bea', 11, 999, CAST(NULL AS BIGINT));
+
+SELECT * FROM profile_totals;
+-- 1, Bea, 11, 8, 100
+```
+
+The stored ordering tuple advances on newer or equal versions. With `sum`, an older or equal
+version still adds its contribution: a sequence group does **not** deduplicate repeated events.
+The same rules apply to groups with multiple ordering fields.
+
+:::warning
+
+Sequence groups do not guarantee a complete historical ordering for order-dependent aggregates
+such as `first_value` or `listagg`. An older contribution is combined with the current aggregate;
+Paimon does not retain and sort all prior contributions by their sequence-group values.
 
 :::
 
-See example:
+### Default Aggregation Function
+
+`fields.default-aggregate-function` supplies a function for value fields without an explicit
+field-level function. The sequence-group requirement above also applies to the default.
+Ordering fields and primary-key fields keep their special roles.
+
+For example, this configuration preserves non-null names while adding score contributions:
 
 ```sql
-CREATE TABLE t
-(
-    k INT,
-    a INT,
-    b INT,
-    c INT,
-    d INT,
-    PRIMARY KEY (k) NOT ENFORCED
+CREATE TABLE profile_scores (
+    user_id BIGINT PRIMARY KEY NOT ENFORCED,
+    name STRING,
+    profile_version BIGINT,
+    score BIGINT,
+    score_version BIGINT
 ) WITH (
-      'merge-engine' = 'partial-update',
-      'fields.a.sequence-group' = 'b',
-      'fields.b.aggregate-function' = 'first_value',
-      'fields.c.sequence-group' = 'd',
-      'fields.d.aggregate-function' = 'sum'
-      );
-INSERT INTO t
-VALUES (1, 1, 1, CAST(NULL AS INT), CAST(NULL AS INT));
-INSERT INTO t
-VALUES (1, CAST(NULL AS INT), CAST(NULL AS INT), 1, 1);
-INSERT INTO t
-VALUES (1, 2, 2, CAST(NULL AS INT), CAST(NULL AS INT));
-INSERT INTO t
-VALUES (1, CAST(NULL AS INT), CAST(NULL AS INT), 2, 2);
-
-
-SELECT *
-FROM t; -- output 1, 2, 1, 2, 3
+    'merge-engine' = 'partial-update',
+    'fields.profile_version.sequence-group' = 'name',
+    'fields.score_version.sequence-group' = 'score',
+    'fields.default-aggregate-function' = 'last_non_null_value',
+    'fields.score.aggregate-function' = 'sum'
+);
 ```
 
-You can also configure an aggregation function for a `sequence-group` within multiple sorted fields.
+The explicit `sum` takes precedence for `score`. The default `last_non_null_value` applies to
+`name`, so a newer profile with a null name now preserves the stored name instead of clearing it.
 
-See example:
+## Delete Handling
 
-```sql
-CREATE TABLE AGG
-(
-    k   INT,
-    a   INT,
-    b   INT,
-    g_1 INT,
-    c   VARCHAR,
-    g_2 INT,
-    g_3 INT,
-    PRIMARY KEY (k) NOT ENFORCED
-) WITH (
-      'merge-engine' = 'partial-update',
-      'fields.a.aggregate-function' = 'sum',
-      'fields.g_1,g_3.sequence-group' = 'a',
-      'fields.g_2.sequence-group' = 'c');
--- a in sequence-group g_1, g_3 with sum agg
--- b not in sequence-group
--- c in sequence-group g_2 without agg
+Choose how to process `DELETE` (`-D`) and `UPDATE_BEFORE` (`-U`) records before connecting a
+source that produces retractions:
 
-INSERT INTO AGG
-VALUES (1, 1, 1, 1, '1', 1, 1);
+| Configuration | `DELETE` | `UPDATE_BEFORE` |
+| --- | --- | --- |
+| Default, without sequence groups | Rejected | Rejected |
+| `ignore-delete = true` | Ignored | Ignored |
+| `partial-update.remove-record-on-delete = true` | Remove the whole row | Ignored |
+| Sequence groups | Retract protected fields according to the group version and aggregate function | Same field-level retraction rules |
+| Sequence groups with `partial-update.remove-record-on-sequence-group` | Remove the whole row when a configured group accepts the delete's version | Apply field-level retractions; do not remove the whole row |
 
--- g_2 is null, c should not be updated
-INSERT INTO AGG
-VALUES (1, 2, 2, 2, '2', CAST(NULL AS INT), 2);
+For a sequence group, a newer or equal retraction clears non-aggregated protected fields to
+null. Aggregated fields use their function's retraction behavior, including for older versions;
+see each [aggregate function's requirements](./aggregation). A group with all-null ordering
+fields is skipped, and ungrouped fields are not retracted.
 
-SELECT *
-FROM AGG;
--- output 1, 3, 2, 2, "1", 1, 2
+Set `partial-update.remove-record-on-sequence-group` to a comma-separated list of ordering
+field names from the groups whose deletes should remove the whole row. For the `profiles`
+schema above, using `profile_version` allows an accepted profile delete to remove the row.
 
--- (g_1, g_3) = (2, 1) is smaller than stored (2, 2), so the stored sequence values are not advanced,
--- but the sum aggregate for a still applies: a = 3 + 3 = 6
-INSERT INTO AGG
-VALUES (1, 3, 3, 2, '3', 3, 1);
-
-SELECT *
-FROM AGG;
--- output 1, 6, 3, 2, "3", 3, 2
-```
-
-You can specify a default aggregation function for all the input fields with `fields.default-aggregate-function`, see
-example:
-
-```sql
-CREATE TABLE t
-(
-    k INT,
-    a INT,
-    b INT,
-    c INT,
-    d INT,
-    PRIMARY KEY (k) NOT ENFORCED
-) WITH (
-      'merge-engine' = 'partial-update',
-      'fields.a.sequence-group' = 'b',
-      'fields.c.sequence-group' = 'd',
-      'fields.default-aggregate-function' = 'last_non_null_value',
-      'fields.d.aggregate-function' = 'sum'
-      );
-
-INSERT INTO t
-VALUES (1, 1, 1, CAST(NULL AS INT), CAST(NULL AS INT));
-INSERT INTO t
-VALUES (1, CAST(NULL AS INT), CAST(NULL AS INT), 1, 1);
-INSERT INTO t
-VALUES (1, 2, 2, CAST(NULL AS INT), CAST(NULL AS INT));
-INSERT INTO t
-VALUES (1, CAST(NULL AS INT), CAST(NULL AS INT), 2, 2);
-
-
-SELECT *
-FROM t; -- output 1, 2, 2, 2, 3
-
-```
+`partial-update.remove-record-on-delete` cannot be combined with sequence groups. Neither
+whole-row removal option can be combined with `ignore-delete`.

--- a/docs/docs/primary-key-table/pk-clustering-override.md
+++ b/docs/docs/primary-key-table/pk-clustering-override.md
@@ -28,8 +28,9 @@ By default, data files in a primary key table are physically sorted by the prima
 lookups but can hurt scan performance when queries filter on non-primary-key columns.
 
 **PK Clustering Override** mode changes the physical sort order of data files from the primary key to user-specified
-clustering columns. This significantly improves scan performance for queries that filter or group by clustering columns,
-while still maintaining primary key uniqueness through deletion vectors.
+clustering columns. Grouping nearby values can improve file pruning for selective filters on those columns.
+The layout maintains primary-key uniqueness through lookup and deletion-vector handling;
+the benefit depends on data distribution and the query predicates.
 
 ## Quick Start
 
@@ -48,7 +49,8 @@ CREATE TABLE my_table (
 );
 ```
 
-For `first-row` merge engine, deletion vectors are already built-in, so you don't need to enable them explicitly:
+For the `first-row` merge engine, this specialized layout handles row retention internally;
+you do not need to enable deletion vectors explicitly:
 
 ```sql
 CREATE TABLE my_table (
@@ -88,8 +90,9 @@ PK Clustering Override is beneficial when:
 :::info
 
 Although data files are no longer sorted by the primary key, filtering on bucket-key fields (which default to the
-primary key) still benefits from bucket pruning. The query engine can skip entire buckets that do not contain matching
-values, so queries like `WHERE id = 12345` remain efficient.
+primary key excluding partition columns) can still benefit from fixed-bucket pruning. The query
+engine can skip entire buckets when predicates determine the bucket key. This does not restore primary-key sorting or
+its file-range pruning, so benchmark point lookups as well as analytical scans.
 
 :::
 
@@ -97,4 +100,5 @@ values, so queries like `WHERE id = 12345` remain efficient.
 
 - Merge engine: `partial-update` or `aggregation`.
 - Changelog producer: `lookup` or `full-compaction`.
-- Configure: `sequence.fields` or `record-level.expire-time`.
+- Configuration: `sequence.field` or `record-level.expire-time`.
+- [Primary-key indexes](./global-index#requirements) and [managed BLOB storage](./blob-storage#requirements-and-limitations).

--- a/docs/docs/primary-key-table/query-performance.md
+++ b/docs/docs/primary-key-table/query-performance.md
@@ -24,79 +24,97 @@ under the License.
 
 # Query Performance
 
+Start with the scan plan and the workload: which partitions and columns are filtered, whether
+rows still need merging, and whether the query is a scan, aggregate, join, or ranked search.
+
+| Symptom or query pattern | Check first | Next step |
+| --- | --- | --- |
+| MOR scan spends time merging | Overlapping sorted runs and bucket sizes | Tune [compaction](./compaction) or evaluate a different [table mode](./table-mode) |
+| Selective primary-key lookup scans too much data | Partition, bucket-key, and file key-range pruning | [Primary-key filters](#data-skipping-by-primary-key-filter) |
+| Filters on non-key columns scan many files | Whether versions must be merged before filtering | [File indexes](#data-skipping-by-file-index) or [clustering](./pk-clustering-override) |
+| Vector, text, or scalar index search | Index family and coverage of compacted data | [Primary-Key Indexes](./global-index) |
+| Large join shuffle | Fixed-bucket layout on both inputs | [Bucketed Join](#bucketed-join) |
+
 ## Table Mode
 
-The table schema has the greatest impact on query performance. See [Table Mode](./table-mode).
+[Table Mode](./table-mode) determines whether files can be read independently. MOR merges
+files with overlapping key ranges, which constrains split planning and parallelism. Bucket count
+and skew therefore matter, alongside the number of sorted runs.
 
-For Merge On Read table, the most important thing you should pay attention to is the number of buckets, which will limit
-the concurrency of reading data.
-
-For MOW (Deletion Vectors) or COW table or [Read Optimized](../concepts/system-tables#read-optimized-table) table,
-there is no limit to the concurrency of reading data, and they can also utilize some filtering conditions for non-primary-key columns.
+MOW, fully compacted COW results, and the
+[read-optimized table](../concepts/system-tables#read-optimized-table) can avoid that merge work
+and use file-based splits. Parallelism still depends on file sizes, split planning, and available
+engine resources. Resolving row versions also makes filters on non-key columns safe to apply at
+the file scan; MOR generally has to apply such filters after merging.
 
 ## Aggregate push down
 
-Table with Deletion Vectors Enabled supports aggregate push down:
+Deletion-vector tables can support metadata-based `COUNT(*)` when the planned splits expose exact
+merged row counts and the connector can push down the query. For example, with `dt` as a partition
+column:
 
 ```sql
-SELECT COUNT(*) FROM TABLE WHERE DT = '20230101';
+SELECT COUNT(*) FROM orders WHERE dt = '20230101';
 ```
 
-This query can be accelerated during compilation and returns very quickly.
+Additional row filters can require reading data. Use the engine's `EXPLAIN` output to verify the
+actual plan rather than assuming every count is answered from metadata.
 
-For Spark SQL, table with default `metadata.stats-mode` can be accelerated:
-
-```sql
-SELECT MIN(a), MAX(b) FROM TABLE WHERE DT = '20230101';
-```
-
-Min max query can be also accelerated during compilation and returns very quickly.
+Spark does **not** currently push `MIN` or `MAX` into metadata aggregation for primary-key tables.
+File statistics can describe obsolete physical rows as well as visible rows, so default
+`metadata.stats-mode` alone does not make this optimization available.
 
 ## Data Skipping By Primary Key Filter
 
-For a regular bucketed table (For example, bucket = 5), the filtering conditions of the primary key will greatly
-accelerate queries and reduce the reading of a large number of files.
+For a fixed-bucket table, equality conditions that determine the bucket key can prune buckets.
+Partition filters prune partitions, and primary-key range statistics can prune files. The default
+bucket key excludes partition columns from the primary key.
+
+A predicate on only part of a composite key does not necessarily identify a bucket. Primary-key
+sorting and key-range pruning are also affected by [PK Clustering Override](./pk-clustering-override),
+which sorts files by other columns.
 
 ## Data Skipping By File Index
 
-For full-compacted file, or for primary-key table with `'deletion-vectors.enabled'`, you can use file index, it filters
-files by indexing on the reading side.
+File indexes can narrow reads of fully compacted files or tables using deletion vectors, where
+row versions do not need to be merged across the filtered files. Paimon still applies the relevant
+row filters and deletion vectors for correctness.
 
-Define `file-index.bitmap.columns`, Data file index is an external index file and Paimon will create its
-corresponding index file for each file. If the index file is too small, it will be stored directly in the manifest,
-otherwise in the directory of the data file. Each data file corresponds to an index file, which has a separate file
-definition and can contain different types of indexes with multiple columns.
+| Index | Table option | Useful predicate pattern |
+| --- | --- | --- |
+| [Bloom filter](../concepts/spec/fileindex#index-bloomfilter) | `file-index.bloom-filter.columns` | Equality and point lookups |
+| [Bitmap](../concepts/spec/fileindex#index-bitmap) | `file-index.bitmap.columns` | Exact matches on indexed values |
+| [Range bitmap](../concepts/spec/fileindex#index-range-bitmap) | `file-index.range-bitmap.columns` | Range predicates |
 
-Different file indexes may be efficient in different scenarios. For example bloom filter may speed up query in point lookup
-scenario. Using a bitmap may consume more space but can result in greater accuracy.
+A data file can have indexes for several columns. Small index data can be embedded in metadata;
+larger index data is stored alongside the data file. Size and selectivity determine whether an
+index saves enough scan work to justify its storage and maintenance cost.
 
-* [BloomFilter](../concepts/spec/fileindex#index-bloomfilter): `file-index.bloom-filter.columns`.
-* [Bitmap](../concepts/spec/fileindex#index-bitmap): `file-index.bitmap.columns`.
-* [Range Bitmap](../concepts/spec/fileindex#index-range-bitmap): `file-index.range-bitmap.columns`.
+To add file indexes to an existing table without rewriting its data files, configure the
+`file-index.<type>.columns` options and run `rewrite_file_index`; see
+[Flink Procedures](../flink/procedures).
 
-If you want to add file index to existing table, without any rewrite, you can use `rewrite_file_index` procedure. Before
-we use the procedure, you should config appropriate configurations in target table. You can use ALTER clause to config
-`file-index.<filter-type>.columns` to the table.
-
-How to invoke: see [flink procedures](../flink/procedures)
+File indexes are separate from [Primary-Key Indexes](./global-index), whose index groups follow
+compacted data levels and support scalar predicates and ranked searches. Check that page's
+coverage rules, especially for Vector and Full Text search.
 
 ## Bucketed Join
 
-Fixed Bucketed table (e.g. bucket = 10) can be used to avoid shuffle if necessary in batch query, for example, you can
-use the following Spark SQL to read a Paimon table:
+Spark can use compatible fixed-bucket layouts to avoid a join shuffle. For example:
 
 ```sql
 SET spark.sql.sources.v2.bucketing.enabled = true;
 
-CREATE TABLE FACT_TABLE (order_id INT, f1 STRING) TBLPROPERTIES ('bucket'='10', 'primary-key' = 'order_id');
+CREATE TABLE fact_table (order_id INT, f1 STRING) USING paimon
+TBLPROPERTIES ('bucket' = '10', 'primary-key' = 'order_id');
 
-CREATE TABLE DIM_TABLE (order_id INT, f2 STRING) TBLPROPERTIES ('bucket'='10', 'primary-key' = 'order_id');
+CREATE TABLE dim_table (order_id INT, f2 STRING) USING paimon
+TBLPROPERTIES ('bucket' = '10', 'primary-key' = 'order_id');
 
-SELECT * FROM FACT_TABLE AS fact JOIN DIM_TABLE AS dim ON fact.order_id = dim.order_id;
+SELECT * FROM fact_table AS fact
+JOIN dim_table AS dim ON fact.order_id = dim.order_id;
 ```
 
-The `spark.sql.sources.v2.bucketing.enabled` config is used to enable bucketing for V2 data sources. When turned on,
-Spark will recognize the specific distribution reported by a V2 data source through SupportsReportPartitioning, and
-will try to avoid shuffle if necessary.
-
-The costly join shuffle will be avoided if two tables have the same bucketing strategy and same number of buckets.
+The setting enables Spark to use partitioning reported by V2 data sources. The join keys, bucket
+keys, and bucket counts must be compatible; the same bucket count alone is not sufficient.
+Check `EXPLAIN` to confirm that Spark avoids the shuffle for the actual query.

--- a/docs/docs/primary-key-table/sequence-rowkind.mdx
+++ b/docs/docs/primary-key-table/sequence-rowkind.mdx
@@ -1,10 +1,7 @@
 ---
-title: "Sequence & Rowkind"
+title: "Sequence and Row Kind"
 sidebar_position: 6
 ---
-
-import Tabs from '@theme/Tabs';
-import TabItem from '@theme/TabItem';
 
 <!--
 Licensed to the Apache Software Foundation (ASF) under one
@@ -25,96 +22,147 @@ specific language governing permissions and limitations
 under the License.
 -->
 
-# Sequence and Rowkind
+<a id="sequence-and-rowkind"></a>
 
-When creating a table, you can specify the `'sequence.field'` by specifying fields to determine the order of updates,
-or you can specify the `'rowkind.field'` to determine the changelog kind of record.
+# Sequence and Row Kind
+
+Record ordering and row kind answer different questions: which update takes precedence, and
+whether that update inserts or retracts a row. Configure them alongside the
+[merge engine](./merge-engine/).
+
+| Option | Use |
+| --- | --- |
+| `sequence.field` | Order updates by one or more source fields |
+| `rowkind.field` | Decode an operation such as `+I` or `-D` from a column |
+| `sequence.snapshot-ordering` | Order updates across writers by commit snapshot ID |
+
+Partial updates from independent streams can use
+[sequence groups](./merge-engine/partial-update#sequence-group) instead of one shared sequence field.
 
 ## Sequence Field
 
-By default, the primary key table determines the merge order according to the input order (the last input record will be the last to merge). However, in distributed computing,
-there will be some cases that lead to data disorder. At this time, you can use a time field as `sequence.field`, for example:
+By default, Paimon assigns internal sequence numbers to order records during merging. This order
+does not necessarily match the order in the source system, especially when updates arrive late
+or come from multiple writers. Set `sequence.field` to a source version or timestamp when the
+source defines which update should take precedence.
 
-<Tabs groupId="sequence-field">
-
-<TabItem value="flink" label="Flink">
+For example, this Flink SQL table uses the source version to keep the latest order status:
 
 ```sql
-CREATE TABLE my_table (
-    pk BIGINT PRIMARY KEY NOT ENFORCED,
-    v1 DOUBLE,
-    v2 BIGINT,
-    update_time TIMESTAMP
+CREATE TABLE order_status (
+    order_id BIGINT PRIMARY KEY NOT ENFORCED,
+    status STRING,
+    source_version BIGINT
 ) WITH (
-    'sequence.field' = 'update_time'
+    'sequence.field' = 'source_version'
 );
+
+INSERT INTO order_status VALUES (1, 'shipped', 12), (1, 'paid', 11);
+
+-- After the INSERT job finishes, query in batch mode.
+SELECT * FROM order_status;
+-- 1, shipped, 12
 ```
 
-</TabItem>
+The default `sequence.field.sort-order = ascending` merges the largest value last. With the
+default `deduplicate` engine, version `12` wins even if version `11` arrives later. Setting
+`sequence.field.sort-order = descending` reverses that comparison, so the smallest value wins
+for `deduplicate`.
 
-</Tabs>
+For multiple fields, such as `'sequence.field' = 'update_time,source_offset'`, Paimon compares
+the first field, then uses the next field to break ties. If all configured values are equal,
+Paimon falls back to its internal record order. Use a source tie-breaker when the result must
+be independent of arrival order.
 
-The record with the largest `sequence.field` value will be the last to merge, if the values are the same, the input
-order will be used to determine which one is the last one. `sequence.field` does not support `GEOMETRY`, `GEOGRAPHY`, or managed `BLOB` fields.
+The merge engine still determines how ordered records are combined. Sequence fields do not
+turn an aggregation engine into deduplication, or guarantee a complete historical ordering
+for order-dependent field aggregates such as `first_value`.
 
-You can define multiple fields for `sequence.field`, for example `'update_time,flag'`, multiple fields will be compared in order.
+Restrictions:
 
-:::info
-
-User defined sequence fields conflict with features such as `first_row` and `first_value`, which may result in unexpected results.
-
-:::
+- `sequence.field` cannot be combined with `merge-engine = first-row`, cross-partition updates,
+  or `sequence.snapshot-ordering`.
+- Do not assign an `aggregate-function` to a sequence field itself.
+- `GEOMETRY`, `GEOGRAPHY`, and managed `BLOB` fields cannot be sequence fields.
 
 ## Row Kind Field
 
-By default, the primary key table determines the row kind according to the input row. You can also define the
-`'rowkind.field'` to use a field to extract row kind.
+By default, Paimon uses the input row's row kind. Set `rowkind.field` when the source instead
+encodes each operation in a data column. The configured column must have a character-string
+type and contain a non-null operation value on every input row.
 
-The valid row kind string should be `'+I'`, `'-U'`, `'+U'` or `'-D'`.
+| Value | Row kind | Meaning |
+| --- | --- | --- |
+| `+I` | `INSERT` | Add a row or contribution |
+| `-U` | `UPDATE_BEFORE` | Retract the old row or contribution |
+| `+U` | `UPDATE_AFTER` | Add the updated row or contribution |
+| `-D` | `DELETE` | Retract a row or contribution |
+
+The merge engine determines how each kind affects stored state; see its delete and retraction
+requirements before choosing an input encoding.
+
+For example, the following Flink SQL table accepts upserts and deletes encoded in `op`.
+Wait for each bounded `INSERT` job to finish before running the next statement, and run the
+queries in batch mode.
+
+```sql
+CREATE TABLE order_changes (
+    order_id BIGINT PRIMARY KEY NOT ENFORCED,
+    status STRING,
+    source_version BIGINT,
+    op STRING NOT NULL
+) WITH (
+    'sequence.field' = 'source_version',
+    'rowkind.field' = 'op'
+);
+
+INSERT INTO order_changes VALUES (1, 'paid', 11, '+I');
+INSERT INTO order_changes VALUES (1, 'shipped', 12, '+U');
+
+SELECT order_id, status FROM order_changes;
+-- 1, shipped
+
+INSERT INTO order_changes VALUES (1, 'shipped', 13, '-D');
+
+SELECT order_id, status FROM order_changes;
+-- No rows
+```
+
+The operation column remains a regular stored column; Paimon does not remove it from the
+schema. Use the short values in the table above, without surrounding whitespace. Long names
+such as `INSERT` and `DELETE` are not accepted.
 
 ## Snapshot Ordering
 
-In multi-writer scenarios where wall-clock sequence numbers cannot be globally ordered across writers,
-you can enable `'sequence.snapshot-ordering'` to use the commit snapshot id as the ordering key when
-merging records with the same primary key. Records from later snapshots are considered newer,
-regardless of their per-record sequence number.
+Use `sequence.snapshot-ordering = true` when updates from multiple writers should be ordered
+by their commit snapshot ID. Records in later snapshots are considered newer, regardless of
+the writers' per-record sequence numbers.
 
-<Tabs>
-<TabItem value="flink" label="Flink">
+For example, with `deduplicate`, a row committed in snapshot `41` takes precedence over a row
+with the same key in snapshot `40`, even if the writer of snapshot `40` assigned a larger
+internal sequence number. This follows **commit order**, which may differ from source event
+time.
+
+Configure the option when creating the table. This Flink SQL example uses fixed buckets for
+multiple writers:
 
 ```sql
-CREATE TABLE my_table (
-    pk BIGINT PRIMARY KEY NOT ENFORCED,
-    v1 DOUBLE,
-    v2 BIGINT
+CREATE TABLE committed_orders (
+    order_id BIGINT PRIMARY KEY NOT ENFORCED,
+    status STRING
 ) WITH (
+    'bucket' = '4',
     'sequence.snapshot-ordering' = 'true',
     'write-only' = 'true'
 );
 ```
 
-</TabItem>
-</Tabs>
+| Requirement or boundary | Meaning |
+| --- | --- |
+| Primary-key table; immutable option | Choose this ordering strategy at table creation |
+| `write-only = true` for writers | Run a separate [dedicated compaction job](./compaction#dedicated-compaction-job) to preserve snapshot ordering during compaction |
+| No `sequence.field` | Source-field ordering and snapshot ordering are mutually exclusive |
+| No ordering within one snapshot | Do not rely on this option to choose among multiple versions of the same key in the same snapshot |
 
-:::warning
-This option requires `'write-only' = 'true'`. Compaction must be performed by a separate dedicated
-compact job. This ensures that compaction correctly preserves the snapshot id of each record.
-:::
-
-:::info
-`'sequence.snapshot-ordering'` is mutually exclusive with `'sequence.field'`. You cannot enable both
-on the same table.
-:::
-
-:::info
-The ordering key is the commit snapshot id only; the order of records **within the same snapshot** is
-not guaranteed, and this is by design. Under the default configuration it is harmless: a writer
-buffers a commit's writes (`'write-buffer-spillable' = 'true'`) and runs them through the merge
-function before flushing, so at most one record per primary key is written per snapshot — the common
-case is fully covered. We therefore deliberately do not handle the case where the same key is spread
-across multiple files of one snapshot. That case only arises with `'write-buffer-spillable' = 'false'`,
-or when the spilled data exceeds `'write-buffer-spill-disk-size'`, where the buffer may be flushed
-mid-commit; the same key can then land in multiple files of the same snapshot with equal sequence
-numbers and their relative order becomes undefined. This affects only intra-snapshot order, never the
-cross-snapshot ordering this feature provides.
-:::
+Writer buffers can merge versions before flushing, but they do not establish a guaranteed order
+across files within a snapshot. Size and spill settings do not change this ordering contract.

--- a/docs/docs/primary-key-table/table-mode.md
+++ b/docs/docs/primary-key-table/table-mode.md
@@ -24,93 +24,105 @@ under the License.
 
 # Table Mode
 
-![](/img/lsm-inside-bucket.png)
+A table mode determines **where the work of resolving row versions happens**. It does not change
+the logical result defined by the [merge engine](./merge-engine/). The modes below use table
+options to control compaction and deletion vectors; there is no separate `table-mode` option.
 
-The file structure of the primary key table is roughly shown in the above figure. The table or partition contains
-multiple buckets, and each bucket is a separate LSM tree structure that contains multiple files.
+## Choose a Mode
 
-The writing process of LSM is roughly as follows: Flink checkpoint flush L0 files, and trigger a compaction as needed
-to merge the data. According to the different processing ways during writing, there are three modes:
+| Mode | Configuration | Read path | Main cost |
+| --- | --- | --- | --- |
+| Merge On Read (MOR) | Default | Merge overlapping sorted runs | Read CPU and memory grow with overlapping versions |
+| Copy On Write (COW) | `full-compaction.delta-commits = 1` | Read the fully compacted result | Frequent full compaction increases write amplification |
+| Merge On Write (MOW) | `deletion-vectors.enabled = true` | Read files and skip invalid row positions | Writers look up previous rows and maintain deletion vectors |
 
-1. MOR (Merge On Read): Default mode, only minor compactions are performed, and merging are required for reading.
-2. COW (Copy On Write): Using `'full-compaction.delta-commits' = '1'`, full compaction will be synchronized, which
-   means the merge is completed on write.
-3. MOW (Merge On Write): Using `'deletion-vectors.enabled' = 'true'`, in writing phase, LSM will be queried to generate
-   the deletion vector file for the data file, which directly filters out unnecessary lines during reading.
+For a typical `deduplicate` table with frequent analytical reads, consider MOW. MOR can suit
+workloads that favor write throughput. COW can suit workloads that can afford to fully compact
+each commit. Evaluate update rate, read latency, and compaction resources before choosing.
 
-The Merge On Write mode is recommended for general primary key tables (merge-engine is default `deduplicate`).
+![MOR merges versions on read; COW rewrites them during full compaction; MOW masks obsolete rows with deletion vectors.](/img/primary-key-read-write-modes.svg)
 
 ## Merge On Read
 
-MOR is the default mode of primary key table.
+MOR is the default. Writes create sorted files, and compaction reduces the number of runs over
+time. Compaction can include full compactions; MOR does not mean that only minor compactions run.
 
-![](/img/mor.png)
+Readers merge overlapping key ranges before returning logical rows. Those ranges must be read
+together, which constrains parallelism and makes bucket sizing important. See
+[Data Distribution](./data-distribution) for bucket assignment and sizing.
 
-When the mode is MOR, it is necessary to merge all files for reading, as all files are ordered and undergo multi way
-merging, which includes a comparison calculation of the primary key.
-
-There is an obvious issue here, where a single LSM tree can only have a single thread to read, so the read parallelism
-is limited. If the amount of data in the bucket is too large, it can lead to poor read performance. So in order to read
-performance, it is recommended to analyze the query requirements table and set the data volume in the bucket to be
-between 200MB and 1GB. But if the bucket is too small, there will be a lot of small file reads and writes, causing
-pressure on the file system.
-
-In addition, due to the merging process, Filter based data skipping cannot be performed on non primary key columns, 
-otherwise new data will be filtered out, resulting in incorrect old data.
-
-- Write performance: very good.
-- Read performance: not so good.
+Filters on mutable non-key columns generally cannot be applied before merging. For example,
+if an old row has `status = 'open'` and its replacement has `status = 'closed'`, filtering files
+for `status = 'open'` too early could discard the replacement and incorrectly return the old row.
+The reader must resolve overlapping versions first. Where files can be read without merging,
+Paimon can apply non-key filters earlier.
 
 ## Copy On Write
+
+In Flink SQL:
 
 ```sql
 ALTER TABLE orders SET ('full-compaction.delta-commits' = '1');
 ```
 
-Set `full-compaction.delta-commits` to 1, which means that every write will be fully merged, and all data will be merged
-to the highest level. When reading, merging is not necessary at this time, and the reading performance is the highest.
-But every write requires full merging, and write amplification is very severe.
+This requests synchronous full compaction for modified buckets after each commit; in a Flink
+streaming write, the interval is counted in checkpoints. It does not compact after every individual input row.
+The resulting fully compacted files can be read without merging overlapping versions.
 
-![](/img/cow.png)
-
-- Write performance: very bad.
-- Read performance: very good.
+Repeated full compaction can rewrite a large amount of unchanged data. Use it when the read
+benefit justifies the write amplification. The `lookup` changelog producer is incompatible with
+`full-compaction.delta-commits`; see [Changelog Producer](./changelog-producer#full-compaction).
 
 ## Merge On Write
 
+Enable deletion vectors when creating the table. For example, in Flink SQL:
+
 ```sql
-ALTER TABLE orders SET ('deletion-vectors.enabled' = 'true');
+CREATE TABLE orders_mow (
+    order_id BIGINT,
+    amount DECIMAL(12, 2),
+    PRIMARY KEY (order_id) NOT ENFORCED
+) WITH (
+    'bucket' = '4',
+    'deletion-vectors.enabled' = 'true'
+);
 ```
 
-Thanks to Paimon's LSM structure, it has the ability to be queried by primary key. We can generate deletion vectors
-files when writing, representing which data in the file has been deleted. This directly filters out unnecessary rows
-during reading, which is equivalent to merging and does not affect reading performance.
+Changing this option on an existing table is blocked by default. A migration requires explicit
+`deletion-vectors.modifiable` configuration and full compaction to avoid exposing duplicate rows;
+setting the enable flag alone is not a complete migration procedure.
 
-![](/img/mow.png)
+During lookup compaction, Paimon finds earlier versions and records their physical row positions
+in deletion vectors. Readers skip those positions while scanning data files, so they can read
+files independently without merging overlapping key versions. Applying the deletion vectors
+still has a cost, but avoids the MOR merge work.
 
-A simple example just like:
+The example below uses `deduplicate`: an update replaces key `7`, while a delete removes key `9`.
+The old data file is retained, with both obsolete positions marked in its deletion vector.
 
-![](/img/mow-example.png)
+![An update to key 7 and a delete of key 9 mark two old file positions; readers see the new value of key 7 and the unchanged key 11.](/img/primary-key-deletion-vector-update.svg)
 
-Updates data by deleting old record first and then adding new one.
+:::info Data visibility
 
-- Write performance: good.
-- Read performance: good.
+By default, batch reads skip Level-0 files until lookup compaction publishes them. Writers wait
+for this compaction by default. Asynchronous compaction or a dedicated compaction job can delay
+visibility; see [Asynchronous Compaction](./compaction#asynchronous-compaction).
 
-:::info
-
-Visibility guarantee: Tables in deletion vectors mode, the files with level 0 will only be visible after compaction.
-So by default, compaction is synchronous, and if asynchronous is turned on, there may be delays in the data.
+For batch scans, `deletion-vectors.merge-on-read = true` includes uncompacted data by merging it
+at read time, with additional read cost. It does not change streaming changelog behavior.
 
 :::
 
+Check the requirements of specialized features before combining them. In particular,
+[First Row](./merge-engine/first-row), [PK Clustering Override](./pk-clustering-override), and
+[Primary-Key Indexes](./global-index#requirements) have their own deletion-vector constraints.
+
 ## MOR Read Optimized
 
-If you don't want to use Deletion Vectors mode, you want to query fast enough in MOR mode, but can only find
-older data, you can also:
+A MOR table can also provide a faster view of older, fully compacted data:
 
-1. Configure 'compaction.optimization-interval' when writing data.
-2. Query from [read-optimized system table](../concepts/system-tables#read-optimized-table). Reading from
-   results of optimized files avoids merging records with the same key, thus improving reading performance.
+1. Configure `compaction.optimization-interval` to schedule optimization full compactions.
+2. Query the [read-optimized system table](../concepts/system-tables#read-optimized-table).
 
-You can flexibly balance query performance and data latency when reading.
+This view reads the optimized result without merging subsequent updates. Its freshness depends
+on completed optimization compactions. Use the regular table when a query must include newer data.

--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -153,7 +153,7 @@ const config = {
             title: 'Documentation',
             items: [
               {label: 'Getting Started', to: '/flink/quick-start'},
-              {label: 'Concepts', to: '/concepts/overview'},
+              {label: 'Concepts', to: '/concepts/'},
             ],
           },
           {

--- a/docs/sidebars.js
+++ b/docs/sidebars.js
@@ -72,35 +72,63 @@ const sidebars = {
   },
   {
     type: "category",
-    "label": "PrimaryKey Table",
+    "label": "Primary-Key Table",
     "collapsed": true,
     "link": {
       type: "doc",
       "id": "primary-key-table/index"
     },
     "items": [
-      "primary-key-table/data-distribution",
-      "primary-key-table/table-mode",
-      "primary-key-table/changelog-producer",
-      "primary-key-table/sequence-rowkind",
-      "primary-key-table/compaction",
-      "primary-key-table/query-performance",
-      "primary-key-table/global-index",
-      "primary-key-table/chain-table",
-      "primary-key-table/pk-clustering-override",
-      "primary-key-table/blob-storage",
       {
         type: "category",
-        "label": "Merge Engine",
+        "label": "Data Layout",
         "collapsed": true,
-        "link": {
-          type: "doc",
-          "id": "primary-key-table/merge-engine/index"
-        },
         "items": [
-          "primary-key-table/merge-engine/partial-update",
-          "primary-key-table/merge-engine/aggregation",
-          "primary-key-table/merge-engine/first-row"
+          "primary-key-table/data-distribution",
+          "primary-key-table/table-mode"
+        ]
+      },
+      {
+        type: "category",
+        "label": "Updates & Changelogs",
+        "collapsed": true,
+        "items": [
+          {
+            type: "category",
+            "label": "Merge Engines",
+            "collapsed": true,
+            "link": {
+              type: "doc",
+              "id": "primary-key-table/merge-engine/index"
+            },
+            "items": [
+              "primary-key-table/merge-engine/partial-update",
+              "primary-key-table/merge-engine/aggregation",
+              "primary-key-table/merge-engine/first-row"
+            ]
+          },
+          "primary-key-table/sequence-rowkind",
+          "primary-key-table/changelog-producer"
+        ]
+      },
+      {
+        type: "category",
+        "label": "Compaction & Querying",
+        "collapsed": true,
+        "items": [
+          "primary-key-table/compaction",
+          "primary-key-table/query-performance"
+        ]
+      },
+      {
+        type: "category",
+        "label": "Advanced Features",
+        "collapsed": true,
+        "items": [
+          "primary-key-table/global-index",
+          "primary-key-table/pk-clustering-override",
+          "primary-key-table/chain-table",
+          "primary-key-table/blob-storage"
         ]
       }
     ]

--- a/docs/static/img/primary-key-blob-lifecycle.svg
+++ b/docs/static/img/primary-key-blob-lifecycle.svg
@@ -1,0 +1,59 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="960" height="589" viewBox="0 0 960 589" role="img" aria-labelledby="title desc">
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements. See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership. The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied. See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+<title id="title">Compaction reuses managed BLOB payloads</title>
+<desc id="desc">Input file A references payload packs P and Q for keys 7 and 11. A newer file B replaces key 7 with a descriptor to R. Deduplicate compaction writes file C and sidecar C referencing Q and R; the managed payload packs are not rewritten. P may still be needed by retained snapshots, and managed BLOB garbage collection is not implemented.</desc>
+<defs><marker id="arrow" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse"><path d="M 0 0 L 10 5 L 0 10 z" fill="#526277"/></marker></defs>
+<g font-family="Arial, Helvetica, sans-serif" fill="#172b4d">
+<rect x="1" y="1" width="958" height="587" rx="12" fill="#ffffff" stroke="#d7dfeb" stroke-width="1.5"/>
+<text x="28" y="43" font-size="27" font-weight="700" text-anchor="start" fill="#172b4d">Compaction reuses managed BLOB payloads</text>
+<text x="28" y="76" font-size="18" font-weight="400" text-anchor="start" fill="#526277">Deduplicate example: key 7 is updated; key 11 stays unchanged. P, Q, R name payload packs.</text>
+<rect x="28" y="109" width="382" height="212" rx="8" fill="#eaf2ff" stroke="#2463b4" stroke-width="1.5"/>
+<text x="44" y="140" font-size="21" font-weight="700" text-anchor="start" fill="#2463b4">Input data files</text>
+<text x="44" y="170" font-size="18" font-weight="400" text-anchor="start" fill="#526277">A: key 7 → P, key 11 → Q</text>
+<text x="44" y="195" font-size="18" font-weight="400" text-anchor="start" fill="#526277">B: key 7 → R (newer row)</text>
+<text x="44" y="220" font-size="18" font-weight="400" text-anchor="start" fill="#526277"></text>
+<text x="44" y="245" font-size="18" font-weight="400" text-anchor="start" fill="#526277">A.blobref = {P, Q}</text>
+<text x="44" y="270" font-size="18" font-weight="400" text-anchor="start" fill="#526277">B.blobref = {R}</text>
+<path d="M 420 215 L 540 215" fill="none" stroke="#526277" stroke-width="2" marker-end="url(#arrow)"/>
+<text x="480" y="193" font-size="18" font-weight="400" text-anchor="middle" fill="#526277">Compact</text>
+<rect x="550" y="109" width="382" height="212" rx="8" fill="#e5f5ef" stroke="#10705d" stroke-width="1.5"/>
+<text x="566" y="140" font-size="21" font-weight="700" text-anchor="start" fill="#10705d">Compacted data file</text>
+<text x="566" y="170" font-size="18" font-weight="400" text-anchor="start" fill="#526277">C: key 7 → R, key 11 → Q</text>
+<text x="566" y="195" font-size="18" font-weight="400" text-anchor="start" fill="#526277">Descriptors survive the merge</text>
+<text x="566" y="220" font-size="18" font-weight="400" text-anchor="start" fill="#526277"></text>
+<text x="566" y="245" font-size="18" font-weight="400" text-anchor="start" fill="#526277">C.blobref = {Q, R}</text>
+<text x="566" y="270" font-size="18" font-weight="400" text-anchor="start" fill="#526277">New sidecar, same payloads</text>
+<text x="28" y="359" font-size="21" font-weight="700" text-anchor="start" fill="#172b4d">Existing managed payload packs · bytes are not rewritten</text>
+<rect x="28" y="377" width="284" height="114" rx="8" fill="#fff2d7" stroke="#9a5200" stroke-width="1.5"/>
+<text x="44" y="408" font-size="21" font-weight="700" text-anchor="start" fill="#9a5200">P · old key 7 payload</text>
+<text x="44" y="438" font-size="18" font-weight="400" text-anchor="start" fill="#526277">May still serve</text>
+<text x="44" y="463" font-size="18" font-weight="400" text-anchor="start" fill="#526277">retained snapshots</text>
+<rect x="338" y="377" width="284" height="114" rx="8" fill="#e5f5ef" stroke="#10705d" stroke-width="1.5"/>
+<text x="354" y="408" font-size="21" font-weight="700" text-anchor="start" fill="#10705d">Q · key 11 payload</text>
+<text x="354" y="438" font-size="18" font-weight="400" text-anchor="start" fill="#526277">Still referenced</text>
+<text x="354" y="463" font-size="18" font-weight="400" text-anchor="start" fill="#526277">by compacted file C</text>
+<rect x="648" y="377" width="284" height="114" rx="8" fill="#e5f5ef" stroke="#10705d" stroke-width="1.5"/>
+<text x="664" y="408" font-size="21" font-weight="700" text-anchor="start" fill="#10705d">R · new key 7 payload</text>
+<text x="664" y="438" font-size="18" font-weight="400" text-anchor="start" fill="#526277">Still referenced</text>
+<text x="664" y="463" font-size="18" font-weight="400" text-anchor="start" fill="#526277">by compacted file C</text>
+<text x="28" y="534" font-size="18" font-weight="400" text-anchor="start" fill="#526277">Data-file retention owns .blobref sidecars; shared payload packs have a separate lifecycle.</text>
+<text x="28" y="560" font-size="18" font-weight="400" text-anchor="start" fill="#526277">Managed BLOB garbage collection is not implemented; orphan-file cleaning preserves packs.</text>
+</g>
+</svg>

--- a/docs/static/img/primary-key-chain-table.svg
+++ b/docs/static/img/primary-key-chain-table.svg
@@ -1,0 +1,55 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="960" height="497" viewBox="0 0 960 497" role="img" aria-labelledby="title desc">
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements. See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership. The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied. See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+<title id="title">A full view from a snapshot and later deltas</title>
+<desc id="desc">A snapshot branch contains a full partition for day 10. The delta branch contains changes for days 11 and 12. A full query for day 12 merges the snapshot and both deltas. Chain compaction can materialize this result in a new day-12 snapshot partition.</desc>
+<defs><marker id="arrow" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse"><path d="M 0 0 L 10 5 L 0 10 z" fill="#526277"/></marker></defs>
+<g font-family="Arial, Helvetica, sans-serif" fill="#172b4d">
+<rect x="1" y="1" width="958" height="495" rx="12" fill="#ffffff" stroke="#d7dfeb" stroke-width="1.5"/>
+<text x="28" y="43" font-size="27" font-weight="700" text-anchor="start" fill="#172b4d">A full view from a snapshot and later deltas</text>
+<text x="28" y="76" font-size="18" font-weight="400" text-anchor="start" fill="#526277">Conceptual batch-read path for one partition group; daily deltas contain only changes.</text>
+<rect x="28" y="113" width="276" height="105" rx="8" fill="#eaf2ff" stroke="#2463b4" stroke-width="1.5"/>
+<text x="44" y="144" font-size="21" font-weight="700" text-anchor="start" fill="#2463b4">Snapshot branch</text>
+<text x="44" y="174" font-size="18" font-weight="400" text-anchor="start" fill="#526277">Day 10</text>
+<text x="44" y="199" font-size="18" font-weight="400" text-anchor="start" fill="#526277">Full dataset</text>
+<rect x="342" y="113" width="276" height="105" rx="8" fill="#fff2d7" stroke="#9a5200" stroke-width="1.5"/>
+<text x="358" y="144" font-size="21" font-weight="700" text-anchor="start" fill="#9a5200">Delta branch</text>
+<text x="358" y="174" font-size="18" font-weight="400" text-anchor="start" fill="#526277">Day 11</text>
+<text x="358" y="199" font-size="18" font-weight="400" text-anchor="start" fill="#526277">Changed rows</text>
+<rect x="656" y="113" width="276" height="105" rx="8" fill="#fff2d7" stroke="#9a5200" stroke-width="1.5"/>
+<text x="672" y="144" font-size="21" font-weight="700" text-anchor="start" fill="#9a5200">Delta branch</text>
+<text x="672" y="174" font-size="18" font-weight="400" text-anchor="start" fill="#526277">Day 12</text>
+<text x="672" y="199" font-size="18" font-weight="400" text-anchor="start" fill="#526277">Changed rows</text>
+<path d="M 166 219 L 166 246 L 480 246 L 480 272" fill="none" stroke="#526277" stroke-width="2" marker-end="url(#arrow)"/>
+<path d="M 480 219 L 480 246 L 480 246 L 480 272" fill="none" stroke="#526277" stroke-width="2" marker-end="url(#arrow)"/>
+<path d="M 794 219 L 794 246 L 480 246 L 480 272" fill="none" stroke="#526277" stroke-width="2" marker-end="url(#arrow)"/>
+<rect x="296" y="280" width="368" height="79" rx="8" fill="#f1ebfa" stroke="#7051a3" stroke-width="1.5"/>
+<text x="312" y="311" font-size="21" font-weight="700" text-anchor="start" fill="#7051a3">Merge for day 12</text>
+<text x="312" y="341" font-size="18" font-weight="400" text-anchor="start" fill="#526277">Snapshot + subsequent deltas</text>
+<path d="M 295 319 L 165 319 L 165 386" fill="none" stroke="#526277" stroke-width="2" marker-end="url(#arrow)"/>
+<path d="M 665 319 L 794 319 L 794 386" fill="none" stroke="#526277" stroke-width="2" marker-end="url(#arrow)"/>
+<rect x="28" y="393" width="276" height="78" rx="8" fill="#e5f5ef" stroke="#10705d" stroke-width="1.5"/>
+<text x="44" y="424" font-size="21" font-weight="700" text-anchor="start" fill="#10705d">Full query result</text>
+<text x="44" y="454" font-size="18" font-weight="400" text-anchor="start" fill="#526277">Return the reconstructed rows</text>
+<text x="773" y="368" font-size="18" font-weight="400" text-anchor="end" fill="#526277">Chain compaction</text>
+<rect x="656" y="393" width="276" height="78" rx="8" fill="#e5f5ef" stroke="#10705d" stroke-width="1.5"/>
+<text x="672" y="424" font-size="21" font-weight="700" text-anchor="start" fill="#10705d">New snapshot: day 12</text>
+<text x="672" y="454" font-size="18" font-weight="400" text-anchor="start" fill="#526277">Materialize a full partition</text>
+</g>
+</svg>

--- a/docs/static/img/primary-key-changelog-producers.svg
+++ b/docs/static/img/primary-key-changelog-producers.svg
@@ -1,0 +1,76 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="960" height="595" viewBox="0 0 960 595" role="img" aria-labelledby="title desc">
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements. See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership. The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied. See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+<title id="title">Where the before image comes from</title>
+<desc id="desc">For an existing key whose value changes from 4 to 5: none sends an upsert without a before image; input preserves the source’s before and after records; lookup reads old state during compaction; full-compaction diffs successive full results. Timing differs by producer.</desc>
+<defs><marker id="arrow" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse"><path d="M 0 0 L 10 5 L 0 10 z" fill="#526277"/></marker></defs>
+<g font-family="Arial, Helvetica, sans-serif" fill="#172b4d">
+<rect x="1" y="1" width="958" height="593" rx="12" fill="#ffffff" stroke="#d7dfeb" stroke-width="1.5"/>
+<text x="28" y="43" font-size="27" font-weight="700" text-anchor="start" fill="#172b4d">Where the before image comes from</text>
+<text x="28" y="76" font-size="18" font-weight="400" text-anchor="start" fill="#526277">Existing value = 4; new value = 5.  −U retracts the old value; +U supplies the new one.</text>
+<text x="28" y="120" font-size="18" font-weight="700" text-anchor="start" fill="#526277">Producer / input</text>
+<text x="303" y="120" font-size="18" font-weight="700" text-anchor="start" fill="#526277">How old state is obtained</text>
+<text x="681" y="120" font-size="18" font-weight="700" text-anchor="start" fill="#526277">Consumer receives</text>
+<rect x="28" y="137" width="226" height="81" rx="8" fill="#eaf2ff" stroke="#2463b4" stroke-width="1.5"/>
+<text x="44" y="167" font-size="21" font-weight="700" text-anchor="start" fill="#2463b4">none</text>
+<text x="44" y="197" font-size="18" font-weight="400" text-anchor="start" fill="#526277">Upsert 5</text>
+<path d="M 259 178 L 288 178" fill="none" stroke="#526277" stroke-width="2" marker-end="url(#arrow)"/>
+<rect x="298" y="137" width="337" height="81" rx="8" fill="#f8fafc" stroke="#d7dfeb" stroke-width="1.5"/>
+<text x="314" y="167" font-size="19" font-weight="700" text-anchor="start" fill="#172b4d">No before image in output</text>
+<text x="314" y="197" font-size="17" font-weight="400" text-anchor="start" fill="#526277">Consumer normalizes if needed</text>
+<path d="M 640 178 L 668 178" fill="none" stroke="#526277" stroke-width="2" marker-end="url(#arrow)"/>
+<rect x="678" y="137" width="254" height="81" rx="8" fill="#eaf2ff" stroke="#2463b4" stroke-width="1.5"/>
+<text x="694" y="167" font-size="21" font-weight="700" text-anchor="start" fill="#2463b4">Upsert 5</text>
+<text x="694" y="197" font-size="17" font-weight="400" text-anchor="start" fill="#526277">After snapshot commit</text>
+<rect x="28" y="236" width="226" height="81" rx="8" fill="#e5f5ef" stroke="#10705d" stroke-width="1.5"/>
+<text x="44" y="266" font-size="21" font-weight="700" text-anchor="start" fill="#10705d">input</text>
+<text x="44" y="296" font-size="18" font-weight="400" text-anchor="start" fill="#526277">−U 4, +U 5</text>
+<path d="M 259 277 L 288 277" fill="none" stroke="#526277" stroke-width="2" marker-end="url(#arrow)"/>
+<rect x="298" y="236" width="337" height="81" rx="8" fill="#f8fafc" stroke="#d7dfeb" stroke-width="1.5"/>
+<text x="314" y="266" font-size="19" font-weight="700" text-anchor="start" fill="#172b4d">Preserve source changelog</text>
+<text x="314" y="296" font-size="17" font-weight="400" text-anchor="start" fill="#526277">Source must supply old values</text>
+<path d="M 640 277 L 668 277" fill="none" stroke="#526277" stroke-width="2" marker-end="url(#arrow)"/>
+<rect x="678" y="236" width="254" height="81" rx="8" fill="#e5f5ef" stroke="#10705d" stroke-width="1.5"/>
+<text x="694" y="266" font-size="21" font-weight="700" text-anchor="start" fill="#10705d">−U 4, +U 5</text>
+<text x="694" y="296" font-size="17" font-weight="400" text-anchor="start" fill="#526277">After changelog commit</text>
+<rect x="28" y="335" width="226" height="81" rx="8" fill="#f1ebfa" stroke="#7051a3" stroke-width="1.5"/>
+<text x="44" y="365" font-size="21" font-weight="700" text-anchor="start" fill="#7051a3">lookup</text>
+<text x="44" y="395" font-size="18" font-weight="400" text-anchor="start" fill="#526277">Upsert 5</text>
+<path d="M 259 376 L 288 376" fill="none" stroke="#526277" stroke-width="2" marker-end="url(#arrow)"/>
+<rect x="298" y="335" width="337" height="81" rx="8" fill="#f8fafc" stroke="#d7dfeb" stroke-width="1.5"/>
+<text x="314" y="365" font-size="19" font-weight="700" text-anchor="start" fill="#172b4d">Look up stored value 4</text>
+<text x="314" y="395" font-size="17" font-weight="400" text-anchor="start" fill="#526277">Reconcile during compaction</text>
+<path d="M 640 376 L 668 376" fill="none" stroke="#526277" stroke-width="2" marker-end="url(#arrow)"/>
+<rect x="678" y="335" width="254" height="81" rx="8" fill="#f1ebfa" stroke="#7051a3" stroke-width="1.5"/>
+<text x="694" y="365" font-size="21" font-weight="700" text-anchor="start" fill="#7051a3">−U 4, +U 5</text>
+<text x="694" y="395" font-size="17" font-weight="400" text-anchor="start" fill="#526277">After lookup compaction</text>
+<rect x="28" y="434" width="226" height="81" rx="8" fill="#fff2d7" stroke="#9a5200" stroke-width="1.5"/>
+<text x="44" y="464" font-size="21" font-weight="700" text-anchor="start" fill="#9a5200">full-compaction</text>
+<text x="44" y="494" font-size="18" font-weight="400" text-anchor="start" fill="#526277">Upsert 5</text>
+<path d="M 259 475 L 288 475" fill="none" stroke="#526277" stroke-width="2" marker-end="url(#arrow)"/>
+<rect x="298" y="434" width="337" height="81" rx="8" fill="#f8fafc" stroke="#d7dfeb" stroke-width="1.5"/>
+<text x="314" y="464" font-size="19" font-weight="700" text-anchor="start" fill="#172b4d">Compare full results: 4 → 5</text>
+<text x="314" y="494" font-size="17" font-weight="400" text-anchor="start" fill="#526277">Changes between results collapse</text>
+<path d="M 640 475 L 668 475" fill="none" stroke="#526277" stroke-width="2" marker-end="url(#arrow)"/>
+<rect x="678" y="434" width="254" height="81" rx="8" fill="#fff2d7" stroke="#9a5200" stroke-width="1.5"/>
+<text x="694" y="464" font-size="21" font-weight="700" text-anchor="start" fill="#9a5200">−U 4, +U 5</text>
+<text x="694" y="494" font-size="17" font-weight="400" text-anchor="start" fill="#526277">After full compaction</text>
+<text x="28" y="567" font-size="18" font-weight="400" text-anchor="start" fill="#526277">Illustrative state transition; generated changelogs need not preserve every intermediate input event.</text>
+</g>
+</svg>

--- a/docs/static/img/primary-key-compaction.svg
+++ b/docs/static/img/primary-key-compaction.svg
@@ -1,0 +1,51 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="960" height="418" viewBox="0 0 960 418" role="img" aria-labelledby="title desc">
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements. See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership. The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied. See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+<title id="title">Compaction reduces overlapping sorted runs</title>
+<desc id="desc">Three input runs include successive values 4, 5, and 6 for key 7. Compaction with deduplicate merges them into a new run retaining value 6. A committed snapshot references the new files; older files can remain referenced by retained snapshots.</desc>
+<defs><marker id="arrow" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse"><path d="M 0 0 L 10 5 L 0 10 z" fill="#526277"/></marker></defs>
+<g font-family="Arial, Helvetica, sans-serif" fill="#172b4d">
+<rect x="1" y="1" width="958" height="416" rx="12" fill="#ffffff" stroke="#d7dfeb" stroke-width="1.5"/>
+<text x="28" y="43" font-size="27" font-weight="700" text-anchor="start" fill="#172b4d">Compaction reduces overlapping sorted runs</text>
+<text x="28" y="76" font-size="18" font-weight="400" text-anchor="start" fill="#526277">Example: deduplicate with input versions ordered from oldest to newest.</text>
+<rect x="28" y="111" width="264" height="66" rx="8" fill="#eaf2ff" stroke="#2463b4" stroke-width="1.5"/>
+<text x="44" y="142" font-size="21" font-weight="700" text-anchor="start" fill="#2463b4">Run A</text>
+<text x="155" y="153" font-size="20" font-weight="400" text-anchor="start" fill="#2463b4">key 7 → 4</text>
+<rect x="28" y="195" width="264" height="66" rx="8" fill="#eaf2ff" stroke="#2463b4" stroke-width="1.5"/>
+<text x="44" y="226" font-size="21" font-weight="700" text-anchor="start" fill="#2463b4">Run B</text>
+<text x="155" y="237" font-size="20" font-weight="400" text-anchor="start" fill="#2463b4">key 7 → 5</text>
+<rect x="28" y="279" width="264" height="66" rx="8" fill="#eaf2ff" stroke="#2463b4" stroke-width="1.5"/>
+<text x="44" y="310" font-size="21" font-weight="700" text-anchor="start" fill="#2463b4">Run C</text>
+<text x="155" y="321" font-size="20" font-weight="400" text-anchor="start" fill="#2463b4">key 7 → 6</text>
+<path d="M 299 144 L 337 144 L 337 312 L 299 312 M 299 228 L 337 228" fill="none" stroke="#526277" stroke-width="2"/>
+<path d="M 337 228 L 377 228" fill="none" stroke="#526277" stroke-width="2" marker-end="url(#arrow)"/>
+<rect x="385" y="179" width="230" height="99" rx="8" fill="#f1ebfa" stroke="#7051a3" stroke-width="1.5"/>
+<text x="401" y="210" font-size="21" font-weight="700" text-anchor="start" fill="#7051a3">Merge versions</text>
+<text x="401" y="240" font-size="18" font-weight="400" text-anchor="start" fill="#526277">Apply the merge engine</text>
+<text x="401" y="265" font-size="18" font-weight="400" text-anchor="start" fill="#526277">and record ordering</text>
+<path d="M 621 228 L 659 228" fill="none" stroke="#526277" stroke-width="2" marker-end="url(#arrow)"/>
+<rect x="668" y="164" width="264" height="129" rx="8" fill="#e5f5ef" stroke="#10705d" stroke-width="1.5"/>
+<text x="684" y="195" font-size="21" font-weight="700" text-anchor="start" fill="#10705d">New sorted run</text>
+<text x="684" y="225" font-size="18" font-weight="400" text-anchor="start" fill="#526277">key 7 → value 6</text>
+<text x="684" y="250" font-size="18" font-weight="400" text-anchor="start" fill="#526277">Files have disjoint</text>
+<text x="684" y="275" font-size="18" font-weight="400" text-anchor="start" fill="#526277">key ranges</text>
+<rect x="28" y="363" width="904" height="33" rx="8" fill="#f8fafc" stroke="#d7dfeb" stroke-width="1.5"/>
+<text x="44" y="386" font-size="18" font-weight="400" text-anchor="start" fill="#526277">Commit publishes new files. Retention determines when old files can be removed.</text>
+</g>
+</svg>

--- a/docs/static/img/primary-key-deletion-vector-update.svg
+++ b/docs/static/img/primary-key-deletion-vector-update.svg
@@ -1,0 +1,67 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="960" height="432" viewBox="0 0 960 432" role="img" aria-labelledby="title desc">
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements. See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership. The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied. See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+<title id="title">An update and a delete with deletion vectors</title>
+<desc id="desc">Old file A has key 7 at position 0, key 9 at position 1, and key 11 at position 2. Updating key 7 to value 5 and deleting key 9 mark positions 0 and 1 invalid. File B contains the new key 7. Readers return key 7 value 5 and key 11 value 6.</desc>
+<defs><marker id="arrow" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse"><path d="M 0 0 L 10 5 L 0 10 z" fill="#526277"/></marker></defs>
+<g font-family="Arial, Helvetica, sans-serif" fill="#172b4d">
+<rect x="1" y="1" width="958" height="430" rx="12" fill="#ffffff" stroke="#d7dfeb" stroke-width="1.5"/>
+<text x="28" y="43" font-size="27" font-weight="700" text-anchor="start" fill="#172b4d">An update and a delete with deletion vectors</text>
+<text x="28" y="76" font-size="18" font-weight="400" text-anchor="start" fill="#526277">Deduplicate example after lookup compaction. Invalid rows stay in the old data file.</text>
+<rect x="28" y="108" width="290" height="227" rx="8" fill="#eaf2ff" stroke="#2463b4" stroke-width="1.5"/>
+<text x="44" y="139" font-size="21" font-weight="700" text-anchor="start" fill="#2463b4">Old file A</text>
+<text x="50" y="169" font-size="17" font-weight="400" text-anchor="start" fill="#526277">Position</text>
+<text x="126" y="169" font-size="17" font-weight="400" text-anchor="start" fill="#526277">Key</text>
+<text x="187" y="169" font-size="17" font-weight="400" text-anchor="start" fill="#526277">Value</text>
+<rect x="44" y="178" width="258" height="33" rx="4" fill="#fff2d7" stroke="#d7dfeb" stroke-width="1.5"/>
+<text x="70" y="201" font-size="19" font-weight="400" text-anchor="middle" fill="#9a5200">0</text>
+<text x="140" y="201" font-size="19" font-weight="400" text-anchor="middle" fill="#9a5200">7</text>
+<text x="209" y="201" font-size="19" font-weight="400" text-anchor="middle" fill="#9a5200">4</text>
+<text x="285" y="201" font-size="16" font-weight="700" text-anchor="end" fill="#9a5200">skip</text>
+<rect x="44" y="215" width="258" height="33" rx="4" fill="#fff2d7" stroke="#d7dfeb" stroke-width="1.5"/>
+<text x="70" y="238" font-size="19" font-weight="400" text-anchor="middle" fill="#9a5200">1</text>
+<text x="140" y="238" font-size="19" font-weight="400" text-anchor="middle" fill="#9a5200">9</text>
+<text x="209" y="238" font-size="19" font-weight="400" text-anchor="middle" fill="#9a5200">8</text>
+<text x="285" y="238" font-size="16" font-weight="700" text-anchor="end" fill="#9a5200">skip</text>
+<rect x="44" y="252" width="258" height="33" rx="4" fill="#ffffff" stroke="#d7dfeb" stroke-width="1.5"/>
+<text x="70" y="275" font-size="19" font-weight="400" text-anchor="middle" fill="#172b4d">2</text>
+<text x="140" y="275" font-size="19" font-weight="400" text-anchor="middle" fill="#172b4d">11</text>
+<text x="209" y="275" font-size="19" font-weight="400" text-anchor="middle" fill="#172b4d">6</text>
+<text x="285" y="275" font-size="16" font-weight="700" text-anchor="end" fill="#10705d">keep</text>
+<text x="46" y="317" font-size="20" font-weight="700" text-anchor="start" fill="#9a5200">Deletion vector: {0, 1}</text>
+<rect x="352" y="108" width="248" height="227" rx="8" fill="#f1ebfa" stroke="#7051a3" stroke-width="1.5"/>
+<text x="368" y="139" font-size="21" font-weight="700" text-anchor="start" fill="#7051a3">Incoming changes</text>
+<text x="368" y="169" font-size="18" font-weight="400" text-anchor="start" fill="#526277">Update key 7 → 5</text>
+<text x="368" y="194" font-size="18" font-weight="400" text-anchor="start" fill="#526277">Delete key 9</text>
+<text x="368" y="219" font-size="18" font-weight="400" text-anchor="start" fill="#526277"></text>
+<text x="368" y="244" font-size="18" font-weight="400" text-anchor="start" fill="#526277">New file B:</text>
+<text x="368" y="269" font-size="18" font-weight="400" text-anchor="start" fill="#526277">key 7 → value 5</text>
+<path d="M 170 335 L 170 347 L 617 347 L 617 195 L 630 195" fill="none" stroke="#526277" stroke-width="2" marker-end="url(#arrow)"/>
+<path d="M 600 247 L 630 247" fill="none" stroke="#526277" stroke-width="2" marker-end="url(#arrow)"/>
+<rect x="638" y="108" width="294" height="227" rx="8" fill="#e5f5ef" stroke="#10705d" stroke-width="1.5"/>
+<text x="654" y="139" font-size="21" font-weight="700" text-anchor="start" fill="#10705d">Visible rows</text>
+<text x="654" y="169" font-size="18" font-weight="400" text-anchor="start" fill="#526277">Read A and B</text>
+<text x="654" y="194" font-size="18" font-weight="400" text-anchor="start" fill="#526277">Apply A’s deletion vector</text>
+<text x="654" y="219" font-size="18" font-weight="400" text-anchor="start" fill="#526277"></text>
+<text x="654" y="244" font-size="18" font-weight="400" text-anchor="start" fill="#526277">key 7 → value 5</text>
+<text x="654" y="269" font-size="18" font-weight="400" text-anchor="start" fill="#526277">key 11 → value 6</text>
+<rect x="28" y="359" width="904" height="47" rx="8" fill="#f8fafc" stroke="#d7dfeb" stroke-width="1.5"/>
+<text x="46" y="389" font-size="18" font-weight="400" text-anchor="start" fill="#526277">A row position identifies a physical version; the primary key identifies the logical row.</text>
+</g>
+</svg>

--- a/docs/static/img/primary-key-index-coverage.svg
+++ b/docs/static/img/primary-key-index-coverage.svg
@@ -1,0 +1,59 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="960" height="538" viewBox="0 0 960 538" role="img" aria-labelledby="title desc">
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements. See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership. The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied. See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+<title id="title">What happens to files without an index?</title>
+<desc id="desc">Two files are already visible to a batch scan: F1 has an active index group and F2 does not. Scalar and array predicates use the F1 index and scan F2. Vector fast and Full Text fast search indexed files only. Vector full or detail combines ANN candidates from F1 with exact evaluation of F2.</desc>
+<defs><marker id="arrow" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse"><path d="M 0 0 L 10 5 L 0 10 z" fill="#526277"/></marker></defs>
+<g font-family="Arial, Helvetica, sans-serif" fill="#172b4d">
+<rect x="1" y="1" width="958" height="536" rx="12" fill="#ffffff" stroke="#d7dfeb" stroke-width="1.5"/>
+<text x="28" y="43" font-size="27" font-weight="700" text-anchor="start" fill="#172b4d">What happens to files without an index?</text>
+<text x="28" y="76" font-size="18" font-weight="400" text-anchor="start" fill="#526277">Coverage applies after data visibility is resolved. Both F1 and F2 are visible in this example.</text>
+<rect x="28" y="105" width="432" height="89" rx="8" fill="#eaf2ff" stroke="#2463b4" stroke-width="1.5"/>
+<text x="44" y="136" font-size="21" font-weight="700" text-anchor="start" fill="#2463b4">F1 · covered</text>
+<text x="44" y="166" font-size="18" font-weight="400" text-anchor="start" fill="#526277">An active index group matches this file</text>
+<rect x="500" y="105" width="432" height="89" rx="8" fill="#fff2d7" stroke="#9a5200" stroke-width="1.5"/>
+<text x="516" y="136" font-size="21" font-weight="700" text-anchor="start" fill="#9a5200">F2 · uncovered</text>
+<text x="516" y="166" font-size="18" font-weight="400" text-anchor="start" fill="#526277">No active index group for this file</text>
+<path d="M 244 194 L 244 218 L 716 218 L 716 194" fill="none" stroke="#526277" stroke-width="2"/>
+<path d="M 480 218 L 480 246" fill="none" stroke="#526277" stroke-width="2" marker-end="url(#arrow)"/>
+<text x="480" y="273" font-size="22" font-weight="700" text-anchor="middle" fill="#172b4d">The query selects the fallback behavior</text>
+<rect x="28" y="298" width="284" height="202" rx="8" fill="#eaf2ff" stroke="#2463b4" stroke-width="1.5"/>
+<text x="44" y="329" font-size="21" font-weight="700" text-anchor="start" fill="#2463b4">Scalar / array predicates</text>
+<text x="44" y="359" font-size="18" font-weight="400" text-anchor="start" fill="#526277">BTree, Bitmap,</text>
+<text x="44" y="384" font-size="18" font-weight="400" text-anchor="start" fill="#526277">Multivalue, FM</text>
+<text x="44" y="409" font-size="18" font-weight="400" text-anchor="start" fill="#526277"></text>
+<text x="44" y="434" font-size="18" font-weight="400" text-anchor="start" fill="#526277">F1: use index</text>
+<text x="44" y="459" font-size="18" font-weight="400" text-anchor="start" fill="#526277">F2: scan normally</text>
+<rect x="338" y="298" width="284" height="202" rx="8" fill="#fff2d7" stroke="#9a5200" stroke-width="1.5"/>
+<text x="354" y="329" font-size="21" font-weight="700" text-anchor="start" fill="#9a5200">Vector / Full Text fast</text>
+<text x="354" y="359" font-size="18" font-weight="400" text-anchor="start" fill="#526277">Default search modes</text>
+<text x="354" y="384" font-size="18" font-weight="400" text-anchor="start" fill="#526277"></text>
+<text x="354" y="409" font-size="18" font-weight="400" text-anchor="start" fill="#526277"></text>
+<text x="354" y="434" font-size="18" font-weight="400" text-anchor="start" fill="#526277">F1: search index</text>
+<text x="354" y="459" font-size="18" font-weight="400" text-anchor="start" fill="#526277">F2: omit from results</text>
+<rect x="648" y="298" width="284" height="202" rx="8" fill="#e5f5ef" stroke="#10705d" stroke-width="1.5"/>
+<text x="664" y="329" font-size="21" font-weight="700" text-anchor="start" fill="#10705d">Vector full / detail</text>
+<text x="664" y="359" font-size="18" font-weight="400" text-anchor="start" fill="#526277">Include unindexed files</text>
+<text x="664" y="384" font-size="18" font-weight="400" text-anchor="start" fill="#526277"></text>
+<text x="664" y="409" font-size="18" font-weight="400" text-anchor="start" fill="#526277"></text>
+<text x="664" y="434" font-size="18" font-weight="400" text-anchor="start" fill="#526277">F1: ANN candidates</text>
+<text x="664" y="459" font-size="18" font-weight="400" text-anchor="start" fill="#526277">F2: exact evaluation</text>
+<text x="28" y="526" font-size="18" font-weight="400" text-anchor="start" fill="#526277">Full Text supports fast only. Vector full/detail still use ANN for indexed files.</text>
+</g>
+</svg>

--- a/docs/static/img/primary-key-read-write-modes.svg
+++ b/docs/static/img/primary-key-read-write-modes.svg
@@ -1,0 +1,76 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="960" height="542" viewBox="0 0 960 542" role="img" aria-labelledby="title desc">
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements. See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership. The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied. See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+<title id="title">Where row versions are resolved</title>
+<desc id="desc">Three paths for an update from value 4 to 5 for the same key. MOR keeps versions and merges on read. COW fully compacts modified buckets before committing. MOW looks up old rows and marks invalid positions, then reads valid rows.</desc>
+<defs><marker id="arrow" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse"><path d="M 0 0 L 10 5 L 0 10 z" fill="#526277"/></marker></defs>
+<g font-family="Arial, Helvetica, sans-serif" fill="#172b4d">
+<rect x="1" y="1" width="958" height="540" rx="12" fill="#ffffff" stroke="#d7dfeb" stroke-width="1.5"/>
+<text x="28" y="43" font-size="27" font-weight="700" text-anchor="start" fill="#172b4d">Where row versions are resolved</text>
+<text x="28" y="76" font-size="18" font-weight="400" text-anchor="start" fill="#526277">Same logical update: key 7 changes from value 4 to value 5. Different work on the path.</text>
+<rect x="28" y="103" width="284" height="410" rx="8" fill="#f8fafc" stroke="#d7dfeb" stroke-width="1.5"/>
+<text x="44" y="137" font-size="25" font-weight="700" text-anchor="start" fill="#2463b4">MOR</text>
+<rect x="40" y="155" width="260" height="99" rx="8" fill="#eaf2ff" stroke="#2463b4" stroke-width="1.5"/>
+<text x="56" y="186" font-size="21" font-weight="700" text-anchor="start" fill="#2463b4">Write sorted files</text>
+<text x="56" y="216" font-size="18" font-weight="400" text-anchor="start" fill="#526277">Old and new versions</text>
+<text x="56" y="241" font-size="18" font-weight="400" text-anchor="start" fill="#526277">can coexist in separate runs</text>
+<path d="M 170 255 L 170 277" fill="none" stroke="#526277" stroke-width="2" marker-end="url(#arrow)"/>
+<rect x="40" y="279" width="260" height="99" rx="8" fill="#eaf2ff" stroke="#2463b4" stroke-width="1.5"/>
+<text x="56" y="310" font-size="21" font-weight="700" text-anchor="start" fill="#2463b4">Read overlapping runs</text>
+<text x="56" y="340" font-size="18" font-weight="400" text-anchor="start" fill="#526277">Merge by key</text>
+<text x="56" y="365" font-size="18" font-weight="400" text-anchor="start" fill="#526277">and record ordering</text>
+<path d="M 170 379 L 170 401" fill="none" stroke="#526277" stroke-width="2" marker-end="url(#arrow)"/>
+<rect x="40" y="403" width="260" height="77" rx="8" fill="#eaf2ff" stroke="#2463b4" stroke-width="1.5"/>
+<text x="56" y="434" font-size="21" font-weight="700" text-anchor="start" fill="#2463b4">Return logical row</text>
+<text x="56" y="464" font-size="18" font-weight="400" text-anchor="start" fill="#526277">key 7 → value 5</text>
+<text x="40" y="498" font-size="16" font-weight="400" text-anchor="start" fill="#526277">Cost: merge work during reads</text>
+<rect x="338" y="103" width="284" height="410" rx="8" fill="#f8fafc" stroke="#d7dfeb" stroke-width="1.5"/>
+<text x="354" y="137" font-size="25" font-weight="700" text-anchor="start" fill="#7051a3">COW</text>
+<rect x="350" y="155" width="260" height="99" rx="8" fill="#f1ebfa" stroke="#7051a3" stroke-width="1.5"/>
+<text x="366" y="186" font-size="21" font-weight="700" text-anchor="start" fill="#7051a3">Full compaction</text>
+<text x="366" y="216" font-size="18" font-weight="400" text-anchor="start" fill="#526277">Merge modified buckets</text>
+<text x="366" y="241" font-size="18" font-weight="400" text-anchor="start" fill="#526277">before the commit completes</text>
+<path d="M 480 255 L 480 277" fill="none" stroke="#526277" stroke-width="2" marker-end="url(#arrow)"/>
+<rect x="350" y="279" width="260" height="99" rx="8" fill="#f1ebfa" stroke="#7051a3" stroke-width="1.5"/>
+<text x="366" y="310" font-size="21" font-weight="700" text-anchor="start" fill="#7051a3">Read compacted files</text>
+<text x="366" y="340" font-size="18" font-weight="400" text-anchor="start" fill="#526277">Versions already resolved</text>
+<text x="366" y="365" font-size="18" font-weight="400" text-anchor="start" fill="#526277">by full compaction</text>
+<path d="M 480 379 L 480 401" fill="none" stroke="#526277" stroke-width="2" marker-end="url(#arrow)"/>
+<rect x="350" y="403" width="260" height="77" rx="8" fill="#f1ebfa" stroke="#7051a3" stroke-width="1.5"/>
+<text x="366" y="434" font-size="21" font-weight="700" text-anchor="start" fill="#7051a3">Return logical row</text>
+<text x="366" y="464" font-size="18" font-weight="400" text-anchor="start" fill="#526277">key 7 → value 5</text>
+<text x="350" y="498" font-size="16" font-weight="400" text-anchor="start" fill="#526277">Cost: full-compaction rewrites</text>
+<rect x="648" y="103" width="284" height="410" rx="8" fill="#f8fafc" stroke="#d7dfeb" stroke-width="1.5"/>
+<text x="664" y="137" font-size="25" font-weight="700" text-anchor="start" fill="#10705d">MOW</text>
+<rect x="660" y="155" width="260" height="99" rx="8" fill="#e5f5ef" stroke="#10705d" stroke-width="1.5"/>
+<text x="676" y="186" font-size="21" font-weight="700" text-anchor="start" fill="#10705d">Lookup compaction</text>
+<text x="676" y="216" font-size="18" font-weight="400" text-anchor="start" fill="#526277">Find old row positions</text>
+<text x="676" y="241" font-size="18" font-weight="400" text-anchor="start" fill="#526277">and mark them invalid</text>
+<path d="M 790 255 L 790 277" fill="none" stroke="#526277" stroke-width="2" marker-end="url(#arrow)"/>
+<rect x="660" y="279" width="260" height="99" rx="8" fill="#e5f5ef" stroke="#10705d" stroke-width="1.5"/>
+<text x="676" y="310" font-size="21" font-weight="700" text-anchor="start" fill="#10705d">Read files + vectors</text>
+<text x="676" y="340" font-size="18" font-weight="400" text-anchor="start" fill="#526277">Skip obsolete positions</text>
+<text x="676" y="365" font-size="18" font-weight="400" text-anchor="start" fill="#526277">without merging versions</text>
+<path d="M 790 379 L 790 401" fill="none" stroke="#526277" stroke-width="2" marker-end="url(#arrow)"/>
+<rect x="660" y="403" width="260" height="77" rx="8" fill="#e5f5ef" stroke="#10705d" stroke-width="1.5"/>
+<text x="676" y="434" font-size="21" font-weight="700" text-anchor="start" fill="#10705d">Return logical row</text>
+<text x="676" y="464" font-size="18" font-weight="400" text-anchor="start" fill="#526277">key 7 → value 5</text>
+<text x="660" y="498" font-size="16" font-weight="400" text-anchor="start" fill="#526277">Cost: lookups + deletion vectors</text>
+</g>
+</svg>

--- a/docs/static/img/primary-key-sequence-groups.svg
+++ b/docs/static/img/primary-key-sequence-groups.svg
@@ -1,0 +1,71 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="960" height="650" viewBox="0 0 960 650" role="img" aria-labelledby="title desc">
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements. See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership. The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied. See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+<title id="title">Independent versions for independent updates</title>
+<desc id="desc">For user 1, the initial profile is Ada in London at version 10, and the score is 40 at version 5. Update 1 has profile version 11 and clears city to null; its null score version skips the score group. Update 2 has an older profile version 9, which is ignored, and score version 6, which sets score to 50. The final row is Ada with null city at profile version 11 and score 50 at score version 6.</desc>
+<defs><marker id="arrow" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse"><path d="M 0 0 L 10 5 L 0 10 z" fill="#526277"/></marker></defs>
+<g font-family="Arial, Helvetica, sans-serif" fill="#172b4d">
+<rect x="1" y="1" width="958" height="648" rx="12" fill="#ffffff" stroke="#d7dfeb" stroke-width="1.5"/>
+<text x="28" y="43" font-size="27" font-weight="700" text-anchor="start" fill="#172b4d">Independent versions for independent updates</text>
+<text x="28" y="76" font-size="18" font-weight="400" text-anchor="start" fill="#526277">Partial update without aggregate functions. Both sequence groups belong to user_id = 1.</text>
+<text x="28" y="122" font-size="19" font-weight="700" text-anchor="start" fill="#526277">Input</text>
+<text x="239" y="122" font-size="21" font-weight="700" text-anchor="start" fill="#2463b4">Profile group: name, city</text>
+<text x="601" y="122" font-size="21" font-weight="700" text-anchor="start" fill="#10705d">Score group: score</text>
+<text x="28" y="177" font-size="22" font-weight="700" text-anchor="start" fill="#172b4d">Initial row</text>
+<text x="28" y="205" font-size="17" font-weight="400" text-anchor="start" fill="#526277">Stored state</text>
+<rect x="223" y="143" width="347" height="91" rx="8" fill="#eaf2ff" stroke="#2463b4" stroke-width="1.5"/>
+<text x="239" y="174" font-size="21" font-weight="700" text-anchor="start" fill="#2463b4">Version 10</text>
+<text x="239" y="204" font-size="18" font-weight="400" text-anchor="start" fill="#526277">Ada · London</text>
+<rect x="585" y="143" width="347" height="91" rx="8" fill="#e5f5ef" stroke="#10705d" stroke-width="1.5"/>
+<text x="601" y="174" font-size="21" font-weight="700" text-anchor="start" fill="#10705d">Version 5</text>
+<text x="601" y="204" font-size="18" font-weight="400" text-anchor="start" fill="#526277">Score = 40</text>
+<path d="M 396 237 L 396 260" fill="none" stroke="#526277" stroke-width="2" marker-end="url(#arrow)"/>
+<path d="M 758 237 L 758 260" fill="none" stroke="#526277" stroke-width="2" marker-end="url(#arrow)"/>
+<text x="28" y="302" font-size="22" font-weight="700" text-anchor="start" fill="#172b4d">Update 1</text>
+<text x="28" y="330" font-size="17" font-weight="400" text-anchor="start" fill="#526277">Profile advances</text>
+<rect x="223" y="268" width="347" height="108" rx="8" fill="#eaf2ff" stroke="#2463b4" stroke-width="1.5"/>
+<text x="239" y="299" font-size="21" font-weight="700" text-anchor="start" fill="#2463b4">Version 11 · accepted</text>
+<text x="239" y="329" font-size="18" font-weight="400" text-anchor="start" fill="#526277">Ada · NULL</text>
+<text x="239" y="354" font-size="18" font-weight="400" text-anchor="start" fill="#526277">Explicitly clear city</text>
+<rect x="585" y="268" width="347" height="108" rx="8" fill="#fff2d7" stroke="#9a5200" stroke-width="1.5"/>
+<text x="601" y="299" font-size="21" font-weight="700" text-anchor="start" fill="#9a5200">NULL version · skipped</text>
+<text x="601" y="329" font-size="18" font-weight="400" text-anchor="start" fill="#526277">Input score = 999</text>
+<text x="601" y="354" font-size="18" font-weight="400" text-anchor="start" fill="#526277">Keep stored score = 40</text>
+<path d="M 396 379 L 396 400" fill="none" stroke="#526277" stroke-width="2" marker-end="url(#arrow)"/>
+<path d="M 758 379 L 758 400" fill="none" stroke="#526277" stroke-width="2" marker-end="url(#arrow)"/>
+<text x="28" y="442" font-size="22" font-weight="700" text-anchor="start" fill="#172b4d">Update 2</text>
+<text x="28" y="470" font-size="17" font-weight="400" text-anchor="start" fill="#526277">Score advances</text>
+<rect x="223" y="408" width="347" height="108" rx="8" fill="#fff2d7" stroke="#9a5200" stroke-width="1.5"/>
+<text x="239" y="439" font-size="21" font-weight="700" text-anchor="start" fill="#9a5200">Version 9 · ignored</text>
+<text x="239" y="469" font-size="18" font-weight="400" text-anchor="start" fill="#526277">Old · Paris</text>
+<text x="239" y="494" font-size="18" font-weight="400" text-anchor="start" fill="#526277">Keep stored profile</text>
+<rect x="585" y="408" width="347" height="108" rx="8" fill="#e5f5ef" stroke="#10705d" stroke-width="1.5"/>
+<text x="601" y="439" font-size="21" font-weight="700" text-anchor="start" fill="#10705d">Version 6 · accepted</text>
+<text x="601" y="469" font-size="18" font-weight="400" text-anchor="start" fill="#526277">Score = 50</text>
+<text x="601" y="494" font-size="18" font-weight="400" text-anchor="start" fill="#526277">Replace stored score</text>
+<path d="M 396 519 L 396 544" fill="none" stroke="#526277" stroke-width="2" marker-end="url(#arrow)"/>
+<path d="M 758 519 L 758 544" fill="none" stroke="#526277" stroke-width="2" marker-end="url(#arrow)"/>
+<rect x="28" y="551" width="904" height="74" rx="8" fill="#f1ebfa" stroke="#7051a3" stroke-width="1.5"/>
+<text x="46" y="582" font-size="22" font-weight="700" text-anchor="start" fill="#7051a3">Final row</text>
+<text x="239" y="582" font-size="22" font-weight="700" text-anchor="start" fill="#7051a3">Ada · NULL</text>
+<text x="601" y="582" font-size="22" font-weight="700" text-anchor="start" fill="#7051a3">Score = 50</text>
+<text x="239" y="610" font-size="18" font-weight="400" text-anchor="start" fill="#526277">profile_version = 11</text>
+<text x="601" y="610" font-size="18" font-weight="400" text-anchor="start" fill="#526277">score_version = 6</text>
+</g>
+</svg>

--- a/docs/static/img/primary-key-sorted-runs.svg
+++ b/docs/static/img/primary-key-sorted-runs.svg
@@ -1,0 +1,60 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="960" height="425" viewBox="0 0 960 425" role="img" aria-labelledby="title desc">
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements. See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership. The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied. See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+<title id="title">Sorted within a run, overlapping across runs</title>
+<desc id="desc">Run A contains files for key ranges 1–4 and 7–10. Run B contains files for ranges 3–8 and 11–14. Key 7 appears in both runs with values 4 and 5; deduplicate retains value 5 from the newer record.</desc>
+<defs><marker id="arrow" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse"><path d="M 0 0 L 10 5 L 0 10 z" fill="#526277"/></marker></defs>
+<g font-family="Arial, Helvetica, sans-serif" fill="#172b4d">
+<rect x="1" y="1" width="958" height="423" rx="12" fill="#ffffff" stroke="#d7dfeb" stroke-width="1.5"/>
+<text x="28" y="43" font-size="27" font-weight="700" text-anchor="start" fill="#172b4d">Sorted within a run, overlapping across runs</text>
+<text x="28" y="76" font-size="18" font-weight="400" text-anchor="start" fill="#526277">Example: deduplicate, with a newer value for key 7 in run B.</text>
+<text x="30" y="130" font-size="18" font-weight="700" text-anchor="start" fill="#526277">Key range</text>
+<text x="196" y="130" font-size="18" font-weight="400" text-anchor="middle" fill="#526277">1</text>
+<text x="246" y="130" font-size="18" font-weight="400" text-anchor="middle" fill="#526277">2</text>
+<text x="296" y="130" font-size="18" font-weight="400" text-anchor="middle" fill="#526277">3</text>
+<text x="346" y="130" font-size="18" font-weight="400" text-anchor="middle" fill="#526277">4</text>
+<text x="396" y="130" font-size="18" font-weight="400" text-anchor="middle" fill="#526277">5</text>
+<text x="446" y="130" font-size="18" font-weight="400" text-anchor="middle" fill="#526277">6</text>
+<text x="496" y="130" font-size="18" font-weight="400" text-anchor="middle" fill="#526277">7</text>
+<text x="546" y="130" font-size="18" font-weight="400" text-anchor="middle" fill="#526277">8</text>
+<text x="596" y="130" font-size="18" font-weight="400" text-anchor="middle" fill="#526277">9</text>
+<text x="646" y="130" font-size="18" font-weight="400" text-anchor="middle" fill="#526277">10</text>
+<text x="696" y="130" font-size="18" font-weight="400" text-anchor="middle" fill="#526277">11</text>
+<text x="746" y="130" font-size="18" font-weight="400" text-anchor="middle" fill="#526277">12</text>
+<text x="796" y="130" font-size="18" font-weight="400" text-anchor="middle" fill="#526277">13</text>
+<text x="846" y="130" font-size="18" font-weight="400" text-anchor="middle" fill="#526277">14</text>
+<text x="30" y="191" font-size="21" font-weight="700" text-anchor="start" fill="#2463b4">Run A</text>
+<rect x="176" y="160" width="190" height="49" rx="8" fill="#eaf2ff" stroke="#2463b4" stroke-width="1.5"/>
+<text x="271.0" y="191" font-size="18" font-weight="400" text-anchor="middle" fill="#2463b4">File [1, 4]</text>
+<rect x="476" y="160" width="190" height="49" rx="8" fill="#eaf2ff" stroke="#2463b4" stroke-width="1.5"/>
+<text x="571.0" y="191" font-size="18" font-weight="400" text-anchor="middle" fill="#2463b4">File [7, 10]</text>
+<text x="30" y="271" font-size="21" font-weight="700" text-anchor="start" fill="#10705d">Run B</text>
+<rect x="276" y="240" width="290" height="49" rx="8" fill="#e5f5ef" stroke="#10705d" stroke-width="1.5"/>
+<text x="421.0" y="271" font-size="18" font-weight="400" text-anchor="middle" fill="#10705d">File [3, 8]</text>
+<rect x="676" y="240" width="190" height="49" rx="8" fill="#e5f5ef" stroke="#10705d" stroke-width="1.5"/>
+<text x="771.0" y="271" font-size="18" font-weight="400" text-anchor="middle" fill="#10705d">File [11, 14]</text>
+<rect x="28" y="325" width="340" height="72" rx="8" fill="#f1ebfa" stroke="#7051a3" stroke-width="1.5"/>
+<text x="44" y="356" font-size="21" font-weight="700" text-anchor="start" fill="#7051a3">Key 7: value 4 → value 5</text>
+<text x="46" y="382" font-size="18" font-weight="400" text-anchor="start" fill="#526277">Compare versions across both runs</text>
+<path d="M 374 361 L 462 361" fill="none" stroke="#526277" stroke-width="2" marker-end="url(#arrow)"/>
+<rect x="480" y="325" width="452" height="72" rx="8" fill="#e5f5ef" stroke="#10705d" stroke-width="1.5"/>
+<text x="496" y="356" font-size="21" font-weight="700" text-anchor="start" fill="#10705d">Merged row: key 7, value 5</text>
+<text x="498" y="382" font-size="18" font-weight="400" text-anchor="start" fill="#526277">The merge engine resolves the logical row</text>
+</g>
+</svg>

--- a/docs/static/img/primary-key-storage-layout.svg
+++ b/docs/static/img/primary-key-storage-layout.svg
@@ -1,0 +1,63 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="960" height="490" viewBox="0 0 960 490" role="img" aria-labelledby="title desc">
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements. See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership. The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied. See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+<title id="title">Inside a primary-key table</title>
+<desc id="desc">A partition contains two independent buckets. Each bucket has two Level-0 files, each its own sorted run, and a higher-level sorted run containing files with disjoint key ranges.</desc>
+<defs><marker id="arrow" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse"><path d="M 0 0 L 10 5 L 0 10 z" fill="#526277"/></marker></defs>
+<g font-family="Arial, Helvetica, sans-serif" fill="#172b4d">
+<rect x="1" y="1" width="958" height="488" rx="12" fill="#ffffff" stroke="#d7dfeb" stroke-width="1.5"/>
+<text x="28" y="43" font-size="27" font-weight="700" text-anchor="start" fill="#172b4d">Inside a primary-key table</text>
+<text x="28" y="76" font-size="18" font-weight="400" text-anchor="start" fill="#526277">Each bucket owns an LSM tree. This diagram shows the default key-sorted layout.</text>
+<rect x="28" y="103" width="904" height="53" rx="8" fill="#eaf2ff" stroke="#2463b4" stroke-width="1.5"/>
+<text x="480" y="138" font-size="22" font-weight="700" text-anchor="middle" fill="#2463b4">Table / one partition</text>
+<path d="M 244 156 L 244 184" fill="none" stroke="#526277" stroke-width="2" marker-end="url(#arrow)"/>
+<rect x="28" y="190" width="432" height="253" rx="8" fill="#f8fafc" stroke="#d7dfeb" stroke-width="1.5"/>
+<text x="46" y="225" font-size="23" font-weight="700" text-anchor="start" fill="#172b4d">Bucket 0</text>
+<text x="46" y="260" font-size="19" font-weight="700" text-anchor="start" fill="#526277">L0</text>
+<rect x="100" y="239" width="150" height="43" rx="8" fill="#fff2d7" stroke="#9a5200" stroke-width="1.5"/>
+<text x="175" y="267" font-size="18" font-weight="400" text-anchor="middle" fill="#9a5200">File · run A</text>
+<rect x="270" y="239" width="168" height="43" rx="8" fill="#fff2d7" stroke="#9a5200" stroke-width="1.5"/>
+<text x="354" y="267" font-size="18" font-weight="400" text-anchor="middle" fill="#9a5200">File · run B</text>
+<text x="46" y="327" font-size="19" font-weight="700" text-anchor="start" fill="#526277">L1</text>
+<rect x="100" y="300" width="338" height="118" rx="8" fill="#e5f5ef" stroke="#10705d" stroke-width="1.5"/>
+<text x="117" y="328" font-size="19" font-weight="700" text-anchor="start" fill="#10705d">One sorted run</text>
+<rect x="116" y="345" width="145" height="43" rx="8" fill="#ffffff" stroke="#10705d" stroke-width="1.5"/>
+<text x="188" y="373" font-size="18" font-weight="400" text-anchor="middle" fill="#10705d">File C</text>
+<rect x="277" y="345" width="145" height="43" rx="8" fill="#ffffff" stroke="#10705d" stroke-width="1.5"/>
+<text x="349" y="373" font-size="18" font-weight="400" text-anchor="middle" fill="#10705d">File D</text>
+<text x="117" y="408" font-size="17" font-weight="400" text-anchor="start" fill="#526277">Disjoint key ranges within the run</text>
+<path d="M 716 156 L 716 184" fill="none" stroke="#526277" stroke-width="2" marker-end="url(#arrow)"/>
+<rect x="500" y="190" width="432" height="253" rx="8" fill="#f8fafc" stroke="#d7dfeb" stroke-width="1.5"/>
+<text x="518" y="225" font-size="23" font-weight="700" text-anchor="start" fill="#172b4d">Bucket 1</text>
+<text x="518" y="260" font-size="19" font-weight="700" text-anchor="start" fill="#526277">L0</text>
+<rect x="572" y="239" width="150" height="43" rx="8" fill="#fff2d7" stroke="#9a5200" stroke-width="1.5"/>
+<text x="647" y="267" font-size="18" font-weight="400" text-anchor="middle" fill="#9a5200">File · run A</text>
+<rect x="742" y="239" width="168" height="43" rx="8" fill="#fff2d7" stroke="#9a5200" stroke-width="1.5"/>
+<text x="826" y="267" font-size="18" font-weight="400" text-anchor="middle" fill="#9a5200">File · run B</text>
+<text x="518" y="327" font-size="19" font-weight="700" text-anchor="start" fill="#526277">L1</text>
+<rect x="572" y="300" width="338" height="118" rx="8" fill="#e5f5ef" stroke="#10705d" stroke-width="1.5"/>
+<text x="589" y="328" font-size="19" font-weight="700" text-anchor="start" fill="#10705d">One sorted run</text>
+<rect x="588" y="345" width="145" height="43" rx="8" fill="#ffffff" stroke="#10705d" stroke-width="1.5"/>
+<text x="660" y="373" font-size="18" font-weight="400" text-anchor="middle" fill="#10705d">File C</text>
+<rect x="749" y="345" width="145" height="43" rx="8" fill="#ffffff" stroke="#10705d" stroke-width="1.5"/>
+<text x="821" y="373" font-size="18" font-weight="400" text-anchor="middle" fill="#10705d">File D</text>
+<text x="589" y="408" font-size="17" font-weight="400" text-anchor="start" fill="#526277">Disjoint key ranges within the run</text>
+<text x="28" y="472" font-size="18" font-weight="400" text-anchor="start" fill="#526277">Changelog files and indexes accompany data files when the table options require them.</text>
+</g>
+</svg>


### PR DESCRIPTION
### Purpose

The primary-key table guides mix conceptual introductions, configuration details, and long examples, making it difficult to choose a table layout or follow update behavior. Reorganize the existing pages into a reading path covering data layout, updates and changelogs, compaction and querying, and advanced features.

- Add decision tables and concrete SQL examples, and clarify ordering, partial-update NULL and retraction behavior, aggregation, changelog production, deletion vectors, and index coverage against the current implementation.
- Replace bitmap references in these guides with editable SVG diagrams and add diagrams for sequence groups, index coverage, and BLOB lifecycle (10 SVGs in total).
- Fold lengthy reference examples, remove duplicated explanations, preserve page URLs and relevant legacy anchors, and repair the Concepts footer link.

### Tests

- `COREPACK_ENABLE_AUTO_PIN=0 yarn build`: production documentation build and REST OpenAPI validation pass on the updated upstream baseline.
- Browser checks: all 15 primary-key pages, 177 internal links, SVG loading, legacy anchors, SQL tabs, and expandable examples pass.
- Mobile layout checks at 390 px: overview, sequence/row-kind, and partial-update pages have no page-wide horizontal overflow.
- All 10 SVGs pass XML, viewBox, title, and description checks; rendered diagrams were visually inspected.
- `git diff --check` passes.

SQL examples were checked against the implementation; they were not executed in Flink. This PR changes documentation and static assets only.

