### PR TITLE
[core] Refuse a catalog-managed Format Table whose location names no scheme

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/table/format/FormatTableCommit.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/format/FormatTableCommit.java
@@ -159,6 +159,16 @@ public class FormatTableCommit implements BatchTableCommit {
                             "Format Table publish thread number must be between 1 and %s, but was %s.",
                             MAX_COMMIT_THREAD_NUM, publishThreadNum));
         }
+        if (partitionManager != null && new Path(location).toUri().getScheme() == null) {
+            // The catalog names every partition directory of such a table, and a request returns a
+            // partition to one by naming it, so the table directory has to say which filesystem it
+            // is on. Refused here, before a commit deletes or publishes anything.
+            throw new IllegalArgumentException(
+                    String.format(
+                            "Format Table %s with catalog-managed partitions must have a location "
+                                    + "with a scheme, but was %s.",
+                            tableIdentifier.getFullName(), location));
+        }
         this.location = location;
         this.fileIO = fileIO;
         this.formatTablePartitionOnlyValueInPath = formatTablePartitionOnlyValueInPath;

--- a/paimon-core/src/test/java/org/apache/paimon/table/format/FormatTableCommitRegistryValidationTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/table/format/FormatTableCommitRegistryValidationTest.java
@@ -51,6 +51,7 @@ import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 /** Partition registry validation tests for {@link FormatTableCommit}. */
@@ -212,6 +213,35 @@ class FormatTableCommitRegistryValidationTest {
                 partitionManager,
                 tablePath,
                 Arrays.asList(exactOutsidePrefix, exactInsidePrefix, prefixOnly));
+    }
+
+    @Test
+    void testCatalogManagedTableWithoutASchemeIsRefusedBeforeMutation() throws Exception {
+        MutationTrackingLocalFileIO fileIO = new MutationTrackingLocalFileIO();
+        Path tablePath = new Path(new Path(tempDir.toUri()), "table-without-scheme");
+        Path oldData = new Path(tablePath, "year=2025/month=10/data-old.csv");
+        fileIO.writeFile(oldData, "old", false);
+        Path withoutScheme = new Path(tablePath.toUri().getPath());
+        FormatTablePartitionManager partitionManager = mock(FormatTablePartitionManager.class);
+        fileIO.startTrackingMutations();
+
+        for (boolean overwrite : new boolean[] {true, false}) {
+            assertThatThrownBy(
+                            () ->
+                                    commit(
+                                            withoutScheme,
+                                            fileIO,
+                                            partitionManager,
+                                            overwrite,
+                                            null,
+                                            true))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessageContaining("must have a location with a scheme");
+        }
+
+        assertThat(fileIO.exists(oldData)).isTrue();
+        assertThat(fileIO.deleteCalls()).isZero();
+        verifyNoInteractions(partitionManager);
     }
 
     @Test


### PR DESCRIPTION
### Purpose

Follow-up to #9710. The catalog names every partition directory of a Format Table with catalog-managed partitions, and a request returns a partition to its default directory by naming that directory. A table location given as a plain path, such as `/warehouse/db/table`, names no filesystem, so that directory cannot be matched against the catalog's rules for locations. Today an overwrite of such a table deletes and publishes its files and only then has its partition report rejected.

Such a table is now refused when its `FormatTableCommit` is created, before anything is deleted or published, with a message that names the table and its location. Filesystem-discovered Format Tables have no partition manager and are unaffected.

### Tests

- `FormatTableCommitRegistryValidationTest`: a catalog-managed table whose location names no scheme is refused for both overwrite and append commits, with no file deleted and no catalog call.
- `FormatTableCommitTest`, `FormatTableCommitEscapedPartitionValueTest`, `FormatTableCommitStatisticsTest`, `MockRESTCatalogTest`, `FormatTablePartitionPathResolverTest`, `CatalogManagedPartitionScanTest`, `FormatTableWriteTest`, `FormatTableScanTest`
