### PR TITLE
[docs] Reorganize multimodal table guides and diagrams

### DIFF
--- a/docs/docs/multimodal-table/blob-references.mdx
+++ b/docs/docs/multimodal-table/blob-references.mdx
@@ -1,0 +1,259 @@
+---
+title: "BLOB References and Sharing"
+---
+
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+# BLOB References and Sharing
+
+A reference lets a table reuse payloads without writing another managed `.blob`
+file. Choose the reference according to what the downstream table needs to follow:
+
+| Mode | Reference stored inline | Dependency |
+| --- | --- | --- |
+| Descriptor-only | URI, byte offset, and length | The referenced object and byte range must stay readable. |
+| BLOB view | Upstream table, BLOB field, and row ID | The upstream table and addressed row must stay resolvable. |
+| Presigned URL export | Temporary URL returned to the caller | OSS credentials and a valid URL lifetime; this is an export API, not a column storage mode. |
+
+For column declarations and the managed storage mode, see [BLOB Storage](./blob#storage-modes).
+Descriptor and view fields accept scalar BLOBs only; collections use managed storage.
+
+## Prepare a Source Table
+
+The reference examples below use Flink SQL with a configured Paimon catalog and
+the `default` database selected. Run them in order with fresh table names. Batch
+mode and synchronous inserts make each write visible before the next query:
+
+```sql
+SET 'execution.runtime-mode' = 'batch';
+SET 'table.dml-sync' = 'true';
+USE default;
+
+CREATE TABLE source_images (
+    id INT,
+    name STRING,
+    image BYTES COMMENT '__BLOB_FIELD'
+) WITH (
+    'row-tracking.enabled' = 'true',
+    'data-evolution.enabled' = 'true'
+);
+
+-- Short test payloads, not complete image files.
+INSERT INTO source_images VALUES
+    (1, 'sample one', X'010203'),
+    (2, 'sample two', X'040506');
+```
+
+## Descriptor-Only Storage
+
+If you want downstream tables to **reuse** upstream blob files (no copying and no new `.blob` files), use `__BLOB_DESCRIPTOR_FIELD`:
+
+```sql
+CREATE TABLE descriptor_table (
+    id INT,
+    image BYTES COMMENT '__BLOB_DESCRIPTOR_FIELD; reused image'
+) WITH (
+    'row-tracking.enabled' = 'true',
+    'data-evolution.enabled' = 'true'
+);
+
+INSERT INTO descriptor_table
+SELECT id, image
+FROM source_images /*+ OPTIONS('blob-as-descriptor'='true') */;
+
+-- Resolves the original payload bytes from source_images.
+SELECT id, image FROM descriptor_table ORDER BY id;
+```
+
+Paimon stores only serialized `BlobDescriptor` bytes in normal data files. Reading the blob follows the descriptor URI to access bytes, and non-null values require descriptor input for those fields.
+The source read must return descriptors: writing its ordinary payload bytes to
+`__BLOB_DESCRIPTOR_FIELD` is rejected. Retain the referenced files for as long as
+the downstream table needs them; a descriptor records a physical location and does
+not follow an upstream row to a replacement file.
+
+## Blob View
+
+Blob view is useful when a downstream table should reference BLOB values already stored in an upstream table, without copying the bytes or creating new `.blob` files. A blob view field stores only a small `BlobViewStruct` inline. When the field is read, Paimon resolves the referenced BLOB from the upstream table.
+
+Blob view requires:
+
+- the upstream table to have row tracking enabled, so each row can be addressed by `_ROW_ID`
+- the downstream field to be declared with `__BLOB_VIEW_FIELD` comment directive
+- writes to provide a serialized `BlobViewStruct`; in Flink SQL, use the built-in `sys.blob_view` function
+
+The Flink SQL function signature is:
+
+```sql
+sys.blob_view(table_name, field_name, row_id)
+```
+
+Arguments:
+
+- `table_name`: the upstream table name. It must be fully qualified as `database.table` or `catalog.database.table`. Unqualified table names are rejected.
+- `field_name`: the upstream BLOB field name.
+- `row_id`: the `_ROW_ID` value from the upstream row-tracking table.
+
+The following example writes a downstream table whose `image_ref` field views the
+`image` field in the populated `source_images` table:
+
+```sql
+CREATE TABLE image_view_table (
+    id INT,
+    label STRING,
+    image_ref BYTES COMMENT '__BLOB_VIEW_FIELD'
+) WITH (
+    'row-tracking.enabled' = 'true',
+    'data-evolution.enabled' = 'true'
+);
+
+INSERT INTO image_view_table
+SELECT
+    id,
+    name AS label,
+    sys.blob_view('default.source_images', 'image', _ROW_ID)
+FROM `source_images$row_tracking`;
+
+SELECT id, label, image_ref FROM image_view_table ORDER BY id;
+```
+
+If the current Paimon catalog name is included in the table name, the function also accepts `catalog.database.table`:
+
+```sql
+SELECT sys.blob_view('my_catalog.default.source_images', 'image', _ROW_ID)
+FROM `source_images$row_tracking`;
+```
+
+Reads from `image_view_table.image_ref` return the referenced BLOB bytes in the same way as normal blob fields. The referenced upstream table and row must remain available for the view to be resolved.
+Row IDs can change during [maintenance](./data-evolution-maintenance#row-id-lifetime);
+coordinate those operations with tables that hold BLOB view references.
+
+### Forward Blob View References
+
+By default, reading a blob view field resolves the `BlobViewStruct` and returns the upstream BLOB
+content. If you want to import data from one blob view table into another blob view table without
+copying the BLOB bytes, read the source table with `blob-view.resolve.enabled=false` and write the
+result into a target field declared with `__BLOB_VIEW_FIELD`.
+
+With this option disabled, Paimon preserves the serialized `BlobViewStruct` during reads. When the
+preserved value is written to another blob view field, the target table stores the same upstream
+reference instead of creating a chained view reference.
+
+Continuing the example, `copied_image_view_table` keeps referencing `source_images`
+directly, using the references already stored in `image_view_table`:
+
+```sql
+CREATE TABLE copied_image_view_table (
+    id INT,
+    image_ref BYTES COMMENT '__BLOB_VIEW_FIELD'
+) WITH (
+    'row-tracking.enabled' = 'true',
+    'data-evolution.enabled' = 'true'
+);
+
+INSERT INTO copied_image_view_table
+SELECT id, image_ref
+FROM image_view_table /*+ OPTIONS('blob-view.resolve.enabled'='false') */;
+
+SELECT id, image_ref FROM copied_image_view_table ORDER BY id;
+```
+
+## Presigned URLs for OSS Blobs
+
+Paimon can create a temporary HTTPS URL for an OSS-backed `BlobDescriptor`. The descriptor may
+refer to a byte range inside a larger `.blob` file. Paimon first materializes exactly that range as
+a separate OSS object without a file extension, sets its content type to
+`application/octet-stream`, and then returns a presigned GET URL.
+
+The descriptor must point below the source table's storage root, with the same URI
+scheme and authority. For a descriptor forwarded from another table, pass the
+original owning table as `source_table`; using the downstream descriptor table or
+an arbitrary external object path fails this check.
+
+Configure the catalog with the standard public HTTPS OSS endpoint. Internal endpoints and
+endpoints without the `https` scheme are rejected because external consumers must be able to fetch
+the returned URL:
+
+```properties
+fs.oss.endpoint=https://oss-cn-hangzhou.aliyuncs.com
+```
+
+This section requires an existing OSS-backed managed BLOB table named
+`default.image_table`. The local reference examples above do not provide an OSS
+table or upload files to OSS.
+
+To obtain descriptors from a regular BLOB column, read the source table with
+`blob-as-descriptor=true`. The SQL functions have strict and error-tolerant forms:
+
+```sql
+-- Flink SQL
+SELECT sys.descriptor_to_presigned_url(
+    'default.image_table',
+    image,
+    INTERVAL '5' MINUTE)
+FROM image_table /*+ OPTIONS('blob-as-descriptor'='true') */;
+
+SELECT sys.try_descriptor_to_presigned_url(
+    'default.image_table',
+    image,
+    INTERVAL '5' MINUTE)
+FROM image_table /*+ OPTIONS('blob-as-descriptor'='true') */;
+```
+
+```sql
+-- Spark SQL
+ALTER TABLE image_table SET TBLPROPERTIES ('blob-as-descriptor' = 'true');
+
+SELECT sys.descriptor_to_presigned_url(
+    'default.image_table',
+    image,
+    INTERVAL '5' MINUTE)
+FROM image_table;
+
+ALTER TABLE image_table SET TBLPROPERTIES ('blob-as-descriptor' = 'false');
+```
+
+In both Flink and Spark, `source_table` must be a non-null string literal in
+`database.table` form. `catalog.database.table` is also accepted when the catalog matches the
+catalog that owns the function. Dynamic columns and `CASE` expressions are rejected during
+planning. The strict function propagates row errors; `try_descriptor_to_presigned_url` returns
+`NULL` for row-level errors. The validity interval must be positive whole seconds.
+
+The Java API applies the same table-root check. Use a descriptor-backed `Blob`
+read from the owning table:
+
+```java
+DataTable table = ...;
+Blob blob = ...;
+String url =
+        blob.toPresignedUrl(
+                table.fileIO(), table.location(), Duration.ofMinutes(5));
+```
+
+The materialized object's bytes are unchanged. Consumers must inspect the content instead of
+relying on a URL suffix or a format-specific content type. For direct model `image_url` inputs, use
+only formats verified with the target model; PDF is not covered by this entry point.
+
+Materialized objects are keyed by the complete descriptor fingerprint. Repeated short-term calls
+for the same descriptor reuse an object whose length, content type, and fingerprint still match,
+while generating a fresh URL. The first version does not resolve races with stale-cache cleanup or
+orphan-file cleaning.
+
+Treat the returned URL as a bearer credential: submit it immediately to the external service, do
+not persist it, and never write the URL or its signature/security-token query parameters to logs.

--- a/docs/docs/multimodal-table/blob.mdx
+++ b/docs/docs/multimodal-table/blob.mdx
@@ -1,6 +1,5 @@
 ---
 title: "Blob Storage"
-sidebar_position: 7
 ---
 
 import Tabs from '@theme/Tabs';
@@ -29,54 +28,16 @@ under the License.
 
 ## Overview
 
-The `BLOB` (Binary Large Object) type is a data type designed for storing multimodal data such as images, videos, audio files, and other large binary objects in Paimon tables. Unlike traditional `BYTES` type which stores binary data inline with other columns, `BLOB` type stores large binary data in separate files and maintains references to them, providing better performance for large objects. A field can also use `ARRAY<BLOB>` for an ordered collection or `MAP<K, BLOB>` for keyed blobs.
+Use `BLOB` for large binary payloads such as images, audio, video clips, and documents.
+Managed BLOB columns keep payload bytes in dedicated files, so metadata-only queries
+can skip them. Use `ARRAY<BLOB>` for ordered collections or `MAP<K, BLOB>` for keyed objects.
+For numeric embeddings, see [Vector Storage](./vector).
 
-The Blob Storage is based on Data Evolution mode.
-
-The Blob type is ideal for:
-
-- **Image Storage**: Store product images, user avatars, medical imaging data
-- **Video Content**: Store video clips, surveillance footage, multimedia content
-- **Audio Files**: Store voice recordings, music files, podcast episodes
-- **Document Storage**: Store PDF documents, office files, large text files
-- **Machine Learning**: Store embeddings, model weights, feature vectors
-- **Any Large Binary Data**: Any data that is too large to store efficiently inline
-
-## Storage Layout
-
-When you define a table with a Blob column, Paimon automatically separates the storage:
-
-1. **Normal Data Files** (e.g., `.parquet`, `.orc`): Store regular columns (INT, STRING, etc.)
-2. **Blob Data Files** (`.blob`): Store the actual blob data
-
-For append-only video-frame workloads, one or more scalar BLOB fields can instead use the
-**video pack format** (`.video`). A video pack concatenates several complete encoded videos and
-embeds a compact frame-run index. The frame ordinal lives in `VideoFrameDescriptor`; it does not
-need a `frame_index` or `frame_timestamp` column in the normal data file. When multiple video
-fields are configured, their physical boundaries may be nested, but every payload change must
-occur at a logical episode boundary so the normal and dedicated files remain one aligned file
-group.
-
-For example, given a table with schema `(id INT, name STRING, picture BLOB)`:
-
-```
-table/
-├── bucket-0/
-│   ├── data-uuid-0.parquet      # Contains id, name columns
-│   ├── data-uuid-1.blob         # Contains picture blob data
-│   ├── data-uuid-2.blob         # Contains more picture blob data
-│   └── ...
-├── manifest/
-├── schema/
-└── snapshot/
-```
-
-This separation provides several benefits:
-- Efficient column projection (reading non-blob columns doesn't load blob data)
-- Optimized file rolling based on blob size
-- Better compression for regular columnar data
-
-For details about the blob file format structure, see [File Format - BLOB](../concepts/spec/fileformat#blob).
+This page covers append tables with [Data Evolution](./data-evolution) enabled.
+For primary-key tables, follow [Primary-Key BLOB Storage](../primary-key-table/blob-storage).
+Start with table creation, writing, and reading below; use
+[BLOB References and Sharing](./blob-references) for reuse across tables and
+[Video Frame Storage](./video) for encoded videos addressed one frame per row.
 
 ## Storage Modes
 
@@ -99,97 +60,14 @@ Map keys support the integer family, `BOOLEAN`, `DECIMAL`, `DATE`, `TIME`, `BINA
 `VARBINARY` (`BYTES`), `CHAR`, and `VARCHAR`. Use non-null keys for compatibility across
 Flink, Spark, and Python.
 
-## Table Options
-
-<table className="table table-bordered">
-    <thead>
-      <tr>
-        <th className="text-left" style={{width: "25%"}}>Option</th>
-        <th className="text-center" style={{width: "8%"}}>Required</th>
-        <th className="text-center" style={{width: "7%"}}>Default</th>
-        <th className="text-center" style={{width: "10%"}}>Type</th>
-        <th className="text-center" style={{width: "50%"}}>Description</th>
-      </tr>
-    </thead>
-    <tbody>
-    <tr>
-      <td><h5>video-frame-field</h5></td>
-      <td>No</td>
-      <td style={{wordWrap: "break-word"}}>-</td>
-      <td>String</td>
-      <td>Names one or more comma-separated scalar BLOB fields whose logical values are frames in complete encoded videos packed into <code>.video</code> files. Configured fields must share logical episode boundaries. This version supports append-only tables and exact <code>VideoFrameDescriptor</code>-backed input only.</td>
-    </tr>
-    <tr>
-      <td><h5>blob-as-descriptor</h5></td>
-      <td>No</td>
-      <td style={{wordWrap: "break-word"}}>false</td>
-      <td>Boolean</td>
-      <td>Controls read output format for blob fields. When set to true, queries return serialized BlobDescriptor bytes; when false, queries return actual blob bytes. This option is dynamic and can be changed with <code>ALTER TABLE ... SET</code>.</td>
-    </tr>
-    <tr>
-      <td><h5>blob-write-null-on-missing-file</h5></td>
-      <td>No</td>
-      <td style={{wordWrap: "break-word"}}>false</td>
-      <td>Boolean</td>
-      <td>
-        When enabled for Flink writes, if a descriptor BLOB value references a file that does not exist, Paimon writes <code>NULL</code> for that value and logs a warning instead of failing when reading the descriptor.
-      </td>
-    </tr>
-    <tr>
-      <td><h5>blob-view.resolve.enabled</h5></td>
-      <td>No</td>
-      <td style={{wordWrap: "break-word"}}>true</td>
-      <td>Boolean</td>
-      <td>
-        Controls whether blob view fields are resolved to the upstream BLOB
-        content at read time. Set to <code>false</code> when forwarding blob view
-        references from one view table to another.
-      </td>
-    </tr>
-    <tr>
-      <td><h5>blob.target-file-size</h5></td>
-      <td>No</td>
-      <td style={{wordWrap: "break-word"}}>(same as target-file-size)</td>
-      <td>MemorySize</td>
-      <td>Target size for blob files. When a blob file reaches this size, a new file is created. If not specified, uses the same value as <code>target-file-size</code>.</td>
-    </tr>
-    <tr>
-      <td><h5>row-tracking.enabled</h5></td>
-      <td>Yes*</td>
-      <td style={{wordWrap: "break-word"}}>false</td>
-      <td>Boolean</td>
-      <td>Must be enabled for blob tables to support row-level operations.</td>
-    </tr>
-    <tr>
-      <td><h5>data-evolution.enabled</h5></td>
-      <td>Yes*</td>
-      <td style={{wordWrap: "break-word"}}>false</td>
-      <td>Boolean</td>
-      <td>Must be enabled for blob tables to support schema evolution.</td>
-    </tr>
-    </tbody>
-</table>
-
-*Required for blob functionality to work correctly.
-
-Specifically, if the storage system of the input BlobDescriptor differs from that used by Paimon, 
-you can specify the storage configuration for the input blob descriptor using the prefix 
-`blob-descriptor.`. For example, if the source data is stored in a different OSS endpoint, 
-you can configure it as below (using flink sql as an example):
-```sql
-CREATE TABLE image_table (
-    id INT,
-    name STRING,
-    image BYTES COMMENT '__BLOB_FIELD'
-) WITH (
-    'row-tracking.enabled' = 'true',
-    'data-evolution.enabled' = 'true',
-    'fs.oss.endpoint' = 'aaa',                   -- This is for Paimon's own config
-    'blob-descriptor.fs.oss.endpoint' = 'bbb'    -- This is for input blob descriptors' config
-);
-```
+![Managed BLOB fields write payload files; descriptor fields store a URI range; BLOB views store a table, field, and row-ID reference.](/img/multimodal-blob-modes.svg)
 
 ## Creating a Table
+
+Select a configured Paimon catalog before running SQL. Run the Flink examples in
+batch mode and wait for each insert to finish before reading its results. The Java
+snippets assume a configured `catalog` and the imports shown in the
+[Java API guide](../program-api/java-api). Use fresh table names for this walkthrough.
 
 The recommended way to create a blob table in SQL is to use the **comment directive** `__BLOB_FIELD`, `__BLOB_DESCRIPTOR_FIELD`, or `__BLOB_VIEW_FIELD` on the column. Paimon automatically converts the column to the corresponding BLOB type and registers it in the corresponding option.
 
@@ -251,6 +129,11 @@ Schema schema = Schema.newBuilder()
         .option("row-tracking.enabled", "true")
         .option("data-evolution.enabled", "true")
         .build();
+
+catalog.createDatabase("my_db", true);
+Identifier identifier = Identifier.create("my_db", "image_table");
+catalog.createTable(identifier, schema, false);
+Table table = catalog.getTable(identifier);
 ```
 
 </TabItem>
@@ -259,7 +142,10 @@ Schema schema = Schema.newBuilder()
 
 ```python
 import pyarrow as pa
-from pypaimon import Schema
+from pypaimon import CatalogFactory, Schema
+
+catalog = CatalogFactory.create({'warehouse': '/tmp/paimon-warehouse'})
+catalog.create_database('my_db', True)
 
 # Scalar, list, and map types with large_binary() values are recognized as blob types.
 pa_schema = pa.schema([
@@ -276,71 +162,13 @@ schema = Schema.from_pyarrow_schema(
         'data-evolution.enabled': 'true',
     }
 )
+catalog.create_table('my_db.image_table', schema, False)
+table = catalog.get_table('my_db.image_table')
 ```
 
 </TabItem>
 
 </Tabs>
-
-## Video Frame Storage
-
-Use `video-frame-field` when the logical table has one row per frame while the physical storage
-and decoding unit is a complete encoded video. The comma-separated option also marks each named
-SQL `BYTES` or `BINARY` column as a BLOB column. It selects the dedicated `.video` format; the
-ordinary `.blob` version and layout are not changed.
-
-```sql
-CREATE TABLE video_frames (
-    episode_id BIGINT,
-    camera_front BYTES,
-    camera_wrist BYTES
-) WITH (
-    'row-tracking.enabled' = 'true',
-    'data-evolution.enabled' = 'true',
-    'video-frame-field' = 'camera_front,camera_wrist'
-);
-```
-
-Each logical value is a `VideoFrameDescriptor`: its URI range identifies one complete encoded
-video and its frame ordinal selects a frame inside that video. On write, a `.video` data region
-concatenates raw video payloads without ordinary BLOB entry wrappers. Four embedded delta-varint
-indexes record physical video lengths, logical run lengths, run-to-video references, and the first
-frame ordinal of each run. Consecutive frames therefore need one run entry rather than one index
-entry per row. NULL and data-evolution placeholders use negative run references.
-
-Physical reuse uses exact payload descriptor identity (URI, offset, and length), not a content
-hash. It is local to each `.video` file: every pack is self-contained and never points at payloads
-owned by another Paimon data file. A pack can contain multiple MP4 payloads. After a size or row
-target is reached, rolling waits for the current physical video group to end, making the target
-soft for large videos. A later commit or an earlier roll can store another physical copy of the
-same source video. For multi-camera tables, payload boundaries may be nested across fields as long
-as every transition is an episode boundary. Once a target is reached within an episode, normal,
-BLOB, and vector rolling is deferred until the next payload boundary and all active writers close
-together. The resulting file group remains row-aligned and a single large episode may exceed the
-configured target.
-
-Compaction byte-copies the complete encoded-video ranges into a new self-contained `.video` pack
-and rebuilds the embedded indexes; it does not decode or re-encode frames. The aligned normal data
-file contains only application columns such as `episode_id`, state, and action. Paimon stores the
-frame mapping in the `.video` descriptor/index path.
-
-Current restrictions:
-
-- Append-only tables only; primary-key tables continue to use managed BLOB storage.
-- Every configured field must be a scalar `BLOB`; `ARRAY<BLOB>` and `MAP<K, BLOB>` continue to use
-  `.blob`.
-- Non-null writes must be exact descriptor-backed `BlobRef` values containing a
-  `VideoFrameDescriptor`. Inline bytes and ordinary `BlobDescriptor` values are rejected.
-- Version 1 addresses frames by zero-based presentation-order ordinal with stride one. It does not
-  store PTS values or parse codec/container metadata.
-- A `BlobConsumer` callback is not supported for the video field.
-
-Reads of a `.video` field return serialized `VideoFrameDescriptor` values even when
-`blob-as-descriptor` is false. Materializing the complete MP4 once per logical frame would defeat
-the format's purpose.
-
-For Python ingestion and PyTorch `DataLoader` usage, including decoder-session reuse in workers,
-see [PyPaimon Multimodal API: Video Frame Storage](../pypaimon/multimodal-api#video-frame-storage).
 
 The comment directive format is `__DIRECTIVE; optional user comment`. Paimon converts `BYTES`/`BINARY` to `BLOB`, `ARRAY<BYTES>`/`ARRAY<BINARY>` to `ARRAY<BLOB>`, and `MAP<K, BYTES>`/`MAP<K, BINARY>` to `MAP<K, BLOB>`. It registers the field in the corresponding option and stores the text after `;` as the column's real comment.
 
@@ -352,8 +180,212 @@ Supported directives:
 | `__BLOB_DESCRIPTOR_FIELD` | Descriptor bytes inline | `blob-descriptor-field` |
 | `__BLOB_VIEW_FIELD` | View reference inline | `blob-view-field` |
 
+## Inserting Blob Data
+
+Continue with the table created above. The short binary values are test payloads,
+not complete image files. Each insert appends a new row; `id` is not a primary key.
+
+<Tabs groupId="blob-insert">
+
+<TabItem value="flink-sql" label="Flink SQL">
+
+```sql
+INSERT INTO image_table VALUES (1, 'sample', X'89504E470D0A1A0A', NULL);
+```
+
+</TabItem>
+
+<TabItem value="spark-sql" label="Spark SQL">
+
+```sql
+INSERT INTO image_table VALUES (1, 'sample', X'89504E470D0A1A0A', NULL);
+```
+
+</TabItem>
+
+<TabItem value="java" label="Java API">
+
+```java
+byte[] imageBytes = new byte[] {1, 2, 3};
+BatchWriteBuilder builder = table.newBatchWriteBuilder();
+try (BatchTableWrite write = builder.newWrite();
+        BatchTableCommit commit = builder.newCommit()) {
+    write.write(GenericRow.of(
+            1, BinaryString.fromString("sample"), new BlobData(imageBytes), null));
+    commit.commit(write.prepareCommit());
+}
+```
+
+</TabItem>
+
+<TabItem value="python" label="Python API">
+
+```python
+data = pa.table({
+    'id': pa.array([1], type=pa.int32()),
+    'name': pa.array(['sample']),
+    'image': pa.array([b'\x89PNG\r\n\x1a\n'], type=pa.large_binary()),
+    'gallery': pa.array([None], type=pa.list_(pa.large_binary())),
+})
+write_builder = table.new_batch_write_builder()
+writer = write_builder.new_write()
+commit = write_builder.new_commit()
+try:
+    writer.write_arrow(data)
+    commit.commit(writer.prepare_commit())
+finally:
+    writer.close()
+    commit.close()
+```
+
+</TabItem>
+
+</Tabs>
+
+For an `ARRAY<BLOB>` field, write an array of binary values. The array itself and
+individual elements may be null when the corresponding array and element types are
+nullable:
+
+<Tabs groupId="array-blob-insert">
+
+<TabItem value="flink-sql" label="Flink SQL">
+
+```sql
+INSERT INTO image_table
+VALUES (2, 'gallery sample', X'89504E470D0A1A0A', ARRAY[X'01', NULL, X'02']);
+```
+
+</TabItem>
+
+<TabItem value="spark-sql" label="Spark SQL">
+
+```sql
+INSERT INTO image_table
+VALUES (2, 'gallery sample', X'89504E470D0A1A0A', array(X'01', NULL, X'02'));
+```
+
+</TabItem>
+
+<TabItem value="java" label="Java API">
+
+```java
+GenericArray gallery = new GenericArray(new Object[] {
+        new BlobData(new byte[] {1}), null, new BlobData(new byte[] {2})
+});
+// Pass gallery as the fourth field of GenericRow in a new batch write.
+```
+
+</TabItem>
+
+<TabItem value="python" label="Python API">
+
+```python
+gallery_type = pa.list_(pa.large_binary())
+gallery = pa.array([[b'\x01', None, b'\x02']], type=gallery_type)
+# Use gallery as the gallery column of an Arrow table in a new batch write.
+```
+
+</TabItem>
+
+</Tabs>
+
+## Querying Blob Data
+
+<Tabs groupId="blob-query">
+
+<TabItem value="sql" label="Flink SQL">
+
+```sql
+-- Select all columns including blob
+SELECT * FROM image_table;
+
+-- Select only non-blob columns (efficient - doesn't load blob data)
+SELECT id, name FROM image_table;
+
+-- Return descriptor bytes instead of actual blob bytes
+SELECT image
+FROM image_table /*+ OPTIONS('blob-as-descriptor'='true') */;
+```
+
+</TabItem>
+
+<TabItem value="spark-sql" label="Spark SQL">
+
+```sql
+SELECT id, name FROM image_table;
+SELECT id, image FROM image_table;
+
+ALTER TABLE image_table SET TBLPROPERTIES ('blob-as-descriptor' = 'true');
+SELECT id, image FROM image_table;
+ALTER TABLE image_table SET TBLPROPERTIES ('blob-as-descriptor' = 'false');
+```
+
+The `ALTER TABLE` setting persists for subsequent reads. Restore it after the
+descriptor query if ordinary readers should continue to receive payload bytes.
+
+</TabItem>
+
+<TabItem value="java" label="Java API">
+
+```java
+Table descriptorTable = table.copy(
+        Collections.singletonMap("blob-as-descriptor", "true"));
+ReadBuilder readBuilder = descriptorTable.newReadBuilder();
+TableScan.Plan plan = readBuilder.newScan().plan();
+try (RecordReader<InternalRow> reader = readBuilder.newRead().createReader(plan)) {
+    reader.forEachRemaining(row -> {
+        Blob blob = row.getBlob(2);
+        if (blob != null) {
+            BlobDescriptor descriptor = blob.toDescriptor();
+            try (SeekableInputStream in = blob.newInputStream()) {
+                byte[] prefix = new byte[1024];
+                int bytesRead = in.read(prefix);
+            }
+        }
+    });
+}
+```
+
+Descriptor reads keep the payload lazy. Call `blob.toData()` instead when you need
+the complete value in memory; use `newInputStream()` for partial or streamed reads.
+
+</TabItem>
+
+<TabItem value="python" label="Python API">
+
+```python
+read_builder = table.new_read_builder()
+splits = read_builder.new_scan().plan().splits()
+read = read_builder.new_read()
+with read.to_arrow_batch_reader(splits, blob_parallelism=4) as batches:
+    for batch in batches:
+        print(batch.column('image').to_pylist())
+```
+
+This reads payload bytes in batches. For lazy descriptor reads and partial streams,
+see [BLOB reading in PyPaimon](../pypaimon/blob#streaming--partial-reads).
+
+</TabItem>
+
+</Tabs>
+
+## Blob Construct Sources (Java API)
+
+Each line below is an alternative way to construct a `Blob`.
+
+```java
+Blob blob = Blob.fromData(imageBytes);                                         // byte array
+Blob blob = Blob.fromLocal("/path/to/image.png");                              // local file
+Blob blob = Blob.fromFile(fileIO, "s3://bucket/path/to/image.png");            // any FileIO
+Blob blob = Blob.fromFile(fileIO, "s3://bucket/large-file.bin", 1024, 2048);   // partial file
+Blob blob = Blob.fromHttp("https://example.com/image.png");                    // HTTP URL
+Blob blob = Blob.fromInputStream(() -> new FileInputStream("..."));            // InputStream
+Blob blob = Blob.fromDescriptor(uriReader, descriptor);                        // BlobDescriptor
+```
+
 ## Adding a Blob Column
 
+The examples below are optional schema changes, separate from the create/write examples above. Adding a column does not backfill existing rows.
 The same comment directive works with `ALTER TABLE ADD COLUMN`:
 
 <Tabs groupId="blob-add-column">
@@ -398,10 +430,12 @@ schemaManager.commitChanges(
 <TabItem value="python" label="Python API">
 
 ```python
-# pa.large_binary() is automatically recognized as BLOB type
+from pypaimon.schema.schema_change import SchemaChange
+from pypaimon.schema.data_types import AtomicType
+
 catalog.alter_table(
     'default.image_table',
-    [('add', 'picture', pa.large_binary())]
+    [SchemaChange.add_column('picture', AtomicType('BLOB'))]
 )
 ```
 
@@ -409,271 +443,53 @@ catalog.alter_table(
 
 </Tabs>
 
-## Inserting Blob Data
+## Storage Layout
 
-<Tabs groupId="blob-insert">
+For managed BLOB columns (`__BLOB_FIELD`), Paimon separates the storage:
 
-<TabItem value="flink-sql" label="Flink SQL">
+1. **Normal Data Files** (e.g., `.parquet`, `.orc`): Store regular columns (INT, STRING, etc.)
+2. **Blob Data Files** (`.blob`): Store the actual blob data
 
-```sql
-INSERT INTO image_table VALUES (1, 'sample', X'89504E470D0A1A0A', NULL);
+Descriptor-only and view columns stay inline in normal data files. They do not
+create dedicated payload files in the referencing table.
 
-INSERT INTO image_table
-SELECT id, name, content, CAST(NULL AS ARRAY<BYTES>) FROM source_table;
+For example, given a table with schema `(id INT, name STRING, picture BLOB)`:
+
+```
+table/
+├── bucket-0/
+│   ├── data-uuid-0.parquet      # Contains id, name columns
+│   ├── data-uuid-1.blob         # Contains picture blob data
+│   ├── data-uuid-2.blob         # Contains more picture blob data
+│   └── ...
+├── manifest/
+├── schema/
+└── snapshot/
 ```
 
-</TabItem>
-
-<TabItem value="spark-sql" label="Spark SQL">
-
-```sql
-INSERT INTO image_table VALUES (1, 'sample', X'89504E470D0A1A0A', NULL);
-```
-
-</TabItem>
-
-<TabItem value="java" label="Java API">
-
-```java
-GenericRow row = GenericRow.of(
-        1,
-        BinaryString.fromString("sample"),
-        new BlobData(imageBytes),
-        null
-);
-write.write(row);
-```
-
-</TabItem>
-
-<TabItem value="python" label="Python API">
-
-```python
-data = pa.table({
-    'id': pa.array([1], type=pa.int32()),
-    'name': pa.array(['sample']),
-    'image': pa.array([b'\x89PNG\r\n\x1a\n'], type=pa.large_binary()),
-    'gallery': pa.array([None], type=pa.list_(pa.large_binary())),
-})
-writer.write_arrow(data)
-```
-
-</TabItem>
-
-</Tabs>
-
-For an `ARRAY<BLOB>` field, write an array of binary values. The array itself and
-individual elements may be null when the corresponding array and element types are
-nullable:
-
-<Tabs groupId="array-blob-insert">
-
-<TabItem value="flink-sql" label="Flink SQL">
-
-```sql
-INSERT INTO image_table
-VALUES (1, 'sample', X'89504E470D0A1A0A', ARRAY[X'01', NULL, X'02']);
-```
-
-</TabItem>
-
-<TabItem value="spark-sql" label="Spark SQL">
-
-```sql
-INSERT INTO image_table
-VALUES (1, 'sample', X'89504E470D0A1A0A', array(X'01', NULL, X'02'));
-```
-
-</TabItem>
-
-<TabItem value="java" label="Java API">
-
-```java
-GenericArray gallery = new GenericArray(new Object[] {
-        new BlobData(firstImageBytes), null, new BlobData(secondImageBytes)
-});
-```
-
-</TabItem>
-
-<TabItem value="python" label="Python API">
-
-```python
-gallery_type = pa.list_(pa.large_binary())
-gallery = pa.array([[first_image, None, second_image]], type=gallery_type)
-```
-
-</TabItem>
-
-</Tabs>
-
-## Querying Blob Data
-
-<Tabs groupId="blob-query">
-
-<TabItem value="sql" label="SQL">
-
-```sql
--- Select all columns including blob
-SELECT * FROM image_table;
-
--- Select only non-blob columns (efficient - doesn't load blob data)
-SELECT id, name FROM image_table;
-
--- Return descriptor bytes instead of actual blob bytes
-ALTER TABLE image_table SET ('blob-as-descriptor' = 'true');
-SELECT image FROM image_table;
-```
-
-</TabItem>
-
-<TabItem value="java" label="Java API">
-
-```java
-Blob blob = row.getBlob(2);
-
-// Load into memory
-byte[] data = blob.toData();
-
-// Stream (recommended for large blobs)
-try (SeekableInputStream in = blob.newInputStream()) {
-    in.seek(100);  // random access
-    byte[] buffer = new byte[1024];
-    int bytesRead = in.read(buffer);
-}
-
-// Get descriptor reference (for descriptor-based blobs)
-BlobDescriptor descriptor = blob.toDescriptor();
-```
-
-</TabItem>
-
-</Tabs>
-
-## Blob Construct Sources (Java API)
-
-```java
-Blob blob = Blob.fromData(imageBytes);                                         // byte array
-Blob blob = Blob.fromLocal("/path/to/image.png");                              // local file
-Blob blob = Blob.fromFile(fileIO, "s3://bucket/path/to/image.png");            // any FileIO
-Blob blob = Blob.fromFile(fileIO, "s3://bucket/large-file.bin", 1024, 2048);   // partial file
-Blob blob = Blob.fromHttp("https://example.com/image.png");                    // HTTP URL
-Blob blob = Blob.fromInputStream(() -> new FileInputStream("..."));            // InputStream
-Blob blob = Blob.fromDescriptor(uriReader, descriptor);                        // BlobDescriptor
-```
-
-## Descriptor-Only Storage
-
-If you want downstream tables to **reuse** upstream blob files (no copying and no new `.blob` files), use `__BLOB_DESCRIPTOR_FIELD`:
-
-```sql
-CREATE TABLE descriptor_table (
-    id INT,
-    image BYTES COMMENT '__BLOB_DESCRIPTOR_FIELD; reused image'
-) WITH (
-    'row-tracking.enabled' = 'true',
-    'data-evolution.enabled' = 'true'
-);
-```
-
-Paimon stores only serialized `BlobDescriptor` bytes in normal data files. Reading the blob follows the descriptor URI to access bytes, and non-null values require descriptor input for those fields.
-
-## Presigned URLs for OSS Blobs
-
-Paimon can create a temporary HTTPS URL for an OSS-backed `BlobDescriptor`. The descriptor may
-refer to a byte range inside a larger `.blob` file. Paimon first materializes exactly that range as
-a separate OSS object without a file extension, sets its content type to
-`application/octet-stream`, and then returns a presigned GET URL.
-
-Configure the catalog with the standard public HTTPS OSS endpoint. Internal endpoints and
-endpoints without the `https` scheme are rejected because external consumers must be able to fetch
-the returned URL:
-
-```properties
-fs.oss.endpoint=https://oss-cn-hangzhou.aliyuncs.com
-```
-
-To obtain descriptors from a regular BLOB column, read the source table with
-`blob-as-descriptor=true`. The SQL functions have strict and error-tolerant forms:
-
-```sql
--- Flink SQL
-SELECT sys.descriptor_to_presigned_url(
-    'default.image_table',
-    image,
-    INTERVAL '5' MINUTE)
-FROM image_table /*+ OPTIONS('blob-as-descriptor'='true') */;
-
-SELECT sys.try_descriptor_to_presigned_url(
-    'default.image_table',
-    image,
-    INTERVAL '5' MINUTE)
-FROM image_table /*+ OPTIONS('blob-as-descriptor'='true') */;
-```
-
-```sql
--- Spark SQL
-ALTER TABLE image_table SET TBLPROPERTIES ('blob-as-descriptor' = 'true');
-
-SELECT sys.descriptor_to_presigned_url(
-    'default.image_table',
-    image,
-    INTERVAL '5' MINUTE)
-FROM image_table;
-```
-
-In both Flink and Spark, `source_table` must be a non-null string literal in
-`database.table` form. `catalog.database.table` is also accepted when the catalog matches the
-catalog that owns the function. Dynamic columns and `CASE` expressions are rejected during
-planning. The strict function propagates row errors; `try_descriptor_to_presigned_url` returns
-`NULL` for row-level errors. The validity interval must be positive whole seconds.
-
-The Java API uses the same table-root safety check:
-
-```java
-DataTable table = ...;
-Blob blob = ...;
-String url =
-        blob.toPresignedUrl(
-                table.fileIO(), table.location(), Duration.ofMinutes(5));
-```
-
-The materialized object's bytes are unchanged. Consumers must inspect the content instead of
-relying on a URL suffix or a format-specific content type. For direct model `image_url` inputs, use
-only formats verified with the target model; PDF is not covered by this entry point.
-
-Materialized objects are keyed by the complete descriptor fingerprint. Repeated short-term calls
-for the same descriptor reuse an object whose length, content type, and fingerprint still match,
-while generating a fresh URL. The first version does not resolve races with stale-cache cleanup or
-orphan-file cleaning.
-
-Treat the returned URL as a bearer credential: submit it immediately to the external service, do
-not persist it, and never write the URL or its signature/security-token query parameters to logs.
-
-## Blob View
-
-Blob view is useful when a downstream table should reference BLOB values already stored in an upstream table, without copying the bytes or creating new `.blob` files. A blob view field stores only a small `BlobViewStruct` inline. When the field is read, Paimon resolves the referenced BLOB from the upstream table.
-
-Blob view requires:
-
-- the upstream table to have row tracking enabled, so each row has a stable `_ROW_ID`
-- the downstream field to be declared with `__BLOB_VIEW_FIELD` comment directive
-- writes to provide a serialized `BlobViewStruct`; in Flink SQL, use the built-in `sys.blob_view` function
-
-The Flink SQL function signature is:
-
-```sql
-sys.blob_view(table_name, field_name, row_id)
-```
-
-Arguments:
-
-- `table_name`: the upstream table name. It must be fully qualified as `database.table` or `catalog.database.table`. Unqualified table names are rejected.
-- `field_name`: the upstream BLOB field name.
-- `row_id`: the `_ROW_ID` value from the upstream row-tracking table.
-
-The following example writes a downstream table whose `image_ref` field views the `image` field in `image_table`:
-
+This separation provides several benefits:
+- Efficient column projection (reading non-blob columns doesn't load blob data)
+- Optimized file rolling based on blob size
+- Better compression for regular columnar data
+
+For details about the blob file format structure, see [File Format - BLOB](../concepts/spec/fileformat#blob).
+
+## Table Options
+
+| Option | Default | Purpose |
+| --- | --- | --- |
+| `row-tracking.enabled` | `false` | Set to `true` for Data Evolution append tables. |
+| `data-evolution.enabled` | `false` | Set to `true` for Data Evolution append tables. |
+| `blob-as-descriptor` | `false` | Return descriptors instead of payload bytes. Can be changed with `ALTER TABLE`. See [video reads](./video#read-frames) for engine-specific behavior. |
+| `blob.target-file-size` | `target-file-size` | Target size for managed BLOB files. |
+| `blob-write-null-on-missing-file` | `false` | On Flink writes, write `NULL` and warn if an input descriptor references a missing file. |
+| `blob-view.resolve.enabled` | `true` | Set to `false` when forwarding serialized BLOB view references. |
+| `video-frame-field` | Not set | Comma-separated scalar BLOB fields using the [video pack format](./video). |
+
+Specifically, if the storage system of the input BlobDescriptor differs from that used by Paimon,
+you can specify the storage configuration for the input blob descriptor using the prefix
+`blob-descriptor.`. For example, if the source data is stored in a different OSS endpoint,
+you can configure it as below (using flink sql as an example):
 ```sql
 CREATE TABLE image_table (
     id INT,
@@ -681,77 +497,42 @@ CREATE TABLE image_table (
     image BYTES COMMENT '__BLOB_FIELD'
 ) WITH (
     'row-tracking.enabled' = 'true',
-    'data-evolution.enabled' = 'true'
+    'data-evolution.enabled' = 'true',
+    'fs.oss.endpoint' = 'aaa',                   -- This is for Paimon's own config
+    'blob-descriptor.fs.oss.endpoint' = 'bbb'    -- This is for input blob descriptors' config
 );
-
-CREATE TABLE image_view_table (
-    id INT,
-    label STRING,
-    image_ref BYTES COMMENT '__BLOB_VIEW_FIELD'
-) WITH (
-    'row-tracking.enabled' = 'true',
-    'data-evolution.enabled' = 'true'
-);
-
-INSERT INTO image_view_table
-SELECT
-    id,
-    name AS label,
-    sys.blob_view('default.image_table', 'image', _ROW_ID)
-FROM `image_table$row_tracking`;
-```
-
-If the current Paimon catalog name is included in the table name, the function also accepts `catalog.database.table`:
-
-```sql
-SELECT sys.blob_view('my_catalog.default.image_table', 'image', _ROW_ID)
-FROM `image_table$row_tracking`;
-```
-
-Reads from `image_view_table.image_ref` return the referenced BLOB bytes in the same way as normal blob fields. The referenced upstream table and row must remain available for the view to be resolved.
-
-**Forward Blob View References**
-
-By default, reading a blob view field resolves the `BlobViewStruct` and returns the upstream BLOB
-content. If you want to import data from one blob view table into another blob view table without
-copying the BLOB bytes, read the source table with `blob-view.resolve.enabled=false` and write the
-result into a target field declared with `__BLOB_VIEW_FIELD`.
-
-With this option disabled, Paimon preserves the serialized `BlobViewStruct` during reads. When the
-preserved value is written to another blob view field, the target table stores the same upstream
-reference instead of creating a chained view reference.
-
-For example, if table `T1` contains blob view references to BLOBs in table `T0`, importing `T1` into
-`T2` with `blob-view.resolve.enabled=false` makes `T2` keep referencing `T0` directly.
-
-```sql
-CREATE TABLE t2 (
-    id INT,
-    image_ref BYTES COMMENT '__BLOB_VIEW_FIELD'
-) WITH (
-    'row-tracking.enabled' = 'true',
-    'data-evolution.enabled' = 'true'
-);
-
--- Flink SQL example: the source table is read with blob view resolution disabled.
-INSERT INTO t2
-SELECT id, image_ref
-FROM t1 /*+ OPTIONS('blob-view.resolve.enabled'='false') */;
 ```
 
 ## MERGE INTO Support
 
-For Data Evolution writes in Flink and Spark:
+Partial-column BLOB updates differ by engine:
 
-- raw-data BLOB columns are still rejected in partial-column `MERGE INTO` updates
-- descriptor-based BLOB columns are allowed
+| Engine | Managed BLOB fields | Descriptor and view fields |
+| --- | --- | --- |
+| Spark `MERGE INTO` | Supports scalar BLOBs, BLOB arrays, and BLOB maps, including updates to `NULL`. | Supports scalar fields. |
+| Flink `sys.merge_into` | Rejects updates to raw-data BLOB fields, including arrays and maps. Other columns in the same table can still be updated. | Supports scalar fields. |
 
-For the Python equivalent, see [Blob Storage in pypaimon](../pypaimon/blob).
+For example, Spark can replace the payload for an existing row from the earlier
+`image_table` example:
+
+```sql
+CREATE TABLE image_updates (id INT, image BINARY);
+INSERT INTO image_updates VALUES (1, X'040506');
+
+MERGE INTO image_table AS t
+USING image_updates AS s
+ON t.id = s.id
+WHEN MATCHED THEN UPDATE SET t.image = s.image;
+```
+
+Unchanged payloads are preserved. See [Data Evolution](./data-evolution#partial-updates)
+for the engine-specific update APIs and [PyPaimon Data Evolution](../pypaimon/data-evolution)
+for Python partial writes.
 
 ## Limitations
 
 1. **Primary Key Tables**: Managed BLOB storage in primary-key tables has additional requirements; see [Primary-Key BLOB Storage](../primary-key-table/blob-storage). Primary-key tables support `merge-engine=partial-update` with scalar `blob-descriptor-field`, managed `blob-field` (`changelog-producer=none`), and scalar `blob-view-field`; `ARRAY` / `MAP` descriptor or view fields are not supported.
-2. **No Predicate Pushdown**: Blob columns cannot be used in filter predicates.
+2. **No Payload Predicate Pushdown**: The BLOB file reader does not push filters into payload files. Payload predicates supported by the calling engine require reading the values; filter on ordinary metadata columns first to reduce payload reads.
 3. **No Statistics**: Statistics collection is not supported for blob columns.
 4. **Append Table Options**: For append tables, `row-tracking.enabled` and `data-evolution.enabled` must be set to `true`.
 5. **Blob View Dependency**: Blob view fields depend on the referenced upstream table and row. If the upstream data is removed or no longer readable, the view cannot be resolved.
@@ -768,3 +549,24 @@ For the Python equivalent, see [Blob Storage in pypaimon](../pypaimon/blob).
 4. **Use Blob View to Avoid Copying BLOB Data**: Use `__BLOB_VIEW_FIELD` when a downstream table only needs to reference BLOB values from an upstream table.
 
 5. **Use Partitioning**: Partition your blob tables by date or other dimensions to improve query performance and data management.
+
+
+## Descriptor-Only Storage
+
+Store a serialized URI range in a normal data file to reuse existing payloads.
+See [descriptor input and table creation](./blob-references#descriptor-only-storage).
+
+## Blob View
+
+Reference an upstream BLOB by table, column, and row ID. See
+[creating and forwarding BLOB views](./blob-references#blob-view), including reference lifetime.
+
+## Video Frame Storage
+
+Store complete encoded videos while addressing individual frames as logical rows.
+See [Video Frame Storage](./video) for the descriptor format, rolling, and read requirements.
+
+## Presigned URLs for OSS Blobs
+
+Export an OSS-backed descriptor as a temporary HTTPS URL. See
+[Presigned URLs for OSS Blobs](./blob-references#presigned-urls-for-oss-blobs) for SQL and Java APIs.

--- a/docs/docs/multimodal-table/blob.mdx
+++ b/docs/docs/multimodal-table/blob.mdx
@@ -434,7 +434,7 @@ from pypaimon.schema.schema_change import SchemaChange
 from pypaimon.schema.data_types import AtomicType
 
 catalog.alter_table(
-    'default.image_table',
+    'my_db.image_table',
     [SchemaChange.add_column('picture', AtomicType('BLOB'))]
 )
 ```

--- a/docs/docs/multimodal-table/data-evolution-file-layout.mdx
+++ b/docs/docs/multimodal-table/data-evolution-file-layout.mdx
@@ -1,0 +1,227 @@
+---
+title: "File Layout and Reads"
+---
+
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+# File Layout and Reads
+
+Data Evolution assembles a logical row from column files aligned by row ID.
+This reference explains the range constraints, version selection, and metadata
+that writers and readers must preserve. For table creation and update examples,
+start with [Data Evolution](./data-evolution).
+
+## Row IDs and File Metadata
+
+Within a Data Evolution file, logical row positions are contiguous and ordered.
+For a file with `firstRowId = s` and `rowCount = n`, its inclusive **RowId Range**
+is:
+
+```text
+R(file) = [s, s + n - 1]
+row ID at zero-based position i = s + i
+```
+
+The row count includes positions hidden by deletion vectors. A logical delete
+does not shrink this range or shift the remaining positions.
+
+Paimon assigns new row IDs at commit time. A new normal file establishes the
+rows; dedicated files written alongside it receive the corresponding IDs,
+not additional row IDs. Partial updates reuse the existing IDs. Row IDs are
+independent of business keys, physical file names, and SQL result ordering.
+
+The metadata needed to reconstruct a row includes:
+
+| Metadata | Contract |
+| --- | --- |
+| `firstRowId`, `rowCount` | Identify the complete logical row interval represented by the file. |
+| `schemaId` | Identifies the schema used to write the file. Resolve its columns against this schema, not just the latest table schema. |
+| `writeCols` | Lists the columns physically written, in their write order. An omitted column supplies no new value. A missing list has a schema-dependent meaning described [below](#compact-write-column-metadata). |
+| `minSequenceNumber`, `maxSequenceNumber` | Track file versions. New writes receive the committing snapshot's sequence number; ordinary compaction preserves the source version bounds. Normal files are considered in descending `maxSequenceNumber` order. |
+
+Column names in `writeCols` are resolved through the file's schema to field
+IDs. This allows readers to distinguish a column that was renamed from a new
+column added after the file was written.
+
+## Normal Files: Equal or Disjoint Ranges
+
+Normal files use the table's ordinary `file.format`, such as Parquet or ORC.
+They can contain all normal columns or only the columns selected by an update.
+For two live normal files, their RowId Ranges must be either **identical** or
+**disjoint**. Partial overlap and strict containment are both invalid.
+
+Normal files with the same range form the normal part of a file group. They
+must have both the same `firstRowId` and the same `rowCount`. Matching only
+`firstRowId` is insufficient.
+
+For example, after updating `b` in a normal file covering `[0, 5]`, the new
+normal file for `b` must also cover `[0, 5]`. It cannot contain only `[2, 3]`,
+even if the update predicate matched only those two rows. The writer supplies
+the old values of `b` for the other positions.
+
+## Dedicated Files: Contained Within One Normal Range
+
+Dedicated files store columns in specialized formats: a BLOB file belongs to
+one BLOB field, while a dedicated vector file can contain a set of vector
+fields. Their file boundaries can differ from normal-file boundaries.
+
+For **every live dedicated file**, there must be a normal file in the same
+partition whose range contains the dedicated file's **entire** range:
+
+```text
+R(dedicated) is a subset of R(normal)
+normal.firstRowId <= dedicated.firstRowId
+dedicated.lastRowId <= normal.lastRowId
+```
+
+Equality is allowed. The reverse containment is not sufficient. A dedicated
+file must not span two adjacent normal ranges, even if their union covers all
+its rows. Consequently, one normal range can own many smaller dedicated
+files, but each dedicated file belongs to exactly one distinct normal range.
+
+During an append, dedicated writers may roll into smaller files independently.
+When the normal writer closes its file, the associated dedicated writers close
+as well. For each written BLOB field, the sum of its dedicated file row counts
+matches the normal file's row count; the same holds for the written vector
+file set. This maintains row alignment without forcing large payloads into
+one physical file.
+
+For a complete vector-column read, the selected vector files must concatenate
+to the normal group's full range in row-ID order, without gaps. BLOB reads
+also support partial coverage: gaps in a newer BLOB version mean “look in an
+older version,” and a row with no value in any version reads as `NULL`. This
+supports backfilling a newly added nullable BLOB column for only some rows.
+
+## Valid and Invalid Layouts
+
+The following is one valid snapshot. Both normal files in group A cover all
+six positions; its BLOB files cover smaller intervals. Group B is adjacent
+and independent.
+
+![Two file groups on a shared row-ID axis: normal versions have identical ranges, while smaller BLOB and vector files stay inside their owning normal range.](/img/data-evolution-file-layout.svg)
+
+The normal/dedicated distinction changes which ranges are legal. Each
+candidate in the next figure is checked separately against the same two
+normal ranges; the candidates are not files committed together.
+
+![Range checks: a normal subset is invalid, a contained or equal dedicated range is valid, and a dedicated range crossing the boundary between normal ranges is invalid.](/img/data-evolution-range-contract.svg)
+
+With normal ranges `[0, 5]` and `[6, 9]`:
+
+| Proposed file | Valid? | Reason |
+| --- | --- | --- |
+| Normal update `[0, 5]` | Yes | Exactly matches group A. |
+| Normal update `[0, 3]` | No | Shares the start, but not the full range. |
+| Normal update `[2, 5]` | No | A normal update cannot cover only a subset. |
+| Normal update `[4, 8]` | No | Partially overlaps existing normal ranges. |
+| Dedicated file `[2, 4]` | Yes | Entirely contained in group A; its column's coverage rules must also hold. |
+| Dedicated file `[0, 5]` | Yes | Equality with a normal range is allowed. |
+| Dedicated file `[4, 7]` | No | Crosses from group A to group B. |
+| Dedicated file `[0, 9]` | No | The union of two normal ranges is not one owning range. |
+| Dedicated file `[10, 12]` | No | No normal file establishes those rows. |
+
+These constraints apply to the **live files in a snapshot**, not to all files
+still retained on storage. Compaction can replace both groups with a new
+normal range `[0, 9]` atomically. Once the old normal files have been removed
+from the new snapshot, existing dedicated files inside `[0, 9]` remain valid,
+and a dedicated file covering `[0, 9]` can be valid too.
+
+## How Reads Reconstruct Rows
+
+A reader first groups live files by overlapping RowId Ranges. Under the above
+contracts, each group has one distinct normal range and its contained
+dedicated files. It then:
+
+1. Resolves each file's written columns using its schema version.
+2. Selects the newest normal file that supplies each requested column. An
+   older file is still needed if it supplies another requested column.
+3. Concatenates the selected vector files and resolves BLOB versions for the
+   same logical row positions.
+4. Combines the selected columns by row position and applies logical deletions
+   consistently across the group. Columns absent from all files are filled
+   with `NULL` if nullable; a missing non-nullable column is an error.
+
+This is a positional column merge, not a join on a user key. Readers can skip
+column files that contribute no requested values. Filtering and index pruning
+must use the current column providers: statistics in an old file cannot be
+used to discard rows based on a column that a newer file has overwritten.
+
+For example, these normal files all cover `[0, 2]`:
+
+![Column merge: id comes from N0 version 1, b from N1 version 2, and c from N2 version 3. Matching row-ID positions form the output rows.](/img/data-evolution-column-merge.svg)
+
+The result is `(10, 1, 101), (20, 22, 200), (30, 3, 300)`. N1 replaces `b`
+for the whole range, including the preserved values for rows 0 and 2. N2
+does not replace `b`, because `b` is absent from its written columns.
+
+There are three different meanings to keep separate:
+
+| Representation | Meaning during a read |
+| --- | --- |
+| Column absent from a normal file's written schema | This file does not update the column; use another provider. |
+| Explicit `NULL` in a written column | The current value is `NULL`; do not fall back to an older non-null value. |
+| Internal BLOB placeholder | Preserve the older BLOB value for this row. Continue through older BLOB versions until a non-placeholder value, including explicit `NULL`, is found. |
+
+BLOB placeholders let an update preserve unchanged payloads without copying
+them into the new BLOB file. They are managed by the writer; applications
+should not substitute `NULL` for “leave unchanged.” Descriptor-only and BLOB
+view fields stored inline follow normal-column storage rules.
+
+![BLOB fallback for three rows: a placeholder preserves image A, explicit NULL replaces image B, and a new image Z replaces image C.](/img/data-evolution-blob-fallback.svg)
+
+## Compact Write-Column Metadata
+
+With `data-evolution.write-cols-optimization.enabled = true`, a normal file
+that contains **all non-dedicated columns** can omit the repeated `writeCols`
+list. Partial subsets and dedicated files keep explicit written columns.
+The option is disabled by default and affects new writes.
+
+A reader interprets a missing list using the file's `schemaId`:
+
+- For a schema without this optimization, missing `writeCols` means the full
+  schema used to write that file.
+- For a schema with the optimization and dedicated columns, it means all
+  non-dedicated columns in that schema.
+
+Persist this option with `CREATE TABLE` or `ALTER TABLE` so the file schema
+records the interpretation. Upgrade all readers and maintenance jobs before
+enabling it: older readers treat a missing list as all table columns. Readers
+support both encodings without a read option. Before rolling back to an older
+reader, rewrite the files produced with this option or keep the readers
+upgraded.
+
+## Inspect the Layout
+
+Use the `$files` system table to inspect the live file metadata:
+
+```sql
+SELECT file_path, schema_id, write_cols,
+       first_row_id,
+       first_row_id + record_count - 1 AS last_row_id,
+       record_count, max_sequence_number
+FROM default.`target_table$files`
+ORDER BY first_row_id, max_sequence_number;
+```
+
+Compare both endpoints when checking normal-file alignment, and compare each
+dedicated range against a **single** normal range. Summing `record_count`
+across all files overcounts logical rows because column versions and dedicated
+files can represent the same positions; deletion vectors reduce visible rows
+further. Use a table query for the logical row count.

--- a/docs/docs/multimodal-table/data-evolution-maintenance.mdx
+++ b/docs/docs/multimodal-table/data-evolution-maintenance.mdx
@@ -1,0 +1,205 @@
+---
+title: "Data Evolution Maintenance"
+sidebar_label: "Maintenance"
+---
+
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+# Data Evolution Maintenance
+
+Use compaction to consolidate column versions. Use deletion-vector materialization
+when deleted positions must be removed from the latest data files. These operations
+have different effects on row IDs and dependent indexes.
+
+| Goal | Operation | Row IDs |
+| --- | --- | --- |
+| Reduce column-file fragmentation | [Ordinary compaction](#ordinary-compaction) | Preserved |
+| Resize large normal files | [Split during compaction](#splitting-large-files-during-compaction) | Preserved |
+| Remove logically deleted positions | [Materialize deletion vectors](#materialize-deletion-vectors) | Reassigned in rewritten ranges |
+
+For updates and logical deletes, see [Data Evolution](./data-evolution).
+For the normal/dedicated range contract, see [File Layout and Reads](./data-evolution-file-layout).
+The unpartitioned examples below use `default.target_table` from the
+[Data Evolution setup](./data-evolution#create-a-table).
+
+## Compaction and Row-ID Lifetime
+
+![Ordinary compaction retains row IDs 0 through 3 and the deleted position at 1. Deletion-vector materialization rewrites the three surviving values under new row IDs.](/img/data-evolution-maintenance.svg)
+
+The new IDs `[100, 102]` in this example are illustrative. Actual IDs are
+allocated at commit time. Both paths preserve the visible values, but only
+materialization removes deleted positions from the rewritten files.
+
+### Ordinary Compaction
+
+Repeated partial updates leave multiple column versions in each group.
+Ordinary Data Evolution compaction reads their merged values and writes
+consolidated normal files. It can also merge adjacent ranges in the same
+partition. It preserves row IDs, row order, version information, and logical
+deletions, and keeps the resulting normal/dedicated layout within the file
+contract.
+
+For example, replacing all normal files for `[0, 5]` and `[6, 9]` with one
+normal file `[0, 9]` changes file boundaries without changing any row's ID.
+Dedicated files contained in either old range are contained in the new range,
+so they do not need rewriting just because the normal files were merged.
+
+Both Spark and Flink provide:
+
+```sql
+CALL sys.compact(`table` => 'default.target_table');
+```
+
+BLOB compaction is separately controlled by `blob-compaction.enabled`
+(default `false`). Dedicated vector-file compaction is not currently
+supported. See [Dedicated Compaction](../maintenance/dedicated-compaction)
+for scheduling compaction jobs.
+
+Ordinary compaction **does not physically remove rows hidden by deletion
+vectors**. Removing their positions would change the alignment with untouched
+column files.
+
+### Splitting Large Files During Compaction
+
+To resize existing large normal data files, enable
+`data-evolution.compaction.split-large-files` (default: `false`) and run compaction:
+
+```sql
+ALTER TABLE default.target_table SET TBLPROPERTIES (
+    'target-file-size' = '128 MB',
+    'data-evolution.compaction.split-large-files' = 'true',
+    'data-evolution.compaction.large-file-ratio' = '3.0'
+);
+CALL sys.compact('default.target_table');
+```
+
+The example uses Spark SQL and selects normal files strictly larger than 384 MB.
+`data-evolution.compaction.large-file-ratio` controls the multiplier relative to
+`target-file-size`; it defaults to `2.0` and accepts finite values of at least `1.0`,
+including fractional values such as `1.5`. Files strictly exceeding the threshold
+qualify for compaction below `compaction.min.file-num` when their dedicated-file
+ranges allow splitting.
+Changing the ratio does not change the output target size. Compaction includes all
+column updates for the same row-ID range. Before writing, it estimates rows per output
+from the total normal input file size, the logical row count, and `target-file-size`.
+It then adjusts the estimated cut points to safe dedicated-file boundaries.
+Actual output sizes can differ from the target because of compression, data skew,
+overwritten column versions, and dedicated-file ranges; the last file may be smaller.
+The write-time `target-file-row-num` limit does not apply to compaction.
+
+Row IDs, column updates, and logical deletions are preserved. This option only rewrites
+normal files: associated BLOB and VECTOR files keep their existing contents and file names,
+and their sizes do not trigger splitting. Separate dedicated-file compaction options keep
+their existing behavior. Files referenced by older snapshots or tags remain until those
+references expire and snapshot expiration removes them.
+
+Every BLOB or VECTOR file must remain fully contained in a single normal file's
+row-ID range. An estimated cut inside a dedicated file moves to the end of its range,
+including any overlapping ranges from different columns or versions and ranges produced
+by dedicated compaction in the same batch. Output files may therefore exceed
+`target-file-size`. If these ranges prevent any split, file size alone does not trigger a compaction task. Normal
+merging based on `compaction.min.file-num` remains available.
+
+### Materialize Deletion Vectors
+
+The target must be a Data Evolution append table with
+`deletion-vectors.enabled=true`, and it must contain logical deletes to materialize.
+The `target_table` setup already enables this option. Flink must run in batch mode;
+before calling the procedure in a Flink SQL session, set:
+
+```sql
+SET 'execution.runtime-mode' = 'batch';
+SET 'table.dml-sync' = 'true';
+```
+
+To remove deleted positions from the latest table state, run:
+
+```sql
+CALL sys.materialize_deletion_vectors(`table` => 'default.target_table');
+```
+
+This operation reads the affected groups with their deletions applied,
+rewrites the surviving data, assigns new row IDs, removes the applied deletion
+vectors, and drops affected global indexes. Concurrent changes to the affected
+row-ID ranges cause the operation to fail instead of committing stale results.
+Materialization of groups containing dedicated vector files is not currently
+supported.
+
+For a partitioned table, select partitions by either `partitions` or a
+partition predicate in `where`; they cannot be used together. These alternative
+examples assume an existing `default.partitioned_table` with an integer partition
+key `dt` in `YYYYMMDD` form and the same required table options:
+
+```sql
+CALL sys.materialize_deletion_vectors(
+    `table` => 'default.partitioned_table',
+    partitions => 'dt=20260812');
+
+CALL sys.materialize_deletion_vectors(
+    `table` => 'default.partitioned_table',
+    `where` => 'dt >= 20260801');
+```
+
+Spark processes bounded batches until all matching deletion vectors are
+materialized. Each Flink invocation processes one batch with a soft target of
+100,000 deletion vectors. An overlapping row-ID component is never split and
+can exceed that target. Wait for each Flink job to finish before repeating the
+call, and continue until it makes no changes.
+
+Historical snapshots and tags can still reference the replaced files.
+Reclaiming their storage requires those references to expire and snapshot
+expiration to remove the files. The legacy
+`data-evolution.compaction.rewrite-row-ids = true` setting is rejected; use the
+materialization procedure instead.
+
+### Row-ID Lifetime
+
+| Operation | Effect on row IDs |
+| --- | --- |
+| Append new rows | Allocates new IDs. |
+| Partial update or column backfill | Preserves existing IDs. |
+| Logical delete | Hides IDs without shifting the remaining rows. |
+| Ordinary Data Evolution compaction | Preserves IDs, but may change file-group boundaries. |
+| Deletion-vector materialization | Assigns new IDs to surviving rows in the rewritten ranges. |
+| Explicit `reassign_row_id` maintenance | Changes IDs by remapping file metadata. |
+| Overwrite or partition removal | Removes the replaced rows from the current table state; do not assume their IDs remain usable. |
+
+Applications that persist `_ROW_ID` values, including references from other
+tables, must coordinate with operations that replace or reassign IDs. Row IDs
+are not permanent application identifiers. The `reassign_row_id` procedure is
+documented in the [Spark](../spark/procedures) and
+[Flink](../flink/procedures) procedure references.
+
+## File Sizing
+
+`target-file-size` controls normal-file sizing. `blob.target-file-size` and
+`vector.target-file-size` control dedicated file sizing and default to the
+normal target size. These are size targets, not permission to break the
+containment rules.
+
+A large normal range makes even a selective normal-column update process many
+rows. `target-file-row-num` can bound newly appended file row counts where the
+writer supports it; it is disabled by default. It does not split existing
+normal ranges during partial updates, and Data Evolution compaction can
+produce larger ranges. Choose file sizing with both scan efficiency and
+future update cost in mind.
+
+For write-column encoding and the `$files` inspection query, see
+[File Layout and Reads](./data-evolution-file-layout#compact-write-column-metadata).

--- a/docs/docs/multimodal-table/data-evolution.mdx
+++ b/docs/docs/multimodal-table/data-evolution.mdx
@@ -1,6 +1,5 @@
 ---
 title: "Data Evolution"
-sidebar_position: 6
 ---
 
 import Tabs from '@theme/Tabs';
@@ -20,9 +19,9 @@ with the License.  You may obtain a copy of the License at
 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-KIND, either express or implied.
-See the License for the specific language governing
-permissions and limitations under the License.
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
 -->
 
 # Data Evolution
@@ -146,163 +145,19 @@ whether the file was created by an update.
 
 ## File Group Spec
 
-### Row IDs and File Metadata
+Normal files for the same group cover the same complete row-ID range. A dedicated
+BLOB or vector file must fit inside one normal range. Readers select the newest
+provider for each requested column, then combine values at matching row positions.
 
-Within a Data Evolution file, logical row positions are contiguous and ordered.
-For a file with `firstRowId = s` and `rowCount = n`, its inclusive **RowId Range**
-is:
+<span id="row-ids-and-file-metadata" />
+<span id="normal-files-equal-or-disjoint-ranges" />
+<span id="dedicated-files-contained-within-one-normal-range" />
+<span id="valid-and-invalid-layouts" />
+<span id="how-reads-reconstruct-rows" />
 
-```text
-R(file) = [s, s + n - 1]
-row ID at zero-based position i = s + i
-```
-
-The row count includes positions hidden by deletion vectors. A logical delete
-does not shrink this range or shift the remaining positions.
-
-Paimon assigns new row IDs at commit time. A new normal file establishes the
-rows; dedicated files written alongside it receive the corresponding IDs,
-not additional row IDs. Partial updates reuse the existing IDs. Row IDs are
-independent of business keys, physical file names, and SQL result ordering.
-
-The metadata needed to reconstruct a row includes:
-
-| Metadata | Contract |
-| --- | --- |
-| `firstRowId`, `rowCount` | Identify the complete logical row interval represented by the file. |
-| `schemaId` | Identifies the schema used to write the file. Resolve its columns against this schema, not just the latest table schema. |
-| `writeCols` | Lists the columns physically written, in their write order. An omitted column supplies no new value. A missing list has a schema-dependent meaning described [below](#compact-write-column-metadata). |
-| `minSequenceNumber`, `maxSequenceNumber` | Track file versions. New writes receive the committing snapshot's sequence number; ordinary compaction preserves the source version bounds. Normal files are considered in descending `maxSequenceNumber` order. |
-
-Column names in `writeCols` are resolved through the file's schema to field
-IDs. This allows readers to distinguish a column that was renamed from a new
-column added after the file was written.
-
-### Normal Files: Equal or Disjoint Ranges
-
-Normal files use the table's ordinary `file.format`, such as Parquet or ORC.
-They can contain all normal columns or only the columns selected by an update.
-For two live normal files, their RowId Ranges must be either **identical** or
-**disjoint**. Partial overlap and strict containment are both invalid.
-
-Normal files with the same range form the normal part of a file group. They
-must have both the same `firstRowId` and the same `rowCount`. Matching only
-`firstRowId` is insufficient.
-
-For example, after updating `b` in a normal file covering `[0, 5]`, the new
-normal file for `b` must also cover `[0, 5]`. It cannot contain only `[2, 3]`,
-even if the update predicate matched only those two rows. The writer supplies
-the old values of `b` for the other positions.
-
-### Dedicated Files: Contained Within One Normal Range
-
-Dedicated files store columns in specialized formats: a BLOB file belongs to
-one BLOB field, while a dedicated vector file can contain a set of vector
-fields. Their file boundaries can differ from normal-file boundaries.
-
-For **every live dedicated file**, there must be a normal file in the same
-partition whose range contains the dedicated file's **entire** range:
-
-```text
-R(dedicated) is a subset of R(normal)
-normal.firstRowId <= dedicated.firstRowId
-dedicated.lastRowId <= normal.lastRowId
-```
-
-Equality is allowed. The reverse containment is not sufficient. A dedicated
-file must not span two adjacent normal ranges, even if their union covers all
-its rows. Consequently, one normal range can own many smaller dedicated
-files, but each dedicated file belongs to exactly one distinct normal range.
-
-During an append, dedicated writers may roll into smaller files independently.
-When the normal writer closes its file, the associated dedicated writers close
-as well. For each written BLOB field, the sum of its dedicated file row counts
-matches the normal file's row count; the same holds for the written vector
-file set. This maintains row alignment without forcing large payloads into
-one physical file.
-
-For a complete vector-column read, the selected vector files must concatenate
-to the normal group's full range in row-ID order, without gaps. BLOB reads
-also support partial coverage: gaps in a newer BLOB version mean “look in an
-older version,” and a row with no value in any version reads as `NULL`. This
-supports backfilling a newly added nullable BLOB column for only some rows.
-
-### Valid and Invalid Layouts
-
-The following is one valid snapshot. Both normal files in group A cover all
-six positions; its BLOB files cover smaller intervals. Group B is adjacent
-and independent.
-
-![Two file groups on a shared row-ID axis: normal versions have identical ranges, while smaller BLOB and vector files stay inside their owning normal range.](/img/data-evolution-file-layout.svg)
-
-The normal/dedicated distinction changes which ranges are legal. Each
-candidate in the next figure is checked separately against the same two
-normal ranges; the candidates are not files committed together.
-
-![Range checks: a normal subset is invalid, a contained or equal dedicated range is valid, and a dedicated range crossing the boundary between normal ranges is invalid.](/img/data-evolution-range-contract.svg)
-
-With normal ranges `[0, 5]` and `[6, 9]`:
-
-| Proposed file | Valid? | Reason |
-| --- | --- | --- |
-| Normal update `[0, 5]` | Yes | Exactly matches group A. |
-| Normal update `[0, 3]` | No | Shares the start, but not the full range. |
-| Normal update `[2, 5]` | No | A normal update cannot cover only a subset. |
-| Normal update `[4, 8]` | No | Partially overlaps existing normal ranges. |
-| Dedicated file `[2, 4]` | Yes | Entirely contained in group A; its column's coverage rules must also hold. |
-| Dedicated file `[0, 5]` | Yes | Equality with a normal range is allowed. |
-| Dedicated file `[4, 7]` | No | Crosses from group A to group B. |
-| Dedicated file `[0, 9]` | No | The union of two normal ranges is not one owning range. |
-| Dedicated file `[10, 12]` | No | No normal file establishes those rows. |
-
-These constraints apply to the **live files in a snapshot**, not to all files
-still retained on storage. Compaction can replace both groups with a new
-normal range `[0, 9]` atomically. Once the old normal files have been removed
-from the new snapshot, existing dedicated files inside `[0, 9]` remain valid,
-and a dedicated file covering `[0, 9]` can be valid too.
-
-### How Reads Reconstruct Rows
-
-A reader first groups live files by overlapping RowId Ranges. Under the above
-contracts, each group has one distinct normal range and its contained
-dedicated files. It then:
-
-1. Resolves each file's written columns using its schema version.
-2. Selects the newest normal file that supplies each requested column. An
-   older file is still needed if it supplies another requested column.
-3. Concatenates the selected vector files and resolves BLOB versions for the
-   same logical row positions.
-4. Combines the selected columns by row position and applies logical deletions
-   consistently across the group. Columns absent from all files are filled
-   with `NULL` if nullable; a missing non-nullable column is an error.
-
-This is a positional column merge, not a join on a user key. Readers can skip
-column files that contribute no requested values. Filtering and index pruning
-must use the current column providers: statistics in an old file cannot be
-used to discard rows based on a column that a newer file has overwritten.
-
-For example, these normal files all cover `[0, 2]`:
-
-![Column merge: id comes from N0 version 1, b from N1 version 2, and c from N2 version 3. Matching row-ID positions form the output rows.](/img/data-evolution-column-merge.svg)
-
-The result is `(10, 1, 101), (20, 22, 200), (30, 3, 300)`. N1 replaces `b`
-for the whole range, including the preserved values for rows 0 and 2. N2
-does not replace `b`, because `b` is absent from its written columns.
-
-There are three different meanings to keep separate:
-
-| Representation | Meaning during a read |
-| --- | --- |
-| Column absent from a normal file's written schema | This file does not update the column; use another provider. |
-| Explicit `NULL` in a written column | The current value is `NULL`; do not fall back to an older non-null value. |
-| Internal BLOB placeholder | Preserve the older BLOB value for this row. Continue through older BLOB versions until a non-placeholder value, including explicit `NULL`, is found. |
-
-BLOB placeholders let an update preserve unchanged payloads without copying
-them into the new BLOB file. They are managed by the writer; applications
-should not substitute `NULL` for “leave unchanged.” Descriptor-only and BLOB
-view fields stored inline follow normal-column storage rules.
-
-![BLOB fallback for three rows: a placeholder preserves image A, explicit NULL replaces image B, and a new image Z replaces image C.](/img/data-evolution-blob-fallback.svg)
+See [File Layout and Reads](./data-evolution-file-layout) for range diagrams,
+column-version selection, and the distinction between an omitted column, explicit
+`NULL`, and a BLOB placeholder.
 
 ## Partial Updates
 
@@ -380,7 +235,7 @@ CALL sys.data_evolution_merge_into(
 
 Use `''` for unused optional positional arguments. Updating partition columns
 is not supported. For BLOB updates, this Flink procedure supports
-[descriptor-only](./blob#descriptor-only-storage) and [BLOB view](./blob#blob-view)
+[descriptor-only](./blob-references#descriptor-only-storage) and [BLOB view](./blob-references#blob-view)
 fields; it rejects raw-data BLOB fields, including BLOB arrays and maps.
 
 ### Python API
@@ -503,7 +358,7 @@ SELECT _ROW_ID, id, b, c FROM default.`target_table$row_tracking`;
 
 Obtain row IDs from the table instead of deriving them from a business key or
 from result order. Ordinary updates and compaction preserve them, but
-[maintenance that reassigns row IDs](#row-id-lifetime) does not.
+[maintenance that reassigns row IDs](./data-evolution-maintenance#row-id-lifetime) does not.
 
 ### Nested Fields
 
@@ -571,141 +426,6 @@ Deleting a row leaves its position in the file range occupied but invisible.
 For example, deleting row ID 2 from `[0, 5]` leaves the metadata range `[0, 5]`,
 with five visible rows. An update must not close that gap or shift rows 3–5.
 
-## Compaction and Row-ID Lifetime
-
-![Ordinary compaction retains row IDs 0 through 3 and the deleted position at 1. Deletion-vector materialization rewrites the three surviving values under new row IDs.](/img/data-evolution-maintenance.svg)
-
-The new IDs `[100, 102]` in this example are illustrative. Actual IDs are
-allocated at commit time. Both paths preserve the visible values, but only
-materialization removes deleted positions from the rewritten files.
-
-### Ordinary Compaction
-
-Repeated partial updates leave multiple column versions in each group.
-Ordinary Data Evolution compaction reads their merged values and writes
-consolidated normal files. It can also merge adjacent ranges in the same
-partition. It preserves row IDs, row order, version information, and logical
-deletions, and keeps the resulting normal/dedicated layout within the file
-contract.
-
-For example, replacing all normal files for `[0, 5]` and `[6, 9]` with one
-normal file `[0, 9]` changes file boundaries without changing any row's ID.
-Dedicated files contained in either old range are contained in the new range,
-so they do not need rewriting just because the normal files were merged.
-
-Both Spark and Flink provide:
-
-```sql
-CALL sys.compact(`table` => 'default.target_table');
-```
-
-BLOB compaction is separately controlled by `blob-compaction.enabled`
-(default `false`). Dedicated vector-file compaction is not currently
-supported. See [Dedicated Compaction](../maintenance/dedicated-compaction)
-for scheduling compaction jobs.
-
-Ordinary compaction **does not physically remove rows hidden by deletion
-vectors**. Removing their positions would change the alignment with untouched
-column files.
-
-### Splitting Large Files During Compaction
-
-To resize existing large normal data files, enable
-`data-evolution.compaction.split-large-files` (default: `false`) and run compaction:
-
-```sql
-ALTER TABLE my_table SET TBLPROPERTIES (
-    'target-file-size' = '128 MB',
-    'data-evolution.compaction.split-large-files' = 'true',
-    'data-evolution.compaction.large-file-ratio' = '3.0'
-);
-CALL sys.compact('default.my_table');
-```
-
-The example uses Spark SQL and selects normal files strictly larger than 384 MB.
-`data-evolution.compaction.large-file-ratio` controls the multiplier relative to
-`target-file-size`; it defaults to `2.0` and accepts finite values of at least `1.0`,
-including fractional values such as `1.5`. Files strictly exceeding the threshold
-qualify for compaction below `compaction.min.file-num` when their dedicated-file
-ranges allow splitting.
-Changing the ratio does not change the output target size. Compaction includes all
-column updates for the same row-ID range. Before writing, it estimates rows per output
-from the total normal input file size, the logical row count, and `target-file-size`.
-It then adjusts the estimated cut points to safe dedicated-file boundaries.
-Actual output sizes can differ from the target because of compression, data skew,
-overwritten column versions, and dedicated-file ranges; the last file may be smaller.
-The write-time `target-file-row-num` limit does not apply to compaction.
-
-Row IDs, column updates, and logical deletions are preserved. This option only rewrites
-normal files: associated BLOB and VECTOR files keep their existing contents and file names,
-and their sizes do not trigger splitting. Separate dedicated-file compaction options keep
-their existing behavior. Files referenced by older snapshots or tags remain until those
-references expire and snapshot expiration removes them.
-
-Every BLOB or VECTOR file must remain fully contained in a single normal file's
-row-ID range. An estimated cut inside a dedicated file moves to the end of its range,
-including any overlapping ranges from different columns or versions and ranges produced
-by dedicated compaction in the same batch. Output files may therefore exceed
-`target-file-size`. If these ranges prevent any split, file size alone does not trigger a compaction task. Normal
-merging based on `compaction.min.file-num` remains available.
-
-### Materialize Deletion Vectors
-
-To remove deleted positions from the latest table state, run:
-
-```sql
-CALL sys.materialize_deletion_vectors(`table` => 'default.target_table');
-```
-
-This operation reads the affected groups with their deletions applied,
-rewrites the surviving data, assigns new row IDs, removes the applied deletion
-vectors, and drops affected global indexes. Concurrent changes to the affected
-row-ID ranges cause the operation to fail instead of committing stale results.
-Materialization of groups containing dedicated vector files is not currently
-supported.
-
-For a partitioned table, select partitions by either `partitions` or a
-partition predicate in `where`; they cannot be used together:
-
-```sql
-CALL sys.materialize_deletion_vectors(
-    `table` => 'default.partitioned_table',
-    partitions => 'dt=2026-08-12');
-
-CALL sys.materialize_deletion_vectors(
-    `table` => 'default.partitioned_table',
-    `where` => 'dt >= 20260801');
-```
-
-Spark processes bounded batches until all matching deletion vectors are
-materialized. Each Flink invocation processes one batch with a soft target of
-100,000 deletion vectors. An overlapping row-ID component is never split and
-can exceed that target. Repeat the Flink call until it makes no changes.
-
-Historical snapshots and tags can still reference the replaced files.
-Reclaiming their storage requires those references to expire and snapshot
-expiration to remove the files. The legacy
-`data-evolution.compaction.rewrite-row-ids = true` setting is rejected; use the
-materialization procedure instead.
-
-### Row-ID Lifetime
-
-| Operation | Effect on row IDs |
-| --- | --- |
-| Append new rows | Allocates new IDs. |
-| Partial update or column backfill | Preserves existing IDs. |
-| Logical delete | Hides IDs without shifting the remaining rows. |
-| Ordinary Data Evolution compaction | Preserves IDs, but may change file-group boundaries. |
-| Deletion-vector materialization | Assigns new IDs to surviving rows in the rewritten ranges. |
-| Explicit `reassign_row_id` maintenance | Changes IDs by remapping file metadata. |
-| Overwrite or partition removal | Removes the replaced rows from the current table state; do not assume their IDs remain usable. |
-
-Applications that persist `_ROW_ID` values, including references from other
-tables, must coordinate with operations that replace or reassign IDs. Row IDs
-are not permanent application identifiers. The `reassign_row_id` procedure is
-documented in the [Spark](../spark/procedures) and
-[Flink](../flink/procedures) procedure references.
-
 ## Concurrent Writes
 
 Updates are planned against a snapshot and checked when committing. Paimon
@@ -739,56 +459,27 @@ when the commit contains existing-row BLOB or VECTOR staged files. It does
 not suppress logical concurrent-update conflicts. If recovery is unavailable,
 re-plan the operation against the latest snapshot.
 
+## Compaction and Row-ID Lifetime
+
+Repeated updates add column files. Ordinary compaction consolidates them while
+preserving row IDs and logical deletions. Deletion-vector materialization removes
+deleted positions and assigns new row IDs to surviving rows in rewritten ranges.
+Persisted row-ID references must be coordinated with this maintenance.
+
+<span id="ordinary-compaction" />
+<span id="splitting-large-files-during-compaction" />
+<span id="materialize-deletion-vectors" />
+<span id="row-id-lifetime" />
+
+See [Data Evolution Maintenance](./data-evolution-maintenance) for commands,
+large-file splitting, limitations, and the row-ID lifetime table.
+
 ## File Sizing and Metadata Compatibility
 
-`target-file-size` controls normal-file sizing. `blob.target-file-size` and
-`vector.target-file-size` control dedicated file sizing and default to the
-normal target size. These are size targets, not permission to break the
-containment rules.
+<span id="compact-write-column-metadata" />
+<span id="inspect-the-layout" />
 
-A large normal range makes even a selective normal-column update process many
-rows. `target-file-row-num` can bound newly appended file row counts where the
-writer supports it; it is disabled by default. It does not split existing
-normal ranges during partial updates, and Data Evolution compaction can
-produce larger ranges. Choose file sizing with both scan efficiency and
-future update cost in mind.
-
-### Compact Write-Column Metadata
-
-With `data-evolution.write-cols-optimization.enabled = true`, a normal file
-that contains **all non-dedicated columns** can omit the repeated `writeCols`
-list. Partial subsets and dedicated files keep explicit written columns.
-The option is disabled by default and affects new writes.
-
-A reader interprets a missing list using the file's `schemaId`:
-
-- For a schema without this optimization, missing `writeCols` means the full
-  schema used to write that file.
-- For a schema with the optimization and dedicated columns, it means all
-  non-dedicated columns in that schema.
-
-Persist this option with `CREATE TABLE` or `ALTER TABLE` so the file schema
-records the interpretation. Upgrade all readers and maintenance jobs before
-enabling it: older readers treat a missing list as all table columns. Readers
-support both encodings without a read option. Before rolling back to an older
-reader, rewrite the files produced with this option or keep the readers
-upgraded.
-
-### Inspect the Layout
-
-Use the `$files` system table to inspect the live file metadata:
-
-```sql
-SELECT file_path, schema_id, write_cols,
-       first_row_id,
-       first_row_id + record_count - 1 AS last_row_id,
-       record_count, max_sequence_number
-FROM default.`target_table$files`
-ORDER BY first_row_id, max_sequence_number;
-```
-
-Compare both endpoints when checking normal-file alignment, and compare each
-dedicated range against a **single** normal range. Summing `record_count`
-across all files overcounts logical rows because column versions and dedicated
-files can represent the same positions; deletion vectors reduce visible rows
-further. Use a table query for the logical row count.
+Choose [file sizes](./data-evolution-maintenance#file-sizing) with future
+partial-update costs in mind. See the [metadata reference](./data-evolution-file-layout#compact-write-column-metadata)
+before enabling compact write-column encoding, and use the
+[`$files` query](./data-evolution-file-layout#inspect-the-layout) to inspect alignment.

--- a/docs/docs/multimodal-table/global-index.mdx
+++ b/docs/docs/multimodal-table/global-index.mdx
@@ -137,12 +137,17 @@ Wait for the insert job to finish before building an index.
 
 <TabItem value="python-sdk" label="Python SDK">
 
+For the partition-scoped Python build and rebuild examples, create the table with
+this setup. It puts `dt` first to work around the current SDK's partition-predicate
+handling; keep the partition column in that position when following those examples.
+
 ```python
 import pyarrow as pa
 from pypaimon import Schema
 
 # `catalog` is the configured Paimon catalog; database `db` already exists.
 pa_schema = pa.schema([
+    ('dt', pa.string()),
     ('id', pa.int32()),
     ('name', pa.string()),
     ('category', pa.string()),
@@ -150,7 +155,6 @@ pa_schema = pa.schema([
     ('tags', pa.list_(pa.string())),
     ('embedding', pa.list_(pa.float32())),
     ('content', pa.string()),
-    ('dt', pa.string()),
 ])
 schema = Schema.from_pyarrow_schema(
     pa_schema,
@@ -163,6 +167,7 @@ schema = Schema.from_pyarrow_schema(
 catalog.create_table('db.my_table', schema, ignore_if_exists=False)
 table = catalog.get_table('db.my_table')
 data = pa.Table.from_pydict({
+    'dt': ['2026-06-18', '2026-06-18', '2026-06-19'],
     'id': [101, 102, 103],
     'name': ['a200', 'a300', 'a400'],
     'category': ['electronics', 'electronics', 'books'],
@@ -171,7 +176,6 @@ data = pa.Table.from_pydict({
     'embedding': [[1.0, 0.0, 0.0], [0.9, 0.1, 0.0], [0.0, 1.0, 0.0]],
     'content': ['paimon lake format and search', 'paimon full text search',
                 'vector search tutorial'],
-    'dt': ['2026-06-18', '2026-06-18', '2026-06-19'],
 }, schema=pa_schema)
 
 builder = table.new_batch_write_builder()

--- a/docs/docs/multimodal-table/global-index.mdx
+++ b/docs/docs/multimodal-table/global-index.mdx
@@ -1,6 +1,5 @@
 ---
 title: "Global Index"
-sidebar_position: 8
 ---
 
 import Tabs from '@theme/Tabs';
@@ -27,57 +26,112 @@ under the License.
 
 # Global Index
 
-## Overview
+<span id="overview" />
 
-Global Index is a powerful indexing mechanism for Data Evolution (append) tables. It enables efficient row-level lookups and filtering
-without full-table scans. Paimon supports multiple global index types:
+Global indexes map predicates or search requests to row IDs, which Paimon uses to
+read matching table rows. Choose scalar indexes for filtering, vector indexes for
+similarity search, and full-text indexes for scored text retrieval. Hybrid search
+combines scored routes; it is a query API rather than another stored index type.
 
-- **[BTree Index](./global-index/btree)**: A B-tree based index for scalar column lookups. Supports equality, IN, range predicates, and can be combined across multiple columns with AND/OR logic.
-- **[Bitmap Index](./global-index/bitmap)**: A bitmap based index for enum-like scalar dimensions and tag columns. Supports equality, IN, prefix match on string columns, complement predicates, and null checks with compressed row-id bitmaps.
-- **[Multivalue Index](./global-index/multivalue)**: A bitmap-backed index for element-membership predicates on `ARRAY` columns.
-- **[FM Index](./global-index/fm)**: An exact partitioned substring index for `CONTAINS` predicates on character columns.
-- **[Vector Index](./global-index/vector)**: An approximate nearest neighbor (ANN) index powered by Paimon's vector index library for vector similarity search.
-- **[Full-Text Index](./global-index/full-text)**: A full-text search index backed by the native full-text engine for text retrieval. Supports term matching and relevance scoring.
-- **[Hybrid Search](./global-index/hybrid-search)**: A multi-route search API that combines results from multiple vector routes, multiple full-text routes, or both before reading table rows.
+This guide covers Data Evolution append tables. Primary-key tables have a separate
+[index configuration and lifecycle](../primary-key-table/global-index).
+
+## Choose an Index
 
 | Index Type | Best For | Notes |
 |---|---|---|
-| BTree | Scalar filters on numeric, string, date, and timestamp columns | Best when predicates are selective, such as equality, IN, range, and null checks. |
-| Bitmap | Enum-like dimensions and tag columns | Best for equality, IN, string prefix match, complement predicates, and null checks over compressed row-id bitmaps. |
-| Multivalue | Membership tests on arrays of supported scalar elements | Best for `ARRAY_CONTAINS`, `ARRAYS_OVERLAP`, and `ARRAY_CONTAINS_ALL`. |
-| FM | Exact substring filters on character columns | Supports needles of any byte length and partitions the indexed text for bounded-memory construction and demand-loaded reads. |
-| Vector | Top-K similarity search on embeddings | Uses ANN algorithms. Tune build-time and search-time options to balance recall, latency, and index size. |
-| Full-Text | Keyword search over text columns | Uses full-text scoring and tokenizer configuration stored with each index file. |
-| Hybrid Search | Combining multiple vector routes, multiple full-text routes, or vector and full-text retrieval together | Runs multiple scored routes and merges them with a ranker before reading rows. |
+| [BTree](./global-index/btree) | Scalar filters on numeric, string, date, and timestamp columns | Best when predicates are selective, such as equality, IN, range, and null checks. |
+| [Bitmap](./global-index/bitmap) | Enum-like dimensions and tag columns | Best for equality, IN, string prefix match, complement predicates, and null checks over compressed row-id bitmaps. |
+| [Multivalue](./global-index/multivalue) | Membership tests on arrays of supported scalar elements | Best for `ARRAY_CONTAINS`, `ARRAYS_OVERLAP`, and `ARRAY_CONTAINS_ALL`. |
+| [FM](./global-index/fm) | Exact substring filters on character columns | Supports needles of any byte length and partitions the indexed text for bounded-memory construction and demand-loaded reads. |
+| [Vector](./global-index/vector) | Top-K similarity search on embeddings | Uses ANN algorithms. Tune build-time and search-time options to balance recall, latency, and index size. |
+| [Full-Text](./global-index/full-text) | Keyword search over text columns | Uses full-text scoring and tokenizer configuration stored with each index file. |
+| [Hybrid Search](./global-index/hybrid-search) | Combining multiple vector routes, multiple full-text routes, or vector and full-text retrieval together | Runs multiple scored routes and merges them with a ranker before reading rows. |
 
-Global indexes work on top of Data Evolution tables. To use global indexes, your table **must** have:
+:::caution Index coverage affects results
 
-- `'row-tracking.enabled' = 'true'`
-- `'data-evolution.enabled' = 'true'`
+The default search mode is `fast`. If an index covers only part of the table,
+matching rows outside that coverage can be omitted. Creating a table or appending
+data does not build a global index. Read [Coverage and Freshness](./global-index/manage-indexes#coverage-and-freshness)
+before using indexed queries on changing data.
 
-> Global index queries may not be exact when the index only covers part of the table data. If a query predicate matches the index, Paimon returns only the results from the indexed portion. Matching records in data that has not been indexed yet will not be returned.
+:::
 
 ## Prerequisites
 
-Create a table with the required properties:
+Start with a [configured Paimon catalog](./quick-start). Data Evolution requires
+an append table with row tracking enabled. The following examples assume the `db`
+database exists and that SQL uses that database. Load data before building indexes.
+
+`global-index.enabled` defaults to `true`; setting it does not create index files.
+
+The example table below is shared by the BTree, Bitmap, Multivalue, Vector, and
+Full-Text guides. It contains three-dimensional sample vectors and is partitioned
+by `dt`, so the partition-scoped build and drop examples also apply. Create and
+populate it once using one of the following alternatives.
 
 <Tabs groupId="global-index-create-table">
 
-<TabItem value="sql" label="SQL">
+<TabItem value="sql" label="Spark SQL">
 
 ```sql
 CREATE TABLE my_table (
     id INT,
     name STRING,
+    category STRING,
+    tag STRING,
     tags ARRAY<STRING>,
     embedding ARRAY<FLOAT>,
-    content STRING
-) TBLPROPERTIES (
+    content STRING,
+    dt STRING
+) PARTITIONED BY (dt) TBLPROPERTIES (
     'row-tracking.enabled' = 'true',
-    'data-evolution.enabled' = 'true',
-    'global-index.enabled' = 'true'
+    'data-evolution.enabled' = 'true'
 );
+
+INSERT INTO my_table VALUES
+    (101, 'a200', 'electronics', 'vip', array('blue', 'green'),
+     array(1.0f, 0.0f, 0.0f), 'paimon lake format and search', '2026-06-18'),
+    (102, 'a300', 'electronics', 'trial', array('green'),
+     array(0.9f, 0.1f, 0.0f), 'paimon full text search', '2026-06-18'),
+    (103, 'a400', 'books', 'standard', array('red'),
+     array(0.0f, 1.0f, 0.0f), 'vector search tutorial', '2026-06-19');
 ```
+
+</TabItem>
+
+<TabItem value="flink-sql" label="Flink SQL">
+
+```sql
+SET 'execution.runtime-mode' = 'batch';
+
+CREATE TABLE my_table (
+    id INT,
+    name STRING,
+    category STRING,
+    tag STRING,
+    tags ARRAY<STRING>,
+    embedding ARRAY<FLOAT>,
+    content STRING,
+    dt STRING
+) PARTITIONED BY (dt) WITH (
+    'row-tracking.enabled' = 'true',
+    'data-evolution.enabled' = 'true'
+);
+
+INSERT INTO my_table VALUES
+    (101, 'a200', 'electronics', 'vip', ARRAY['blue', 'green'],
+     ARRAY[CAST(1.0 AS FLOAT), CAST(0.0 AS FLOAT), CAST(0.0 AS FLOAT)],
+     'paimon lake format and search', '2026-06-18'),
+    (102, 'a300', 'electronics', 'trial', ARRAY['green'],
+     ARRAY[CAST(0.9 AS FLOAT), CAST(0.1 AS FLOAT), CAST(0.0 AS FLOAT)],
+     'paimon full text search', '2026-06-18'),
+    (103, 'a400', 'books', 'standard', ARRAY['red'],
+     ARRAY[CAST(0.0 AS FLOAT), CAST(1.0 AS FLOAT), CAST(0.0 AS FLOAT)],
+     'vector search tutorial', '2026-06-19');
+```
+
+Wait for the insert job to finish before building an index.
 
 </TabItem>
 
@@ -85,367 +139,90 @@ CREATE TABLE my_table (
 
 ```python
 import pyarrow as pa
-
 from pypaimon import Schema
 
+# `catalog` is the configured Paimon catalog; database `db` already exists.
+pa_schema = pa.schema([
+    ('id', pa.int32()),
+    ('name', pa.string()),
+    ('category', pa.string()),
+    ('tag', pa.string()),
+    ('tags', pa.list_(pa.string())),
+    ('embedding', pa.list_(pa.float32())),
+    ('content', pa.string()),
+    ('dt', pa.string()),
+])
 schema = Schema.from_pyarrow_schema(
-    pa.schema([
-        pa.field("id", pa.int32()),
-        pa.field("name", pa.string()),
-        pa.field("tags", pa.list_(pa.string())),
-        pa.field("embedding", pa.list_(pa.float32())),
-        pa.field("content", pa.string()),
-    ]),
+    pa_schema,
+    partition_keys=['dt'],
     options={
-        "row-tracking.enabled": "true",
-        "data-evolution.enabled": "true",
-        "global-index.enabled": "true",
+        'row-tracking.enabled': 'true',
+        'data-evolution.enabled': 'true',
     },
 )
+catalog.create_table('db.my_table', schema, ignore_if_exists=False)
+table = catalog.get_table('db.my_table')
+data = pa.Table.from_pydict({
+    'id': [101, 102, 103],
+    'name': ['a200', 'a300', 'a400'],
+    'category': ['electronics', 'electronics', 'books'],
+    'tag': ['vip', 'trial', 'standard'],
+    'tags': [['blue', 'green'], ['green'], ['red']],
+    'embedding': [[1.0, 0.0, 0.0], [0.9, 0.1, 0.0], [0.0, 1.0, 0.0]],
+    'content': ['paimon lake format and search', 'paimon full text search',
+                'vector search tutorial'],
+    'dt': ['2026-06-18', '2026-06-18', '2026-06-19'],
+}, schema=pa_schema)
 
-catalog.create_table("db.my_table", schema, ignore_if_exists=False)
+builder = table.new_batch_write_builder()
+write = builder.new_write()
+commit = builder.new_commit()
+try:
+    write.write_arrow(data)
+    commit.commit(write.prepare_commit())
+finally:
+    write.close()
+    commit.close()
 ```
 
 </TabItem>
 
 </Tabs>
+
+The sample vectors illustrate the API; they are not model-generated embeddings.
+For real data, use the same model, dimension, and preprocessing for stored and
+query vectors. The Hybrid Search guide creates a separate table with two vector columns.
 
 ## Lifecycle
 
-Create global indexes for all partitions or only selected partitions:
+1. Load rows into the table.
+2. [Build indexes](./global-index/manage-indexes#build-an-index) for the columns and partitions used by queries.
+3. [Inspect row-ID coverage](./global-index/manage-indexes#inspect-index-coverage).
+4. Query through the relevant index or search API, then build again after ingesting more rows.
 
-<Tabs groupId="global-index-build">
-
-<TabItem value="sql" label="SQL">
-
-```sql
-CALL sys.create_global_index(
-    table => 'db.my_table',
-    index_column => 'name',
-    index_type => 'btree'
-);
-
-CALL sys.create_global_index(
-    table => 'db.my_table',
-    index_column => 'name',
-    index_type => 'btree',
-    partitions => 'dt=2026-06-18;dt=2026-06-19'
-);
-```
-
-</TabItem>
-
-<TabItem value="python-sdk" label="Python SDK">
-
-```python
-table = catalog.get_table("db.my_table")
-
-added_files = table.create_global_index("name")
-print(added_files)
-```
-
-The API returns the number of committed index files. You can pass build options and restrict the
-build to selected partitions:
-
-```python
-added_files = table.create_global_index(
-    "name",
-    index_type="btree",
-    partitions=[{"dt": "2026-06-18"}, {"dt": "2026-06-19"}],
-    options={"sorted-index.records-per-range": "10000000"},
-)
-```
-
-</TabItem>
-
-</Tabs>
-
-PyPaimon global index build currently supports single-column BTree indexes,
-single-column Bitmap indexes, single-column paimon-vindex vector indexes,
-and single-column full-text indexes on tables with row tracking enabled.
-
-Drop index files:
-
-<Tabs groupId="global-index-drop">
-
-<TabItem value="sql" label="SQL">
-
-```sql
-CALL sys.drop_global_index(
-    table => 'db.my_table',
-    index_column => 'name',
-    index_type => 'btree'
-);
-```
-
-</TabItem>
-
-<TabItem value="python-sdk" label="Python SDK">
-
-```python
-table = catalog.get_table("db.my_table")
-
-dropped_files = table.drop_global_index("name", index_type="btree")
-print(dropped_files)
-```
-
-You can also restrict the drop to selected partitions, or count matched files without committing:
-
-```python
-matched_files = table.drop_global_index(
-    "name",
-    index_type="btree",
-    partitions=[{"dt": "2026-06-18"}, {"dt": "2026-06-19"}],
-    dry_run=True,
-)
-```
-
-</TabItem>
-
-</Tabs>
-
-Global indexes are stored in index files and recorded in table metadata. To inspect index files and
-their row-id coverage, query the `table_indexes` system table:
-
-<Tabs groupId="global-index-table-indexes">
-
-<TabItem value="sql" label="SQL">
-
-```sql
-SELECT index_type, index_field_name, row_range_start, row_range_end
-FROM my_table$table_indexes
-WHERE index_field_name IS NOT NULL;
-```
-
-</TabItem>
-
-<TabItem value="python-sdk" label="Python SDK">
-
-```python
-import pyarrow.compute as pc
-
-table_indexes = catalog.get_table("db.my_table$table_indexes")
-read_builder = table_indexes.new_read_builder().with_projection([
-    "index_type",
-    "index_field_name",
-    "row_range_start",
-    "row_range_end",
-])
-
-pa_table = read_builder.new_read().to_arrow(
-    read_builder.new_scan().plan().splits()
-)
-pa_table = pa_table.filter(pc.is_valid(pa_table["index_field_name"]))
-print(pa_table)
-```
-
-</TabItem>
-
-</Tabs>
-
-You can also query `file_key_ranges` to inspect data file row-id ranges and diagnose coverage:
-
-<Tabs groupId="global-index-file-key-ranges">
-
-<TabItem value="sql" label="SQL">
-
-```sql
-SELECT file_path, first_row_id, record_count
-FROM my_table$file_key_ranges;
-```
-
-</TabItem>
-
-<TabItem value="python-sdk" label="Python SDK">
-
-```python
-file_key_ranges = catalog.get_table("db.my_table$file_key_ranges")
-read_builder = file_key_ranges.new_read_builder().with_projection([
-    "file_path",
-    "first_row_id",
-    "record_count",
-])
-
-pa_table = read_builder.new_read().to_arrow(
-    read_builder.new_scan().plan().splits()
-)
-print(pa_table)
-```
-
-</TabItem>
-
-</Tabs>
-
-For workloads that need newly appended rows to become visible only after existing global indexes
-cover them, enable the visibility callback:
-
-<Tabs groupId="global-index-visibility-callback">
-
-<TabItem value="sql" label="SQL">
-
-```sql
-ALTER TABLE my_table SET (
-    'visibility-callback.enabled' = 'true',
-    'visibility-callback.timeout' = '30 min'
-);
-```
-
-</TabItem>
-
-<TabItem value="python-sdk" label="Python SDK">
-
-```python
-from pypaimon.schema.schema_change import SchemaChange
-
-catalog.alter_table(
-    "db.my_table",
-    [
-        SchemaChange.set_option("visibility-callback.enabled", "true"),
-        SchemaChange.set_option("visibility-callback.timeout", "30 min"),
-    ],
-)
-```
-
-</TabItem>
-
-</Tabs>
+Use [Manage Global Indexes](./global-index/manage-indexes) for SQL/Python build and drop
+examples, inspection queries, and visibility callbacks.
 
 ## Coverage and Freshness
 
-Global index files cover row-id ranges. If more rows are appended after an index is built, those
-new rows are not automatically covered by the existing index files. Build the global index again
-to create index files for newly uncovered data. Scalar queries default to `fast` search, while
-vector and full-text queries default to `fast` and only search indexed row ranges.
-
-To improve freshness for query types that support raw-data search, set:
-
-<Tabs groupId="global-index-search-mode">
-
-<TabItem value="sql" label="SQL">
-
-```sql
-ALTER TABLE my_table SET ('vector-index.search-mode' = 'full');
-```
-
-</TabItem>
-
-<TabItem value="python-sdk" label="Python SDK">
-
-```python
-from pypaimon.schema.schema_change import SchemaChange
-
-catalog.alter_table(
-    "db.my_table",
-    [SchemaChange.set_option("vector-index.search-mode", "full")],
-)
-```
-
-For a read-only override on an existing `Table` instance:
-
-```python
-full_table = table.copy({"vector-index.search-mode": "full"})
-```
-
-</TabItem>
-
-</Tabs>
-
-With `full` search, supported global-index queries first use the snapshot `nextRowId` and global
-index row-id coverage to detect whether any row range is missing from the index. Raw data is scanned
-only when such a gap exists. Use `detail` search when data files may have been rewritten or updated
-after index creation; it scans data file metadata to find the exact unindexed row ranges and can
-handle index invalidation caused by updates or rewrites.
-
-Use `scalar-index.search-mode`, `vector-index.search-mode`, or
-`full-text-index.search-mode` for one index family. The legacy
-`global-index.search-mode` has no default and is used as a fallback when the corresponding
-family-specific option is not explicitly configured.
-
-To temporarily disable global-index scan acceleration while keeping the index files, set:
-
-<Tabs groupId="global-index-enabled">
-
-<TabItem value="sql" label="SQL">
-
-```sql
-ALTER TABLE my_table SET ('global-index.enabled' = 'false');
-```
-
-</TabItem>
-
-<TabItem value="python-sdk" label="Python SDK">
-
-```python
-from pypaimon.schema.schema_change import SchemaChange
-
-catalog.alter_table(
-    "db.my_table",
-    [SchemaChange.set_option("global-index.enabled", "false")],
-)
-```
-
-</TabItem>
-
-</Tabs>
-
-Set it back to `true` to use global indexes during scans again.
+Choose `fast`, `full`, or `detail` according to how queries should include uncovered
+rows. See the [search-mode comparison](./global-index/manage-indexes#coverage-and-freshness).
+Updates to indexed values also need an
+[update policy and index refresh](./global-index/manage-indexes#update-indexed-columns);
+row-ID coverage alone does not prove that indexed values are current.
 
 ## Build Options
 
-These table options affect global index build and read behavior:
+See [shared options](./global-index/manage-indexes#shared-options) for shard sizing,
+build parallelism, update policy, and search modes. Each index page documents its
+own format and tuning options.
 
-| Option | Default | Description |
-|---|---|---|
-| `global-index.enabled` | `true` | Whether scans can use global indexes. |
-| `global-index.search-mode` | Not set | Legacy fallback search mode for global-index queries. Family-specific options take precedence. |
-| `scalar-index.search-mode` | `fast` | Search mode for BTree, Bitmap, Multivalue, and FM queries. |
-| `vector-index.search-mode` | `fast` | Search mode for vector queries. |
-| `full-text-index.search-mode` | `fast` | Search mode for full-text queries. |
-| `global-index.external-path` | Not set | Root directory for global index files. If not set, files are stored under the table index directory. |
-| `global-index.column-update-action` | `THROW_ERROR` | Action for updates to indexed columns. `THROW_ERROR` rejects the update, `DROP_PARTITION_INDEX` drops affected partition indexes, and `IGNORE` keeps existing index files unchanged during the update and causes the next incremental index build to scan active data manifests and rebuild affected row ranges. Index files created before source metadata was introduced are not refreshed automatically. |
-| `sorted-index.records-per-range` | `10000000` | Expected number of records per sorted global index file for BTree, Bitmap, and Multivalue builds. |
-| `sorted-index.build.max-parallelism` | `4096` | Maximum Flink or Spark parallelism for building sorted global indexes. |
-| `global-index.row-count-per-shard` | `100000` | Target row count per shard for non-sorted global index builds such as vector and full-text indexes. |
-| `global-index.build.max-shard` | `32` | Preferred maximum shard count for global index builds. |
-| `global-index.build.max-parallelism` | `4096` | Maximum Flink or Spark parallelism for building non-sorted global indexes. |
-| `global-index.thread-num` | `32` | Maximum number of concurrent threads for global index I/O. |
-| `visibility-callback.enabled` | `false` | Whether batch or bounded-stream commits wait until existing global indexes cover newly added files. |
-| `visibility-callback.timeout` | `30 min` | Maximum wait time for visibility callback. |
+<span id="btree-index" />
+<span id="bitmap-index" />
+<span id="multivalue-index" />
+<span id="fm-index" />
+<span id="vector-index" />
+<span id="full-text-index" />
+<span id="hybrid-search" />
 
-## BTree Index
-
-Use BTree indexes for scalar column lookups and range predicates. See [BTree Index](./global-index/btree)
-for build and query examples.
-
-## Bitmap Index
-
-Use Bitmap indexes for enum-like dimensions and tag columns queried by equality, IN, string prefix
-match, complement, or null predicates. See [Bitmap Index](./global-index/bitmap) for build examples,
-options, and file format details.
-
-## Multivalue Index
-
-Use Multivalue indexes for element-membership predicates on `ARRAY` columns. See
-[Multivalue Index](./global-index/multivalue) for Data Evolution build examples, Core query usage,
-options, and null/empty membership semantics.
-
-## FM Index
-
-Use FM indexes for exact substring predicates on character columns. See
-[FM Index](./global-index/fm) for build examples, exactness and coverage semantics, tuning options,
-and primary-key table configuration.
-
-## Vector Index
-
-Use Vector indexes for approximate nearest neighbor (ANN) search. See [Vector Index](./global-index/vector)
-for supported index types, options, and search examples.
-
-## Full-Text Index
-
-Use Full-Text indexes for text retrieval backed by the native full-text engine. See [Full-Text Index](./global-index/full-text)
-for tokenizer options and search examples.
-
-## Hybrid Search
-
-Use Hybrid Search to query multiple vector routes, multiple full-text routes, or a mix of both in one request. See
-[Hybrid Search](./global-index/hybrid-search) for route configuration, rankers, and API examples.
+Use the [index selection table](#choose-an-index) above to open build and query examples.

--- a/docs/docs/multimodal-table/global-index/bitmap.mdx
+++ b/docs/docs/multimodal-table/global-index/bitmap.mdx
@@ -57,7 +57,14 @@ fall back to scanning bitmap dictionary entries only when the total size of cand
 bitmap index files is within the configured fallback scan budget. If the budget is
 exceeded, Paimon falls back to other matching indexes or regular table scans.
 
+For table prerequisites, see [Global Index](../global-index#prerequisites).
+For refresh, coverage modes, and shared build options, see
+[Manage Global Indexes](./manage-indexes).
+
 ## Build Bitmap Index
+
+Use the populated [shared example table](../global-index#prerequisites). It includes
+the indexed column and the `dt` partition key used in the examples below.
 
 <Tabs groupId="bitmap-build">
 
@@ -125,59 +132,6 @@ PyPaimon bitmap index build currently supports `bitmap-index.compression` set to
 `none`, which is also the default. Use SQL if you need to build bitmap index files
 with compressed dictionary blocks.
 
-## Drop Bitmap Index
-
-<Tabs groupId="bitmap-drop">
-
-<TabItem value="sql" label="SQL">
-
-```sql
-CALL sys.drop_global_index(
-    table => 'db.my_table',
-    index_column => 'tag',
-    index_type => 'bitmap'
-);
-```
-
-</TabItem>
-
-<TabItem value="python-sdk" label="Python SDK">
-
-```python
-table = catalog.get_table("db.my_table")
-
-dropped_files = table.drop_global_index("tag", index_type="bitmap")
-print(dropped_files)
-```
-
-You can also restrict the drop to selected partitions, or count matched files
-without committing:
-
-```python
-matched_files = table.drop_global_index(
-    "tag",
-    index_type="bitmap",
-    partitions=[{"dt": "2026-06-18"}, {"dt": "2026-06-19"}],
-    dry_run=True,
-)
-print(matched_files)
-```
-
-</TabItem>
-
-</Tabs>
-
-## Bitmap Options
-
-| Option | Default | Description |
-|---|---|---|
-| `sorted-index.records-per-range` | `10000000` | Expected number of records per sorted global index file for BTree, Bitmap, and Multivalue builds. |
-| `sorted-index.build.max-parallelism` | `4096` | Maximum Flink or Spark parallelism for building sorted global indexes. |
-| `bitmap-index.dictionary-block-size` | `16 kb` | Target size of dictionary blocks in bitmap global index files. Smaller blocks reduce dictionary read amplification for high-cardinality columns; larger blocks reduce dictionary block index size. |
-| `bitmap-index.compression` | `none` | Compression algorithm for bitmap dictionary blocks and the dictionary block index. Supported values are the same block codecs as BTree index, such as `none`, `lz4`, `lzo`, and `zstd`. |
-| `bitmap-index.compression-level` | `1` | Compression level used by codecs that support levels, such as `zstd`. |
-| `bitmap-index.fallback-scan-max-size` | `256 mb` | Maximum total size of bitmap global index files in one reader to allow fallback dictionary scans for predicates that cannot use direct bitmap lookup. Set to `0 b` to disable fallback scans. |
-
 ## Query with Bitmap Index
 
 Once a bitmap index is built, it is automatically used during scan when a filter
@@ -221,6 +175,59 @@ For complement predicates such as `tag != 'blocked'` or
 index file's own non-null row-id bitmap. This keeps results correct when one logical
 query unions multiple bitmap index files.
 
+## Bitmap Options
+
+| Option | Default | Description |
+|---|---|---|
+| `sorted-index.records-per-range` | `10000000` | Expected number of records per sorted global index file for BTree, Bitmap, and Multivalue builds. |
+| `sorted-index.build.max-parallelism` | `4096` | Maximum Flink or Spark parallelism for building sorted global indexes. |
+| `bitmap-index.dictionary-block-size` | `16 kb` | Target size of dictionary blocks in bitmap global index files. Smaller blocks reduce dictionary read amplification for high-cardinality columns; larger blocks reduce dictionary block index size. |
+| `bitmap-index.compression` | `none` | Compression algorithm for bitmap dictionary blocks and the dictionary block index. Supported values are the same block codecs as BTree index, such as `none`, `lz4`, `lzo`, and `zstd`. |
+| `bitmap-index.compression-level` | `1` | Compression level used by codecs that support levels, such as `zstd`. |
+| `bitmap-index.fallback-scan-max-size` | `256 mb` | Maximum total size of bitmap global index files in one reader to allow fallback dictionary scans for predicates that cannot use direct bitmap lookup. Set to `0 b` to disable fallback scans. |
+
+## Drop Bitmap Index
+
+<Tabs groupId="bitmap-drop">
+
+<TabItem value="sql" label="SQL">
+
+```sql
+CALL sys.drop_global_index(
+    table => 'db.my_table',
+    index_column => 'tag',
+    index_type => 'bitmap'
+);
+```
+
+</TabItem>
+
+<TabItem value="python-sdk" label="Python SDK">
+
+```python
+table = catalog.get_table("db.my_table")
+
+dropped_files = table.drop_global_index("tag", index_type="bitmap")
+print(dropped_files)
+```
+
+You can also restrict the drop to selected partitions, or count matched files
+without committing:
+
+```python
+matched_files = table.drop_global_index(
+    "tag",
+    index_type="bitmap",
+    partitions=[{"dt": "2026-06-18"}, {"dt": "2026-06-19"}],
+    dry_run=True,
+)
+print(matched_files)
+```
+
+</TabItem>
+
+</Tabs>
+
 ## File Format
 
 A bitmap global index file stores exact row-id bitmaps and a block-indexed dictionary.
@@ -230,21 +237,7 @@ predicate needs them. Point lookups then read the dictionary block containing th
 target value and the corresponding bitmap block. The format is footer-driven: the
 footer stores the version, magic number, and offsets to all metadata blocks.
 
-```text
-+----------------------------------------------+
-| null rows bitmap block                       |
-+----------------------------------------------+
-| non-null rows bitmap block                   |
-+----------------------------------------------+
-| value bitmap and dictionary payload blocks   |
-+----------------------------------------------+
-| ...                                          |
-+----------------------------------------------+
-| dictionary block index                       |
-+----------------------------------------------+
-| footer                                       |
-+----------------------------------------------+
-```
+![Bitmap file regions and footer-first point lookup through the dictionary index, dictionary block, and value bitmap.](/img/multimodal-bitmap-layout.svg)
 
 Each bitmap block is a serialized `RoaringNavigableMap64`. Bitmap blocks are not wrapped
 with an additional compression layer because Roaring already stores row ids compactly.
@@ -257,17 +250,12 @@ to be physically contiguous.
 Each dictionary block stores sorted value entries. Keys are serialized with the same
 key serializer as BTree global index keys, and are ordered by serialized bytes:
 
-```text
-+----------------------------------------------+
-| entry count (var-length int)                 |
-+----------------------------------------------+
-| key length (var-length int), key bytes       |
-| bitmap block offset (var-length long)        |
-| bitmap block length (var-length int)         |
-+----------------------------------------------+
-| ...                                          |
-+----------------------------------------------+
-```
+| Dictionary block field | Encoding |
+| --- | --- |
+| Entry count | Variable-length int |
+| Key length and bytes (per entry) | Variable-length int, byte array |
+| Bitmap offset (per entry) | Variable-length long |
+| Bitmap length (per entry) | Variable-length int |
 
 The dictionary block body above is stored as a BTree-style compressed block. The
 configured dictionary compression is attempted when writing, and the uncompressed body is
@@ -278,17 +266,12 @@ dictionary block `length` is the block body length and does not include the trai
 The dictionary block index stores one entry per dictionary block and is small enough to
 load when the index file is opened:
 
-```text
-+----------------------------------------------+
-| block count (var-length int)                 |
-+----------------------------------------------+
-| first key length (var-length int), key bytes |
-| dictionary block offset (var-length long)    |
-| dictionary block length (var-length int)     |
-+----------------------------------------------+
-| ...                                          |
-+----------------------------------------------+
-```
+| Dictionary block index field | Encoding |
+| --- | --- |
+| Block count | Variable-length int |
+| First key length and bytes (per block) | Variable-length int, byte array |
+| Dictionary block offset (per block) | Variable-length long |
+| Dictionary block length (per block) | Variable-length int |
 
 The dictionary block index uses the same compressed-block encoding and 5-byte trailer as
 dictionary blocks. The footer's dictionary block index `length` also excludes this
@@ -296,19 +279,14 @@ trailer.
 
 The footer has fixed length and points to the main metadata blocks:
 
-```text
-+----------------------------------------------+
-| null rows block offset (long)                |
-| null rows block length (int)                 |
-| non-null rows block offset (long)            |
-| non-null rows block length (int)             |
-| dictionary block index offset (long)         |
-| dictionary block index length (int)          |
-| value count (int)                            |
-| version (int) = 1                            |
-| magic (int)                                  |
-+----------------------------------------------+
-```
+| Footer field (in order) | Encoding |
+| --- | --- |
+| Null-row bitmap offset, length | Long, int |
+| Non-null-row bitmap offset, length | Long, int |
+| Dictionary block index offset, length | Long, int |
+| Value count | Int |
+| Version | Int (`1`) |
+| Magic | Int |
 
 The sorted dictionary block index lets equality and `IN` predicates locate candidate
 values by binary search without deserializing every dictionary block or value bitmap in
@@ -319,15 +297,13 @@ non-null key, maximum non-null key, and whether the file contains null values. T
 uses this metadata to skip impossible files before opening bitmap index files, similar to
 BTree global index file pruning.
 
-```text
-+----------------------------------------------+
-| first key length (int), first key bytes      |
-| last key length (int), last key bytes        |
-| has nulls (byte)                             |
-| metadata version (byte) = 1                  |
-| null key flags (byte)                        |
-+----------------------------------------------+
-```
+| Manifest metadata field (in order) | Encoding |
+| --- | --- |
+| First key length and bytes | Int, byte array |
+| Last key length and bytes | Int, byte array |
+| Has nulls | Byte |
+| Metadata version | Byte (`1`) |
+| Null-key flags | Byte |
 
 For predicates that cannot be resolved by point or prefix lookup, the reader may scan all
 dictionary blocks and read matching bitmap blocks. This fallback is guarded by

--- a/docs/docs/multimodal-table/global-index/btree.mdx
+++ b/docs/docs/multimodal-table/global-index/btree.mdx
@@ -46,7 +46,14 @@ Use `btree-index.fallback-scan-max-size` to cap fallback range and string scans 
 candidate index file size.
 For keyword-style text retrieval, use [Full-Text Index](./full-text) instead.
 
+For table prerequisites, see [Global Index](../global-index#prerequisites).
+For refresh, coverage modes, and shared build options, see
+[Manage Global Indexes](./manage-indexes).
+
 ## Build BTree Index
+
+Use the populated [shared example table](../global-index#prerequisites). It includes
+the indexed column and the `dt` partition key used in the examples below.
 
 <Tabs groupId="btree-build">
 
@@ -101,6 +108,57 @@ print(added_files)
 
 </Tabs>
 
+## Query with BTree Index
+
+Once a BTree index is built, it is automatically used during scan when a filter predicate matches the indexed column.
+
+<Tabs groupId="btree-search">
+
+<TabItem value="sql" label="SQL">
+
+```sql
+SELECT * FROM my_table WHERE name IN ('a200', 'a300');
+```
+
+</TabItem>
+
+<TabItem value="python-sdk" label="Python SDK">
+
+```python
+from pypaimon.common.predicate_builder import PredicateBuilder
+
+table = catalog.get_table("db.my_table")
+
+read_builder = table.new_read_builder()
+read_builder = read_builder.with_filter(
+    PredicateBuilder(table.fields)
+    .is_in("name", ["a200", "a300"])
+)
+
+scan = read_builder.new_scan()
+read = read_builder.new_read()
+pa_table = read.to_arrow(scan.plan().splits())
+print(pa_table)
+```
+
+</TabItem>
+
+</Tabs>
+
+## BTree Options
+
+| Option | Default | Description |
+|---|---|---|
+| `sorted-index.records-per-range` | `10000000` | Expected number of records per sorted global index file for BTree, Bitmap, and Multivalue builds. |
+| `sorted-index.build.max-parallelism` | `4096` | Maximum Flink or Spark parallelism for building sorted global indexes. |
+| `btree-index.block-size` | `64 kb` | Block size used by BTree index files. |
+| `btree-index.cache-size` | `128 mb` | Cache size used by BTree index readers. |
+| `btree-index.fallback-scan-max-size` | `256 mb` | Maximum total size of candidate BTree global index files to allow fallback index scans. Set to `0 b` to disable fallback scans. |
+| `btree-index.compression` | `none` | Compression algorithm used by BTree index blocks. |
+
+The legacy `btree-index.records-per-range` and
+`btree-index.build.max-parallelism` keys are still recognized as fallback keys.
+
 ## Drop BTree Index
 
 <Tabs groupId="btree-drop">
@@ -137,57 +195,6 @@ matched_files = table.drop_global_index(
     dry_run=True,
 )
 print(matched_files)
-```
-
-</TabItem>
-
-</Tabs>
-
-## BTree Options
-
-| Option | Default | Description |
-|---|---|---|
-| `sorted-index.records-per-range` | `10000000` | Expected number of records per sorted global index file for BTree, Bitmap, and Multivalue builds. |
-| `sorted-index.build.max-parallelism` | `4096` | Maximum Flink or Spark parallelism for building sorted global indexes. |
-| `btree-index.block-size` | `64 kb` | Block size used by BTree index files. |
-| `btree-index.cache-size` | `128 mb` | Cache size used by BTree index readers. |
-| `btree-index.fallback-scan-max-size` | `256 mb` | Maximum total size of candidate BTree global index files to allow fallback index scans. Set to `0 b` to disable fallback scans. |
-| `btree-index.compression` | `none` | Compression algorithm used by BTree index blocks. |
-
-The legacy `btree-index.records-per-range` and
-`btree-index.build.max-parallelism` keys are still recognized as fallback keys.
-
-## Query with BTree Index
-
-Once a BTree index is built, it is automatically used during scan when a filter predicate matches the indexed column.
-
-<Tabs groupId="btree-search">
-
-<TabItem value="sql" label="SQL">
-
-```sql
-SELECT * FROM my_table WHERE name IN ('a200', 'a300');
-```
-
-</TabItem>
-
-<TabItem value="python-sdk" label="Python SDK">
-
-```python
-from pypaimon.common.predicate_builder import PredicateBuilder
-
-table = catalog.get_table("db.my_table")
-
-read_builder = table.new_read_builder()
-read_builder = read_builder.with_filter(
-    PredicateBuilder(table.fields)
-    .is_in("name", ["a200", "a300"])
-)
-
-scan = read_builder.new_scan()
-read = read_builder.new_read()
-pa_table = read.to_arrow(scan.plan().splits())
-print(pa_table)
 ```
 
 </TabItem>

--- a/docs/docs/multimodal-table/global-index/fm.mdx
+++ b/docs/docs/multimodal-table/global-index/fm.mdx
@@ -35,26 +35,20 @@ blocks instead of downloading the complete container. If locating matches would 
 index declines the predicate so the normal data path can scan the source values and preserve exact
 results.
 
+For shared build, refresh, and coverage behavior, see
+[Manage Global Indexes](./manage-indexes).
+
 ## Create a Global FM Index
 
-Create the index on a Data Evolution table with row tracking enabled:
+Create and populate the [shared example table](../global-index#prerequisites),
+then index its `content` column:
 
 ```sql
 CALL sys.create_global_index(
-    table => 'db.documents',
+    table => 'db.my_table',
     index_column => 'content',
     index_type => 'fm',
     options => 'fm-index.partition-row-count=100000'
-);
-```
-
-Drop it with the same index type:
-
-```sql
-CALL sys.drop_global_index(
-    table => 'db.documents',
-    index_column => 'content',
-    index_type => 'fm'
 );
 ```
 
@@ -68,17 +62,29 @@ normal batch scan uses the FM index automatically. For example, Spark pushes dow
 
 ```sql
 SELECT id, content
-FROM documents
-WHERE content LIKE '%needle%';
+FROM my_table
+WHERE content LIKE '%paimon%';
 ```
 
 Results are exact inside every indexed row range. A table-wide global-index query can still omit
 matches in row ranges that have never been indexed; rebuild the index for newly appended ranges or
-use the visibility callback described on the Global Index page.
+choose a suitable [search mode](./manage-indexes#coverage-and-freshness).
+The [visibility callback](./manage-indexes#wait-for-index-visibility) can wait for
+a separate index-building job to cover committed data; it does not build indexes.
 
 For a primary-key table, configure `pk-fm.index.columns` instead. Primary-key FM indexes follow
 data compaction and scan uncovered files through the ordinary data path, so partial coverage does
 not make `CONTAINS` results incomplete. See [Primary-Key Indexes](../../primary-key-table/global-index).
+
+## Drop the Index
+
+```sql
+CALL sys.drop_global_index(
+    table => 'db.my_table',
+    index_column => 'content',
+    index_type => 'fm'
+);
+```
 
 ## Options
 

--- a/docs/docs/multimodal-table/global-index/full-text.mdx
+++ b/docs/docs/multimodal-table/global-index/full-text.mdx
@@ -38,11 +38,20 @@ itself is a JSON string accepted by `paimon-full-text-index`.
 Full-text indexes are scored by the native engine and can be used directly, or
 combined with vector routes in [Hybrid Search](./hybrid-search).
 
+For table prerequisites, see [Global Index](../global-index#prerequisites).
+For refresh, coverage modes, and shared build options, see
+[Manage Global Indexes](./manage-indexes).
+
 ## Build Full-Text Index
 
 Build full-text indexes on `STRING`, `CHAR`, or `VARCHAR` columns. Null values
 are skipped by the native text index, while row-id coverage is still tracked by
 Paimon.
+
+Start with the populated [shared example table](../global-index#prerequisites).
+Choose one tokenizer before the initial build: the SQL and Python calls below
+show alternative configurations. Repeating a build with different options does
+not retokenize rows already covered by the index.
 
 <Tabs groupId="fulltext-build">
 
@@ -151,50 +160,10 @@ Tokenizer settings are stored in the global index file metadata. Existing index
 files keep the tokenizer options they were built with, even if later index
 builds use different options.
 
-## Drop Full-Text Index
-
-<Tabs groupId="fulltext-drop">
-
-<TabItem value="sql" label="SQL">
-
-```sql
-CALL sys.drop_global_index(
-    table => 'db.my_table',
-    index_column => 'content',
-    index_type => 'full-text'
-);
-```
-
-</TabItem>
-
-<TabItem value="python-sdk" label="Python SDK">
-
-```python
-table = catalog.get_table("db.my_table")
-
-dropped_files = table.drop_global_index(
-    "content",
-    index_type="full-text",
-)
-print(dropped_files)
-```
-
-You can also restrict the drop to selected partitions, or count matched files
-without committing:
-
-```python
-matched_files = table.drop_global_index(
-    "content",
-    index_type="full-text",
-    partitions=[{"dt": "2026-06-18"}, {"dt": "2026-06-19"}],
-    dry_run=True,
-)
-print(matched_files)
-```
-
-</TabItem>
-
-</Tabs>
+To change tokenization for already indexed rows, [drop the index](#drop-full-text-index)
+and build it again with the new options. Use the same partition scope for both
+operations if changing only selected partitions. Coordinate the rebuild with
+queries that rely on complete coverage; `fast` searches only indexed ranges.
 
 ## Full-Text Search
 
@@ -215,7 +184,8 @@ FROM full_text_search(
     'content',
     '{"match":{"query":"paimon lake format"}}',
     10
-);
+)
+ORDER BY __paimon_search_score DESC, id;
 
 -- Require all query terms.
 SELECT id, content, __paimon_search_score
@@ -224,7 +194,8 @@ FROM full_text_search(
     'content',
     '{"match":{"query":"paimon lake format","operator":"And"}}',
     10
-);
+)
+ORDER BY __paimon_search_score DESC, id;
 
 -- Phrase query. The index must be built with full-text.with-position=true.
 SELECT id, content, __paimon_search_score
@@ -233,7 +204,8 @@ FROM full_text_search(
     'content',
     '{"match_phrase":{"query":"paimon lake"}}',
     10
-);
+)
+ORDER BY __paimon_search_score DESC, id;
 ```
 
 Spark exposes the score as the `__paimon_search_score` metadata column.
@@ -410,6 +382,51 @@ Use `boost` to down-rank rows that also match a negative query.
 | `negative` | Yes | N/A | Query used to down-rank matching rows. |
 | `negative_boost` | No | `0.5` | Positive multiplier applied to rows that also match `negative`. |
 
+## Drop Full-Text Index
+
+<Tabs groupId="fulltext-drop">
+
+<TabItem value="sql" label="SQL">
+
+```sql
+CALL sys.drop_global_index(
+    table => 'db.my_table',
+    index_column => 'content',
+    index_type => 'full-text'
+);
+```
+
+</TabItem>
+
+<TabItem value="python-sdk" label="Python SDK">
+
+```python
+table = catalog.get_table("db.my_table")
+
+dropped_files = table.drop_global_index(
+    "content",
+    index_type="full-text",
+)
+print(dropped_files)
+```
+
+You can also restrict the drop to selected partitions, or count matched files
+without committing:
+
+```python
+matched_files = table.drop_global_index(
+    "content",
+    index_type="full-text",
+    partitions=[{"dt": "2026-06-18"}, {"dt": "2026-06-19"}],
+    dry_run=True,
+)
+print(matched_files)
+```
+
+</TabItem>
+
+</Tabs>
+
 ## Notes
 
 - The table column is supplied by `full_text_search(..., column, query, limit)`,
@@ -419,5 +436,7 @@ Use `boost` to down-rank rows that also match a negative query.
   Paimon table column through the Paimon API instead.
 - The query string must be valid JSON understood by the native full-text reader.
   Invalid query syntax fails during search.
-- `limit` must be positive. Full-text results are returned in score order and
-  can be merged with vector results by hybrid search rankers.
+- `limit` must be positive. Full-text search selects top-K scored matches, which
+  can be combined with vector results by hybrid search rankers. A subsequent
+  table scan does not guarantee score order. Use explicit SQL ordering or access
+  scores by row ID; see [Read Scored Results](./manage-indexes#read-scored-results).

--- a/docs/docs/multimodal-table/global-index/hybrid-search.mdx
+++ b/docs/docs/multimodal-table/global-index/hybrid-search.mdx
@@ -33,30 +33,79 @@ combine multiple vector indexes, multiple full-text indexes, or a mix of vector 
 indexes. This is useful when one table stores several searchable representations for the same
 record, such as title embeddings, body embeddings, and content text.
 
+![Vector and full-text routes return scored row IDs; a ranker merges candidates and selects the final rows to read.](/img/multimodal-hybrid-search.svg)
+
+## Create the Example Table
+
+This example uses a separate table with two three-dimensional vector columns.
+In a configured Spark Paimon catalog, select the existing `db` database and run:
+
+```sql
+CREATE TABLE hybrid_documents (
+    id INT,
+    title_embedding ARRAY<FLOAT>,
+    body_embedding ARRAY<FLOAT>,
+    content STRING
+) TBLPROPERTIES (
+    'row-tracking.enabled' = 'true',
+    'data-evolution.enabled' = 'true'
+);
+
+INSERT INTO hybrid_documents VALUES
+    (1, array(1.0f, 0.0f, 0.0f), array(0.0f, 1.0f, 0.0f), 'paimon hybrid search'),
+    (2, array(0.9f, 0.1f, 0.0f), array(0.1f, 0.9f, 0.0f), 'paimon lake format'),
+    (3, array(0.0f, 1.0f, 0.0f), array(1.0f, 0.0f, 0.0f), 'vector search tutorial');
+```
+
+The Java and Python examples query this same table through their catalog. Use
+matching dimensions and model preprocessing for stored and query vectors in a
+real pipeline. The sample vectors here only illustrate route configuration.
+
+## Build the Route Indexes
+
 Before running hybrid search, create a global index for every vector or text column used by
 the query:
 
 ```sql
 CALL sys.create_global_index(
-    table => 'db.my_table',
+    table => 'db.hybrid_documents',
     index_column => 'title_embedding',
-    index_type => 'ivf-pq',
-    options => 'ivf-pq.distance.metric=cosine,ivf-pq.nlist=256,ivf-pq.pq.m=16'
+    index_type => 'ivf-flat',
+    options => 'ivf-flat.dimension=3,ivf-flat.distance.metric=cosine,ivf-flat.nlist=1'
 );
 
 CALL sys.create_global_index(
-    table => 'db.my_table',
+    table => 'db.hybrid_documents',
     index_column => 'body_embedding',
-    index_type => 'ivf-pq',
-    options => 'ivf-pq.distance.metric=cosine,ivf-pq.nlist=256,ivf-pq.pq.m=16'
+    index_type => 'ivf-flat',
+    options => 'ivf-flat.dimension=3,ivf-flat.distance.metric=cosine,ivf-flat.nlist=1'
 );
 
 CALL sys.create_global_index(
-    table => 'db.my_table',
+    table => 'db.hybrid_documents',
     index_column => 'content',
     index_type => 'full-text'
 );
 ```
+
+Alternatively, after creating and populating the table, build the same indexes
+with Python. Install `pypaimon[vindex,full-text]` for the native index dependencies:
+
+```python
+table = catalog.get_table("db.hybrid_documents")
+for column in ("title_embedding", "body_embedding"):
+    table.create_global_index(column, index_type="ivf-flat", options={
+        "ivf-flat.dimension": "3",
+        "ivf-flat.distance.metric": "cosine",
+        "ivf-flat.nlist": "1",
+    })
+table.create_global_index("content", index_type="full-text")
+```
+
+The sample uses one IVF cluster and queries it with `ivf.nprobe=1`. Larger indexes
+can use different build and [search options](./vector#search-options).
+
+## Choose a Ranker
 
 For Spark SQL, use the `hybrid_search(table_name, vector_routes, full_text_routes, limit[, ranker])`
 table-valued function. The fourth argument is the final number of ranked results to return.
@@ -70,6 +119,8 @@ Rankers combine route scores differently:
 | `rrf` | Combining routes with different score scales | Reciprocal rank fusion uses each route's rank order, so vector and full-text scores do not need to be normalized. |
 | `weighted_score` | Weighting routes by normalized score, not just rank | Min-max normalizes each route's scores to `[0, 1]`, then sums them weighted by route `weight`, so weights (not raw score magnitude) control each route's influence. The exposed `__paimon_search_score` is therefore a per-query relative value in `[0, sum of weights]`, not a raw similarity or BM25 score. |
 | `mrr` | Emphasizing top-ranked hits from each route | Weighted reciprocal-rank fusion sums `weight / rank` for each row returned by a route, where rank starts at 1. |
+
+## Configure Routes
 
 The second argument is an array of vector route configs created by `named_struct`:
 
@@ -99,6 +150,11 @@ Use route `limit` values larger than the final limit when each route should cont
 candidates for ranking. For example, with a final limit of `10`, route limits such as `50` or `100`
 give the ranker more candidates to merge.
 
+## Run Hybrid Search
+
+Route limits and the final limit are upper bounds. The three-row sample table
+returns at most three rows even when a route asks for `50` and the final limit is `10`.
+
 <Tabs groupId="hybrid-search">
 
 <TabItem value="spark-sql" label="Spark SQL">
@@ -108,14 +164,14 @@ Vector and full-text routes can be searched together:
 ```sql
 SELECT id, __paimon_search_score
 FROM hybrid_search(
-  'my_table',
+  'hybrid_documents',
   array(
     named_struct(
       'field', 'title_embedding',
       'query_vector', array(1.0f, 0.0f, 0.0f),
       'limit', 50,
       'weight', 2.0f,
-      'options', map('ivf.nprobe', '32'))),
+      'options', map('ivf.nprobe', '1'))),
   array(
     named_struct(
       'column', 'content',
@@ -124,7 +180,8 @@ FROM hybrid_search(
       'weight', 1.0f,
       'options', map())),
   10,
-  'rrf');
+  'rrf')
+ORDER BY __paimon_search_score DESC, id;
 ```
 
 To search two vector indexes without a full-text route, pass `array()` as the third argument:
@@ -132,23 +189,24 @@ To search two vector indexes without a full-text route, pass `array()` as the th
 ```sql
 SELECT id, __paimon_search_score
 FROM hybrid_search(
-  'my_table',
+  'hybrid_documents',
   array(
     named_struct(
       'field', 'title_embedding',
       'query_vector', array(1.0f, 0.0f, 0.0f),
       'limit', 50,
       'weight', 2.0f,
-      'options', map('ivf.nprobe', '32')),
+      'options', map('ivf.nprobe', '1')),
     named_struct(
       'field', 'body_embedding',
       'query_vector', array(0.0f, 1.0f, 0.0f),
       'limit', 50,
       'weight', 1.0f,
-      'options', map('ivf.nprobe', '32'))),
+      'options', map('ivf.nprobe', '1'))),
   array(),
   10,
-  'weighted_score');
+  'weighted_score')
+ORDER BY __paimon_search_score DESC, id;
 ```
 
 Use `mrr` when you want weighted reciprocal-rank fusion:
@@ -156,20 +214,22 @@ Use `mrr` when you want weighted reciprocal-rank fusion:
 ```sql
 SELECT id, __paimon_search_score
 FROM hybrid_search(
-  'my_table',
+  'hybrid_documents',
   array(
     named_struct(
       'field', 'title_embedding',
       'query_vector', array(1.0f, 0.0f, 0.0f),
       'limit', 50,
       'weight', 2.0f,
-      'options', map('ivf.nprobe', '32'))),
+      'options', map('ivf.nprobe', '1'))),
   array(),
   10,
-  'mrr');
+  'mrr')
+ORDER BY __paimon_search_score DESC, id;
 ```
 
-Spark SQL adds `__paimon_search_score` to expose the ranked score.
+Spark SQL adds `__paimon_search_score` to expose the ranked score. Use `ORDER BY`
+when the displayed row order must follow that score.
 
 </TabItem>
 
@@ -185,7 +245,7 @@ HybridSearchBuilder searchBuilder =
                         new float[] {1.0f, 0.0f, 0.0f},
                         50,
                         2.0f,
-                        java.util.Collections.singletonMap("ivf.nprobe", "32"))
+                        java.util.Collections.singletonMap("ivf.nprobe", "1"))
                 .addFullTextRoute(
                         "content",
                         "{\"match\":{\"query\":\"paimon search\"}}",
@@ -215,13 +275,13 @@ GlobalIndexResult vectorOnlyResult =
                         new float[] {1.0f, 0.0f, 0.0f},
                         50,
                         2.0f,
-                        java.util.Collections.singletonMap("ivf.nprobe", "32"))
+                        java.util.Collections.singletonMap("ivf.nprobe", "1"))
                 .addVectorRoute(
                         "body_embedding",
                         new float[] {0.0f, 1.0f, 0.0f},
                         50,
                         1.0f,
-                        java.util.Collections.singletonMap("ivf.nprobe", "32"))
+                        java.util.Collections.singletonMap("ivf.nprobe", "1"))
                 .withLimit(10)
                 .withWeightedScoreRanker()
                 .executeLocal();
@@ -237,7 +297,7 @@ GlobalIndexResult mrrResult =
                         new float[] {1.0f, 0.0f, 0.0f},
                         50,
                         1.0f,
-                        java.util.Collections.singletonMap("ivf.nprobe", "32"))
+                        java.util.Collections.singletonMap("ivf.nprobe", "1"))
                 .withLimit(10)
                 .withRanker("mrr")
                 .executeLocal();
@@ -251,7 +311,7 @@ directly. `VectorSearch` and `HybridSearch` are internal pushdown representation
 <TabItem value="python-sdk" label="Python SDK">
 
 ```python
-table = catalog.get_table("db.my_table")
+table = catalog.get_table("db.hybrid_documents")
 
 result = (
     table.new_hybrid_search_builder()
@@ -260,7 +320,7 @@ result = (
         [1.0, 0.0, 0.0],
         limit=50,
         weight=2.0,
-        options={"ivf.nprobe": "32"},
+        options={"ivf.nprobe": "1"},
     )
     .add_full_text_route(
         "content",
@@ -291,14 +351,14 @@ result = (
         [1.0, 0.0, 0.0],
         limit=50,
         weight=2.0,
-        options={"ivf.nprobe": "32"},
+        options={"ivf.nprobe": "1"},
     )
     .add_vector_route(
         "body_embedding",
         [0.0, 1.0, 0.0],
         limit=50,
         weight=1.0,
-        options={"ivf.nprobe": "32"},
+        options={"ivf.nprobe": "1"},
     )
     .with_limit(10)
     .with_weighted_score_ranker()
@@ -316,7 +376,7 @@ result = (
         [1.0, 0.0, 0.0],
         limit=50,
         weight=1.0,
-        options={"ivf.nprobe": "32"},
+        options={"ivf.nprobe": "1"},
     )
     .with_limit(10)
     .with_ranker("mrr")
@@ -327,3 +387,13 @@ result = (
 </TabItem>
 
 </Tabs>
+
+## Coverage and Candidate Limits
+
+Each route depends on its own index coverage and search mode. Review
+[Coverage and Freshness](./manage-indexes#coverage-and-freshness) when ingesting or
+updating data. The ranker can only combine candidates returned by the routes;
+increase route limits when a small candidate set restricts final recall.
+
+For Java and Python, the subsequent table scan does not preserve ranking order.
+See [Read Scored Results](./manage-indexes#read-scored-results) to access scores by row ID.

--- a/docs/docs/multimodal-table/global-index/manage-indexes.mdx
+++ b/docs/docs/multimodal-table/global-index/manage-indexes.mdx
@@ -1,0 +1,461 @@
+---
+title: "Manage Global Indexes"
+---
+
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+# Manage Global Indexes
+
+Build and inspect indexes separately from ingesting table data. Use this guide to
+choose freshness behavior, coordinate index visibility, and remove index files.
+The SQL examples use a Paimon catalog with `db` as the current database.
+`CALL` examples apply to Spark and Flink; `ALTER TABLE` examples below use Spark SQL.
+In Flink, replace `SET TBLPROPERTIES (...)` with `SET (...)`.
+Index-specific build and query examples are listed in [Global Index](../global-index).
+
+## Build an Index
+
+Create a global index on an existing table. The examples assume a populated
+`db.my_table`; partition-scoped examples additionally require a partition column
+named `dt`. See [Global Index](../global-index#prerequisites) for table setup.
+
+Create global indexes for all partitions or only selected partitions:
+
+<Tabs groupId="global-index-build">
+
+<TabItem value="sql" label="SQL">
+
+```sql
+CALL sys.create_global_index(
+    table => 'db.my_table',
+    index_column => 'name',
+    index_type => 'btree'
+);
+
+CALL sys.create_global_index(
+    table => 'db.my_table',
+    index_column => 'name',
+    index_type => 'btree',
+    partitions => 'dt=2026-06-18;dt=2026-06-19'
+);
+```
+
+</TabItem>
+
+<TabItem value="python-sdk" label="Python SDK">
+
+```python
+table = catalog.get_table("db.my_table")
+
+added_files = table.create_global_index("name")
+print(added_files)
+```
+
+The API returns the number of committed index files. You can pass build options and restrict the
+build to selected partitions:
+
+```python
+added_files = table.create_global_index(
+    "name",
+    index_type="btree",
+    partitions=[{"dt": "2026-06-18"}, {"dt": "2026-06-19"}],
+    options={"sorted-index.records-per-range": "10000000"},
+)
+```
+
+</TabItem>
+
+</Tabs>
+
+PyPaimon global index build currently supports single-column BTree indexes,
+single-column Bitmap indexes, single-column paimon-vindex vector indexes,
+and single-column full-text indexes on tables with row tracking enabled.
+
+Re-running a build is incremental: it fills missing coverage. Spark and Flink can
+also refresh changed ranges under the `IGNORE` update policy; see
+[Update Indexed Columns](#update-indexed-columns) for the PyPaimon difference and
+the required source metadata. Changing a build option alone does not rebuild
+already covered rows. To replace existing tokenizer or vector-index settings,
+[drop the relevant index](#drop-an-index) and build it again, using the same
+partition scope when replacing only selected partitions.
+
+## Inspect Index Coverage
+
+Global indexes are stored in index files and recorded in table metadata. To inspect index files and
+their row-id coverage, query the `table_indexes` system table:
+
+<Tabs groupId="global-index-table-indexes">
+
+<TabItem value="sql" label="SQL">
+
+```sql
+SELECT index_type, index_field_name, row_range_start, row_range_end
+FROM `my_table$table_indexes`
+WHERE index_field_name IS NOT NULL;
+```
+
+</TabItem>
+
+<TabItem value="python-sdk" label="Python SDK">
+
+```python
+import pyarrow.compute as pc
+
+table_indexes = catalog.get_table("db.my_table$table_indexes")
+read_builder = table_indexes.new_read_builder().with_projection([
+    "index_type",
+    "index_field_name",
+    "row_range_start",
+    "row_range_end",
+])
+
+pa_table = read_builder.new_read().to_arrow(
+    read_builder.new_scan().plan().splits()
+)
+pa_table = pa_table.filter(pc.is_valid(pa_table["index_field_name"]))
+print(pa_table)
+```
+
+</TabItem>
+
+</Tabs>
+
+You can also query `file_key_ranges` to inspect data file row-id ranges and diagnose coverage:
+
+<Tabs groupId="global-index-file-key-ranges">
+
+<TabItem value="sql" label="SQL">
+
+```sql
+SELECT file_path, first_row_id, record_count
+FROM `my_table$file_key_ranges`;
+```
+
+</TabItem>
+
+<TabItem value="python-sdk" label="Python SDK">
+
+```python
+file_key_ranges = catalog.get_table("db.my_table$file_key_ranges")
+read_builder = file_key_ranges.new_read_builder().with_projection([
+    "file_path",
+    "first_row_id",
+    "record_count",
+])
+
+pa_table = read_builder.new_read().to_arrow(
+    read_builder.new_scan().plan().splits()
+)
+print(pa_table)
+```
+
+</TabItem>
+
+</Tabs>
+
+## Wait for Index Visibility
+
+For Spark, Flink, and Java batch or bounded-stream writers, the visibility callback
+waits **after the data snapshot is committed** for existing indexes to cover newly
+appended ranges. It delays completion of the writer's commit call; other readers
+can already see the committed snapshot while it waits.
+
+Build the initial indexes before enabling the callback, and run subsequent index
+builds in a separate job or session. Running the index build only after the same
+blocked write returns would make the write time out. The callback waits for
+coverage; it does not create indexes:
+
+<Tabs groupId="global-index-visibility-callback">
+
+<TabItem value="spark" label="Spark SQL">
+
+```sql
+ALTER TABLE my_table SET TBLPROPERTIES (
+    'visibility-callback.enabled' = 'true',
+    'visibility-callback.timeout' = '30 min'
+);
+```
+
+</TabItem>
+
+<TabItem value="flink" label="Flink SQL">
+
+```sql
+ALTER TABLE my_table SET (
+    'visibility-callback.enabled' = 'true',
+    'visibility-callback.timeout' = '30 min'
+);
+```
+
+</TabItem>
+
+</Tabs>
+
+The callback tracks index definitions already present in each affected partition.
+It does not wait for a partition that has no existing index, including a newly
+created partition. On timeout, the committed data remains in the table; inspect
+the committed snapshot before retrying an append.
+
+PyPaimon writers do not implement this built-in visibility callback. Setting the
+table property through the Python catalog configures JVM writers of that table,
+but does not make a Python commit wait. For a Python pipeline, commit the data,
+run `table.create_global_index(...)`, and inspect coverage before treating that
+batch as ready for indexed queries.
+
+## Coverage and Freshness
+
+Global index files cover row-id ranges. If more rows are appended after an index is built, those
+new rows are not automatically covered by the existing index files. Build the global index again
+to create index files for newly uncovered data. The scalar, vector, and full-text families
+default to `fast`, which searches indexed row ranges.
+Choose a search mode deliberately when recently appended data must be included.
+Updates to already indexed rows also require the [update policy](#update-indexed-columns).
+
+| Mode | How coverage is checked | Use when |
+| --- | --- | --- |
+| `fast` | Search indexed coverage only. | The index is current, or partial coverage is acceptable. |
+| `full` | Check row-ID coverage against snapshot `nextRowId`; scan raw data for detected gaps where supported. | Newly appended ranges need to be included. |
+| `detail` | Compare active data-file row-ID ranges with index coverage, then scan detected gaps where supported. | Coverage should be checked against current files, including partition filtering. |
+
+![An index covers the original row range; appended rows need another index build or a search mode that includes uncovered data.](/img/multimodal-index-coverage.svg)
+
+To include appended data for query types that support raw-data search, set:
+
+<Tabs groupId="global-index-search-mode">
+
+<TabItem value="sql" label="SQL">
+
+```sql
+ALTER TABLE my_table SET TBLPROPERTIES ('vector-index.search-mode' = 'full');
+```
+
+</TabItem>
+
+<TabItem value="python-sdk" label="Python SDK">
+
+```python
+from pypaimon.schema.schema_change import SchemaChange
+
+catalog.alter_table(
+    "db.my_table",
+    [SchemaChange.set_option("vector-index.search-mode", "full")],
+)
+```
+
+For a read-only override on an existing `Table` instance:
+
+```python
+full_table = table.copy({"vector-index.search-mode": "full"})
+```
+
+</TabItem>
+
+</Tabs>
+
+With `full` search, supported global-index queries compare the allocated row-ID
+space `[0, nextRowId)` with index coverage. With `detail`, they instead inspect the
+row-ID ranges of current data files. Neither mode compares indexed values with
+the latest column values. An update that preserves row IDs can therefore leave
+stale index entries even when coverage is complete. Handle those updates through
+the [index update policy](#update-indexed-columns) and an index build.
+
+Use `scalar-index.search-mode`, `vector-index.search-mode`, or
+`full-text-index.search-mode` for one index family. The legacy
+`global-index.search-mode` has no default and is used as a fallback when the corresponding
+family-specific option is not explicitly configured.
+
+To temporarily disable global-index scan acceleration while keeping the index files, set:
+
+<Tabs groupId="global-index-enabled">
+
+<TabItem value="sql" label="SQL">
+
+```sql
+ALTER TABLE my_table SET TBLPROPERTIES ('global-index.enabled' = 'false');
+```
+
+</TabItem>
+
+<TabItem value="python-sdk" label="Python SDK">
+
+```python
+from pypaimon.schema.schema_change import SchemaChange
+
+catalog.alter_table(
+    "db.my_table",
+    [SchemaChange.set_option("global-index.enabled", "false")],
+)
+```
+
+</TabItem>
+
+</Tabs>
+
+Set it back to `true` to use global indexes during scans again.
+
+## Update Indexed Columns
+
+Coverage and freshness are different checks: an index can cover a row ID while
+still holding that row's old value. For example, changing an indexed `name` from
+`a200` to `a250` keeps the row ID but makes the old index entry stale. Switching to
+`detail` does not repair or detect that value change.
+
+Choose `global-index.column-update-action` before updating an indexed column:
+
+| Policy | Effect of the update | What to do next |
+| --- | --- | --- |
+| `THROW_ERROR` (default) | Rejects the indexed-column update. | Choose a supported update policy or explicitly drop the index before updating. |
+| `DROP_PARTITION_INDEX` | Drops affected partition indexes as part of the update. | Build indexes again for the affected scope. |
+| `IGNORE` | Keeps existing index files with their old values. | Refresh or replace those indexes before relying on indexed results for the changed data. |
+
+With `IGNORE`, Spark and Flink incremental builds use source metadata stored in
+index files to find and rebuild changed row ranges. Older index files without
+that metadata are not refreshed automatically; drop and rebuild them.
+PyPaimon incremental builds currently fill uncovered ranges only. For updates to
+already covered rows through a Python pipeline, explicitly drop and rebuild the
+affected index instead of relying on a repeated `create_global_index` call alone.
+
+Keep the same partition scope when dropping and replacing an index. Until the
+replacement is built, query results depend on the remaining coverage, search
+mode, and query API.
+
+## Read Scored Results
+
+Vector, full-text, and hybrid search select a set of top-K matching row IDs and
+associate scores with them. A subsequent table scan reads the selected records
+in its scan order. The top-K selection does not guarantee that returned rows are
+displayed in descending score order.
+
+In Spark SQL, request the score and sort explicitly. For example, after building
+the [Full-Text Index](./full-text):
+
+```sql
+SELECT id, content, __paimon_search_score
+FROM full_text_search('my_table', 'content', '{"match":{"query":"paimon"}}', 10)
+ORDER BY __paimon_search_score DESC, id;
+```
+
+For Java or Python, obtain each score from the search result by Paimon row ID.
+The following snippets assume `result` is the scored result returned by a search
+builder; the IDs below are Paimon row IDs, not values of the business `id` column.
+
+<Tabs groupId="global-index-read-scores">
+
+<TabItem value="java" label="Java API">
+
+```java
+ScoredGlobalIndexResult scored = (ScoredGlobalIndexResult) result;
+ScoreGetter scores = scored.scoreGetter();
+List<Long> rowIds = new ArrayList<>();
+for (long rowId : scored.results()) {
+    rowIds.add(rowId);
+}
+rowIds.sort(Comparator.<Long>comparingDouble(rowId -> scores.score(rowId))
+        .reversed()
+        .thenComparingLong(rowId -> rowId));
+for (long rowId : rowIds) {
+    System.out.println(rowId + ": " + scores.score(rowId));
+}
+```
+
+</TabItem>
+
+<TabItem value="python" label="Python API">
+
+```python
+score = result.score_getter()
+ranked_row_ids = sorted(result.results(), key=lambda row_id: (-score(row_id), row_id))
+for row_id in ranked_row_ids:
+    print(row_id, score(row_id))
+```
+
+</TabItem>
+
+</Tabs>
+
+Associate materialized rows and scores by row ID. Do not zip a table scan's rows
+with a separately sorted score list: the two orders can differ.
+
+## Drop an Index
+
+Drop index files:
+
+<Tabs groupId="global-index-drop">
+
+<TabItem value="sql" label="SQL">
+
+```sql
+CALL sys.drop_global_index(
+    table => 'db.my_table',
+    index_column => 'name',
+    index_type => 'btree'
+);
+```
+
+</TabItem>
+
+<TabItem value="python-sdk" label="Python SDK">
+
+```python
+table = catalog.get_table("db.my_table")
+
+dropped_files = table.drop_global_index("name", index_type="btree")
+print(dropped_files)
+```
+
+You can also restrict the drop to selected partitions, or count matched files without committing:
+
+```python
+matched_files = table.drop_global_index(
+    "name",
+    index_type="btree",
+    partitions=[{"dt": "2026-06-18"}, {"dt": "2026-06-19"}],
+    dry_run=True,
+)
+```
+
+</TabItem>
+
+</Tabs>
+
+## Shared Options
+
+These table options affect global index build and read behavior:
+
+| Option | Default | Description |
+|---|---|---|
+| `global-index.enabled` | `true` | Whether scans can use global indexes. |
+| `global-index.search-mode` | Not set | Legacy fallback search mode for global-index queries. Family-specific options take precedence. |
+| `scalar-index.search-mode` | `fast` | Search mode for BTree, Bitmap, Multivalue, and FM queries. |
+| `vector-index.search-mode` | `fast` | Search mode for vector queries. |
+| `full-text-index.search-mode` | `fast` | Search mode for full-text queries. |
+| `global-index.external-path` | Not set | Root directory for global index files. If not set, files are stored under the table index directory. |
+| `global-index.column-update-action` | `THROW_ERROR` | Update policy: `THROW_ERROR`, `DROP_PARTITION_INDEX`, or `IGNORE`. See [Update Indexed Columns](#update-indexed-columns) for refresh requirements and engine differences. |
+| `sorted-index.records-per-range` | `10000000` | Expected number of records per sorted global index file for BTree, Bitmap, and Multivalue builds. |
+| `sorted-index.build.max-parallelism` | `4096` | Maximum Flink or Spark parallelism for building sorted global indexes. |
+| `global-index.row-count-per-shard` | `100000` | Target row count per shard for non-sorted global index builds such as vector and full-text indexes. |
+| `global-index.build.max-shard` | `32` | Preferred maximum shard count for global index builds. |
+| `global-index.build.max-parallelism` | `4096` | Maximum Flink or Spark parallelism for building non-sorted global indexes. |
+| `global-index.thread-num` | `32` | Maximum number of concurrent threads for global index I/O. |
+| `visibility-callback.enabled` | `false` | Whether JVM batch or bounded-stream writers wait after commit for existing partition indexes to cover newly appended ranges. Does not hide the committed snapshot. |
+| `visibility-callback.timeout` | `30 min` | Maximum wait time for visibility callback. |

--- a/docs/docs/multimodal-table/global-index/multivalue.mdx
+++ b/docs/docs/multimodal-table/global-index/multivalue.mdx
@@ -41,20 +41,14 @@ For membership lookup, the index has these semantics:
 The indexed column must be an `ARRAY` whose element type is supported by the global-index key
 serializer. A Multivalue index is single-column.
 
+For shared build, refresh, and coverage behavior, see
+[Manage Global Indexes](./manage-indexes).
+
 ## Build on a Data Evolution Table
 
-Create a table with the regular global-index prerequisites:
-
-```sql
-CREATE TABLE my_table (
-    id INT,
-    tags ARRAY<STRING>
-) TBLPROPERTIES (
-    'row-tracking.enabled' = 'true',
-    'data-evolution.enabled' = 'true',
-    'global-index.enabled' = 'true'
-);
-```
+Create and populate the [shared example table](../global-index#prerequisites).
+Its `tags ARRAY<STRING>` column includes `blue`, `green`, and `red` values for the
+membership examples below.
 
 Flink and Spark can build the index with `create_global_index`:
 

--- a/docs/docs/multimodal-table/global-index/vector.mdx
+++ b/docs/docs/multimodal-table/global-index/vector.mdx
@@ -62,27 +62,30 @@ is accepted.
 
 :::
 
+For table prerequisites, see [Global Index](../global-index#prerequisites).
+For refresh, coverage modes, and shared build options, see
+[Manage Global Indexes](./manage-indexes).
+
 ## Build Vector Index
+
+Create and populate the [shared example table](../global-index#prerequisites) first.
+The build and search examples below use its three-dimensional `embedding` column.
+For this small dataset, use `ivf-flat` with one cluster; production workloads should
+choose an index type and cluster count for their own data.
+
+For Python, install `pypaimon[vindex]` (or its matching `paimon-vindex==0.4.0`
+dependency) before building or querying native vector indexes.
 
 <Tabs groupId="vector-build">
 
-<TabItem value="sql" label="SQL">
+<TabItem value="sql" label="Spark / Flink SQL">
 
 ```sql
--- Create IVF-PQ vector index on 'embedding' column
 CALL sys.create_global_index(
     table => 'db.my_table',
     index_column => 'embedding',
-    index_type => 'ivf-pq',
-    options => 'ivf-pq.distance.metric=cosine,ivf-pq.nlist=256,ivf-pq.pq.code-ratio=0.0625'
-);
-
--- Create a paimon-vindex DiskANN vector index
-CALL sys.create_global_index(
-    table => 'db.my_table',
-    index_column => 'embedding',
-    index_type => 'diskann',
-    options => 'diskann.dimension=768,diskann.distance.metric=l2,diskann.build-preset=balanced'
+    index_type => 'ivf-flat',
+    options => 'ivf-flat.dimension=3,ivf-flat.distance.metric=cosine,ivf-flat.nlist=1'
 );
 ```
 
@@ -93,22 +96,20 @@ CALL sys.create_global_index(
 ```python
 table = catalog.get_table("db.my_table")
 
-# Create IVF-PQ vector index on 'embedding' column.
 added_files = table.create_global_index(
     "embedding",
-    index_type="ivf-pq",
+    index_type="ivf-flat",
     options={
-        "ivf-pq.dimension": "768",
-        "ivf-pq.distance.metric": "cosine",
-        "ivf-pq.nlist": "256",
-        "ivf-pq.pq.code-ratio": "0.0625",
+        "ivf-flat.dimension": "3",
+        "ivf-flat.distance.metric": "cosine",
+        "ivf-flat.nlist": "1",
     },
 )
 print(added_files)
 ```
 
-You can also build only selected partitions or tune the row-id shard size used
-by non-sorted global indexes:
+To limit a build to selected partitions, pass `partitions` with the same build
+options. The shared example table is partitioned by `dt`:
 
 ```python
 added_files = table.create_global_index(
@@ -116,193 +117,28 @@ added_files = table.create_global_index(
     index_type="ivf-flat",
     partitions=[{"dt": "2026-06-18"}, {"dt": "2026-06-19"}],
     options={
-        "ivf-flat.dimension": "768",
+        "ivf-flat.dimension": "3",
+        "ivf-flat.distance.metric": "cosine",
+        "ivf-flat.nlist": "1",
         "global-index.row-count-per-shard": "100000",
     },
 )
 print(added_files)
 ```
 
-PyPaimon vector index build supports the paimon-vindex 0.4.0 identifiers `ivf-flat`, `ivf-pq`,
-`ivf-sq`, `ivf-rq`, and `diskann`. Install `paimon-vindex==0.4.0` or `pypaimon[vindex]` before
-building or querying paimon-vindex indexes from Python.
-
 </TabItem>
 
 </Tabs>
 
-For `ARRAY<FLOAT>` vector columns, specify the vector dimension with `<index-type>.dimension` for
-paimon-vindex indexes. For `VECTOR<FLOAT>` columns, Paimon uses the dimension from the column type.
-
-## Drop Vector Index
-
-<Tabs groupId="vector-drop">
-
-<TabItem value="sql" label="SQL">
-
-```sql
-CALL sys.drop_global_index(
-    table => 'db.my_table',
-    index_column => 'embedding',
-    index_type => 'ivf-pq'
-);
-```
-
-</TabItem>
-
-<TabItem value="python-sdk" label="Python SDK">
-
-```python
-table = catalog.get_table("db.my_table")
-
-dropped_files = table.drop_global_index("embedding", index_type="ivf-pq")
-print(dropped_files)
-```
-
-You can also restrict the drop to selected partitions, or count matched files
-without committing:
-
-```python
-matched_files = table.drop_global_index(
-    "embedding",
-    index_type="ivf-pq",
-    partitions=[{"dt": "2026-06-18"}, {"dt": "2026-06-19"}],
-    dry_run=True,
-)
-print(matched_files)
-```
-
-</TabItem>
-
-</Tabs>
-
-Supported paimon-vindex options:
-
-| Option | Default | Description |
-|---|---|---|
-| `<index-type>.dimension` | `128` | Vector dimension for `ARRAY<FLOAT>` columns. Ignored for `VECTOR<FLOAT>` columns. |
-| `<index-type>.distance.metric` | `inner_product` | Distance metric. Supported values: `l2`, `cosine`, `inner_product`. |
-| `<index-type>.train.sample-ratio` | `1.0` | Ratio of vectors sampled for native index training. Must be greater than `0` and less than or equal to `1`. Lower values reduce training memory and build cost, but may reduce index quality. |
-| `<index-type>.nlist` | Automatic | Number of clusters for the four IVF types. When omitted, paimon-vindex resolves it from the shard's non-null vector count. |
-| `<index-type>.pq.code-ratio` | `0.0625` | Relative PQ-code budget for `ivf-pq` and `diskann`. |
-| `<index-type>.pq.m` | Automatic | Expert override for the PQ sub-vector count used by `ivf-pq` and `diskann`. |
-| `ivf-pq.pq.use-opq` | Automatic | Explicitly enables or disables OPQ. Without an explicit value, a `target-recall` of at least `0.9` enables it. |
-| `ivf-rq.rq.bits` | `4` | Persisted IVF-RQ residual width. Supported values are `1` through `8`; changing it requires rebuilding the index. |
-| `<index-type>.target-recall` | Not set | Build-policy hint used by `ivf-pq` and `diskann`. Validate the resulting recall on held-out queries. |
-| `<index-type>.max-bytes-per-vector` | Not set | Storage objective and conservative preflight bound for `ivf-pq`, `ivf-rq`, and `diskann`. |
-
-Additional paimon-vindex DiskANN build options:
-
-| Option | Default | Description |
-|---|---|---|
-| `diskann.build-preset` | `balanced` | Coherent `fast_build`, `balanced`, or `high_recall` build policy. |
-| `diskann.deployment-profile` | Not set | Deployment objective used to choose a storage layout. |
-| `diskann.pq.bits` | `8` | Resident PQ-code width. Supported values are `4` and `8`. |
-| `diskann.max-degree` | `64` | Maximum graph out-degree. |
-| `diskann.build-search-list-size` | `max(100, max-degree)` | Candidate width during graph construction. |
-| `diskann.alpha` | `1.2` | Robust-prune threshold. |
-| `diskann.seed` | `42` | Reproducible initialization and build-order seed. |
-| `diskann.memory-budget-bytes` | `8 GiB` | Internal graph-build memory estimate used to select normal or sharded construction. |
-| `diskann.storage-layout` | `auto` | Explicit `compact` or `interleaved` layout override. |
-| `diskann.raw-vector-encoding` | `auto` | Explicit `f32` or `f16` persisted rerank-vector encoding. |
-| `diskann.build-distance` | `auto` | Explicit product-quantized or full-precision build traversal override. |
-
-## Per-Field Options
-
-The options above can also be set at the table level (in `TBLPROPERTIES`), where they are shared
-by every vector column of the same index type. When a table has multiple vector columns, you can
-scope an option to a single column with `fields.<field-name>.<option>`. The field-level form takes
-precedence over the column-agnostic option for that column. Use the stored table column name exactly
-as `<field-name>`. Field-level vector options do not include the index-type prefix; for example,
-use `fields.image_embedding.nlist` to override the shared `ivf-pq.nlist` option for
-`image_embedding`:
-
-<Tabs groupId="vector-per-field-options">
-
-<TabItem value="sql" label="SQL">
-
-```sql
-CREATE TABLE my_table (
-    id INT,
-    title_embedding ARRAY<FLOAT>,
-    image_embedding ARRAY<FLOAT>
-) TBLPROPERTIES (
-    'row-tracking.enabled' = 'true',
-    'data-evolution.enabled' = 'true',
-    'global-index.enabled' = 'true',
-    -- per-column dimensions
-    'fields.title_embedding.dimension' = '768',
-    'fields.image_embedding.dimension' = '512',
-    -- shared by every ivf-pq column, overridden only for 'image_embedding'
-    'ivf-pq.nlist' = '256',
-    'fields.image_embedding.nlist' = '512',
-    -- per-column training sample ratio
-    'fields.image_embedding.train.sample-ratio' = '0.5'
-);
-```
-
-</TabItem>
-
-<TabItem value="python-sdk" label="Python SDK">
-
-```python
-import pyarrow as pa
-
-from pypaimon import Schema
-
-schema = Schema.from_pyarrow_schema(
-    pa.schema([
-        pa.field("id", pa.int32()),
-        pa.field("title_embedding", pa.list_(pa.float32())),
-        pa.field("image_embedding", pa.list_(pa.float32())),
-    ]),
-    options={
-        "row-tracking.enabled": "true",
-        "data-evolution.enabled": "true",
-        "global-index.enabled": "true",
-        "fields.title_embedding.dimension": "768",
-        "fields.image_embedding.dimension": "512",
-        "ivf-pq.nlist": "256",
-        "fields.image_embedding.nlist": "512",
-    },
-)
-
-catalog.create_table("db.my_table", schema, ignore_if_exists=False)
-```
-
-</TabItem>
-
-</Tabs>
-
-With the properties above, `title_embedding` is indexed with `nlist=256` while `image_embedding`
-uses `nlist=512` and trains with half of the non-null vectors.
+For `ARRAY<FLOAT>` columns, specify the dimension with `<index-type>.dimension`.
+For `VECTOR<FLOAT, n>` columns, Paimon uses the dimension from the column type.
+Every query vector must have that same dimension.
 
 ## Vector Search
 
-Search-time options are passed with each vector search request:
-
-| Option | Default | Description |
-|---|---|---|
-| `ivf.nprobe` | Automatic | Explicit number of IVF clusters to probe. When omitted, paimon-vindex derives the width from the index, `top_k`, and filter selectivity. |
-| `ivf.max_initial_filter_expansion_factor` | Disabled | Positive integer limiting filter-driven expansion of the initial automatic IVF probe width. A factor of `1` disables initial filter expansion. Progressive retries may still probe more clusters when fewer than `top_k` filtered results are found. |
-| `ivf.refine_factor` | Disabled | Retrieves `top_k * refine_factor` IVF candidates and reranks them with the original vectors stored in the Paimon table. It is most useful for compressed indexes such as `ivf-pq`, `ivf-sq`, and `ivf-rq` when recall is more important than latency. |
-| `ivf_pq.batch_table_reuse` | `auto` | IVF-PQ batch search distance-table reuse mode: `auto`, `on`, or `off`. Other index types and scalar searches ignore it. |
-| `ivf_pq.batch_table_reuse.max_bytes` | 512 MiB | Positive long integer limiting the memory used by IVF-PQ batch distance-table reuse. Search falls back to direct table construction when the reusable tables exceed the budget. |
-| `diskann.l_search` | Automatic | paimon-vindex DiskANN graph candidate width. The automatic value uses calibration when available, otherwise `max(100, 2 * top_k)`. |
-
-Use the same distance metric at build time and query time. Search options can be passed per query,
-so you can use a larger `ivf.nprobe` or `diskann.l_search` for higher recall queries and a smaller
-value for latency-sensitive queries. Do not set both in one query.
-
-`ivf.max_initial_filter_expansion_factor` applies only to automatic IVF search and cannot be combined
-with `ivf.nprobe` or `diskann.l_search`. Lower factors reduce initial filtered-search work but may
-reduce Recall@K compared with uncapped automatic search. Progressive expansion occurs only when
-fewer than `top_k` valid results are returned; if the capped initial search already fills `top_k`,
-probing stops.
-
-`ivf.refine_factor` can also be configured with `refine_factor`, `rerank_factor`, and hyphenated
-spellings such as `ivf.refine-factor`. Setting `ivf.refine_factor=1` still performs the raw-vector
-rerank for the indexed candidates; leaving it unset skips the rerank stage.
+The examples search the three-dimensional IVF-flat index built above. A limit of
+`5` returns at most five matches; the three-row sample table returns fewer.
+`ivf.nprobe=1` matches the single cluster in this example.
 
 <Tabs groupId="vector-search">
 
@@ -310,7 +146,9 @@ rerank for the indexed candidates; leaving it unset skips the rerank stage.
 
 ```sql
 -- Search for top-5 nearest neighbors
-SELECT * FROM vector_search('my_table', 'embedding', array(1.0f, 2.0f, 3.0f), 5);
+SELECT id, name, __paimon_search_score
+FROM vector_search('my_table', 'embedding', array(1.0f, 2.0f, 3.0f), 5)
+ORDER BY __paimon_search_score DESC, id;
 ```
 
 </TabItem>
@@ -336,7 +174,7 @@ CALL sys.vector_search(
     query_vector => '1.0,2.0,3.0',
     top_k => 5,
     projection => 'id,name,__paimon_search_score',
-    options => 'ivf.nprobe=32',
+    options => 'ivf.nprobe=1',
     `where` => 'id > 100'
 );
 ```
@@ -354,7 +192,7 @@ GlobalIndexResult result = table.newVectorSearchBuilder()
         .withVector(queryVector)
         .withLimit(5)
         .withVectorColumn("embedding")
-        .withOption("ivf.nprobe", "16")
+        .withOption("ivf.nprobe", "1")
         .executeLocal();
 
 // Step 2: Read matching rows using the search result
@@ -398,7 +236,7 @@ result = (
     .with_vector_column("embedding")
     .with_query_vector([1.0, 2.0, 3.0])
     .with_limit(5)
-    .with_option("ivf.nprobe", "16")
+    .with_option("ivf.nprobe", "1")
     .execute_local()
 )
 
@@ -415,6 +253,8 @@ You can also add a scalar filter to pre-filter rows before vector search:
 
 ```python
 from pypaimon.common.predicate_builder import PredicateBuilder
+
+table.create_global_index("category", index_type="btree")
 
 predicate = (
     PredicateBuilder(table.fields)
@@ -434,6 +274,215 @@ result = (
 The scalar filter is evaluated with matching scalar global indexes before vector search. Build a
 BTree index for frequently used metadata filters, such as `category`, `tenant_id`, or `event_time`,
 so vector search can restrict the candidate row ids before running ANN search.
+
+</TabItem>
+
+</Tabs>
+
+A search selects top-K row IDs; reading those rows through a regular table scan
+does not imply score order. See [Read Scored Results](./manage-indexes#read-scored-results)
+for SQL ordering and Java/Python score access.
+
+## Search Options
+
+Search-time options are passed with each vector search request:
+
+| Option | Default | Description |
+|---|---|---|
+| `ivf.nprobe` | Automatic | Explicit number of IVF clusters to probe. When omitted, paimon-vindex derives the width from the index, `top_k`, and filter selectivity. |
+| `ivf.max_initial_filter_expansion_factor` | Disabled | Positive integer limiting filter-driven expansion of the initial automatic IVF probe width. A factor of `1` disables initial filter expansion. Progressive retries may still probe more clusters when fewer than `top_k` filtered results are found. |
+| `ivf.refine_factor` | Disabled | Retrieves `top_k * refine_factor` IVF candidates and reranks them with the original vectors stored in the Paimon table. It is most useful for compressed indexes such as `ivf-pq`, `ivf-sq`, and `ivf-rq` when recall is more important than latency. |
+| `ivf_pq.batch_table_reuse` | `auto` | IVF-PQ batch search distance-table reuse mode: `auto`, `on`, or `off`. Other index types and scalar searches ignore it. |
+| `ivf_pq.batch_table_reuse.max_bytes` | 512 MiB | Positive long integer limiting the memory used by IVF-PQ batch distance-table reuse. Search falls back to direct table construction when the reusable tables exceed the budget. |
+| `diskann.l_search` | Automatic | paimon-vindex DiskANN graph candidate width. The automatic value uses calibration when available, otherwise `max(100, 2 * top_k)`. |
+
+Use the same distance metric at build time and query time. Search options can be passed per query,
+so you can use a larger `ivf.nprobe` or `diskann.l_search` for higher recall queries and a smaller
+value for latency-sensitive queries. Do not set both in one query.
+
+`ivf.max_initial_filter_expansion_factor` applies only to automatic IVF search and cannot be combined
+with `ivf.nprobe` or `diskann.l_search`. Lower factors reduce initial filtered-search work but may
+reduce Recall@K compared with uncapped automatic search. Progressive expansion occurs only when
+fewer than `top_k` valid results are returned; if the capped initial search already fills `top_k`,
+probing stops.
+
+`ivf.refine_factor` can also be configured with `refine_factor`, `rerank_factor`, and hyphenated
+spellings such as `ivf.refine-factor`. Setting `ivf.refine_factor=1` still performs the raw-vector
+rerank for the indexed candidates; leaving it unset skips the rerank stage.
+
+## Build Options
+
+Supported paimon-vindex options:
+
+| Option | Default | Description |
+|---|---|---|
+| `<index-type>.dimension` | `128` | Vector dimension for `ARRAY<FLOAT>` columns. Ignored for `VECTOR<FLOAT, n>` columns. |
+| `<index-type>.distance.metric` | `inner_product` | Distance metric. Supported values: `l2`, `cosine`, `inner_product`. |
+| `<index-type>.train.sample-ratio` | `1.0` | Ratio of vectors sampled for native index training. Must be greater than `0` and less than or equal to `1`. Lower values reduce training memory and build cost, but may reduce index quality. |
+| `<index-type>.nlist` | Automatic | Number of clusters for the four IVF types. When omitted, paimon-vindex resolves it from the shard's non-null vector count. |
+| `<index-type>.pq.code-ratio` | `0.0625` | Relative PQ-code budget for `ivf-pq` and `diskann`. |
+| `<index-type>.pq.m` | Automatic | Expert override for the PQ sub-vector count used by `ivf-pq` and `diskann`. |
+| `ivf-pq.pq.use-opq` | Automatic | Explicitly enables or disables OPQ. Without an explicit value, a `target-recall` of at least `0.9` enables it. |
+| `ivf-rq.rq.bits` | `4` | Persisted IVF-RQ residual width. Supported values are `1` through `8`; changing it requires rebuilding the index. |
+| `<index-type>.target-recall` | Not set | Build-policy hint used by `ivf-pq` and `diskann`. Validate the resulting recall on held-out queries. |
+| `<index-type>.max-bytes-per-vector` | Not set | Storage objective and conservative preflight bound for `ivf-pq`, `ivf-rq`, and `diskann`. |
+
+Additional paimon-vindex DiskANN build options:
+
+| Option | Default | Description |
+|---|---|---|
+| `diskann.build-preset` | `balanced` | Coherent `fast_build`, `balanced`, or `high_recall` build policy. |
+| `diskann.deployment-profile` | Not set | Deployment objective used to choose a storage layout. |
+| `diskann.pq.bits` | `8` | Resident PQ-code width. Supported values are `4` and `8`. |
+| `diskann.max-degree` | `64` | Maximum graph out-degree. |
+| `diskann.build-search-list-size` | `max(100, max-degree)` | Candidate width during graph construction. |
+| `diskann.alpha` | `1.2` | Robust-prune threshold. |
+| `diskann.seed` | `42` | Reproducible initialization and build-order seed. |
+| `diskann.memory-budget-bytes` | `8 GiB` | Internal graph-build memory estimate used to select normal or sharded construction. |
+| `diskann.storage-layout` | `auto` | Explicit `compact` or `interleaved` layout override. |
+| `diskann.raw-vector-encoding` | `auto` | Explicit `f32` or `f16` persisted rerank-vector encoding. |
+| `diskann.build-distance` | `auto` | Explicit product-quantized or full-precision build traversal override. |
+
+### Quantized and DiskANN Builds
+
+The following are alternative builds for a **separate, populated** table
+`db.model_embeddings` whose `embedding ARRAY<FLOAT>` values have dimension `768`.
+They do not apply to the three-dimensional sample table. Choose one alternative;
+train quantized indexes on a representative dataset large enough for the chosen
+clustering and quantization parameters.
+
+```sql
+CALL sys.create_global_index(
+    table => 'db.model_embeddings',
+    index_column => 'embedding',
+    index_type => 'ivf-pq',
+    options => 'ivf-pq.dimension=768,ivf-pq.distance.metric=cosine,ivf-pq.nlist=256,ivf-pq.pq.code-ratio=0.0625'
+);
+```
+
+Alternatively, build a DiskANN index:
+
+```sql
+CALL sys.create_global_index(
+    table => 'db.model_embeddings',
+    index_column => 'embedding',
+    index_type => 'diskann',
+    options => 'diskann.dimension=768,diskann.distance.metric=l2,diskann.build-preset=balanced'
+);
+```
+
+Pass the same option keys to Python's `create_global_index(..., options={...})`.
+Use full 768-dimensional query vectors when searching either of these indexes.
+
+## Per-Field Options
+
+The options above can also be set at the table level (in `TBLPROPERTIES`), where they are shared
+by every vector column of the same index type. When a table has multiple vector columns, you can
+scope an option to a single column with `fields.<field-name>.<option>`. The field-level form takes
+precedence over the column-agnostic option for that column. Use the stored table column name exactly
+as `<field-name>`. Field-level vector options do not include the index-type prefix; for example,
+use `fields.image_embedding.nlist` to override the shared `ivf-pq.nlist` option for
+`image_embedding`:
+
+<Tabs groupId="vector-per-field-options">
+
+<TabItem value="sql" label="Spark SQL">
+
+```sql
+CREATE TABLE multi_embedding_table (
+    id INT,
+    title_embedding ARRAY<FLOAT>,
+    image_embedding ARRAY<FLOAT>
+) TBLPROPERTIES (
+    'row-tracking.enabled' = 'true',
+    'data-evolution.enabled' = 'true',
+    'global-index.enabled' = 'true',
+    -- per-column dimensions
+    'fields.title_embedding.dimension' = '768',
+    'fields.image_embedding.dimension' = '512',
+    -- shared by every ivf-pq column, overridden only for 'image_embedding'
+    'ivf-pq.nlist' = '256',
+    'fields.image_embedding.nlist' = '512',
+    -- per-column training sample ratio
+    'fields.image_embedding.train.sample-ratio' = '0.5'
+);
+```
+
+</TabItem>
+
+<TabItem value="python-sdk" label="Python SDK">
+
+```python
+import pyarrow as pa
+
+from pypaimon import Schema
+
+schema = Schema.from_pyarrow_schema(
+    pa.schema([
+        pa.field("id", pa.int32()),
+        pa.field("title_embedding", pa.list_(pa.float32())),
+        pa.field("image_embedding", pa.list_(pa.float32())),
+    ]),
+    options={
+        "row-tracking.enabled": "true",
+        "data-evolution.enabled": "true",
+        "global-index.enabled": "true",
+        "fields.title_embedding.dimension": "768",
+        "fields.image_embedding.dimension": "512",
+        "ivf-pq.nlist": "256",
+        "fields.image_embedding.nlist": "512",
+        "fields.image_embedding.train.sample-ratio": "0.5",
+    },
+)
+
+catalog.create_table("db.multi_embedding_table", schema, ignore_if_exists=False)
+```
+
+</TabItem>
+
+</Tabs>
+
+These properties configure subsequent IVF-PQ builds; creating the table does not
+build an index. After loading data, a build on `title_embedding` uses `nlist=256`,
+while one on `image_embedding` uses `nlist=512` and trains with half of its non-null vectors.
+
+## Drop Vector Index
+
+<Tabs groupId="vector-drop">
+
+<TabItem value="sql" label="SQL">
+
+```sql
+CALL sys.drop_global_index(
+    table => 'db.my_table',
+    index_column => 'embedding',
+    index_type => 'ivf-flat'
+);
+```
+
+</TabItem>
+
+<TabItem value="python-sdk" label="Python SDK">
+
+```python
+table = catalog.get_table("db.my_table")
+
+dropped_files = table.drop_global_index("embedding", index_type="ivf-flat")
+print(dropped_files)
+```
+
+You can also restrict the drop to selected partitions, or count matched files
+without committing:
+
+```python
+matched_files = table.drop_global_index(
+    "embedding",
+    index_type="ivf-flat",
+    partitions=[{"dt": "2026-06-18"}, {"dt": "2026-06-19"}],
+    dry_run=True,
+)
+print(matched_files)
+```
 
 </TabItem>
 

--- a/docs/docs/multimodal-table/index.mdx
+++ b/docs/docs/multimodal-table/index.mdx
@@ -1,10 +1,6 @@
 ---
 title: "Multimodal Table"
-sidebar_position: 4
 ---
-
-import Tabs from '@theme/Tabs';
-import TabItem from '@theme/TabItem';
 
 <!--
 Licensed to the Apache Software Foundation (ASF) under one
@@ -27,23 +23,68 @@ under the License.
 
 # Overview
 
-Multimodal Table extends the Append Table with capabilities for storing and querying multimodal data — images, videos,
-audio, vectors, and full-text content — all within a single table. It is built on top of the
-[Data Evolution](./data-evolution) mode, which enables efficient partial column updates and schema evolution without
-rewriting entire data files.
+A multimodal table keeps metadata, binary payloads, embeddings, and text in one
+logical table. An ingestion pipeline can append records, enrich selected columns,
+and build indexes for filtering or retrieval.
 
-Key capabilities:
+This chapter focuses on append tables with **Data Evolution**: column files share
+row IDs, so adding captions or replacing embeddings can leave large media payloads
+in their existing files. It is an append table with additional storage and update
+capabilities, not a primary-key table that deduplicates records by a business key.
 
-- **[Data Evolution](./data-evolution)**: Update partial columns without rewriting entire files, enabling efficient schema evolution.
-- **[Variant Storage](./variant)**: Store and query schema-flexible semi-structured data with optional typed sub-column shredding.
-- **[Blob Storage](./blob)**: Store large binary objects (images, videos, audio) in dedicated `.blob` files with efficient column projection.
-- **[Vector Storage](./vector)**: Store and manage vector embeddings in dedicated Vortex-format files optimized for vector workloads.
-- **[Global Index](./global-index)**: Build BTree, Bitmap, Multivalue, FM, vector, and full-text indexes for efficient lookups, exact substring filtering, and similarity search.
+![One logical record combines normal columns, dedicated BLOB payloads, and optional dedicated vectors by row ID; indexes select matching row IDs for reads.](/img/multimodal-table-overview.svg)
 
-Data Evolution, Blob Storage, Vector Storage, and Global Index require the following table properties.
-Variant Storage can also be used in a regular Paimon table without these properties:
+## Start Here
+
+Follow the [Quick Start](./quick-start) to create a table, write sample data, update
+selected columns, and build a scalar index. It uses Spark SQL in a configured
+Paimon catalog. The topic pages also provide Flink, Java, and Python examples where
+supported.
+
+| If you need to… | Read |
+| --- | --- |
+| Store images, audio, documents, or collections of binary objects | [BLOB Storage](./blob) |
+| Reuse payloads across tables or export a temporary URL | [BLOB References and Sharing](./blob-references) |
+| Address video frames while storing complete encoded videos | [Video Frame Storage](./video) |
+| Store fixed-dimension embeddings | [Vector Storage](./vector) |
+| Query metadata whose structure varies between rows | [Variant Storage](./variant) |
+| Backfill or replace selected columns; update and delete rows | [Data Evolution](./data-evolution) |
+| Understand file ranges, column versions, and row reconstruction | [File Layout and Reads](./data-evolution-file-layout) |
+| Compact column files or materialize logical deletions | [Data Evolution Maintenance](./data-evolution-maintenance) |
+| Choose an index and retrieve matching records | [Global Index](./global-index) |
+
+## Choose Storage and Indexing Separately
+
+Storage determines how values are represented and read. Indexes determine how
+queries find matching row IDs. A stored vector does not automatically have an ANN
+index, and a text column does not automatically have a full-text index.
+
+| Capability | Setup for this append-table workflow |
+| --- | --- |
+| Partial-column updates and managed BLOB storage | Enable `row-tracking.enabled` and `data-evolution.enabled` at table creation. |
+| Dedicated vector files | Enable both properties above and set `vector.file.format = vortex`. |
+| Global indexes | Use a Data Evolution table, load data, then explicitly build indexes. |
+| Variant | Use Parquet and a supported engine; Data Evolution is optional. |
+
+Data Evolution requires no primary key and `bucket = -1`, the default for append
+tables. The basic properties are:
 
 ```sql
 'row-tracking.enabled' = 'true',
 'data-evolution.enabled' = 'true'
 ```
+
+For JVM primary-key workloads, use the separate guides for
+[BLOB storage](../primary-key-table/blob-storage) and
+[indexes](../primary-key-table/global-index). Their requirements differ from this chapter.
+
+## Plan for Updates and Freshness
+
+- A normal-column update writes the selected columns over complete affected file
+  ranges. It saves I/O on untouched columns; it can still process more rows than
+  the update predicate matches.
+- Appending data does not refresh existing indexes. The default `fast` search mode
+  can omit uncovered rows; choose a [coverage policy](./global-index/manage-indexes#coverage-and-freshness).
+- Ordinary updates and compaction preserve row IDs. Some maintenance operations
+  reassign them; coordinate [row-ID lifetime](./data-evolution-maintenance#row-id-lifetime)
+  with BLOB views or applications that persist row references.

--- a/docs/docs/multimodal-table/quick-start.mdx
+++ b/docs/docs/multimodal-table/quick-start.mdx
@@ -1,0 +1,161 @@
+---
+title: "Quick Start"
+---
+
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+# Quick Start
+
+This Spark SQL walkthrough creates a small media table, enriches it, and uses a
+scalar index to find records. It assumes a [configured Paimon Spark catalog](../spark/quick-start)
+is selected and the current database already exists. Use a fresh table name if
+`media_samples` already exists.
+
+For other engines, use the [Flink examples](./blob#creating-a-table) or
+[PyPaimon multimodal API](../pypaimon/multimodal-api). SQL engine support and
+dependencies are described in their setup guides.
+
+## 1. Create the Table
+
+Keep searchable metadata beside the payload. `image` is a managed BLOB column;
+`embedding` starts as an ordinary float array. Using a float array here avoids
+requiring the dedicated Vortex storage format for this walkthrough.
+
+```sql
+CREATE TABLE media_samples (
+    id BIGINT,
+    category STRING,
+    image BINARY COMMENT '__BLOB_FIELD; source image',
+    caption STRING,
+    embedding ARRAY<FLOAT>
+) TBLPROPERTIES (
+    'row-tracking.enabled' = 'true',
+    'data-evolution.enabled' = 'true'
+);
+```
+
+`id` is a business identifier, not a primary key. Inserting the same identifier
+again appends another row. Paimon assigns its own row IDs for column alignment.
+
+## 2. Append Sample Records
+
+The short binary values below are test payloads, not encoded image files. In a
+real pipeline, supply the image bytes or supported descriptors through the
+[BLOB write APIs](./blob#inserting-blob-data).
+
+```sql
+INSERT INTO media_samples VALUES
+    (1, 'animals', X'010203', NULL, NULL),
+    (2, 'travel',  X'040506', NULL, NULL);
+
+SELECT id, category FROM media_samples ORDER BY id;
+-- (1, animals), (2, travel)
+```
+
+This query projects only normal columns and does not load the BLOB payloads.
+
+## 3. Enrich Selected Columns
+
+Assume a model has produced the caption and three-dimensional example embedding.
+Write those values to the existing row:
+
+```sql
+UPDATE media_samples
+SET caption = 'A cat on a chair', embedding = array(1.0f, 0.0f, 0.0f)
+WHERE id = 1;
+
+SELECT id, caption, embedding FROM media_samples WHERE id = 1;
+-- (1, A cat on a chair, [1.0, 0.0, 0.0])
+```
+
+The update writes the selected normal columns over the affected file range.
+Existing image payloads remain in their BLOB files. Use
+[Data Evolution](./data-evolution#partial-updates) for batch backfills, merges,
+deletes, and concurrency behavior.
+
+## 4. Build and Use a Scalar Index
+
+Build the index after loading data:
+
+```sql
+CALL sys.create_global_index(
+    table => 'media_samples',
+    index_column => 'category',
+    index_type => 'btree'
+);
+
+SELECT id, caption FROM media_samples WHERE category = 'animals';
+-- (1, A cat on a chair)
+```
+
+Inspect the recorded row-ID coverage:
+
+```sql
+SELECT index_type, index_field_name, row_range_start, row_range_end
+FROM `media_samples$table_indexes`
+WHERE index_field_name = 'category';
+```
+
+The default search mode is `fast`, which searches indexed coverage. If you append
+more records, build again before expecting indexed queries to include them, or
+select an appropriate [search mode](./global-index/manage-indexes#coverage-and-freshness).
+Updates to an indexed column also have a separate
+[update policy](./global-index/manage-indexes#update-indexed-columns); this example enriches
+the data before building the index.
+
+## 5. Refresh After an Append
+
+Append another matching record after the first index build. With the default
+`scalar-index.search-mode=fast`, the indexed query still searches the original
+coverage:
+
+```sql
+INSERT INTO media_samples VALUES (3, 'animals', X'070809', NULL, NULL);
+
+SELECT id FROM media_samples WHERE category = 'animals' ORDER BY id;
+-- 1 (the new row is outside the current index coverage)
+```
+
+Build again to cover the new row, then repeat the query:
+
+```sql
+CALL sys.create_global_index(
+    table => 'media_samples',
+    index_column => 'category',
+    index_type => 'btree'
+);
+
+SELECT id FROM media_samples WHERE category = 'animals' ORDER BY id;
+-- 1, 3
+```
+
+The second build adds missing coverage. It does not make later appends refresh
+automatically. For reads that must include uncovered rows before the next build,
+see the `full` and `detail` [search modes](./global-index/manage-indexes#coverage-and-freshness).
+
+## Next Steps
+
+| Goal | Next guide |
+| --- | --- |
+| Store fixed-dimension vectors in dedicated files | [Vector Storage](./vector) |
+| Search similar embeddings | [Vector Index](./global-index/vector) |
+| Search captions by text relevance | [Full-Text Index](./global-index/full-text) |
+| Combine vector and text results | [Hybrid Search](./global-index/hybrid-search) |
+| Consolidate files after repeated enrichment | [Data Evolution Maintenance](./data-evolution-maintenance) |

--- a/docs/docs/multimodal-table/variant.mdx
+++ b/docs/docs/multimodal-table/variant.mdx
@@ -92,8 +92,9 @@ Paths can address nested objects and arrays, for example `$.user.id`, `$.items[0
 `$[0]`. A missing path returns `NULL`. Conversion behavior for incompatible values is defined by
 the query engine and the Variant function being used.
 
-With a JSON string, an equivalent query uses string-oriented JSON functions and normally parses the
-text while evaluating the query:
+For an existing `json_events` table that instead stores JSON text in a
+`payload_json STRING` column, an equivalent query uses string-oriented JSON
+functions and normally parses the text while evaluating the query:
 
 ```sql
 SELECT
@@ -103,6 +104,8 @@ FROM json_events;
 ```
 
 ## Storage Layout
+
+![Plain Variant stores binary value and metadata; shredding adds typed Parquet leaves while preserving other values in overflow bytes.](/img/multimodal-variant-shredding.svg)
 
 ### Plain Variant
 
@@ -171,11 +174,17 @@ TBLPROPERTIES (
     'variant.shreddingSchema' =
     '{"type":"ROW","fields":[{"name":"payload","type":{"type":"ROW","fields":[{"name":"user_id","type":"BIGINT"},{"name":"city","type":"STRING"}]}}]}'
 );
+
+INSERT INTO user_events VALUES
+    (1, parse_json('{"user_id":1001,"city":"Hangzhou","active":true}')),
+    (2, parse_json('{"user_id":1002,"city":"Beijing","score":9.5}'));
 ```
 
-This schema shreds `$.user_id` as `BIGINT` and `$.city` as `STRING`. Other fields remain available
-through the overflow bytes. The legacy key `parquet.variant.shreddingSchema` is accepted as an
-alias.
+This schema shreds the sample's top-level `$.user_id` as `BIGINT` and `$.city` as
+`STRING`. The `active` and `score` fields remain available through the overflow
+bytes. Unlike the earlier `events` example, this table uses a top-level `user_id`
+field rather than nested `user.id`. The legacy key
+`parquet.variant.shreddingSchema` is accepted as an alias.
 
 Shredded typed values support character and binary types, booleans, decimal and numeric types, and
 nested `ROW` and `ARRAY` types. A `VARIANT` branch in the shredding schema leaves that branch in its
@@ -186,7 +195,8 @@ predictable physical layout and avoids inference buffering.
 
 ### Automatic Schema Inference
 
-Paimon can infer a shredding schema independently for each output file:
+By default, Paimon infers a shredding schema independently for each output file
+when inference is enabled:
 
 ```sql
 CREATE TABLE inferred_events (
@@ -201,6 +211,9 @@ TBLPROPERTIES (
     'variant.shredding.maxSchemaDepth' = '50',
     'variant.shredding.minFieldCardinalityRatio' = '0.1'
 );
+
+-- Reuse the populated sample from the explicit-schema example.
+INSERT INTO inferred_events SELECT id, payload FROM user_events;
 ```
 
 The writer buffers the initial rows of a file, infers their common shape, creates the physical
@@ -211,13 +224,16 @@ fields with incompatible observed types remain unshredded.
 |---|---:|---|
 | `variant.inferShreddingSchema` | `false` | Enables per-file shredding schema inference when no explicit schema is configured. |
 | `variant.shredding.maxInferBufferRow` | `4096` | Maximum number of initial rows buffered for inference. |
-| `variant.shredding.maxSchemaWidth` | `300` | Maximum number of fields in an inferred shredding schema. |
+| `variant.shredding.maxSchemaWidth` | `300` | Inferred shredding width budget, including `value` and `typed_value` entries; not a count of JSON keys. |
 | `variant.shredding.maxSchemaDepth` | `50` | Maximum Variant traversal depth during inference. |
 | `variant.shredding.minFieldCardinalityRatio` | `0.1` | Minimum fraction of sampled non-null Variant values that must contain a field before it is shredded. |
 
-Automatic inference is convenient for exploratory or rapidly evolving data. Because inference is
-per file, different files can have different shredded paths; readers use each file's physical
-schema transparently.
+For example, an object with five shredded scalar fields needs a width budget of
+11: one root `value` entry plus one `value` and one `typed_value` entry per field.
+
+Automatic inference is convenient for exploratory or rapidly evolving data. With
+the default per-file inference, files can have different shredded paths; readers
+use each file's physical schema transparently.
 
 ## Query Pushdown
 
@@ -232,9 +248,12 @@ Spark 4.1 and later can push `variant_get` extractions into Paimon when
 SET spark.sql.variant.pushVariantIntoScan = true;
 
 SELECT
-    variant_get(payload, '$.user_id', 'bigint'),
-    variant_get(payload, '$.city', 'string')
-FROM user_events;
+    id,
+    variant_get(payload, '$.user_id', 'bigint') AS user_id,
+    variant_get(payload, '$.city', 'string') AS city
+FROM user_events
+ORDER BY id;
+-- (1, 1001, Hangzhou), (2, 1002, Beijing)
 ```
 
 The SQL and result are the same for plain, shredded, and mixed-layout files. Shredded files provide

--- a/docs/docs/multimodal-table/vector.mdx
+++ b/docs/docs/multimodal-table/vector.mdx
@@ -340,7 +340,7 @@ from pypaimon.schema.schema_change import SchemaChange
 from pypaimon.schema.data_types import AtomicType, VectorType
 
 catalog.alter_table(
-    'default.vector_table',
+    'my_db.vector_table',
     [SchemaChange.add_column('embed2', VectorType(True, AtomicType('FLOAT'), 768))]
 )
 ```

--- a/docs/docs/multimodal-table/vector.mdx
+++ b/docs/docs/multimodal-table/vector.mdx
@@ -29,9 +29,13 @@ under the License.
 
 ## Overview
 
-With the explosive growth of AI scenarios, vector storage has become increasingly important. Paimon provides optimized storage solutions specifically designed for vector data.
+Use `VECTOR` for fixed-length dense numeric data such as model embeddings. This page
+shows how to create, write, and read vector columns, including dedicated storage
+using the Vortex columnar format.
 
-Paimon stores vector columns in dedicated files using the [Vortex](https://github.com/spiraldb/vortex) columnar format, which is optimized for vector workloads with high compression ratio and fast scan performance.
+Storage and similarity search are configured separately. After loading vectors,
+build a [Vector Index](./global-index/vector) to use ANN search. Vector indexes can
+also index `ARRAY<FLOAT>` columns without dedicated vector files.
 
 ## Vector Data Type
 
@@ -68,11 +72,14 @@ table/
 | Option | Description |
 |--------|-------------|
 | `vector.file.format` | File format for dedicated vector files. Set to `vortex` to enable dedicated vector storage. |
-| `vector.target-file-size` | Target file size for vector files. Defaults to `10 * 'target-file-size'`. |
+| `vector.target-file-size` | Target file size for vector files. Defaults to `target-file-size`. |
 | `row-tracking.enabled` | Must be `true` for dedicated vector storage. |
 | `data-evolution.enabled` | Must be `true` for dedicated vector storage. |
 
 ## Create Table
+
+The single-vector examples use dimension `3` so the write examples are complete.
+Use the dimension produced by your embedding model in an application.
 
 The recommended way to create a vector table in SQL is to use the **comment directive** `__VECTOR_FIELD;dim` on the column. Paimon automatically converts the `ARRAY` type to `VECTOR` and registers the field in the `vector-field` option.
 
@@ -84,7 +91,7 @@ The recommended way to create a vector table in SQL is to use the **comment dire
 -- Comment directive: __VECTOR_FIELD;{dim}; optional comment
 CREATE TABLE vector_table (
     id BIGINT,
-    embed ARRAY<FLOAT> COMMENT '__VECTOR_FIELD;128; product embedding'
+    embed ARRAY<FLOAT> COMMENT '__VECTOR_FIELD;3; product embedding'
 ) WITH (
     'vector.file.format' = 'vortex',
     'row-tracking.enabled' = 'true',
@@ -111,7 +118,7 @@ CREATE TABLE multi_vector_table (
 ```sql
 CREATE TABLE vector_table (
     id BIGINT,
-    embed ARRAY<FLOAT> COMMENT '__VECTOR_FIELD;128; product embedding'
+    embed ARRAY<FLOAT> COMMENT '__VECTOR_FIELD;3; product embedding'
 ) TBLPROPERTIES (
     'vector.file.format' = 'vortex',
     'row-tracking.enabled' = 'true',
@@ -127,11 +134,17 @@ CREATE TABLE vector_table (
 // Java API uses VectorType directly — no comment directive needed
 Schema schema = Schema.newBuilder()
         .column("id", DataTypes.BIGINT())
-        .column("embed", DataTypes.VECTOR(128, DataTypes.FLOAT()))
+        .column("embed", DataTypes.VECTOR(3, DataTypes.FLOAT()))
         .option("vector.file.format", "vortex")
         .option("row-tracking.enabled", "true")
         .option("data-evolution.enabled", "true")
         .build();
+
+// Use a catalog configured as described in the Java API guide.
+catalog.createDatabase("my_db", true);
+Identifier identifier = Identifier.create("my_db", "vector_table");
+catalog.createTable(identifier, schema, false);
+Table table = catalog.getTable(identifier);
 ```
 
 </TabItem>
@@ -140,12 +153,15 @@ Schema schema = Schema.newBuilder()
 
 ```python
 import pyarrow as pa
-from pypaimon import Schema
+from pypaimon import CatalogFactory, Schema
+
+catalog = CatalogFactory.create({'warehouse': '/tmp/paimon-warehouse'})
+catalog.create_database('my_db', True)
 
 # Fixed-size list is automatically recognized as VECTOR type
 pa_schema = pa.schema([
     ('id', pa.int64()),
-    ('embed', pa.list_(pa.float32(), 128)),
+    ('embed', pa.list_(pa.float32(), 3)),
 ])
 
 schema = Schema.from_pyarrow_schema(
@@ -156,56 +172,8 @@ schema = Schema.from_pyarrow_schema(
         'data-evolution.enabled': 'true',
     }
 )
-```
-
-</TabItem>
-
-</Tabs>
-
-## Adding a Vector Column
-
-<Tabs groupId="vector-add-column">
-
-<TabItem value="flink" label="Flink SQL">
-
-```sql
-ALTER TABLE vector_table
-    ADD embed2 ARRAY<FLOAT> COMMENT '__VECTOR_FIELD;768; text embedding';
-```
-
-</TabItem>
-
-<TabItem value="spark" label="Spark SQL">
-
-```sql
-ALTER TABLE vector_table
-    ADD COLUMN embed2 ARRAY<FLOAT> COMMENT '__VECTOR_FIELD;768; text embedding';
-```
-
-</TabItem>
-
-<TabItem value="java" label="Java API">
-
-```java
-// Java API: add column with VectorType directly
-schemaManager.commitChanges(
-    SchemaChange.addColumn("embed2", DataTypes.VECTOR(768, DataTypes.FLOAT())));
-
-// Or use comment directive like SQL
-schemaManager.commitChanges(
-    SchemaChange.addColumn("embed2", DataTypes.ARRAY(DataTypes.FLOAT()),
-        "__VECTOR_FIELD;768; text embedding", null));
-```
-
-</TabItem>
-
-<TabItem value="python" label="Python API">
-
-```python
-catalog.alter_table(
-    'default.vector_table',
-    [('add', 'embed2', pa.list_(pa.float32(), 768))]
-)
+catalog.create_table('my_db.vector_table', schema, False)
+table = catalog.get_table('my_db.vector_table')
 ```
 
 </TabItem>
@@ -219,7 +187,7 @@ catalog.alter_table(
 <TabItem value="flink" label="Flink SQL">
 
 ```sql
-INSERT INTO vector_table VALUES (1, ARRAY[1.0, 2.0, 3.0, ...]);
+INSERT INTO vector_table VALUES (1, ARRAY[CAST(1.0 AS FLOAT), CAST(2.0 AS FLOAT), CAST(3.0 AS FLOAT)]);
 ```
 
 </TabItem>
@@ -227,7 +195,7 @@ INSERT INTO vector_table VALUES (1, ARRAY[1.0, 2.0, 3.0, ...]);
 <TabItem value="spark" label="Spark SQL">
 
 ```sql
-INSERT INTO vector_table VALUES (1, ARRAY(1.0, 2.0, 3.0, ...));
+INSERT INTO vector_table VALUES (1, array(1.0f, 2.0f, 3.0f));
 ```
 
 </TabItem>
@@ -261,10 +229,13 @@ data = pa.table({
 
 write_builder = table.new_batch_write_builder()
 writer = write_builder.new_write()
-writer.write_arrow(data)
-commit_messages = writer.prepare_commit()
-write_builder.new_commit().commit(commit_messages)
-writer.close()
+commit = write_builder.new_commit()
+try:
+    writer.write_arrow(data)
+    commit.commit(writer.prepare_commit())
+finally:
+    writer.close()
+    commit.close()
 ```
 
 </TabItem>
@@ -316,6 +287,62 @@ result = read_builder.new_read().to_arrow(splits)
 
 print(result.column('embed').to_pylist())
 # [[1.0, 2.0, 3.0], [4.0, 5.0, 6.0], [7.0, 8.0, 9.0]]
+```
+
+</TabItem>
+
+</Tabs>
+
+## Adding a Vector Column
+
+This is a separate schema-change example to run after the create/write/read
+walkthrough. Add the column, then backfill it with [Data Evolution](./data-evolution#self-updates).
+
+<Tabs groupId="vector-add-column">
+
+<TabItem value="flink" label="Flink SQL">
+
+```sql
+ALTER TABLE vector_table
+    ADD embed2 ARRAY<FLOAT> COMMENT '__VECTOR_FIELD;768; text embedding';
+```
+
+</TabItem>
+
+<TabItem value="spark" label="Spark SQL">
+
+```sql
+ALTER TABLE vector_table
+    ADD COLUMN embed2 ARRAY<FLOAT> COMMENT '__VECTOR_FIELD;768; text embedding';
+```
+
+</TabItem>
+
+<TabItem value="java" label="Java API">
+
+```java
+// Java API: add column with VectorType directly
+schemaManager.commitChanges(
+    SchemaChange.addColumn("embed2", DataTypes.VECTOR(768, DataTypes.FLOAT())));
+
+// Or use comment directive like SQL
+schemaManager.commitChanges(
+    SchemaChange.addColumn("embed2", DataTypes.ARRAY(DataTypes.FLOAT()),
+        "__VECTOR_FIELD;768; text embedding", null));
+```
+
+</TabItem>
+
+<TabItem value="python" label="Python API">
+
+```python
+from pypaimon.schema.schema_change import SchemaChange
+from pypaimon.schema.data_types import AtomicType, VectorType
+
+catalog.alter_table(
+    'default.vector_table',
+    [SchemaChange.add_column('embed2', VectorType(True, AtomicType('FLOAT'), 768))]
+)
 ```
 
 </TabItem>

--- a/docs/docs/multimodal-table/video.mdx
+++ b/docs/docs/multimodal-table/video.mdx
@@ -1,0 +1,160 @@
+---
+title: "Video Frame Storage"
+---
+
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+# Video Frame Storage
+
+Store one logical row per frame while keeping complete encoded videos as the
+physical payload. Use ordinary [BLOB storage](./blob) when each row contains an
+independent image, audio clip, or binary object.
+
+![Logical frame rows reference complete encoded videos in a self-contained pack; the run index maps row positions to video payloads and frame ordinals.](/img/multimodal-video-pack.svg)
+
+## Create a Video Table
+
+Use `video-frame-field` when the logical table has one row per frame while the physical storage
+and decoding unit is a complete encoded video. The comma-separated option also marks each named
+SQL `BYTES` or `BINARY` column as a BLOB column. It selects the dedicated `.video` format; the
+ordinary `.blob` version and layout are not changed.
+
+<Tabs groupId="video-create">
+
+<TabItem value="flink" label="Flink SQL">
+
+```sql
+CREATE TABLE video_frames (
+    episode_id BIGINT,
+    camera_front BYTES,
+    camera_wrist BYTES
+) WITH (
+    'row-tracking.enabled' = 'true',
+    'data-evolution.enabled' = 'true',
+    'video-frame-field' = 'camera_front,camera_wrist'
+);
+```
+
+</TabItem>
+
+<TabItem value="spark" label="Spark SQL">
+
+```sql
+CREATE TABLE video_frames (
+    episode_id BIGINT,
+    camera_front BINARY,
+    camera_wrist BINARY
+) TBLPROPERTIES (
+    'row-tracking.enabled' = 'true',
+    'data-evolution.enabled' = 'true',
+    'video-frame-field' = 'camera_front,camera_wrist'
+);
+```
+
+</TabItem>
+
+</Tabs>
+
+Creating the table does not ingest or decode video files. Use the
+[PyPaimon video ingestion API](../pypaimon/multimodal-api#video-frame-storage)
+to write complete videos and their logical frame rows.
+
+## Descriptors and Physical Layout
+
+Each logical value is a `VideoFrameDescriptor`: its URI range identifies one complete encoded
+video and its frame ordinal selects a frame inside that video. On write, a `.video` data region
+concatenates raw video payloads without ordinary BLOB entry wrappers. Four embedded delta-varint
+indexes record physical video lengths, logical run lengths, run-to-video references, and the first
+frame ordinal of each run. Consecutive frames therefore need one run entry rather than one index
+entry per row. NULL and data-evolution placeholders use negative run references.
+
+## Reuse, Rolling, and Compaction
+
+Physical reuse uses exact payload descriptor identity (URI, offset, and length), not a content
+hash. It is local to each `.video` file: every pack is self-contained and never points at payloads
+owned by another Paimon data file. A pack can contain multiple MP4 payloads. After a size or row
+target is reached, rolling waits for the current physical video group to end, making the target
+soft for large videos. A later commit or an earlier roll can store another physical copy of the
+same source video. For multi-camera tables, payload boundaries may be nested across fields as long
+as every transition is an episode boundary. Once a target is reached within an episode, normal,
+BLOB, and vector rolling is deferred until the next payload boundary and all active writers close
+together. The resulting file group remains row-aligned and a single large episode may exceed the
+configured target.
+
+When BLOB compaction is enabled, it byte-copies the complete encoded-video ranges into a new self-contained `.video` pack
+and rebuilds the embedded indexes; it does not decode or re-encode frames. The aligned normal data
+file contains only application columns such as `episode_id`, state, and action. Paimon stores the
+frame mapping in the `.video` descriptor/index path.
+`blob-compaction.enabled` defaults to `false`; ordinary normal-file compaction can
+leave the video packs unchanged. See [Data Evolution Maintenance](./data-evolution-maintenance#ordinary-compaction).
+
+## Requirements and Limitations
+
+- Append-only tables only; primary-key tables continue to use managed BLOB storage.
+- Every configured field must be a scalar `BLOB`; `ARRAY<BLOB>` and `MAP<K, BLOB>` continue to use
+  `.blob`.
+- Non-null writes must be exact descriptor-backed `BlobRef` values containing a
+  `VideoFrameDescriptor`. Inline bytes and ordinary `BlobDescriptor` values are rejected.
+- Version 1 addresses frames by zero-based presentation-order ordinal with stride one. It does not
+  store PTS values or parse codec/container metadata.
+- A `BlobConsumer` callback is not supported for the video field.
+
+## Read Frames
+
+A frame descriptor identifies the encoded video and the frame to decode. It does
+not contain decoded image pixels. Read behavior differs by API:
+
+| API | How to obtain frame descriptors |
+| --- | --- |
+| Flink and Spark SQL | Set `blob-as-descriptor=true`. With `false`, the SQL adapter materializes the complete encoded video payload for each selected frame row. |
+| PyPaimon reads of `.video` fields | Return serialized `VideoFrameDescriptor` values even when `blob-as-descriptor=false`. |
+| Java internal-row API | `row.getBlob(position)` returns a descriptor-backed `BlobRef`; call `toDescriptor()` to access the frame descriptor. `toData()` reads the complete video payload. |
+
+After ingesting data, query descriptors without loading a complete video for every row:
+
+<Tabs groupId="video-read">
+
+<TabItem value="flink" label="Flink SQL">
+
+```sql
+SELECT episode_id, camera_front, camera_wrist
+FROM video_frames /*+ OPTIONS('blob-as-descriptor'='true') */;
+```
+
+</TabItem>
+
+<TabItem value="spark" label="Spark SQL">
+
+```sql
+ALTER TABLE video_frames SET TBLPROPERTIES ('blob-as-descriptor' = 'true');
+SELECT episode_id, camera_front, camera_wrist FROM video_frames;
+```
+
+This table property remains enabled for subsequent SQL reads.
+
+</TabItem>
+
+</Tabs>
+
+For Python ingestion and PyTorch `DataLoader` usage, including decoder-session reuse in workers,
+see [PyPaimon Multimodal API: Video Frame Storage](../pypaimon/multimodal-api#video-frame-storage).

--- a/docs/docs/spark/sql-functions.md
+++ b/docs/docs/spark/sql-functions.md
@@ -126,7 +126,7 @@ FROM image_table;
 Repeated short-term calls for the same descriptor reuse the materialized object and issue a fresh
 URL. Treat the URL as a bearer credential: send it immediately to the consumer and never log or
 persist it. Direct model `image_url` use is supported only for image formats verified with that
-model; PDF is not covered. See [Blob Storage](../multimodal-table/blob#presigned-urls-for-oss-blobs)
+model; PDF is not covered. See [Blob Storage](../multimodal-table/blob-references#presigned-urls-for-oss-blobs)
 for Java and Flink examples, caching behavior, and current limitations.
 
 ## User-defined Function

--- a/docs/sidebars.js
+++ b/docs/sidebars.js
@@ -142,10 +142,32 @@ const sidebars = {
       "id": "multimodal-table/index"
     },
     "items": [
-      "multimodal-table/data-evolution",
-      "multimodal-table/variant",
-      "multimodal-table/blob",
-      "multimodal-table/vector",
+      "multimodal-table/quick-start",
+      {
+        type: "category",
+        "label": "Storage Types",
+        "collapsed": true,
+        "items": [
+          "multimodal-table/blob",
+          "multimodal-table/blob-references",
+          "multimodal-table/video",
+          "multimodal-table/vector",
+          "multimodal-table/variant"
+        ]
+      },
+      {
+        type: "category",
+        "label": "Data Evolution",
+        "collapsed": true,
+        "link": {
+          type: "doc",
+          "id": "multimodal-table/data-evolution"
+        },
+        "items": [
+          "multimodal-table/data-evolution-file-layout",
+          "multimodal-table/data-evolution-maintenance"
+        ]
+      },
       {
         type: "category",
         "label": "Global Index",
@@ -155,6 +177,7 @@ const sidebars = {
           "id": "multimodal-table/global-index"
         },
         "items": [
+          "multimodal-table/global-index/manage-indexes",
           "multimodal-table/global-index/btree",
           "multimodal-table/global-index/bitmap",
           "multimodal-table/global-index/multivalue",

--- a/docs/static/img/multimodal-bitmap-layout.svg
+++ b/docs/static/img/multimodal-bitmap-layout.svg
@@ -1,0 +1,58 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="900" height="574" viewBox="0 0 900 574" role="img" aria-labelledby="title desc">
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements. See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership. The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied. See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+<title id="title">Bitmap file layout and point lookup</title>
+<desc id="desc">The file stores null and non-null row bitmaps, interleaved value-bitmap and dictionary payload blocks, a dictionary block index, and a fixed footer. A point lookup reads the footer, locates a dictionary block, looks up the key, and reads the referenced row bitmap.</desc>
+<defs><marker id="arrow" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse"><path d="M0 0 L10 5 L0 10 Z" fill="#526277"/></marker></defs>
+<g font-family="Arial, Helvetica, sans-serif" fill="#172b4d">
+<rect x="1" y="1" width="898" height="572" rx="12" fill="#ffffff" stroke="#d7dfeb" stroke-width="1.5"/>
+<text x="28" y="44" font-size="27" font-weight="700" fill="#172b4d" text-anchor="start">Bitmap file layout and point lookup</text>
+<text x="28" y="76" font-size="17" font-weight="400" fill="#526277" text-anchor="start">Physical block order is independent of the demand-driven read path.</text>
+<text x="28" y="116" font-size="21" font-weight="700" fill="#172b4d" text-anchor="start">File order</text>
+<rect x="28" y="132" width="420" height="48" rx="8" fill="#e7f5f1" stroke="#d7dfeb" stroke-width="1.5"/>
+<text x="46" y="163" font-size="19" font-weight="700" fill="#172b4d" text-anchor="start">Null-row bitmap</text>
+<rect x="28" y="188" width="420" height="48" rx="8" fill="#e7f5f1" stroke="#d7dfeb" stroke-width="1.5"/>
+<text x="46" y="219" font-size="19" font-weight="700" fill="#172b4d" text-anchor="start">Non-null-row bitmap</text>
+<rect x="28" y="244" width="420" height="105" rx="8" fill="#eaf2ff" stroke="#d7dfeb" stroke-width="1.5"/>
+<text x="46" y="275" font-size="19" font-weight="700" fill="#172b4d" text-anchor="start">Value bitmaps + dictionary blocks</text>
+<text x="46" y="303" font-size="17" font-weight="400" fill="#526277" text-anchor="start">Payload blocks may be interleaved.</text>
+<text x="46" y="328" font-size="17" font-weight="400" fill="#526277" text-anchor="start">Offsets identify each block.</text>
+<rect x="28" y="357" width="420" height="48" rx="8" fill="#eaf2ff" stroke="#d7dfeb" stroke-width="1.5"/>
+<text x="46" y="388" font-size="19" font-weight="700" fill="#172b4d" text-anchor="start">Dictionary block index</text>
+<rect x="28" y="413" width="420" height="66" rx="8" fill="#fff3df" stroke="#d7dfeb" stroke-width="1.5"/>
+<text x="46" y="444" font-size="19" font-weight="700" fill="#172b4d" text-anchor="start">Fixed footer: offsets + lengths</text>
+<text x="508" y="116" font-size="21" font-weight="700" fill="#172b4d" text-anchor="start">Read order for one key</text>
+<rect x="508" y="132" width="364" height="78" rx="8" fill="#fff3df" stroke="#d7dfeb" stroke-width="1.5"/>
+<text x="526" y="164" font-size="21" font-weight="700" fill="#9a5200" text-anchor="start">1  Read footer</text>
+<text x="526" y="193" font-size="18" font-weight="400" fill="#526277" text-anchor="start">Find metadata locations.</text>
+<path d="M690 212 L690 223" fill="none" stroke="#526277" stroke-width="2" marker-end="url(#arrow)"/>
+<rect x="508" y="226" width="364" height="78" rx="8" fill="#eaf2ff" stroke="#d7dfeb" stroke-width="1.5"/>
+<text x="526" y="258" font-size="21" font-weight="700" fill="#2463b4" text-anchor="start">2  Read dictionary index</text>
+<text x="526" y="287" font-size="18" font-weight="400" fill="#526277" text-anchor="start">Locate the candidate key block.</text>
+<path d="M690 306 L690 317" fill="none" stroke="#526277" stroke-width="2" marker-end="url(#arrow)"/>
+<rect x="508" y="320" width="364" height="78" rx="8" fill="#eaf2ff" stroke="#d7dfeb" stroke-width="1.5"/>
+<text x="526" y="352" font-size="21" font-weight="700" fill="#2463b4" text-anchor="start">3  Read dictionary block</text>
+<text x="526" y="381" font-size="18" font-weight="400" fill="#526277" text-anchor="start">Resolve bitmap offset and length.</text>
+<path d="M690 400 L690 411" fill="none" stroke="#526277" stroke-width="2" marker-end="url(#arrow)"/>
+<rect x="508" y="414" width="364" height="78" rx="8" fill="#e7f5f1" stroke="#d7dfeb" stroke-width="1.5"/>
+<text x="526" y="446" font-size="21" font-weight="700" fill="#14766b" text-anchor="start">4  Read value bitmap</text>
+<text x="526" y="475" font-size="18" font-weight="400" fill="#526277" text-anchor="start">Return matching row IDs.</text>
+<text x="28" y="535" font-size="18" font-weight="400" fill="#172b4d" text-anchor="start">Null predicates can read only the required null/non-null bitmap.</text>
+</g>
+</svg>

--- a/docs/static/img/multimodal-blob-modes.svg
+++ b/docs/static/img/multimodal-blob-modes.svg
@@ -1,0 +1,56 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="900" height="538" viewBox="0 0 900 538" role="img" aria-labelledby="title desc">
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements. See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership. The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied. See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+<title id="title">Choose what a BLOB field stores</title>
+<desc id="desc">Managed fields write payload bytes in files owned by the table. Descriptor-only fields store an inline URI, offset, and length. BLOB views store an inline upstream table, field, and row ID. Descriptors and views depend on the referenced data remaining available.</desc>
+<defs><marker id="arrow" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse"><path d="M0 0 L10 5 L0 10 Z" fill="#526277"/></marker></defs>
+<g font-family="Arial, Helvetica, sans-serif" fill="#172b4d">
+<rect x="1" y="1" width="898" height="536" rx="12" fill="#ffffff" stroke="#d7dfeb" stroke-width="1.5"/>
+<text x="28" y="44" font-size="27" font-weight="700" fill="#172b4d" text-anchor="start">Choose what a BLOB field stores</text>
+<text x="28" y="76" font-size="17" font-weight="400" fill="#526277" text-anchor="start">A single table can use different modes for different BLOB columns.</text>
+<rect x="28" y="111" width="320" height="108" rx="8" fill="#e7f5f1" stroke="#d7dfeb" stroke-width="1.5"/>
+<text x="46" y="143" font-size="21" font-weight="700" fill="#14766b" text-anchor="start">Managed BLOB</text>
+<text x="46" y="172" font-size="18" font-weight="400" fill="#526277" text-anchor="start">__BLOB_FIELD</text>
+<text x="46" y="197" font-size="18" font-weight="400" fill="#526277" text-anchor="start">Scalar · array · map values</text>
+<path d="M358 165 L406 165" fill="none" stroke="#526277" stroke-width="2" marker-end="url(#arrow)"/>
+<rect x="418" y="111" width="454" height="108" rx="8" fill="#e7f5f1" stroke="#d7dfeb" stroke-width="1.5"/>
+<text x="436" y="143" font-size="21" font-weight="700" fill="#14766b" text-anchor="start">Paimon-managed payload</text>
+<text x="436" y="172" font-size="18" font-weight="400" fill="#526277" text-anchor="start">Bytes written to dedicated .blob files</text>
+<text x="436" y="197" font-size="18" font-weight="400" fill="#526277" text-anchor="start">Owned by this table</text>
+<rect x="28" y="241" width="320" height="108" rx="8" fill="#eaf2ff" stroke="#d7dfeb" stroke-width="1.5"/>
+<text x="46" y="273" font-size="21" font-weight="700" fill="#2463b4" text-anchor="start">Descriptor-only</text>
+<text x="46" y="302" font-size="18" font-weight="400" fill="#526277" text-anchor="start">__BLOB_DESCRIPTOR_FIELD</text>
+<text x="46" y="327" font-size="18" font-weight="400" fill="#526277" text-anchor="start">Scalar only</text>
+<path d="M358 295 L406 295" fill="none" stroke="#526277" stroke-width="2" marker-end="url(#arrow)"/>
+<rect x="418" y="241" width="454" height="108" rx="8" fill="#eaf2ff" stroke="#d7dfeb" stroke-width="1.5"/>
+<text x="436" y="273" font-size="21" font-weight="700" fill="#2463b4" text-anchor="start">Inline file reference</text>
+<text x="436" y="302" font-size="18" font-weight="400" fill="#526277" text-anchor="start">URI + byte offset + byte length</text>
+<text x="436" y="327" font-size="18" font-weight="400" fill="#526277" text-anchor="start">Read bytes from the referenced object</text>
+<rect x="28" y="371" width="320" height="108" rx="8" fill="#f2ecfb" stroke="#d7dfeb" stroke-width="1.5"/>
+<text x="46" y="403" font-size="21" font-weight="700" fill="#7046a4" text-anchor="start">BLOB view</text>
+<text x="46" y="432" font-size="18" font-weight="400" fill="#526277" text-anchor="start">__BLOB_VIEW_FIELD</text>
+<text x="46" y="457" font-size="18" font-weight="400" fill="#526277" text-anchor="start">Scalar only</text>
+<path d="M358 425 L406 425" fill="none" stroke="#526277" stroke-width="2" marker-end="url(#arrow)"/>
+<rect x="418" y="371" width="454" height="108" rx="8" fill="#f2ecfb" stroke="#d7dfeb" stroke-width="1.5"/>
+<text x="436" y="403" font-size="21" font-weight="700" fill="#7046a4" text-anchor="start">Inline table reference</text>
+<text x="436" y="432" font-size="18" font-weight="400" fill="#526277" text-anchor="start">Upstream table + BLOB field + row ID</text>
+<text x="436" y="457" font-size="18" font-weight="400" fill="#526277" text-anchor="start">Resolve the upstream value at read time</text>
+<text x="28" y="514" font-size="17" font-weight="400" fill="#526277" text-anchor="start">Keep referenced objects and upstream rows available for descriptors and views.</text>
+</g>
+</svg>

--- a/docs/static/img/multimodal-hybrid-search.svg
+++ b/docs/static/img/multimodal-hybrid-search.svg
@@ -1,0 +1,55 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="900" height="536" viewBox="0 0 900 536" role="img" aria-labelledby="title desc">
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements. See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership. The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied. See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+<title id="title">Retrieve candidates, then rank once</title>
+<desc id="desc">A query runs against vector and full-text routes. Each route returns its own scored row IDs. A ranker merges candidates by row ID and selects a final top K, after which projected table columns are read. Multiple routes of either kind are allowed.</desc>
+<defs><marker id="arrow" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse"><path d="M0 0 L10 5 L0 10 Z" fill="#526277"/></marker></defs>
+<g font-family="Arial, Helvetica, sans-serif" fill="#172b4d">
+<rect x="1" y="1" width="898" height="534" rx="12" fill="#ffffff" stroke="#d7dfeb" stroke-width="1.5"/>
+<text x="28" y="44" font-size="27" font-weight="700" fill="#172b4d" text-anchor="start">Retrieve candidates, then rank once</text>
+<text x="28" y="76" font-size="17" font-weight="400" fill="#526277" text-anchor="start">Example: route limits of 50 feed a final limit of 10.</text>
+<rect x="28" y="110" width="244" height="115" rx="8" fill="#f2ecfb" stroke="#d7dfeb" stroke-width="1.5"/>
+<text x="46" y="142" font-size="21" font-weight="700" fill="#7046a4" text-anchor="start">Vector route</text>
+<text x="46" y="171" font-size="18" font-weight="400" fill="#526277" text-anchor="start">Title embedding index</text>
+<text x="46" y="196" font-size="18" font-weight="400" fill="#526277" text-anchor="start">Up to 50 scored row IDs</text>
+<rect x="28" y="248" width="244" height="115" rx="8" fill="#fff3df" stroke="#d7dfeb" stroke-width="1.5"/>
+<text x="46" y="280" font-size="21" font-weight="700" fill="#9a5200" text-anchor="start">Full-text route</text>
+<text x="46" y="309" font-size="18" font-weight="400" fill="#526277" text-anchor="start">Caption or content index</text>
+<text x="46" y="334" font-size="18" font-weight="400" fill="#526277" text-anchor="start">Up to 50 scored row IDs</text>
+<path d="M282 168 L361 222" fill="none" stroke="#526277" stroke-width="2" marker-end="url(#arrow)"/>
+<path d="M282 307 L361 253" fill="none" stroke="#526277" stroke-width="2" marker-end="url(#arrow)"/>
+<rect x="375" y="173" width="228" height="146" rx="8" fill="#eaf2ff" stroke="#d7dfeb" stroke-width="1.5"/>
+<text x="393" y="205" font-size="21" font-weight="700" fill="#2463b4" text-anchor="start">Rank candidates</text>
+<text x="393" y="234" font-size="18" font-weight="400" fill="#526277" text-anchor="start">Merge by row ID</text>
+<text x="393" y="259" font-size="18" font-weight="400" fill="#526277" text-anchor="start">rrf · weighted_score</text>
+<text x="393" y="284" font-size="18" font-weight="400" fill="#526277" text-anchor="start">or mrr</text>
+<path d="M613 246 L652 246" fill="none" stroke="#526277" stroke-width="2" marker-end="url(#arrow)"/>
+<rect x="666" y="173" width="206" height="146" rx="8" fill="#eaf2ff" stroke="#d7dfeb" stroke-width="1.5"/>
+<text x="684" y="205" font-size="21" font-weight="700" fill="#2463b4" text-anchor="start">Final top 10</text>
+<text x="684" y="234" font-size="18" font-weight="400" fill="#526277" text-anchor="start">Selected row IDs</text>
+<text x="684" y="259" font-size="18" font-weight="400" fill="#526277" text-anchor="start">+ ranked scores</text>
+<path d="M769 329 L769 380" fill="none" stroke="#526277" stroke-width="2" marker-end="url(#arrow)"/>
+<rect x="375" y="390" width="497" height="102" rx="8" fill="#e7f5f1" stroke="#d7dfeb" stroke-width="1.5"/>
+<text x="393" y="422" font-size="21" font-weight="700" fill="#14766b" text-anchor="start">Read the table</text>
+<text x="393" y="451" font-size="18" font-weight="400" fill="#526277" text-anchor="start">Fetch requested columns for the selected row IDs.</text>
+<text x="28" y="413" font-size="17" font-weight="400" fill="#526277" text-anchor="start">More routes can use</text>
+<text x="28" y="439" font-size="17" font-weight="400" fill="#526277" text-anchor="start">either index family.</text>
+<text x="28" y="520" font-size="17" font-weight="400" fill="#172b4d" text-anchor="start">A ranker only sees the candidates returned by its routes.</text>
+</g>
+</svg>

--- a/docs/static/img/multimodal-index-coverage.svg
+++ b/docs/static/img/multimodal-index-coverage.svg
@@ -1,0 +1,67 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="900" height="449" viewBox="0 0 900 449" role="img" aria-labelledby="title desc">
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements. See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership. The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied. See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+<title id="title">Index coverage after an append</title>
+<desc id="desc">An existing index covers row IDs 0 to 5. Later appended rows 6 to 9 are outside that index. Fast searches only the indexed range; a new index build covers new rows, while supported full or detail searches can include uncovered ranges. Updates also require freshness handling.</desc>
+<defs><marker id="arrow" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse"><path d="M0 0 L10 5 L0 10 Z" fill="#526277"/></marker></defs>
+<g font-family="Arial, Helvetica, sans-serif" fill="#172b4d">
+<rect x="1" y="1" width="898" height="447" rx="12" fill="#ffffff" stroke="#d7dfeb" stroke-width="1.5"/>
+<text x="28" y="44" font-size="27" font-weight="700" fill="#172b4d" text-anchor="start">Index coverage after an append</text>
+<text x="28" y="76" font-size="17" font-weight="400" fill="#526277" text-anchor="start">Index files track row-ID ranges; an append does not extend existing coverage.</text>
+<text x="28" y="124" font-size="19" font-weight="700" fill="#172b4d" text-anchor="start">Table rows</text>
+<rect x="208" y="101" width="60" height="50" rx="8" fill="#eaf2ff" stroke="#d7dfeb" stroke-width="1.5"/>
+<text x="238" y="134" font-size="21" font-weight="700" fill="#172b4d" text-anchor="middle">0</text>
+<rect x="274" y="101" width="60" height="50" rx="8" fill="#eaf2ff" stroke="#d7dfeb" stroke-width="1.5"/>
+<text x="304" y="134" font-size="21" font-weight="700" fill="#172b4d" text-anchor="middle">1</text>
+<rect x="340" y="101" width="60" height="50" rx="8" fill="#eaf2ff" stroke="#d7dfeb" stroke-width="1.5"/>
+<text x="370" y="134" font-size="21" font-weight="700" fill="#172b4d" text-anchor="middle">2</text>
+<rect x="406" y="101" width="60" height="50" rx="8" fill="#eaf2ff" stroke="#d7dfeb" stroke-width="1.5"/>
+<text x="436" y="134" font-size="21" font-weight="700" fill="#172b4d" text-anchor="middle">3</text>
+<rect x="472" y="101" width="60" height="50" rx="8" fill="#eaf2ff" stroke="#d7dfeb" stroke-width="1.5"/>
+<text x="502" y="134" font-size="21" font-weight="700" fill="#172b4d" text-anchor="middle">4</text>
+<rect x="538" y="101" width="60" height="50" rx="8" fill="#eaf2ff" stroke="#d7dfeb" stroke-width="1.5"/>
+<text x="568" y="134" font-size="21" font-weight="700" fill="#172b4d" text-anchor="middle">5</text>
+<rect x="604" y="101" width="60" height="50" rx="8" fill="#fff3df" stroke="#d7dfeb" stroke-width="1.5"/>
+<text x="634" y="134" font-size="21" font-weight="700" fill="#172b4d" text-anchor="middle">6</text>
+<rect x="670" y="101" width="60" height="50" rx="8" fill="#fff3df" stroke="#d7dfeb" stroke-width="1.5"/>
+<text x="700" y="134" font-size="21" font-weight="700" fill="#172b4d" text-anchor="middle">7</text>
+<rect x="736" y="101" width="60" height="50" rx="8" fill="#fff3df" stroke="#d7dfeb" stroke-width="1.5"/>
+<text x="766" y="134" font-size="21" font-weight="700" fill="#172b4d" text-anchor="middle">8</text>
+<rect x="802" y="101" width="60" height="50" rx="8" fill="#fff3df" stroke="#d7dfeb" stroke-width="1.5"/>
+<text x="832" y="134" font-size="21" font-weight="700" fill="#172b4d" text-anchor="middle">9</text>
+<text x="28" y="196" font-size="19" font-weight="700" fill="#172b4d" text-anchor="start">Existing index</text>
+<rect x="208" y="168" width="390" height="47" rx="8" fill="#e7f5f1" stroke="#d7dfeb" stroke-width="1.5"/>
+<text x="403" y="198" font-size="20" font-weight="700" fill="#14766b" text-anchor="middle">Indexed: [0, 5]</text>
+<rect x="604" y="168" width="258" height="47" rx="8" fill="#fff3df" stroke="#d7dfeb" stroke-width="1.5"/>
+<text x="733" y="198" font-size="20" font-weight="700" fill="#9a5200" text-anchor="middle">Uncovered: [6, 9]</text>
+<rect x="28" y="246" width="264" height="117" rx="8" fill="#fff3df" stroke="#d7dfeb" stroke-width="1.5"/>
+<text x="46" y="278" font-size="21" font-weight="700" fill="#9a5200" text-anchor="start">fast</text>
+<text x="46" y="307" font-size="18" font-weight="400" fill="#526277" text-anchor="start">Search indexed coverage</text>
+<text x="46" y="332" font-size="18" font-weight="400" fill="#526277" text-anchor="start">New matches may be omitted</text>
+<rect x="308" y="246" width="264" height="117" rx="8" fill="#eaf2ff" stroke="#d7dfeb" stroke-width="1.5"/>
+<text x="326" y="278" font-size="21" font-weight="700" fill="#2463b4" text-anchor="start">full</text>
+<text x="326" y="307" font-size="18" font-weight="400" fill="#526277" text-anchor="start">Check row-ID coverage</text>
+<text x="326" y="332" font-size="18" font-weight="400" fill="#526277" text-anchor="start">Scan gaps where supported</text>
+<rect x="588" y="246" width="284" height="117" rx="8" fill="#f2ecfb" stroke="#d7dfeb" stroke-width="1.5"/>
+<text x="606" y="278" font-size="21" font-weight="700" fill="#7046a4" text-anchor="start">detail</text>
+<text x="606" y="307" font-size="18" font-weight="400" fill="#526277" text-anchor="start">Inspect active file metadata</text>
+<text x="606" y="332" font-size="18" font-weight="400" fill="#526277" text-anchor="start">Find current coverage gaps</text>
+<text x="28" y="401" font-size="17" font-weight="400" fill="#172b4d" text-anchor="start">Coverage does not detect changed values at the same row IDs. Refresh after updates.</text>
+</g>
+</svg>

--- a/docs/static/img/multimodal-table-overview.svg
+++ b/docs/static/img/multimodal-table-overview.svg
@@ -1,0 +1,58 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="900" height="564" viewBox="0 0 900 564" role="img" aria-labelledby="title desc">
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements. See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership. The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied. See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+<title id="title">One table, separate column storage</title>
+<desc id="desc">A logical record has metadata, an image, an embedding, and text. Normal files, managed BLOB files, and optional dedicated vector files align by row ID. Separately built indexes select row IDs for projected reads.</desc>
+<defs><marker id="arrow" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse"><path d="M0 0 L10 5 L0 10 Z" fill="#526277"/></marker></defs>
+<g font-family="Arial, Helvetica, sans-serif" fill="#172b4d">
+<rect x="1" y="1" width="898" height="562" rx="12" fill="#ffffff" stroke="#d7dfeb" stroke-width="1.5"/>
+<text x="28" y="44" font-size="27" font-weight="700" fill="#172b4d" text-anchor="start">One table, separate column storage</text>
+<text x="28" y="76" font-size="17" font-weight="400" fill="#526277" text-anchor="start">Store once, enrich selected columns, then retrieve matching records.</text>
+<rect x="28" y="101" width="844" height="76" rx="8" fill="#f5f7fb" stroke="#d7dfeb" stroke-width="1.5"/>
+<text x="46" y="131" font-size="20" font-weight="700" fill="#172b4d" text-anchor="start">Logical record</text>
+<text x="46" y="158" font-size="20" font-weight="400" fill="#172b4d" text-anchor="start">id  ·  category  ·  image  ·  caption  ·  embedding  ·  attributes</text>
+<path d="M450 178 L450 210" fill="none" stroke="#526277" stroke-width="2" marker-end="url(#arrow)"/>
+<rect x="28" y="220" width="844" height="39" rx="8" fill="#f5f7fb" stroke="#d7dfeb" stroke-width="1.5"/>
+<text x="450" y="246" font-size="19" font-weight="700" fill="#172b4d" text-anchor="middle">ROW ID  ·  shared positions align columns across files</text>
+<rect x="28" y="279" width="268" height="116" rx="8" fill="#eaf2ff" stroke="#d7dfeb" stroke-width="1.5"/>
+<text x="46" y="311" font-size="21" font-weight="700" fill="#2463b4" text-anchor="start">Normal files</text>
+<text x="46" y="340" font-size="18" font-weight="400" fill="#526277" text-anchor="start">Scalar, text, and Variant</text>
+<text x="46" y="365" font-size="18" font-weight="400" fill="#526277" text-anchor="start">Parquet / ORC*</text>
+<rect x="316" y="279" width="268" height="116" rx="8" fill="#e7f5f1" stroke="#d7dfeb" stroke-width="1.5"/>
+<text x="334" y="311" font-size="21" font-weight="700" fill="#14766b" text-anchor="start">Managed BLOB files</text>
+<text x="334" y="340" font-size="18" font-weight="400" fill="#526277" text-anchor="start">Images, audio, documents</text>
+<text x="334" y="365" font-size="18" font-weight="400" fill="#526277" text-anchor="start">Dedicated .blob payloads</text>
+<rect x="604" y="279" width="268" height="116" rx="8" fill="#f2ecfb" stroke="#d7dfeb" stroke-width="1.5"/>
+<text x="622" y="311" font-size="21" font-weight="700" fill="#7046a4" text-anchor="start">Dedicated vectors</text>
+<text x="622" y="340" font-size="18" font-weight="400" fill="#526277" text-anchor="start">Fixed-dimension vectors</text>
+<text x="622" y="365" font-size="18" font-weight="400" fill="#526277" text-anchor="start">Optional .vector.vortex</text>
+<text x="28" y="421" font-size="16" font-weight="400" fill="#526277" text-anchor="start">* Variant requires Parquet. Ordinary float arrays can stay in normal files.</text>
+<rect x="28" y="449" width="254" height="83" rx="8" fill="#fff3df" stroke="#d7dfeb" stroke-width="1.5"/>
+<text x="46" y="481" font-size="21" font-weight="700" fill="#9a5200" text-anchor="start">Build indexes</text>
+<text x="46" y="510" font-size="18" font-weight="400" fill="#526277" text-anchor="start">Scalar · vector · full-text</text>
+<path d="M287 490 L328 490" fill="none" stroke="#526277" stroke-width="2" marker-end="url(#arrow)"/>
+<rect x="336" y="449" width="228" height="83" rx="8" fill="#fff3df" stroke="#d7dfeb" stroke-width="1.5"/>
+<text x="354" y="481" font-size="21" font-weight="700" fill="#9a5200" text-anchor="start">Find row IDs</text>
+<text x="354" y="510" font-size="18" font-weight="400" fill="#526277" text-anchor="start">Filter or scored search</text>
+<path d="M569 490 L610 490" fill="none" stroke="#526277" stroke-width="2" marker-end="url(#arrow)"/>
+<rect x="618" y="449" width="254" height="83" rx="8" fill="#eaf2ff" stroke="#d7dfeb" stroke-width="1.5"/>
+<text x="636" y="481" font-size="21" font-weight="700" fill="#2463b4" text-anchor="start">Read columns</text>
+<text x="636" y="510" font-size="18" font-weight="400" fill="#526277" text-anchor="start">Project only what is needed</text>
+</g>
+</svg>

--- a/docs/static/img/multimodal-variant-shredding.svg
+++ b/docs/static/img/multimodal-variant-shredding.svg
@@ -1,0 +1,44 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="900" height="476" viewBox="0 0 900 476" role="img" aria-labelledby="title desc">
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements. See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership. The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied. See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+<title id="title">One Variant column, two physical layouts</title>
+<desc id="desc">Plain Variant stores binary value and metadata. Shredded Variant adds typed subcolumns for selected paths and keeps overflow value bytes for other fields or incompatible types. Both reconstruct the same logical Variant; projected reads benefit when the engine pushes path extraction into the scan.</desc>
+<defs><marker id="arrow" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse"><path d="M0 0 L10 5 L0 10 Z" fill="#526277"/></marker></defs>
+<g font-family="Arial, Helvetica, sans-serif" fill="#172b4d">
+<rect x="1" y="1" width="898" height="474" rx="12" fill="#ffffff" stroke="#d7dfeb" stroke-width="1.5"/>
+<text x="28" y="44" font-size="27" font-weight="700" fill="#172b4d" text-anchor="start">One Variant column, two physical layouts</text>
+<text x="28" y="76" font-size="17" font-weight="400" fill="#526277" text-anchor="start">Shredding changes the Parquet layout, not the logical table schema.</text>
+<rect x="28" y="109" width="844" height="58" rx="8" fill="#f5f7fb" stroke="#d7dfeb" stroke-width="1.5"/>
+<text x="46" y="144" font-size="20" font-weight="400" fill="#172b4d" text-anchor="start">payload VARIANT:  {&quot;age&quot;: 42, &quot;city&quot;: &quot;Hangzhou&quot;, &quot;extra&quot;: ...}</text>
+<path d="M238 175 L238 208" fill="none" stroke="#526277" stroke-width="2" marker-end="url(#arrow)"/>
+<path d="M662 175 L662 208" fill="none" stroke="#526277" stroke-width="2" marker-end="url(#arrow)"/>
+<rect x="28" y="219" width="402" height="158" rx="8" fill="#eaf2ff" stroke="#d7dfeb" stroke-width="1.5"/>
+<text x="46" y="251" font-size="21" font-weight="700" fill="#2463b4" text-anchor="start">Plain Variant</text>
+<text x="46" y="280" font-size="18" font-weight="400" fill="#526277" text-anchor="start">metadata: key dictionary</text>
+<text x="46" y="305" font-size="18" font-weight="400" fill="#526277" text-anchor="start">value: binary document</text>
+<text x="46" y="330" font-size="18" font-weight="400" fill="#526277" text-anchor="start">Extract paths from the binary value.</text>
+<rect x="450" y="219" width="422" height="158" rx="8" fill="#f2ecfb" stroke="#d7dfeb" stroke-width="1.5"/>
+<text x="468" y="251" font-size="21" font-weight="700" fill="#7046a4" text-anchor="start">Shredded Variant</text>
+<text x="468" y="280" font-size="18" font-weight="400" fill="#526277" text-anchor="start">metadata + overflow value</text>
+<text x="468" y="305" font-size="18" font-weight="400" fill="#526277" text-anchor="start">typed_value: age INT, city STRING</text>
+<text x="468" y="330" font-size="18" font-weight="400" fill="#526277" text-anchor="start">Read typed leaves for pushed paths.</text>
+<text x="28" y="417" font-size="17" font-weight="400" fill="#172b4d" text-anchor="start">Other fields and incompatible values stay in overflow bytes. Full reads reconstruct all values.</text>
+<text x="28" y="445" font-size="17" font-weight="400" fill="#526277" text-anchor="start">A table can contain both layouts; only new files use changed shredding settings.</text>
+</g>
+</svg>

--- a/docs/static/img/multimodal-video-pack.svg
+++ b/docs/static/img/multimodal-video-pack.svg
@@ -1,0 +1,62 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="900" height="563" viewBox="0 0 900 563" role="img" aria-labelledby="title desc">
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements. See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership. The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied. See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+<title id="title">Logical frames, complete video payloads</title>
+<desc id="desc">Five logical frame rows map through two run-index entries to video A frames 0 to 2 and video B frames 0 to 1. One self-contained .video pack contains both encoded videos and its run index. Frame descriptors identify a complete encoded video and a frame ordinal.</desc>
+<defs><marker id="arrow" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse"><path d="M0 0 L10 5 L0 10 Z" fill="#526277"/></marker></defs>
+<g font-family="Arial, Helvetica, sans-serif" fill="#172b4d">
+<rect x="1" y="1" width="898" height="561" rx="12" fill="#ffffff" stroke="#d7dfeb" stroke-width="1.5"/>
+<text x="28" y="44" font-size="27" font-weight="700" fill="#172b4d" text-anchor="start">Logical frames, complete video payloads</text>
+<text x="28" y="76" font-size="17" font-weight="400" fill="#526277" text-anchor="start">Illustrative single-camera pack: frame ordinals are zero-based.</text>
+<text x="28" y="117" font-size="21" font-weight="700" fill="#2463b4" text-anchor="start">Logical table rows</text>
+<rect x="28" y="132" width="160" height="73" rx="8" fill="#eaf2ff" stroke="#d7dfeb" stroke-width="1.5"/>
+<text x="44" y="159" font-size="18" font-weight="700" fill="#2463b4" text-anchor="start">Row 0</text>
+<text x="44" y="188" font-size="15" font-weight="400" fill="#172b4d" text-anchor="start">Video / frame: A / 0</text>
+<rect x="199" y="132" width="160" height="73" rx="8" fill="#eaf2ff" stroke="#d7dfeb" stroke-width="1.5"/>
+<text x="215" y="159" font-size="18" font-weight="700" fill="#2463b4" text-anchor="start">Row 1</text>
+<text x="215" y="188" font-size="15" font-weight="400" fill="#172b4d" text-anchor="start">Video / frame: A / 1</text>
+<rect x="370" y="132" width="160" height="73" rx="8" fill="#eaf2ff" stroke="#d7dfeb" stroke-width="1.5"/>
+<text x="386" y="159" font-size="18" font-weight="700" fill="#2463b4" text-anchor="start">Row 2</text>
+<text x="386" y="188" font-size="15" font-weight="400" fill="#172b4d" text-anchor="start">Video / frame: A / 2</text>
+<rect x="541" y="132" width="160" height="73" rx="8" fill="#eaf2ff" stroke="#d7dfeb" stroke-width="1.5"/>
+<text x="557" y="159" font-size="18" font-weight="700" fill="#2463b4" text-anchor="start">Row 3</text>
+<text x="557" y="188" font-size="15" font-weight="400" fill="#172b4d" text-anchor="start">Video / frame: B / 0</text>
+<rect x="712" y="132" width="160" height="73" rx="8" fill="#eaf2ff" stroke="#d7dfeb" stroke-width="1.5"/>
+<text x="728" y="159" font-size="18" font-weight="700" fill="#2463b4" text-anchor="start">Row 4</text>
+<text x="728" y="188" font-size="15" font-weight="400" fill="#172b4d" text-anchor="start">Video / frame: B / 1</text>
+<path d="M450 208 L450 244" fill="none" stroke="#526277" stroke-width="2" marker-end="url(#arrow)"/>
+<rect x="28" y="253" width="844" height="234" rx="8" fill="#f8fbfa" stroke="#d7dfeb" stroke-width="1.5"/>
+<text x="46" y="285" font-size="22" font-weight="700" fill="#14766b" text-anchor="start">One self-contained .video pack</text>
+<rect x="46" y="306" width="366" height="126" rx="8" fill="#e7f5f1" stroke="#d7dfeb" stroke-width="1.5"/>
+<text x="64" y="338" font-size="21" font-weight="700" fill="#14766b" text-anchor="start">Run index</text>
+<text x="64" y="367" font-size="18" font-weight="400" fill="#526277" text-anchor="start">Rows 0–2 → video A, start frame 0</text>
+<text x="64" y="392" font-size="18" font-weight="400" fill="#526277" text-anchor="start">Rows 3–4 → video B, start frame 0</text>
+<path d="M422 368 L463 368" fill="none" stroke="#526277" stroke-width="2" marker-end="url(#arrow)"/>
+<rect x="477" y="306" width="176" height="126" rx="8" fill="#e7f5f1" stroke="#d7dfeb" stroke-width="1.5"/>
+<text x="495" y="338" font-size="21" font-weight="700" fill="#14766b" text-anchor="start">Video A</text>
+<text x="495" y="367" font-size="18" font-weight="400" fill="#526277" text-anchor="start">Complete</text>
+<text x="495" y="392" font-size="18" font-weight="400" fill="#526277" text-anchor="start">encoded bytes</text>
+<rect x="671" y="306" width="183" height="126" rx="8" fill="#e7f5f1" stroke="#d7dfeb" stroke-width="1.5"/>
+<text x="689" y="338" font-size="21" font-weight="700" fill="#14766b" text-anchor="start">Video B</text>
+<text x="689" y="367" font-size="18" font-weight="400" fill="#526277" text-anchor="start">Complete</text>
+<text x="689" y="392" font-size="18" font-weight="400" fill="#526277" text-anchor="start">encoded bytes</text>
+<text x="46" y="464" font-size="17" font-weight="400" fill="#526277" text-anchor="start">BLOB compaction copies encoded ranges and rebuilds the index without re-encoding.</text>
+<text x="28" y="520" font-size="17" font-weight="400" fill="#172b4d" text-anchor="start">Frame descriptors select frames. Decode and reuse video sessions in the client.</text>
+</g>
+</svg>


### PR DESCRIPTION
### Purpose

The multimodal table guides mix introductory workflows, storage formats, maintenance, and index reference material in long pages. Reorganize them into a quick start, storage guides, Data Evolution usage/layout/maintenance, and global-index selection/management/reference pages. Preserve existing page URLs and all 101 original section anchors, and add seven SVG diagrams for storage modes, video packs, index coverage, hybrid search, bitmap layout, and Variant shredding.

Make examples consistent with the current implementations: share populated index sample data, separate three-dimensional vector examples from advanced builds, complete BLOB and Variant workflows, and explain scored-result ordering. Clarify engine differences for BLOB updates, video descriptors, index refresh, and visibility callbacks. The quick start now demonstrates why an append needs another index build; coverage modes are explicitly distinguished from freshness after an indexed value changes.

### Tests

- `cd docs && COREPACK_ENABLE_AUTO_PIN=0 yarn build` passed, including REST OpenAPI contract validation.
- Validated 1,043 internal links/fragments in rendered multimodal pages and preservation of all 101 original section anchors.
- Parsed all 49 Python examples and seven SVGs; checked sample Arrow schemas/data, score ordering, and Variant JSON paths. Visually inspected the SVG diagrams in the browser.
- `git diff --check` passed.
- Executed the documented Python BTree and IVF-flat full-build, partition-rebuild, append-refresh, and query workflows with `paimon-vindex==0.4.0`. Also executed the BLOB and Vector create/alter sequences. Reproduced the four reviewed failures with the original snippets and verified that the corrected snippets pass.
- All six tests in `pypaimon.tests.global_index_scalar_search_mode_test` passed.
- Spark/Flink SQL and native full-text/hybrid examples were not executed locally.
