### PR TITLE
[docs] Reorganize Spark guides and diagrams

### DIFF
--- a/docs/docs/spark/auxiliary.md
+++ b/docs/docs/spark/auxiliary.md
@@ -1,5 +1,5 @@
 ---
-title: "Auxiliary"
+title: "Inspect and Maintain Tables"
 sidebar_position: 7
 ---
 
@@ -22,39 +22,15 @@ specific language governing permissions and limitations
 under the License.
 -->
 
-# Auxiliary Statements
+# Inspect and Maintain Tables
+
+Inspect schemas, partitions, statistics, and cached metadata with these Spark SQL statements.
+For file maintenance and retention operations, see [Procedures](./procedures).
 
 ## Set / Reset
-The SET command sets a property, returns the value of an existing property or returns all SQLConf properties with value and meaning.
-The RESET command resets runtime configurations specific to the current session which were set via the SET command to their default values.
 
-To set dynamic options globally, you need add the `spark.paimon.` prefix. You can also set dynamic table options at this format: 
-`spark.paimon.${catalogName}.${dbName}.${tableName}.${config_key}`. The catalogName/dbName/tableName can be `*`, which means matching all 
-the specific parts. Dynamic table options will override global options if there are conflicts.
-
-```sql
--- set spark conf
-SET spark.sql.sources.partitionOverwriteMode=dynamic;
-
--- set paimon conf
-SET spark.paimon.file.block-size=512M;
-
--- reset conf
-RESET spark.paimon.file.block-size;
-
--- set scan.snapshot-id=1 for the table default.T in any catalogs
-SET spark.paimon.*.default.T.scan.snapshot-id=1;
-SELECT * FROM default.T;
-
--- set scan.snapshot-id=1 for the table T in any databases and catalogs
-SET spark.paimon.*.*.T.scan.snapshot-id=1;
-SELECT * FROM default.T;
-
--- set scan.snapshot-id=2 for the table default.T1 in any catalogs and scan.snapshot-id=1 on other tables
-SET spark.paimon.scan.snapshot-id=1;
-SET spark.paimon.*.default.T1.scan.snapshot-id=2;
-SELECT * FROM default.T1 JOIN default.T2 ON xxxx;
-```
+See [Configuration](./configuration#set-and-reset-session-options) for `SET` / `RESET`,
+option scopes, table-specific overrides, and connector defaults.
 
 ## Describe table
 DESCRIBE TABLE statement returns the basic metadata information of a table or view. The metadata information includes column name, column type and column comment.

--- a/docs/docs/spark/catalogs.md
+++ b/docs/docs/spark/catalogs.md
@@ -1,0 +1,201 @@
+---
+title: "Catalogs"
+---
+
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+# Catalogs
+
+Configure the connector JAR and `PaimonSparkSessionExtensions` as shown in
+[Quick Start](./quick-start#setup) before using the snippets below. The `...` in each shell
+command stands for those common startup arguments.
+
+## Create Catalog
+
+Choose a metastore for your Paimon catalog:
+
+* `filesystem` metastore (default), which stores both metadata and table files in filesystems.
+* `hive` metastore, which additionally stores metadata in Hive metastore. Users can directly access the tables from Hive.
+* `jdbc` metastore, which additionally stores metadata in a relational database.
+* `rest` metastore, which accesses a remote catalog service over HTTP.
+
+See [CatalogOptions](../maintenance/configurations#catalogoptions) for detailed options when creating a catalog.
+
+### Create Filesystem Catalog
+
+The following shell command registers a Paimon catalog named `paimon`. Metadata and table files are stored under `hdfs:///path/to/warehouse`.
+
+```bash
+spark-sql ... \
+    --conf spark.sql.catalog.paimon=org.apache.paimon.spark.SparkCatalog \
+    --conf spark.sql.catalog.paimon.warehouse=hdfs:///path/to/warehouse
+```
+
+You can define any default table options with the prefix `spark.sql.catalog.paimon.table-default.` for tables created in the catalog.
+
+After `spark-sql` is started, you can switch to the `default` database of the `paimon` catalog with the following SQL.
+
+```sql
+USE paimon.default;
+```
+
+### Creating Hive Catalog
+
+By using Paimon Hive catalog, changes to the catalog will directly affect the corresponding Hive metastore. Tables created in such catalog can also be accessed directly from Hive.
+
+To use Hive catalog, database, table, and field names must be lowercase.
+
+Your Spark installation should be able to detect, or already contains Hive dependencies. See [Spark Hive Tables](https://spark.apache.org/docs/latest/sql-data-sources-hive-tables.html) for more information.
+
+The following shell command registers a Paimon Hive catalog named `paimon`. Metadata and table files are stored under `hdfs:///path/to/warehouse`. In addition, metadata is also stored in Hive metastore.
+
+```bash
+spark-sql ... \
+    --conf spark.sql.catalog.paimon=org.apache.paimon.spark.SparkCatalog \
+    --conf spark.sql.catalog.paimon.warehouse=hdfs:///path/to/warehouse \
+    --conf spark.sql.catalog.paimon.metastore=hive \
+    --conf spark.sql.catalog.paimon.uri=thrift://<hive-metastore-host-name>:<port>
+```
+
+You can define any default table options with the prefix `spark.sql.catalog.paimon.table-default.` for tables created in the catalog.
+
+After `spark-sql` is started, you can switch to the `default` database of the `paimon` catalog with the following SQL.
+
+```sql
+USE paimon.default;
+```
+
+To share Spark's built-in catalog with non-Paimon tables, see [SparkGenericCatalog](#sparkgenericcatalog).
+
+**Synchronizing Partitions into Hive Metastore**
+
+By default, Paimon does not synchronize newly created partitions into Hive metastore. Users will see an unpartitioned table in Hive. Partition push-down will be carried out by filter push-down instead.
+
+If you want to see a partitioned table in Hive and also synchronize newly created partitions into Hive metastore, please set the table property `metastore.partitioned-table` to true. Also see [CoreOptions](../maintenance/configurations#coreoptions).
+
+### Creating JDBC Catalog
+
+The JDBC catalog stores catalog metadata in a relational database such as SQLite, MySQL, or PostgreSQL.
+
+Currently, lock configuration is only supported for MySQL and SQLite. If you are using a different type of database for catalog storage, please do not configure `lock.enabled`.
+
+Add the JDBC driver for your database to Spark's classpath along with the Paimon connector.
+
+| database type | Bundle Name          | SQL Client JAR                                                             |
+|:--------------|:---------------------|:---------------------------------------------------------------------------|
+| mysql         | mysql-connector-java | [Download](https://mvnrepository.com/artifact/mysql/mysql-connector-java)  |
+| postgres      | postgresql           | [Download](https://mvnrepository.com/artifact/org.postgresql/postgresql)   |
+
+JDBC catalog supports persistent Paimon views. View metadata is stored in the automatically created
+`paimon_views` table in the catalog database.
+
+Within a single database, a name cannot be used by both a table and a view; all writers
+(`createTable`, `renameTable`, `createView`, `renameView`) reject conflicting identifiers. See
+[Views](../concepts/views#jdbc-catalog-notes) for upgrade-time permissions, single-process locking
+semantics, and database visibility details.
+
+```bash
+spark-sql ... \
+    --conf spark.sql.catalog.paimon=org.apache.paimon.spark.SparkCatalog \
+    --conf spark.sql.catalog.paimon.warehouse=hdfs:///path/to/warehouse \
+    --conf spark.sql.catalog.paimon.metastore=jdbc \
+    --conf spark.sql.catalog.paimon.uri=jdbc:mysql://<host>:<port>/<databaseName> \
+    --conf spark.sql.catalog.paimon.jdbc.user=... \
+    --conf spark.sql.catalog.paimon.jdbc.password=...
+
+```
+
+```sql
+USE paimon.default;
+```
+### Creating REST Catalog
+
+The REST catalog sends catalog operations to a remote service. Choose the authentication
+method configured by that service. The provider key is spelled `bear` for bearer tokens.
+
+#### Bearer Token
+```bash
+spark-sql ... \
+    --conf spark.sql.catalog.paimon=org.apache.paimon.spark.SparkCatalog \
+    --conf spark.sql.catalog.paimon.metastore=rest \
+    --conf spark.sql.catalog.paimon.uri=<catalog server url> \
+    --conf spark.sql.catalog.paimon.token.provider=bear \
+    --conf spark.sql.catalog.paimon.token=<token>
+
+```
+
+#### DLF Access Key
+```bash
+spark-sql ... \
+    --conf spark.sql.catalog.paimon=org.apache.paimon.spark.SparkCatalog \
+    --conf spark.sql.catalog.paimon.metastore=rest \
+    --conf spark.sql.catalog.paimon.uri=<catalog server url> \
+    --conf spark.sql.catalog.paimon.token.provider=dlf \
+    --conf spark.sql.catalog.paimon.dlf.access-key-id=<access-key-id> \
+    --conf spark.sql.catalog.paimon.dlf.access-key-secret=<access-key-secret>
+
+```
+
+#### DLF STS Token
+```bash
+spark-sql ... \
+    --conf spark.sql.catalog.paimon=org.apache.paimon.spark.SparkCatalog \
+    --conf spark.sql.catalog.paimon.metastore=rest \
+    --conf spark.sql.catalog.paimon.uri=<catalog server url> \
+    --conf spark.sql.catalog.paimon.token.provider=dlf \
+    --conf spark.sql.catalog.paimon.dlf.access-key-id=<access-key-id> \
+    --conf spark.sql.catalog.paimon.dlf.access-key-secret=<access-key-secret> \
+    --conf spark.sql.catalog.paimon.dlf.security-token=<security-token>
+
+```
+
+```sql
+USE paimon.default;
+```
+
+## SparkGenericCatalog
+
+When starting `spark-sql`, use the following command to register Paimon's Spark Generic catalog to replace Spark
+default catalog `spark_catalog`. (default warehouse is Spark `spark.sql.warehouse.dir`)
+
+Currently, it is only recommended to use `SparkGenericCatalog` in the case of Hive metastore, Paimon will infer
+Hive conf from Spark session, you just need to configure Spark's Hive conf.
+
+```bash
+spark-sql ... \
+    --conf spark.sql.catalog.spark_catalog=org.apache.paimon.spark.SparkGenericCatalog \
+    --conf spark.sql.extensions=org.apache.paimon.spark.extensions.PaimonSparkSessionExtensions
+```
+
+Using `SparkGenericCatalog`, you can use Paimon tables in this Catalog or non-Paimon tables such as Spark's csv,
+parquet, Hive tables, etc.
+
+Use `USING paimon` when creating a Paimon table in `SparkGenericCatalog`:
+
+```sql
+CREATE TABLE my_table (k INT, v STRING)
+USING paimon
+TBLPROPERTIES ('primary-key' = 'k');
+```
+
+## Next Steps
+
+See [Configuration](./configuration) for option scopes, and [Create Tables, Views, and Tags](./sql-ddl)
+for SQL DDL.

--- a/docs/docs/spark/configuration.mdx
+++ b/docs/docs/spark/configuration.mdx
@@ -1,0 +1,93 @@
+---
+title: "Configuration"
+---
+
+import ConfigTable from '@site/src/components/ConfigTable';
+import sparkCatalogConfigurationHtml from '@site/generated/spark_catalog_configuration.html';
+import sparkConnectorConfigurationHtml from '@site/generated/spark_connector_configuration.html';
+
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+# Configuration
+
+Use the scope that matches the setting you want to change:
+
+| Scope | How to set it | Example |
+| --- | --- | --- |
+| Catalog connection | Startup `--conf spark.sql.catalog.<name>.<key>=<value>` | `spark.sql.catalog.paimon.warehouse=file:/tmp/paimon` |
+| Default options for newly created tables | Catalog option `table-default.<key>` | `spark.sql.catalog.paimon.table-default.file.format=parquet` |
+| Persistent table options | `CREATE TABLE ... TBLPROPERTIES` or `ALTER TABLE ... SET TBLPROPERTIES` | `'bucket' = '4'` |
+| Session options | `SET spark.paimon.<key>=<value>` | `spark.paimon.scan.snapshot-id=1` |
+| Table-specific session options | `SET spark.paimon.<catalog>.<database>.<table>.<key>=<value>` | `spark.paimon.paimon.default.t.scan.snapshot-id=1` |
+| Individual reads or writes | DataFrame `.option("<key>", "<value>")` for options supported by that path | `.option("scan.snapshot-id", "1")` |
+
+Session and operation options are temporary; use table properties for persistent settings.
+Some connector options are session-only. Follow the scope in the option description and the
+relevant feature guide, such as [Schema Evolution on Write](./schema-evolution).
+
+## Set and Reset Session Options
+
+The SET command sets a property, returns the value of an existing property or returns all SQLConf properties with value and meaning.
+The RESET command resets runtime configurations specific to the current session which were set via the SET command to their default values.
+
+To set dynamic options globally, you need add the `spark.paimon.` prefix. You can also set dynamic table options at this format:
+`spark.paimon.${catalogName}.${dbName}.${tableName}.${config_key}`. The catalogName/dbName/tableName can be `*`, which means matching all
+the specific parts. Dynamic table options will override global options if there are conflicts.
+
+```sql
+-- set spark conf
+SET spark.sql.sources.partitionOverwriteMode=dynamic;
+
+-- set paimon conf
+SET spark.paimon.file.block-size=512M;
+
+-- reset conf
+RESET spark.paimon.file.block-size;
+
+-- set scan.snapshot-id=1 for the table default.T in any catalogs
+SET spark.paimon.*.default.T.scan.snapshot-id=1;
+SELECT * FROM default.T;
+
+-- set scan.snapshot-id=1 for the table T in any databases and catalogs
+SET spark.paimon.*.*.T.scan.snapshot-id=1;
+SELECT * FROM default.T;
+
+-- set scan.snapshot-id=2 for the table default.T1 in any catalogs and scan.snapshot-id=1 on other tables
+SET spark.paimon.scan.snapshot-id=1;
+SET spark.paimon.*.default.T1.scan.snapshot-id=2;
+SELECT * FROM default.T1 JOIN default.T2 ON xxxx;
+```
+
+## Spark Catalog Options
+
+<ConfigTable html={sparkCatalogConfigurationHtml} />
+
+## Spark Connector Options
+
+Streaming admission limits operate on whole splits. See [Triggers and Read Limits](./structured-streaming#triggers-and-read-limits)
+for how byte, row, and file thresholds are applied.
+
+<ConfigTable html={sparkConnectorConfigurationHtml} />
+
+## Shared Paimon Options
+
+See [CatalogOptions](../maintenance/configurations#catalogoptions) for catalog settings and
+[CoreOptions](../maintenance/configurations#coreoptions) for storage, scan, retention, and
+other table options.

--- a/docs/docs/spark/copy-into.md
+++ b/docs/docs/spark/copy-into.md
@@ -1,0 +1,351 @@
+---
+title: "COPY INTO"
+---
+
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+# COPY INTO
+
+`COPY INTO` provides a SQL command for bulk loading data files into Paimon tables and exporting table data to files. Supported formats: **CSV**, **JSON**, and **Parquet**.
+
+:::info
+**SQL dialect:** Paimon's `COPY INTO` is a Snowflake-style extension (`FILE_FORMAT = (TYPE = ...)`, `PATTERN`, `FORCE`, `ON_ERROR`), not the Databricks `COPY INTO` form (`FILEFORMAT` + `FORMAT_OPTIONS (...)` / `COPY_OPTIONS (...)`). It implements only a subset of the Snowflake syntax. In particular, `ON_ERROR` supports `ABORT_STATEMENT` (default), `CONTINUE`, and `SKIP_FILE`; the Snowflake variants `SKIP_FILE_<num>` and `SKIP_FILE_<num>%` are **not** supported.
+:::
+
+## CSV Import
+
+```sql
+COPY INTO table_name [(col1, col2, ...)]
+FROM 'source_path'
+FILE_FORMAT = (TYPE = CSV [, option = value, ...])
+[PATTERN = 'regex']
+[FORCE = TRUE|FALSE]
+[ON_ERROR = { ABORT_STATEMENT | CONTINUE | SKIP_FILE }]
+```
+
+**Basic import:**
+
+```sql
+COPY INTO my_db.my_table
+FROM '/data/csv_files/'
+FILE_FORMAT = (TYPE = CSV);
+```
+
+**Import with explicit column mapping:**
+
+```sql
+-- Only load into specified columns; omitted columns use their DEFAULT value or NULL
+COPY INTO my_db.users (id, name)
+FROM '/data/new_users/'
+FILE_FORMAT = (TYPE = CSV, SKIP_HEADER = 1);
+```
+
+**Import with NULL_IF and PATTERN:**
+
+```sql
+COPY INTO my_db.events
+FROM '/data/logs/'
+FILE_FORMAT = (TYPE = CSV, FIELD_DELIMITER = '|', NULL_IF = ('NULL', '\\N', ''))
+PATTERN = '.*\.csv'
+FORCE = FALSE;
+```
+
+## JSON Import
+
+```sql
+COPY INTO table_name [(col1, col2, ...)]
+FROM 'source_path'
+FILE_FORMAT = (TYPE = JSON [, option = value, ...])
+[PATTERN = 'regex']
+[FORCE = TRUE|FALSE]
+[ON_ERROR = { ABORT_STATEMENT | CONTINUE | SKIP_FILE }]
+```
+
+**Basic import:**
+
+```sql
+COPY INTO my_db.my_table
+FROM '/data/json_files/'
+FILE_FORMAT = (TYPE = JSON);
+```
+
+**Import multi-line JSON array:**
+
+```sql
+COPY INTO my_db.events
+FROM '/data/events/'
+FILE_FORMAT = (TYPE = JSON, MULTI_LINE = TRUE);
+```
+
+JSON columns are matched **by column name** (not by position), so source field order does not matter.
+
+## Parquet Import
+
+```sql
+COPY INTO table_name [(col1, col2, ...)]
+FROM 'source_path'
+FILE_FORMAT = (TYPE = PARQUET [, option = value, ...])
+[PATTERN = 'regex']
+[FORCE = TRUE|FALSE]
+[ON_ERROR = { ABORT_STATEMENT | CONTINUE | SKIP_FILE }]
+```
+
+**Basic import:**
+
+```sql
+COPY INTO my_db.my_table
+FROM '/data/parquet_files/'
+FILE_FORMAT = (TYPE = PARQUET);
+```
+
+**Import with PATTERN:**
+
+```sql
+COPY INTO my_db.events
+FROM '/data/lake/'
+FILE_FORMAT = (TYPE = PARQUET)
+PATTERN = '.*\.parquet'
+FORCE = FALSE;
+```
+
+Parquet columns are matched **by column name** (not by position). Extra columns in the source files are ignored; missing columns become NULL.
+
+## Write CSV Files
+
+```sql
+COPY INTO 'target_path'
+FROM { table_name | (SELECT ...) }
+FILE_FORMAT = (TYPE = CSV [, option = value, ...])
+[OVERWRITE = TRUE|FALSE]
+```
+
+**Write with header and overwrite:**
+
+```sql
+COPY INTO '/export/users_backup/'
+FROM my_db.users
+FILE_FORMAT = (TYPE = CSV, HEADER = TRUE, FIELD_DELIMITER = ',')
+OVERWRITE = TRUE;
+```
+
+**Write from query:**
+
+```sql
+COPY INTO '/export/active_users/'
+FROM (SELECT id, name FROM my_db.users WHERE active = TRUE)
+FILE_FORMAT = (TYPE = CSV, HEADER = TRUE);
+```
+
+## Write JSON Files
+
+```sql
+COPY INTO 'target_path'
+FROM { table_name | (SELECT ...) }
+FILE_FORMAT = (TYPE = JSON [, option = value, ...])
+[OVERWRITE = TRUE|FALSE]
+```
+
+**Basic JSON export:**
+
+```sql
+COPY INTO '/export/events_backup/'
+FROM my_db.events
+FILE_FORMAT = (TYPE = JSON)
+OVERWRITE = TRUE;
+```
+
+**JSON export from query:**
+
+```sql
+COPY INTO '/export/recent_events/'
+FROM (SELECT * FROM my_db.events WHERE event_date > '2024-01-01')
+FILE_FORMAT = (TYPE = JSON);
+```
+
+## Write Parquet Files
+
+```sql
+COPY INTO 'target_path'
+FROM { table_name | (SELECT ...) }
+FILE_FORMAT = (TYPE = PARQUET [, option = value, ...])
+[OVERWRITE = TRUE|FALSE]
+```
+
+**Basic Parquet export:**
+
+```sql
+COPY INTO '/export/data_backup/'
+FROM my_db.events
+FILE_FORMAT = (TYPE = PARQUET)
+OVERWRITE = TRUE;
+```
+
+**Export with compression:**
+
+```sql
+COPY INTO '/export/data_compressed/'
+FROM my_db.events
+FILE_FORMAT = (TYPE = PARQUET, COMPRESSION = GZIP)
+OVERWRITE = TRUE;
+```
+
+**Parquet export from aggregation query:**
+
+```sql
+COPY INTO '/export/summary/'
+FROM (SELECT dept, COUNT(*) AS cnt FROM my_db.employees GROUP BY dept)
+FILE_FORMAT = (TYPE = PARQUET);
+```
+
+## FILE_FORMAT Options
+
+`FILE_FORMAT` is required and must include `TYPE = CSV`, `TYPE = JSON`, or `TYPE = PARQUET`.
+
+**CSV import options:**
+
+| Option | Description | Default |
+|--------|-------------|---------|
+| TYPE | File format type. `CSV`, `JSON`, or `PARQUET`. | (required) |
+| FIELD_DELIMITER | Column delimiter character. | `,` |
+| SKIP_HEADER | Skip the first line as header. Only `0` or `1`. | `0` |
+| QUOTE | Quote character for enclosing fields. | `"` |
+| ESCAPE | Escape character within quoted fields. | `\` |
+| NULL_IF | List of string values to interpret as NULL, e.g. `('NULL', '\\N')`. | (none) |
+| EMPTY_FIELD_AS_NULL | Treat empty fields as NULL. `TRUE` or `FALSE`. | `FALSE` |
+| COMPRESSION | Compression codec (e.g. `GZIP`). | `NONE` |
+
+**JSON import options:**
+
+| Option | Description | Default |
+|--------|-------------|---------|
+| TYPE | File format type. `CSV`, `JSON`, or `PARQUET`. | (required) |
+| MULTI_LINE | Parse multi-line JSON (e.g. JSON arrays or pretty-printed objects). | `FALSE` |
+| NULL_IF | List of string values to interpret as NULL. | (none) |
+| EMPTY_FIELD_AS_NULL | Treat empty string values as NULL. | `FALSE` |
+| COMPRESSION | Compression codec (e.g. `GZIP`). | `NONE` |
+
+**Parquet import options:**
+
+| Option | Description | Default |
+|--------|-------------|---------|
+| TYPE | File format type. `CSV`, `JSON`, or `PARQUET`. | (required) |
+| COMPRESSION | Compression codec. Usually auto-detected; rarely needed for import. | (auto) |
+
+**CSV write options:**
+
+| Option | Description | Default |
+|--------|-------------|---------|
+| TYPE | File format type. `CSV`, `JSON`, or `PARQUET`. | (required) |
+| FIELD_DELIMITER | Column delimiter character. | `,` |
+| HEADER | Write column names as the first line. `TRUE` or `FALSE`. | `FALSE` |
+| QUOTE | Quote character for enclosing fields. | `"` |
+| ESCAPE | Escape character within quoted fields. | `\` |
+| COMPRESSION | Compression codec (e.g. `GZIP`). | `NONE` |
+
+**JSON write options:**
+
+| Option | Description | Default |
+|--------|-------------|---------|
+| TYPE | File format type. `CSV`, `JSON`, or `PARQUET`. | (required) |
+| DATE_FORMAT | Custom date format pattern. | Spark default |
+| TIMESTAMP_FORMAT | Custom timestamp format pattern. | Spark default |
+| COMPRESSION | Compression codec (e.g. `GZIP`). | `NONE` |
+
+**Parquet write options:**
+
+| Option | Description | Default |
+|--------|-------------|---------|
+| TYPE | File format type. `CSV`, `JSON`, or `PARQUET`. | (required) |
+| COMPRESSION | Compression codec (`SNAPPY`, `GZIP`, `NONE`, etc.). | `SNAPPY` |
+
+## Import Options
+
+| Option | Description | Default |
+|--------|-------------|---------|
+| PATTERN | Regex to filter source files by base file name. Only matching files are loaded. | (all files) |
+| FORCE | `FALSE`: skip files already loaded (idempotent). `TRUE`: reload all files. | `FALSE` |
+| ON_ERROR | Error handling strategy. `ABORT_STATEMENT`: abort on any error. `CONTINUE`: skip bad rows and continue loading. `SKIP_FILE`: skip files that contain errors. | `ABORT_STATEMENT` |
+
+## File Write Options
+
+| Option | Description | Default |
+|--------|-------------|---------|
+| OVERWRITE | `FALSE`: fail if target path exists. `TRUE`: overwrite existing files. | `FALSE` |
+
+## Column Mapping
+
+When an explicit column list is provided (e.g., `COPY INTO t (col1, col2) FROM ...`):
+
+- **CSV**: Columns are mapped **positionally** to the specified column list.
+- **JSON**: Columns are matched **by name** to the specified column list.
+- **Parquet**: Columns are matched **by name** to the specified column list.
+- The number of source columns must match the column list length (CSV). For JSON and Parquet, missing fields in the source become NULL.
+- Columns not in the list are filled with their **DEFAULT value** (if defined in the table schema) or **NULL**.
+- Non-nullable columns without a default value that are not in the list will cause an error.
+
+When no column list is provided:
+
+- **CSV**: Columns are mapped positionally to all writable columns in the target table. The number of CSV columns must match the number of writable columns.
+- **JSON**: Columns are matched by name to the writable columns. Missing fields in JSON become NULL.
+
+## Repeated Imports
+
+By default (`FORCE = FALSE`), COPY INTO tracks which files have been successfully loaded. A file is identified by its path, size, and last-modified timestamp.
+
+- Re-running the same COPY INTO command will **skip** already-loaded files and return status `SKIPPED`.
+- If a source file is modified (size or timestamp changes), it becomes eligible for re-loading.
+- `FORCE = TRUE` bypasses load history and always re-imports all matching files.
+
+## Result Output
+
+**Import** returns one row per source file:
+
+| Column | Type | Description |
+|--------|------|-------------|
+| file_name | STRING | Source file name |
+| status | STRING | `LOADED`, `PARTIALLY_LOADED`, `LOAD_FAILED`, or `SKIPPED` |
+| rows_loaded | BIGINT | Number of rows written |
+| rows_parsed | BIGINT | Number of rows parsed from the file |
+| errors_seen | BIGINT | Number of error rows (parse or cast failures) |
+| first_error | STRING | First error message encountered (NULL if no errors) |
+
+**File write** returns a single row:
+
+| Column | Type | Description |
+|--------|------|-------------|
+| output_path | STRING | Target output path |
+| file_count | INT | Number of files written |
+| rows_written | BIGINT | Total rows written |
+
+## Limitations
+
+- **CSV column-count mismatch**: Rows with fewer or more columns than the target schema are treated as malformed records. With `ON_ERROR = CONTINUE`, these rows are skipped and counted as errors.
+- Only **CSV**, **JSON**, and **Parquet** formats are supported.
+- `SINGLE = TRUE` (single-file output) is not supported.
+- File format options must be specified inline in `FILE_FORMAT = (...)`.
+- File listing is **non-recursive**: only direct files under the source path are processed. Subdirectories are ignored.
+- `PATTERN` matches the **base file name** only (not the full path).
+- Concurrent COPY INTO commands targeting the same table may produce duplicate data.
+- `SKIP_HEADER` only supports values `0` or `1`.
+- `FROM (...)` accepts any read-only query (e.g. `SELECT`, `WITH ... SELECT`, `VALUES`); statements with side effects (e.g. `INSERT`, `INSERT OVERWRITE DIRECTORY`, DDL) are rejected.
+- For a `FROM (...)` export, `rows_written` is an execution-time statistic counted by a separate pass before the files are written. Because the DataFrame is lazy and not cached, writing re-executes the query a second time; if the query is non-deterministic (e.g. uses `rand()`, `current_timestamp()`, or reads a volatile source), the two runs can produce different rows, so `rows_written` may not match the actual file contents. The result is intentionally not staged, so the export does not consume extra executor disk.
+
+For table-to-table row writes, see [SQL Writes](./sql-write). For copying existing Paimon
+table files, see the [copy procedure](./procedures/migration#copy).

--- a/docs/docs/spark/data-types.md
+++ b/docs/docs/spark/data-types.md
@@ -1,0 +1,69 @@
+---
+title: "Data Types"
+---
+
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+# Data Types
+
+Use this table to check the mapping between Spark and Paimon types. Spark types are in
+`org.apache.spark.sql.types`; Paimon types are in `org.apache.paimon.types`.
+Version-specific rows apply only to the indicated Spark versions. The binary row lists Paimon
+types Spark can read as `BinaryType`; it does not imply a unique mapping in both directions.
+
+## Type Mapping
+
+| Spark type | Paimon type | Atomic |
+| --- | --- | --- |
+| `StructType` | `RowType` | false |
+| `MapType` | `MapType` | false |
+| `ArrayType` | `ArrayType` | false |
+| `BooleanType` | `BooleanType` | true |
+| `ByteType` | `TinyIntType` | true |
+| `ShortType` | `SmallIntType` | true |
+| `IntegerType` | `IntType` | true |
+| `LongType` | `BigIntType` | true |
+| `FloatType` | `FloatType` | true |
+| `DoubleType` | `DoubleType` | true |
+| `StringType` | `VarCharType(Integer.MAX_VALUE)` | true |
+| `VarCharType(length)` | `VarCharType(length)` | true |
+| `CharType(length)` | `CharType(length)` | true |
+| `DateType` | `DateType` | true |
+| `TimestampType` | `LocalZonedTimestampType` | true |
+| `TimestampNTZType (Spark 3.4+)` | `TimestampType` | true |
+| `DecimalType(precision, scale)` | `DecimalType(precision, scale)` | true |
+| `BinaryType` | `VarBinaryType`, `BinaryType` | true |
+| `GeometryType (Spark 4.1)` | `GeometryType` | true |
+| `GeographyType (Spark 4.1)` | `GeographyType` | true |
+| `VariantType (Spark 4.0+)` | `VariantType` | true |
+
+## Timestamps
+
+On Spark 3.3 and earlier, Paimon maps both `TimestampType` and `LocalZonedTimestampType`
+to Spark `TimestampType`. Only Paimon `TimestampType` is handled correctly by this legacy mapping.
+
+Reading `LocalZonedTimestampType` values written by another engine, such as Flink, can therefore
+produce a time zone offset that needs to be adjusted manually.
+
+Spark 3.4 and later distinguish the two timestamp types.
+
+## Geospatial Types
+
+Native `GeometryType` and `GeographyType` conversion is supported only in Spark 4.1 and only for CRSs recognized by Spark. Enable it explicitly in production with `--conf spark.sql.geospatial.enabled=true`; Spark enables it automatically only in its test environment. Spark 4.1 supports only the `spherical` geography edge algorithm, so Paimon geography types using `vincenty`, `thomas`, `andoyer`, or `karney` cannot be converted. Spark 3.x and Spark 4.0 reject Paimon geospatial columns instead of exposing them as `BinaryType`, which would lose the CRS or edge algorithm. Paimon does not support Spark geospatial types with mixed SRIDs.

--- a/docs/docs/spark/dataframe.md
+++ b/docs/docs/spark/dataframe.md
@@ -1,5 +1,5 @@
 ---
-title: "DataFrame"
+title: "DataFrame API"
 sidebar_position: 9
 ---
 
@@ -22,91 +22,164 @@ specific language governing permissions and limitations
 under the License.
 -->
 
-# DataFrame
+# DataFrame API
 
-Paimon supports creating table, inserting data, and querying through the Spark DataFrame API.
-
-## Create Table
-You can specify table properties with `option` or set partition columns with `partitionBy` if needed.
+Use the Spark DataFrame API to create tables, write rows, and query data. Start `spark-shell`
+with the same JAR, catalog, and extension options as [Quick Start](./quick-start#setup), then run:
 
 ```scala
-val data: DataFrame = Seq((1, "x1", "p1"), (2, "x2", "p2")).toDF("a", "b", "pt")
-
-data.write.format("paimon")
-  .option("primary-key", "a,pt")
-  .option("k1", "v1")
-  .partitionBy("pt")
-  .saveAsTable("test_tbl") // or .save("/path/to/default.db/test_tbl")
+import spark.implicits._
+spark.sql("USE paimon.default")
 ```
+
+The examples below use Scala and an existing Paimon catalog. Follow them in order with a new
+`test_tbl`, or adapt the names to your own tables. For streaming DataFrames, see
+[Structured Streaming](./structured-streaming).
+
+## Choose a Write Method
+
+| Method | Column alignment | Target |
+| --- | --- | --- |
+| `saveAsTable(name)` | By name when appending to an existing table | Catalog table; can also create a new table. |
+| `insertInto(name)` | By position; source column names are ignored | Existing catalog table. |
+| `save(path)` | Depends on the write path; default V1 writes are positional | Existing Paimon table location. Select columns in target order explicitly. |
+
+![A DataFrame with columns b and a is written to a table with columns a and b. insertInto maps positions, while saveAsTable aligns names.](/img/spark-dataframe-alignment.svg)
+
+## Create Table
+
+Use `saveAsTable` to create a table and write its initial rows. Set table properties with
+`option` and partition columns with `partitionBy`:
+
+```scala
+val initial = Seq((1, "x1", "p1"), (2, "x2", "p2")).toDF("a", "b", "pt")
+
+initial.write.format("paimon")
+  .option("primary-key", "a,pt")
+  .option("bucket", "1")
+  .partitionBy("pt")
+  .saveAsTable("test_tbl")
+```
+
+A path write with `.save(path)` requires a table schema already stored at that location.
+Create the table first; `.save(path)` is not a substitute for this creation step.
 
 ## Insert
 
 ### Insert Into
-You can achieve INSERT INTO semantics by setting the mode to `append`.
+
+Append a batch with columns in a different order. `saveAsTable` aligns them by name:
 
 ```scala
-val data: DataFrame = ...
+val nextBatch = Seq(("p1", "updated", 1), ("p3", "x3", 3)).toDF("pt", "b", "a")
 
-data.write.format("paimon")
+nextBatch.write.format("paimon")
   .mode("append")
-  .insertInto("test_tbl") // or .saveAsTable("test_tbl") or .save("/path/to/default.db/test_tbl")
+  .saveAsTable("test_tbl")
 ```
 
-Note: `insertInto` ignores the column names and just uses position-based write,
-if you need to write by column name, use `saveAsTable` or `save` instead.
+Because `test_tbl` is a primary key table, this updates key `(1, p1)` and adds key `(3, p3)`.
+
+For `insertInto`, select columns in the target order first. This is an alternative way to
+write the same batch:
+
+```scala
+nextBatch.select("a", "b", "pt")
+  .write
+  .mode("append")
+  .insertInto("test_tbl")
+```
 
 ### Insert Overwrite
-You can achieve INSERT OVERWRITE semantics by setting the mode to `overwrite`.
 
-It supports dynamic partition overwritten for partitioned table.
-To enable dynamic overwritten you need to set the Spark session configuration `spark.sql.sources.partitionOverwriteMode` to `dynamic`.
+For a partitioned catalog table, dynamic overwrite replaces only partitions present in the
+input. The following example replaces `p1` and preserves `p2` and `p3`:
 
 ```scala
-val data: DataFrame = ...
+spark.conf.set("spark.sql.sources.partitionOverwriteMode", "dynamic")
 
-data.write.format("paimon")
+val replacement = Seq((4, "x4", "p1")).toDF("a", "b", "pt")
+replacement.write
   .mode("overwrite")
-  .insertInto("test_tbl") // or .saveAsTable("test_tbl")
+  .insertInto("test_tbl")
 ```
 
-{{< hint info >}}
-Since Spark 3.4, `saveAsTable` with `overwrite` mode only overwrites data and preserves
-the existing table definition (partitions, primary keys, and properties).
-If you need to replace the table definition, use SQL `CREATE OR REPLACE TABLE ... AS SELECT`.
+In static mode, an overwrite without a partition filter replaces the whole table. See
+[overwrite scope](./sql-write#dynamic-overwrite-partition) for the SQL equivalents.
 
-Before Spark 3.4, `saveAsTable` with `overwrite` mode drops and recreates the table, so the
-table definition is reset to the DataFrame's schema and only the partitions and options
-explicitly re-specified via `partitionBy()` / write options are kept.
-{{< /hint >}}
+:::info
+
+Since Spark 3.4, `saveAsTable` with `overwrite` mode on an existing Paimon catalog table preserves
+the table definition, including partitions, primary keys, and properties. Configure the Paimon
+extensions as in Quick Start. To replace the definition, use
+[`CREATE OR REPLACE TABLE ... AS SELECT`](./sql-ddl#replace-table).
+
+Before Spark 3.4, `saveAsTable` with `overwrite` drops and recreates the table. Only partitioning
+and options explicitly supplied to the writer are kept, and the DataFrame supplies the new schema.
+
+:::
 
 ## Query
 
+Read through the catalog and inspect the result of the preceding writes:
+
 ```scala
 spark.read.format("paimon")
-  .table("t") // or .load("/path/to/default.db/test_tbl")
+  .table("paimon.default.test_tbl")
+  .orderBy("a")
+  .show()
+// +---+---+---+
+// |  a|  b| pt|
+// +---+---+---+
+// |  2| x2| p2|
+// |  3| x3| p3|
+// |  4| x4| p1|
+// +---+---+---+
+```
+
+Use a fully qualified name to select another catalog or database. Read options can be supplied
+per operation, for example to read a retained snapshot:
+
+```scala
+spark.read.format("paimon")
+  .option("scan.snapshot-id", "1")
+  .table("paimon.default.test_tbl")
   .show()
 ```
 
-To specify the catalog or database, you can use
+Replace `1` with a snapshot ID that exists in your table. See
+[SQL Queries](./sql-query) for time travel and incremental read semantics.
+
+## Read or Write by Location
+
+For the local warehouse used in Quick Start, the table above is stored at
+`file:/tmp/paimon/default.db/test_tbl`. Use the actual table location for another warehouse:
 
 ```scala
-// recommend
-spark.read.format("paimon")
-  .table("<catalogName>.<databaseName>.<tableName>")
+val tableLocation = "file:/tmp/paimon/default.db/test_tbl"
 
-// or
-spark.read.format("paimon")
-  .option("catalog", "<catalogName>")
-  .option("database", "<databaseName>")
-  .option("table", "<tableName>")
-  .load("/path/to/default.db/test_tbl")
+spark.read.format("paimon").load(tableLocation).show()
+
+// Explicitly order columns for a path write.
+nextBatch.select("a", "b", "pt")
+  .write.format("paimon")
+  .mode("append")
+  .save(tableLocation)
 ```
 
-You can specify other read configs through option:
+For `.save(tableLocation)`, `overwrite` replaces the entire table even when the session's
+partition overwrite mode is `dynamic`. Use a catalog write when you need dynamic partition
+overwrite.
+
+To associate a location-based read with a catalog identifier, supply all three identifier options:
 
 ```scala
-// time travel
 spark.read.format("paimon")
-  .option("scan.snapshot-id", 1)
-  .table("t")
+  .option("catalog", "paimon")
+  .option("database", "default")
+  .option("table", "test_tbl")
+  .load(tableLocation)
 ```
+
+For missing or extra columns, see
+[Schema Evolution on Write](./schema-evolution#column-alignment-by-write-path).

--- a/docs/docs/spark/default-value.md
+++ b/docs/docs/spark/default-value.md
@@ -1,5 +1,5 @@
 ---
-title: "Default Value"
+title: "Default Values"
 sidebar_position: 8
 ---
 
@@ -22,14 +22,20 @@ specific language governing permissions and limitations
 under the License.
 -->
 
-# Default Value
+# Default Values
 
-Paimon allows specifying default values for columns. When users write to these tables without explicitly providing
-values for certain columns, Paimon automatically generates default values for these columns.
+Column default values require **Spark 3.4 or later**. Define defaults when creating a table or
+change the default of an existing column with `ALTER TABLE`.
+
+Paimon applies a configured default when a write supplies no value for that column. It also
+replaces an explicit `NULL` in a nullable column with the configured default during writing.
+This applies to writes from SQL and the DataFrame API. `NOT NULL` constraints are checked before
+Paimon's write-time default substitution, so a null value in a `NOT NULL` column is rejected even
+if the column has a default.
 
 ## Create Table
 
-You can create a table with columns with default values using the following SQL:
+Defaults can be scalar values or values of complex types:
 
 ```sql
 CREATE TABLE my_table (
@@ -44,56 +50,73 @@ CREATE TABLE my_table (
 
 ## Insert Table
 
-For SQL commands that execute table writes, such as the `INSERT`, `UPDATE`, and `MERGE` commands, the `DEFAULT` keyword
-or `NULL` value is parsed into the default value specified for the corresponding column.
-
-For example:
+Omit columns from an explicit column list to use their defaults:
 
 ```sql
 INSERT INTO my_table (a) VALUES (1), (2);
 
-SELECT * FROM my_table;
--- result: [[1, my_value, 5, [tag1, tag2, tag3], {'key1' -> 'value1', 'key2' -> 'value2'}, {42, default_value}],
---          [2, my_value, 5, [tag1, tag2, tag3], {'key1' -> 'value1', 'key2' -> 'value2'}, {42, default_value}]]
+SELECT a, b, c FROM my_table ORDER BY a;
+-- 1  my_value  5
+-- 2  my_value  5
 ```
+
+`DEFAULT` requests the column default explicitly. A written `NULL` in the nullable column `c`
+is also replaced by its default:
+
+```sql
+INSERT INTO my_table (a, b, c) VALUES (3, DEFAULT, NULL);
+
+SELECT a, b, c FROM my_table WHERE a = 3;
+-- 3  my_value  5
+```
+
+The complex columns receive the defaults declared above. Inspect individual fields instead
+of printing an entire nested row:
+
+```sql
+SELECT tags, properties['key1'], nested.x FROM my_table WHERE a = 3;
+-- [tag1, tag2, tag3]  value1  42
+```
+
+If a column has no default, an omitted or null value remains null, subject to the column's
+nullability constraints. For write-path-specific handling of missing columns, see
+[Schema Evolution on Write](./schema-evolution#column-alignment-by-write-path).
 
 ## Alter Default Value
 
-Paimon supports alter column default value.
-
-For example:
+A changed default is used by subsequent writes. Previously stored non-null values are preserved:
 
 ```sql
-CREATE TABLE T (a INT, b INT DEFAULT 2);
+CREATE TABLE default_example (a INT, b INT DEFAULT 2);
+INSERT INTO default_example (a) VALUES (1);
 
-INSERT INTO T (a) VALUES (1);
--- result: [[1, 2]]
+ALTER TABLE default_example ALTER COLUMN b SET DEFAULT 3;
+INSERT INTO default_example (a) VALUES (2);
 
-ALTER TABLE T ALTER COLUMN b SET DEFAULT 3;
-
-INSERT INTO T (a) VALUES (2);
--- result: [[1, 2], [2, 3]]
+SELECT * FROM default_example ORDER BY a;
+-- 1  2
+-- 2  3
 ```
 
-The default value of `'b'` column has been changed to 3 from 2. You can also alter default values for complex types:
+Change complex defaults with the same statement:
 
 ```sql
 ALTER TABLE my_table ALTER COLUMN tags SET DEFAULT ARRAY('new_tag1', 'new_tag2');
-
-INSERT INTO my_table (a) VALUES (3);
--- result: [[1, my_value, 5, [tag1, tag2, tag3], {'key1' -> 'value1', 'key2' -> 'value2'}, {42, default_value}],
---          [2, my_value, 5, [tag1, tag2, tag3], {'key1' -> 'value1', 'key2' -> 'value2'}, {42, default_value}],
---          [3, my_value, 5, [new_tag1, new_tag2], {'key1' -> 'value1', 'key2' -> 'value2'}, {42, default_value}]]
-
 ALTER TABLE my_table ALTER COLUMN properties SET DEFAULT MAP('new_key', 'new_value');
-
 INSERT INTO my_table (a) VALUES (4);
--- result: [[1, my_value, 5, [tag1, tag2, tag3], {'key1' -> 'value1', 'key2' -> 'value2'}, {42, default_value}],
---          [2, my_value, 5, [tag1, tag2, tag3], {'key1' -> 'value1', 'key2' -> 'value2'}, {42, default_value}],
---          [3, my_value, 5, [new_tag1, new_tag2], {'key1' -> 'value1', 'key2' -> 'value2'}, {42, default_value}],
---          [4, my_value, 5, [new_tag1, new_tag2], {'new_key' -> 'new_value'}, {42, default_value}]]
+
+SELECT a, tags, properties['new_key'] FROM my_table WHERE a = 4;
+-- 4  [new_tag1, new_tag2]  new_value
 ```
 
 ## Limitation
 
-Not support alter table add column with default value, for example: `ALTER TABLE T ADD COLUMN d INT DEFAULT 5;`.
+- `ALTER TABLE ADD COLUMN` cannot include a default. Add the column first, then set its default
+  with a separate statement as shown below.
+- Dynamic default expressions such as `current_timestamp()` and `current_date()` are not supported.
+  Supply these values in the incoming query or DataFrame instead.
+
+```sql
+ALTER TABLE default_example ADD COLUMN d INT;
+ALTER TABLE default_example ALTER COLUMN d SET DEFAULT 5;
+```

--- a/docs/docs/spark/default-value.md
+++ b/docs/docs/spark/default-value.md
@@ -42,9 +42,9 @@ CREATE TABLE my_table (
     a BIGINT,
     b STRING DEFAULT 'my_value',
     c INT DEFAULT 5,
-    tags ARRAY<STRING> DEFAULT ARRAY('tag1', 'tag2', 'tag3'),
-    properties MAP<STRING, STRING> DEFAULT MAP('key1', 'value1', 'key2', 'value2'),
-    nested STRUCT<x: INT, y: STRING> DEFAULT STRUCT(42, 'default_value')
+    numbers ARRAY<INT> DEFAULT ARRAY(1, 2, 3),
+    scores MAP<INT, INT> DEFAULT MAP(1, 10, 2, 20),
+    nested STRUCT<x: INT, y: INT> DEFAULT STRUCT(42, 7)
 );
 ```
 
@@ -74,8 +74,8 @@ The complex columns receive the defaults declared above. Inspect individual fiel
 of printing an entire nested row:
 
 ```sql
-SELECT tags, properties['key1'], nested.x FROM my_table WHERE a = 3;
--- [tag1, tag2, tag3]  value1  42
+SELECT numbers, scores[1], nested.x FROM my_table WHERE a = 3;
+-- [1, 2, 3]  10  42
 ```
 
 If a column has no default, an omitted or null value remains null, subject to the column's
@@ -101,16 +101,21 @@ SELECT * FROM default_example ORDER BY a;
 Change complex defaults with the same statement:
 
 ```sql
-ALTER TABLE my_table ALTER COLUMN tags SET DEFAULT ARRAY('new_tag1', 'new_tag2');
-ALTER TABLE my_table ALTER COLUMN properties SET DEFAULT MAP('new_key', 'new_value');
+ALTER TABLE my_table ALTER COLUMN numbers SET DEFAULT ARRAY(4, 5);
+ALTER TABLE my_table ALTER COLUMN scores SET DEFAULT MAP(3, 30);
 INSERT INTO my_table (a) VALUES (4);
 
-SELECT a, tags, properties['new_key'] FROM my_table WHERE a = 4;
--- 4  [new_tag1, new_tag2]  new_value
+SELECT a, numbers, scores[3] FROM my_table WHERE a = 4;
+-- 4  [4, 5]  30
 ```
 
 ## Limitation
 
+- Complex default expressions currently have a string-quoting limitation: single quotes in
+  `ARRAY`, `MAP`, and `STRUCT` string elements can be retained in the stored values. For example,
+  `MAP('key1', 'value1')` stores a key containing the quote characters, so looking up `['key1']`
+  returns `NULL`. The examples above use numeric elements to avoid this limitation. Supply
+  complex values containing strings explicitly in the incoming query or DataFrame instead.
 - `ALTER TABLE ADD COLUMN` cannot include a default. Add the column first, then set its default
   with a separate statement as shown below.
 - Dynamic default expressions such as `current_timestamp()` and `current_date()` are not supported.

--- a/docs/docs/spark/format-table.md
+++ b/docs/docs/spark/format-table.md
@@ -1,0 +1,116 @@
+---
+title: "Format Table Partitions"
+---
+
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+# Format Table Partitions
+
+This page covers Spark partition DDL and statistics for Format Tables. For Paimon snapshot
+tables, see [Create Tables, Views, and Tags](./sql-ddl) and [Alter Tables](./sql-alter).
+
+## Catalog-managed Partitions
+
+For a Format Table whose `metastore.partitioned-table` option is `true`, the catalog holds the
+partitions and Spark supports the standard partition DDL:
+
+```sql
+ALTER TABLE my_table ADD PARTITION (dt='2025-01-01');
+ALTER TABLE my_table ADD PARTITION (dt='2024-12-31')
+    LOCATION 'oss://archive-bucket/events/dt=2024-12-31';
+ALTER TABLE my_table DROP PARTITION (dt='2025-01-01');
+MSCK REPAIR TABLE my_table;
+SHOW PARTITIONS my_table;
+ANALYZE TABLE my_table PARTITION (dt='2025-01-01') COMPUTE STATISTICS NOSCAN;
+```
+
+On a Format Table whose partitions are discovered from the filesystem, `ADD PARTITION`,
+`DROP PARTITION`, `MSCK REPAIR TABLE` and `ANALYZE TABLE` fail with an error.
+
+`ADD PARTITION` creates the partition directory and registers the partition; querying a newly
+added partition before any data is written returns no rows. `DROP PARTITION` unregisters the
+partition and deletes its directory.
+
+`ADD PARTITION ... LOCATION` registers a custom absolute URI without moving data and requires a
+compatible REST catalog. Paimon can read the partition but does not write, delete, or analyze its
+data. `DROP PARTITION` only unregisters it, and `MSCK REPAIR TABLE` leaves it unchanged.
+
+A partition value that is empty or all whitespace is rejected by `ADD PARTITION`, `DROP PARTITION`
+and `TRUNCATE PARTITION`. Such a value is written to the partition named by
+`partition.default-name` (`__DEFAULT_PARTITION__` unless configured otherwise), the same partition
+a `NULL` is written to, so it names that partition rather than one of its own - name it directly
+instead. Writing one through `INSERT` is unaffected and still lands there.
+
+`ANALYZE TABLE` measures partitions. A Format Table has no snapshot to carry a table-level
+statistic and no column statistics, so `COMPUTE STATISTICS FOR COLUMNS` and `FOR ALL COLUMNS` are
+not supported on it; what the statement writes back to the catalog is the file count, byte size,
+last file creation time and row count of the partitions it measured. Each measured field replaces
+the one the catalog held, so running it twice reports the same numbers as running it once, while a
+field it could not measure leaves the stored one as it was. It never adds or removes a partition —
+use `MSCK REPAIR TABLE` for that.
+
+`NOSCAN` stops at the directory listing, which gives everything except the row count. Without it,
+the row count is read from each file's footer, so it is exact for the formats that carry one
+(Parquet, ORC) and a partition holding no files counts as zero, while a format that carries none
+(CSV, TEXT, JSON) leaves the row count the catalog already held rather than guessing one. Reading
+footers costs one open per file, so it runs on the executors and `NOSCAN` is the cheaper of the
+two.
+
+A `PARTITION (...)` clause must give values for a leading run of the partition columns, because
+that is the shape the catalog can select on. On a table partitioned by `(dt, hh)`,
+`PARTITION (dt='2025-01-01')` and `PARTITION (dt='2025-01-01', hh)` both measure every hour of
+that day, while `PARTITION (hh='01')` is rejected rather than widened to every day. Naming a
+partition that is not registered is an error too, rather than a statement that reports success for
+having measured nothing.
+
+:::info
+
+`metastore.partitioned-table = true` enables catalog-managed partitions, which requires an
+internal Format Table in a catalog that supports it (currently the REST catalog) and cannot be
+combined with `format-table.implementation = engine`. The REST catalog validates this
+combination on `CREATE TABLE`, with catalog-level table defaults
+(`spark.sql.catalog.paimon.table-default.*`) participating in the effective options: a default
+that makes the combination invalid fails the DDL.
+
+In a REST catalog, asking for catalog-managed partitions on a table that cannot have them — an
+external table, or `format-table.implementation = engine` — fails, rather than handing back a
+table whose options say one thing and whose partitions come from somewhere else. Remove the option
+with `ALTER TABLE my_table UNSET TBLPROPERTIES ('metastore.partitioned-table')`.
+
+In any other catalog the option keeps the meaning it has always had on a Format Table — none. Such
+a table loads and reads its partitions from the filesystem, so on a Format Table it
+only takes effect in a REST catalog; elsewhere partitions are discovered from the filesystem.
+On a REST catalog, an existing Format Table whose partitions were never registered reads as empty
+until you register them with `MSCK REPAIR TABLE my_table`.
+
+Mixed-version note: only writers that support catalog-managed partitions register the partitions
+they produce. During a rolling upgrade, upgrade all writers before relying on catalog-managed
+partitions, or run `MSCK REPAIR TABLE` afterwards, since data written by an older writer is not
+visible until its partitions are registered.
+
+For a Format Table, `metastore.partitioned-table` only changes where partitions come from; it does not
+change the table's managed/external ownership.
+
+:::
+
+## Writes and Maintenance
+
+See [SQL Writes](./sql-write#insert-overwrite) for overwrite behavior and
+[TRUNCATE TABLE](./sql-write#truncate-table) for how data, registrations, and statistics are updated.

--- a/docs/docs/spark/index.md
+++ b/docs/docs/spark/index.md
@@ -1,6 +1,5 @@
 ---
-title: "Engine Spark"
-sidebar_position: 6
+title: "Spark"
 ---
 
 <!--
@@ -21,3 +20,45 @@ KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->
+
+# Spark
+
+Use Spark SQL, the DataFrame API, or Structured Streaming to work with Paimon tables.
+Start with a local example, configure your catalog, then choose the guide for the operation
+you need.
+
+![Spark SQL, DataFrames, and Structured Streaming access Paimon through the connector and catalog, with table data stored in the warehouse.](/img/spark-integration.svg)
+
+## Start Here
+
+1. [Quick Start](./quick-start): create a table, write an update, and read the result locally.
+2. [Installation](./installation): match the Spark and Scala versions and install the connector.
+3. [Catalogs](./catalogs): connect to a filesystem, Hive, JDBC, or REST catalog.
+4. [Configuration](./configuration): distinguish catalog, table, session, and operation options.
+
+## Choose a Guide
+
+| Task | Read next |
+| --- | --- |
+| Create a table, view, or tag | [SQL DDL](./sql-ddl) |
+| Change a schema or table property | [Alter Tables](./sql-alter) |
+| Work with catalog-managed Format Table partitions | [Format Table Partitions](./format-table) |
+| Query current state, time travel, or bounded changes | [SQL Queries](./sql-query) |
+| Insert, overwrite, update, delete, or merge rows | [SQL Writes](./sql-write) |
+| Import or export CSV, JSON, or Parquet | [COPY INTO](./copy-into) |
+| Work from Scala | [DataFrame API](./dataframe) |
+| Add columns during writes | [Schema Evolution on Write](./schema-evolution) |
+| Build a streaming job | [Structured Streaming](./structured-streaming) |
+| Recover a stream and retain unread data | [Streaming Recovery](./streaming-recovery) |
+| Compact, expire, migrate, or build indexes | [Procedures](./procedures) |
+
+## Reference
+
+- [Data Types](./data-types): type mappings and version-specific timestamp and geospatial behavior.
+- [Default Values](./default-value): defaults for new writes and how to change them.
+- [SQL Functions](./sql-functions): partition helpers, blob functions, and user-defined functions.
+- [Inspect and Maintain Tables](./auxiliary): schemas, partitions, statistics, and metadata refresh.
+
+Feature requirements are called out on each page. In particular, SQL time travel and streaming
+reads require Spark 3.3+, `INSERT ... BY NAME` requires Spark 3.5+, and SQL-defined scalar
+functions require Spark 4.0+.

--- a/docs/docs/spark/installation.mdx
+++ b/docs/docs/spark/installation.mdx
@@ -1,0 +1,107 @@
+---
+title: "Installation"
+---
+
+import Stable from '@site/src/components/Stable';
+import Unstable from '@site/src/components/Unstable';
+
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+# Installation
+
+Match the connector to the Spark minor version and Scala binary version of your distribution.
+The Java versions below describe how the connector artifacts are built; your Spark distribution
+may require a newer Java runtime. Check its runtime requirements before starting Spark.
+
+- Spark 4.x (including 4.1, 4.0) : Pre-built with Java 17 and Scala 2.13
+
+- Spark 3.x (including 3.5, 3.4, 3.3, 3.2) : Pre-built with Java 8 and Scala 2.12/2.13
+
+## Download the Connector
+
+Choose the JAR matching your Spark and Scala versions:
+
+<Stable>
+
+| Version   | Jar (Scala 2.12)                                                                                                                                                                    | Jar (Scala 2.13)                                                                                                                                                                    |
+|-----------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| Spark 4.1 | -                                                                                                                                                                                   | [JAR](https://repo.maven.apache.org/maven2/org/apache/paimon/paimon-spark-4.1_2.13/@@VERSION@@/paimon-spark-4.1_2.13-@@VERSION@@.jar) |
+| Spark 4.0 | -                                                                                                                                                                                   | [JAR](https://repo.maven.apache.org/maven2/org/apache/paimon/paimon-spark-4.0_2.13/@@VERSION@@/paimon-spark-4.0_2.13-@@VERSION@@.jar) |
+| Spark 3.5 | [JAR](https://repo.maven.apache.org/maven2/org/apache/paimon/paimon-spark-3.5_2.12/@@VERSION@@/paimon-spark-3.5_2.12-@@VERSION@@.jar) | [JAR](https://repo.maven.apache.org/maven2/org/apache/paimon/paimon-spark-3.5_2.13/@@VERSION@@/paimon-spark-3.5_2.13-@@VERSION@@.jar) |
+| Spark 3.4 | [JAR](https://repo.maven.apache.org/maven2/org/apache/paimon/paimon-spark-3.4_2.12/@@VERSION@@/paimon-spark-3.4_2.12-@@VERSION@@.jar) | [JAR](https://repo.maven.apache.org/maven2/org/apache/paimon/paimon-spark-3.4_2.13/@@VERSION@@/paimon-spark-3.4_2.13-@@VERSION@@.jar) |
+| Spark 3.3 | [JAR](https://repo.maven.apache.org/maven2/org/apache/paimon/paimon-spark-3.3_2.12/@@VERSION@@/paimon-spark-3.3_2.12-@@VERSION@@.jar) | [JAR](https://repo.maven.apache.org/maven2/org/apache/paimon/paimon-spark-3.3_2.13/@@VERSION@@/paimon-spark-3.3_2.13-@@VERSION@@.jar) |
+| Spark 3.2 | [JAR](https://repo.maven.apache.org/maven2/org/apache/paimon/paimon-spark-3.2_2.12/@@VERSION@@/paimon-spark-3.2_2.12-@@VERSION@@.jar) | [JAR](https://repo.maven.apache.org/maven2/org/apache/paimon/paimon-spark-3.2_2.13/@@VERSION@@/paimon-spark-3.2_2.13-@@VERSION@@.jar) |
+
+</Stable>
+
+<Unstable>
+
+| Version   | Jar (Scala 2.12)                                                                                                                              | Jar (Scala 2.13)                                                                                                                              |
+|-----------|-----------------------------------------------------------------------------------------------------------------------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------|
+| Spark 4.1 | -                                                                                                                                             | [JAR](https://repository.apache.org/snapshots/org/apache/paimon/paimon-spark-4.1_2.13/@@VERSION@@/) |
+| Spark 4.0 | -                                                                                                                                             | [JAR](https://repository.apache.org/snapshots/org/apache/paimon/paimon-spark-4.0_2.13/@@VERSION@@/) |
+| Spark 3.5 | [JAR](https://repository.apache.org/snapshots/org/apache/paimon/paimon-spark-3.5_2.12/@@VERSION@@/) | [JAR](https://repository.apache.org/snapshots/org/apache/paimon/paimon-spark-3.5_2.13/@@VERSION@@/) |
+| Spark 3.4 | [JAR](https://repository.apache.org/snapshots/org/apache/paimon/paimon-spark-3.4_2.12/@@VERSION@@/) | [JAR](https://repository.apache.org/snapshots/org/apache/paimon/paimon-spark-3.4_2.13/@@VERSION@@/) |
+| Spark 3.3 | [JAR](https://repository.apache.org/snapshots/org/apache/paimon/paimon-spark-3.3_2.12/@@VERSION@@/) | [JAR](https://repository.apache.org/snapshots/org/apache/paimon/paimon-spark-3.3_2.13/@@VERSION@@/) |
+| Spark 3.2 | [JAR](https://repository.apache.org/snapshots/org/apache/paimon/paimon-spark-3.2_2.12/@@VERSION@@/) | [JAR](https://repository.apache.org/snapshots/org/apache/paimon/paimon-spark-3.2_2.13/@@VERSION@@/) |
+
+</Unstable>
+
+## Build from Source
+
+You can also build the bundled JAR from source.
+
+To build from source code, [clone the git repository](@@GITHUB_REPO@@), then build the bundled jar with the following command.
+
+```bash
+# build paimon spark 3.5 with scala 2.12
+mvn clean package -DskipTests -pl paimon-spark/paimon-spark-3.5 -am -Pspark3
+
+# build paimon spark 3.5 with scala 2.13
+mvn clean package -DskipTests -pl paimon-spark/paimon-spark-3.5 -am -Pspark3,scala-2.13
+
+# build paimon spark 4.0
+mvn clean package -DskipTests -pl paimon-spark/paimon-spark-4.0 -am -Pspark4
+
+# build paimon spark 4.1
+mvn clean package -DskipTests -pl paimon-spark/paimon-spark-4.1 -am -Pspark4
+```
+
+For Spark 3.5, you can find the bundled jar in `./paimon-spark/paimon-spark-3.5/target/paimon-spark-3.5_2.12-@@VERSION@@.jar`.
+
+## Add the Connector to Spark
+
+Pass `--jars /path/to/paimon-connector.jar` when starting `spark-sql` or `spark-shell`, or put the
+JAR in your Spark installation's `jars` directory. For published releases, Maven coordinates
+are another option:
+
+```bash
+spark-sql --packages org.apache.paimon:paimon-spark-3.5_2.12:@@VERSION@@
+```
+
+Snapshot artifacts are hosted in the Apache snapshot repository linked above. Download the
+snapshot JAR and use `--jars` for the local quick start.
+
+## Configure Storage and a Catalog
+
+Use the complete command in [Quick Start](./quick-start#setup) for local storage, or configure
+[Catalogs](./catalogs) for your deployment. When using HDFS, set `HADOOP_HOME` or `HADOOP_CONF_DIR`
+so Spark can load the Hadoop configuration. Add the filesystem dependencies required by your
+warehouse as described in [Filesystems](../maintenance/filesystems).

--- a/docs/docs/spark/procedures.md
+++ b/docs/docs/spark/procedures.md
@@ -1,6 +1,5 @@
 ---
 title: "Procedures"
-sidebar_position: 99
 ---
 
 <!--
@@ -24,609 +23,105 @@ under the License.
 
 # Procedures
 
-This section introduce all available spark procedures about paimon.
+Run procedures through the `sys` namespace of a Paimon catalog, with
+`PaimonSparkSessionExtensions` enabled as in [Quick Start](./quick-start#setup).
 
-<table class="table table-bordered">
-    <thead>
-    <tr>
-      <th class="text-left" style="width: 4%">Procedure Name</th>
-      <th class="text-left" style="width: 20%">Explanation</th>
-      <th class="text-left" style="width: 4%">Example</th>
-    </tr>
-    </thead>
-    <tbody style="font-size: 12px; ">
-    <tr>
-      <td>compact</td>
-      <td>
-         To compact files. Argument:
-            <li>table: the target table identifier. Cannot be empty.</li>
-            <li>partitions: partition filter. the comma (",") represents "AND", the semicolon (";") represents "OR". If you want to compact one partition with date=01 and day=01, you need to write 'date=01,day=01'. Left empty for all partitions. (Can't be used together with "where")</li>
-            <li>where: partition predicate. Left empty for all partitions. (Can't be used together with "partitions")</li>          
-            <li>order_strategy: 'order' or 'zorder' or 'hilbert' or 'none'. Left empty for 'none'.</li>
-            <li>order_by: the columns need to be sort. Left empty if 'order_strategy' is 'none'.</li>
-            <li>options: additional dynamic options of the table. It prioritizes higher than original `tableProp` and lower than `procedureArg`.</li>
-            <li>partition_idle_time: this is used to do a full compaction for partition which had not received any new data for 'partition_idle_time'. And only these partitions will be compacted. This argument can not be used with order compact.</li>
-            <li>compact_strategy: this determines how to pick files to be merged, the default is determined by the runtime execution mode. 'full' strategy only supports batch mode. All files will be selected for merging. 'minor' strategy: Pick the set of files that need to be merged based on specified conditions.</li>
-      </td>
-      <td>
-         SET spark.sql.shuffle.partitions=10; --set the compact parallelism <br/><br/>
-         CALL sys.compact(table => 'T', partitions => 'p=0;p=1',  order_strategy => 'zorder', order_by => 'a,b') <br/><br/>
-         CALL sys.compact(table => 'T', where => 'p>0 and p<3', order_strategy => 'zorder', order_by => 'a,b') <br/><br/>
-         CALL sys.compact(table => 'T', where => 'dt>10 and h<20', order_strategy => 'zorder', order_by => 'a,b', options => 'target-file-size=128m')<br/><br/> 
-         CALL sys.compact(table => 'T', partition_idle_time => '60s')<br/><br/>
-         CALL sys.compact(table => 'T', compact_strategy => 'minor')<br/><br/>
-      </td>
-    </tr>
-    <tr>
-      <td>materialize_deletion_vectors</td>
-      <td>
-         Applies deletion vectors to the latest state of an unaware-bucket Data Evolution table and assigns new row IDs to surviving rows. Affected global indexes are dropped. Spark processes bounded batches until all matching deletion vectors are materialized. Historical snapshots and tags can retain the replaced files until snapshot expiration. Arguments:
-            <li>table: the target table identifier. Cannot be empty.</li>
-            <li>partitions: partition filter. Cannot be used together with where.</li>
-            <li>options: additional dynamic table options.</li>
-            <li>where: partition predicate. Cannot be used together with partitions.</li>
-      </td>
-      <td>
-         CALL sys.materialize_deletion_vectors(table => 'T') <br/><br/>
-         CALL sys.materialize_deletion_vectors(table => 'T', partitions => 'dt=2026-08-12')
-      </td>
-    </tr>
-    <tr>
-      <td>compact_database</td>
-      <td>
-         To compact all tables across one or more databases. Arguments:
-            <li>including_databases: regular expression to match databases to compact. Left empty to match all databases (i.e. '.*').</li>
-            <li>including_tables: regular expression to match table identifiers (in 'db.table' form) to compact. Left empty to match all tables (i.e. '.*').</li>
-            <li>excluding_tables: regular expression to match table identifiers to exclude from compaction.</li>
-            <li>options: additional dynamic options of the table. It prioritizes higher than original `tableProp` and lower than `procedureArg`.</li>
-      </td>
-      <td>
-         -- compact all databases<br/>
-         CALL sys.compact_database()<br/><br/>
-         -- compact some databases (accept regular expression)<br/>
-         CALL sys.compact_database(including_databases => 'db1|db2')<br/><br/>
-         -- compact some tables (accept regular expression)<br/>
-         CALL sys.compact_database(including_databases => 'db1', including_tables => 'db1.table1|db1.table2')<br/><br/>
-         -- exclude some tables (accept regular expression)<br/>
-         CALL sys.compact_database(including_databases => 'db1', including_tables => '.*', excluding_tables => '.*ignore_table')<br/><br/>
-         -- set table options<br/>
-         CALL sys.compact_database(including_databases => 'db1', options => 'target-file-size=128m')
-      </td>
-    </tr>
-    <tr>
-      <td>compact_chain_table</td>
-      <td>
-         To compact chain table by merging snapshot and delta branches into the snapshot branch. Arguments:
-            <li>table: The target chain table identifier. Cannot be empty.</li>
-            <li>partition: Partition specification format (e.g., 'dt="20250810",hour="22"'). Cannot be empty.</li>
-            <li>overwrite: Whether to overwrite if the partition already exists in the snapshot branch. Default is false. Optional.</li>
-      </td>
-      <td>
-         CALL sys.compact_chain_table(table => 'default.T', partition => 'dt="20250810",hour="22"')<br/><br/>
-      </td>
-    </tr>
-    <tr>
-      <td>expire_snapshots</td>
-      <td>
-         To expire snapshots. Argument:
-            <li>table: the target table identifier. Cannot be empty.</li>
-            <li>retain_max: the maximum number of completed snapshots to retain.</li>
-            <li>retain_min: the minimum number of completed snapshots to retain.</li>
-            <li>older_than: timestamp before which snapshots will be removed.</li>
-            <li>max_deletes: the maximum number of snapshots that can be deleted at once.</li>
-            <li>options: the additional dynamic options of the table. It prioritizes higher than original `tableProp` and lower than `procedureArg`.</li>
-      </td>
-      <td>CALL sys.expire_snapshots(table => 'default.T', retain_max => 10, options => 'snapshot.expire.limit=1')</td>
-    </tr>
-    <tr>
-      <td>expire_partitions</td>
-      <td>
-         To expire partitions. Argument:
-            <li>table: the target table identifier. Cannot be empty.</li>
-            <li>expiration_time: the expiration interval of a partition. A partition will be expired if it's lifetime is over this value. Partition time is extracted from the partition value.</li>
-            <li>timestamp_formatter: the formatter to format timestamp from string.</li>
-            <li>timestamp_pattern: the pattern to get a timestamp from partitions.</li>
-            <li>expire_strategy: specifies the expiration strategy for partition expiration, possible values: 'values-time' or 'update-time' , 'values-time' as default.</li>
-            <li>max_expires: The maximum of limited expired partitions, it is optional.</li>
-            <li>options: the additional dynamic options of the table. It prioritizes higher than original `tableProp` and lower than `procedureArg`.</li>
-      </td>
-      <td>CALL sys.expire_partitions(table => 'default.T', expiration_time => '1 d', timestamp_formatter => 
-'yyyy-MM-dd', timestamp_pattern => '$dt', expire_strategy => 'values-time', options => 'partition.expiration-max-num=2')</td>
-    </tr>
-    <tr>
-      <td>create_tag</td>
-      <td>
-         To create a tag based on given snapshot. Arguments:
-            <li>table: the target table identifier. Cannot be empty.</li>
-            <li>tag: name of the new tag. Cannot be empty.</li>
-            <li>snapshot(Long):  id of the snapshot which the new tag is based on.</li>
-            <li>time_retained: The maximum time retained for newly created tags.</li>
-      </td>
-      <td>
-         -- based on snapshot 10 with 1d <br/>
-         CALL sys.create_tag(table => 'default.T', tag => 'my_tag', snapshot => 10, time_retained => '1 d') <br/><br/>
-         -- based on the latest snapshot <br/>
-         CALL sys.create_tag(table => 'default.T', tag => 'my_tag')
-      </td>
-    </tr>
-    <tr>
-      <td>create_tag_from_timestamp</td>
-      <td>
-         To create a tag based on given timestamp. Arguments:
-            <li>table: the target table identifier. Cannot be empty.</li>
-            <li>tag: name of the new tag.</li>
-            <li>timestamp (Long): Find the first snapshot whose commit-time is greater than this timestamp.</li>
-            <li>time_retained : The maximum time retained for newly created tags.</li>
-      </td>
-      <td>
-         CALL sys.create_tag_from_timestamp(`table` => 'default.T', `tag` => 'my_tag', `timestamp` => 1724404318750, time_retained => '1 d')
-      </td>
-    </tr>
-    <tr>
-      <td>rename_tag</td>
-      <td>
-         Rename a tag with a new tag name. Arguments:
-            <li>table: the target table identifier. Cannot be empty.</li>
-            <li>tag: name of the tag. Cannot be empty.</li>
-            <li>target_tag: the new tag name to rename. Cannot be empty.</li>
-      </td>
-      <td>
-         CALL sys.rename_tag(table => 'default.T', tag => 'tag1', target_tag => 'tag2')
-      </td>
-    </tr>
-    <tr>
-      <td>replace_tag</td>
-      <td>
-         Replace an existing tag with new tag info. Arguments:
-            <li>table: the target table identifier. Cannot be empty.</li>
-            <li>tag: name of the existed tag. Cannot be empty.</li>
-            <li>snapshot(Long):  id of the snapshot which the tag is based on, it is optional.</li>
-            <li>time_retained: The maximum time retained for the existing tag, it is optional.</li>
-      </td>
-      <td>
-         CALL sys.replace_tag(table => 'default.T', tag => 'tag1', snapshot => 10, time_retained => '1 d')
-      </td>
-    </tr>
-    <tr>
-      <td>delete_tag</td>
-      <td>
-         To delete a tag. Arguments:
-            <li>table: the target table identifier. Cannot be empty.</li>
-            <li>tag: name of the tag to be deleted. If you specify multiple tags, delimiter is ','.</li>
-      </td>
-      <td>CALL sys.delete_tag(table => 'default.T', tag => 'my_tag')</td>
-    </tr>
-    <tr>
-      <td>expire_tags</td>
-      <td>
-         To expire tags by time. Arguments:
-            <li>table: the target table identifier. Cannot be empty.</li>
-            <li>older_than: tagCreateTime before which tags will be removed.</li>
-      </td>
-      <td>
-         CALL sys.expire_tags(table => 'default.T', older_than => '2024-09-06 11:00:00')
-      </td>
-    </tr>
-    <tr>
-      <td>trigger_tag_automatic_creation</td>
-      <td>
-         Trigger the tag automatic creation. Arguments:
-            <li>table: the target table identifier. Cannot be empty.</li>
-      </td>
-      <td>
-         CALL sys.trigger_tag_automatic_creation(table => 'default.T')
-      </td>
-    </tr>
-    <tr>
-      <td>rollback</td>
-      <td>
-         To rollback to a specific version of target table, note version/snapshot/tag must set one of them. Argument:
-            <li>table: the target table identifier. Cannot be empty.</li>
-            <li>version: id of the snapshot or name of tag that will roll back to, version would be Deprecated.</li>
-            <li>snapshot: snapshot that will roll back to.</li>
-            <li>tag: tag that will roll back to.</li>
-      </td>
-      <td>
-          CALL sys.rollback(table => 'default.T', version => 'my_tag')<br/><br/>
-          CALL sys.rollback(table => 'default.T', version => 10)<br/><br/>
-          CALL sys.rollback(table => 'default.T', tag => 'tag1')
-          CALL sys.rollback(table => 'default.T', snapshot => 2)
-      </td>
-    </tr>
-    <tr>
-      <td>rollback_to_timestamp</td>
-      <td>
-         To rollback to the snapshot which earlier or equal than timestamp. Argument:
-            <li>table: the target table identifier. Cannot be empty.</li>
-            <li>timestamp: roll back to the snapshot which earlier or equal than timestamp.</li>
-      </td>
-      <td>
-          CALL sys.rollback_to_timestamp(table => 'default.T', timestamp => 1730292023000)<br/><br/>
-      </td>
-    </tr>
-    <tr>
-      <td>rollback_to_watermark</td>
-      <td>
-         To rollback to the snapshot which earlier or equal than watermark. Argument:
-            <li>table: the target table identifier. Cannot be empty.</li>
-            <li>watermark: roll back to the snapshot which earlier or equal than watermark.</li>
-      </td>
-      <td>
-          CALL sys.rollback_to_watermark(table => 'default.T', watermark => 1730292023000)<br/><br/>
-      </td>
-    </tr>
-    <tr>
-      <td>purge_files</td>
-      <td>
-         To clear table with purge files. Argument:
-            <li>table: the target table identifier. Cannot be empty.</li>
-      </td>
-      <td>
-          CALL sys.purge_files(table => 'default.T')<br/>
-      </td>
-    </tr>
-    <tr>
-      <td>migrate_database</td>
-      <td>
-         Migrate all hive tables in database to paimon tables. Arguments:
-            <li>source_type: the origin database's type to be migrated, such as hive. Cannot be empty.</li>
-            <li>database: name of the origin database to be migrated. Cannot be empty.</li>
-            <li>options: the table options of the paimon table to migrate.</li>
-            <li>options_map: Options map for adding key-value options which is a map.</li>
-            <li>parallelism: the parallelism for migrate process, default is core numbers of machine.</li>
-      </td>
-      <td>CALL sys.migrate_database(source_type => 'hive', database => 'db01', options => 'file.format=parquet', options_map => map('k1','v1'), parallelism => 6)</td>
-    </tr>
-    <tr>
-      <td>migrate_table</td>
-      <td>
-         Migrate hive table to a paimon table. Arguments:
-            <li>source_type: the origin table's type to be migrated, such as hive. Cannot be empty.</li>
-            <li>table: name of the origin table to be migrated. Cannot be empty.</li>
-            <li>options: the table options of the paimon table to migrate.</li>
-            <li>target_table: name of the target paimon table to migrate. If not set would keep the same name with origin table</li>
-            <li>delete_origin: If had set target_table, can set delete_origin to decide whether delete the origin table metadata from hms after migrate. Default is true</li>
-            <li>options_map: Options map for adding key-value options which is a map.</li>
-            <li>parallelism: the parallelism for migrate process, default is core numbers of machine.</li>
-      </td>
-      <td>CALL sys.migrate_table(source_type => 'hive', table => 'default.T', options => 'file.format=parquet', options_map => map('k1','v1'), parallelism => 6)</td>
-    </tr>
-    <tr>
-      <td>remove_orphan_files</td>
-      <td>
-         To remove the orphan data files and metadata files. Arguments:
-            <li>table: the target table identifier. Cannot be empty, you can use database_name.* to clean whole database.</li>
-            <li>older_than: to avoid deleting newly written files, this procedure only deletes orphan files older than 1 day by default. This argument can modify the interval.</li>
-            <li>dry_run: when true, view only orphan files, don't actually remove files. Default is false.</li>
-            <li>parallelism: The maximum number of concurrent deleting files. By default is the number of processors available to the Java virtual machine.</li>
-            <li>mode: The mode of remove orphan clean procedure (local or distributed) . By default is distributed.</li>
-      </td>
-      <td>
-          CALL sys.remove_orphan_files(table => 'default.T', older_than => '2023-10-31 12:00:00')<br/><br/>
-          CALL sys.remove_orphan_files(table => 'default.*', older_than => '2023-10-31 12:00:00')<br/><br/>
-          CALL sys.remove_orphan_files(table => 'default.T', older_than => '2023-10-31 12:00:00', dry_run => true)<br/><br/>
-          CALL sys.remove_orphan_files(table => 'default.T', older_than => '2023-10-31 12:00:00', dry_run => true, parallelism => 5)<br/><br/>
-          CALL sys.remove_orphan_files(table => 'default.T', older_than => '2023-10-31 12:00:00', dry_run => true, parallelism => 5, mode => 'local')
-      </td>
-    </tr>
-    <tr>
-      <td>remove_unexisting_files</td>
-      <td>
-        Procedure to remove unexisting data files from manifest entries. See <a href="https://paimon.apache.org/docs/master/api/java/org/apache/paimon/flink/action/RemoveUnexistingFilesAction.html">Java docs</a> for detailed use cases. Arguments:
-            <li>table: the target table identifier. Cannot be empty, you can use database_name.* to clean whole database.</li>
-            <li>dry_run (optional): only check what files will be removed, but not really remove them. Default is false.</li>
-            <li>parallelism (optional): number of parallelisms to check files in the manifests.</li>
-         <br>
-         Note that user is on his own risk using this procedure, which may cause data loss when used outside from the use cases listed in Java docs.
-      </td>
-      <td>
-        -- remove unexisting data files in the table `mydb.myt`<br/>
-        CALL sys.remove_unexisting_files(table => 'mydb.myt')<br/><br/>
-        -- only check what files will be removed, but not really remove them (dry run)<br/>
-        CALL sys.remove_unexisting_files(table => 'mydb.myt', dry_run = true)
-      </td>
-   </tr>
-    <tr>
-      <td>repair</td>
-      <td>
-         Synchronize information from the file system to Metastore. Argument:
-            <li>database_or_table: empty or the target database name or the target table identifier, if you specify multiple tags, delimiter is ','</li>
-      </td>
-      <td>
-          CALL sys.repair('test_db.T')<br/><br/>
-          CALL sys.repair('test_db.T,test_db01,test_db.T2')
-      </td>
-    </tr>
-    <tr>
-      <td>repair_earliest_snapshot</td>
-      <td>
-         Repair the earliest snapshot hint for a table. Arguments:
-            <li>table: the target table identifier. Cannot be empty.</li>
-            <li>snapshot_id: the snapshot ID to set as the earliest snapshot.</li>
-      </td>
-      <td>
-          CALL sys.repair_earliest_snapshot(table => 'test_db.T', snapshot_id => 10)
-      </td>
-    </tr>
-    <tr>
-      <td>create_branch</td>
-      <td>
-         To merge a branch to main branch. Arguments:
-            <li>table: the target table identifier or branch identifier. Cannot be empty.</li>
-            <li>branch: name of the branch to be merged.</li>
-            <li>tag: name of the new tag. Cannot be empty.</li>
-            <li>ignoreIfExists: ignore if branch exists, default is false.</li>
-      </td>
-      <td>
-          CALL sys.create_branch(table => 'test_db.T', branch => 'test_branch')<br/><br/>
-          CALL sys.create_branch(table => 'test_db.T', branch => 'test_branch', tag => 'my_tag')<br/><br/>
-          CALL sys.create_branch(table => 'test_db.T$branch_existBranchName', branch => 'test_branch', tag => 'my_tag')<br/><br/>
-      </td>
-    </tr>
-    <tr>
-      <td>delete_branch</td>
-      <td>
-         To merge a branch to main branch. Arguments:
-            <li>table: the target table identifier. Cannot be empty.</li>
-            <li>branch: name of the branch to be merged. If you specify multiple branches, delimiter is ','.</li>
-      </td>
-      <td>
-          CALL sys.delete_branch(table => 'test_db.T', branch => 'test_branch')
-      </td>
-    </tr>
-    <tr>
-      <td>rename_branch</td>
-      <td>
-         To rename a branch. Arguments:
-            <li>table: the target table identifier. Cannot be empty.</li>
-            <li>from_branch: name of the branch to be renamed.</li>
-            <li>to_branch: new name of the branch.</li>
-      </td>
-      <td>
-          CALL sys.rename_branch(table => 'test_db.T', from_branch => 'test_branch', to_branch => 'new_branch')
-      </td>
-    </tr>
-    <tr>
-      <td>fast_forward</td>
-      <td>
-         To fast_forward a branch to main branch. Arguments:
-            <li>table: the target table identifier. Cannot be empty.</li>
-            <li>branch: name of the branch to be merged.</li>
-      </td>
-      <td>
-          CALL sys.fast_forward(table => 'test_db.T', branch => 'test_branch')
-      </td>
-    </tr>
-   <tr>
-      <td>merge_branch</td>
-      <td>
-         Merge data files from source branch into target branch for append-only tables.
-         The table must be created with <code>'branch-merge.enabled' = 'true'</code>. This option enforces a pure-append table history by rejecting compaction and INSERT OVERWRITE, and it is incompatible with deletion vectors.
-         Requires compatible schema history and consistent row-tracking settings between source and target. Arguments:
-            <li>table: the table identifier. Cannot be empty.</li>
-            <li>source_branch: name of the source branch to merge from. Cannot be empty.</li>
-            <li>target_branch(optional): name of the target branch to merge into. Default is 'main'.</li>
-      </td>
-      <td>
-         CALL sys.merge_branch(table => 'test_db.T', source_branch => 'branch1')<br/><br/>
-         CALL sys.merge_branch(table => 'test_db.T', source_branch => 'branch1', target_branch => 'branch2')
-      </td>
-    </tr>
-   <tr>
-      <td>reset_consumer</td>
-      <td>
-         To reset or delete consumer. Arguments:
-            <li>table: the target table identifier. Cannot be empty.</li>
-            <li>consumerId: consumer to be reset or deleted.</li>
-            <li>nextSnapshotId (Long): the new next snapshot id of the consumer.</li>
-      </td>
-      <td>
-         -- reset the new next snapshot id in the consumer<br/>
-         CALL sys.reset_consumer(table => 'default.T', consumerId => 'myid', nextSnapshotId => 10)<br/><br/>
-         -- delete consumer<br/>
-         CALL sys.reset_consumer(table => 'default.T', consumerId => 'myid')
-      </td>
-   </tr>
-   <tr>
-      <td>clear_consumers</td>
-      <td>
-         To clear consumers. Arguments:
-            <li>table: the target table identifier. Cannot be empty.</li>
-            <li>includingConsumers: consumers to be cleared.</li>
-            <li>excludingConsumers: consumers which not to be cleared.</li>
-      </td>
-      <td>
-         -- clear all consumers in the table<br/>
-         CALL sys.clear_consumers(table => 'default.T')<br/><br/>
-         -- clear some consumers in the table (accept regular expression)<br/>
-         CALL sys.clear_consumers(table => 'default.T', includingConsumers => 'myid.*')<br/><br/>
-         -- clear all consumers except excludingConsumers in the table (accept regular expression)<br/>
-         CALL sys.clear_consumers(table => 'default.T', includingConsumers => '', excludingConsumers => 'myid1.*')<br/><br/>
-         -- clear all consumers with includingConsumers and excludingConsumers (accept regular expression)<br/>
-         CALL sys.clear_consumers(table => 'default.T', includingConsumers => 'myid.*', excludingConsumers => 'myid1.*')
-      </td>
-   </tr>
-    <tr>
-      <td>mark_partition_done</td>
-      <td>
-         To mark partition to be done. Arguments:
-            <li>table: the target table identifier. Cannot be empty.</li>
-            <li>partitions: partitions need to be mark done, If you specify multiple partitions, delimiter is ';'.</li>
-      </td>
-      <td>
-         -- mark single partition done<br/>
-         CALL sys.mark_partition_done(table => 'default.T', partitions => 'day=2024-07-01')<br/><br/>
-         -- mark multiple partitions done<br/>
-         CALL sys.mark_partition_done(table => 'default.T', partitions => 'day=2024-07-01;day=2024-07-02')
-      </td>
-   </tr>
-   <tr>
-      <td>compact_manifest</td>
-      <td>
-         To compact_manifest the manifests. Arguments:
-            <li>table: the target table identifier. Cannot be empty.</li>
-            <li>options: the additional dynamic options of the table. It prioritizes higher than original `tableProp` and lower than `procedureArg`.</li>
-            <li>dry_run (Boolean, optional): when true, logs manifest metadata statistics without actually compacting. When manifest sort is enabled, the log also contains the number of manifest files in each level built by manifest sort. The result is printed to the application log; the SQL return value is still `true`.</li>
-            <li>manifest_sort_enabled (Boolean, optional): whether to use manifest sort rewrite for this invocation.</li>
-            <li>manifest_sort_partition_field (String, optional): partition field used to sort manifest entries. Defaults to the first partition field.</li>
-            <li>manifest_sort_max_rewrite_size (String, optional): maximum manifest size rewritten by one sort pass.</li>
-      </td>
-      <td>
-         CALL sys.compact_manifest(`table` => 'default.T')<br/>
-         CALL sys.compact_manifest(`table` => 'default.T', dry_run => true)<br/>
-         CALL sys.compact_manifest(`table` => 'default.T', manifest_sort_enabled => true, manifest_sort_partition_field => 'dt', manifest_sort_max_rewrite_size => '1 gb')
-      </td>
-   </tr>
-   <tr>
-      <td>alter_view_dialect</td>
-      <td>
-         To alter view dialect. Arguments:
-            <li>view: the target view identifier. Cannot be empty.</li>
-            <li>action: define change action like: add, update, drop. Cannot be empty.</li>
-            <li>engine: when engine which is not spark need define it.</li>
-            <li>query: query for the dialect when action is add and update it couldn't be empty.</li>
-      </td>
-      <td>
-         -- add dialect in the view<br/>
-         CALL sys.alter_view_dialect('view_identifier', 'add', 'spark', 'query')<br/>
-         CALL sys.alter_view_dialect(`view` => 'view_identifier', `action` => 'add', `query` => 'query')<br/><br/>
-         -- update dialect in the view<br/>
-         CALL sys.alter_view_dialect('view_identifier', 'update', 'spark', 'query')<br/>
-         CALL sys.alter_view_dialect(`view` => 'view_identifier', `action` => 'update', `query` => 'query')<br/><br/>
-         -- drop dialect in the view<br/>
-         CALL sys.alter_view_dialect('view_identifier', 'drop', 'spark')<br/>
-         CALL sys.alter_view_dialect(`view` => 'view_identifier', `action` => 'drop')<br/><br/>
-      </td>
-   </tr>
-      <tr>
-      <td>create_function</td>
-      <td>
-         To create a function. Arguments:
-            <li>function: the target function identifier. Cannot be empty.</li>
-            <li>inputParams: inputParams of the function.</li>
-            <li>returnParams: returnParams of the function.</li>
-            <li>deterministic: Whether the function is deterministic.</li>
-            <li>comment: The comment for the function.</li>
-            <li>options: the additional dynamic options of the function.</li>
-      </td>
-      <td>
-         CALL sys.create_function(`function` => 'function_identifier',<br/>
-              `inputParams` => '[{"id": 0, "name":"length", "type":"INT"}, {"id": 1, "name":"width", "type":"INT"}]',<br/>
-              `returnParams` => '[{"id": 0, "name":"area", "type":"BIGINT"}]',<br/>
-              `deterministic` => true,<br/>
-              `comment` => 'comment',<br/>
-              `options` => 'k1=v1,k2=v2'<br/>
-         )<br/>
-      </td>
-   </tr>
-   <tr>
-      <td>alter_function</td>
-      <td>
-         To alter a function. Arguments:
-            <li>function: the target function identifier. Cannot be empty.</li>
-            <li>change: change of the function.</li>
-      </td>
-      <td>
-         CALL sys.alter_function(`function` => 'function_identifier',<br/>
-              `change` => '{"action" : "addDefinition", "name" : "spark", "definition" : {"type" : "lambda", "definition" : "(Integer length, Integer width) -> { return (long) length * width; }", "language": "JAVA" } }'<br/>
-         )<br/>
-      </td>
-   </tr>
-   <tr>
-      <td>drop_function</td>
-      <td>
-         To drop a function. Arguments:
-            <li>function: the target function identifier. Cannot be empty.</li>
-      </td>
-      <td>
-         CALL sys.drop_function(`function` => 'function_identifier')<br/>
-      </td>
-   </tr>
-   <tr>
-      <td>rewrite_file_index</td>
-      <td>
-         To rewrite the file index for the table. Arguments:
-            <li>table: the target table identifier. Cannot be empty.</li>
-            <li>where: partition predicate. Left empty for all partitions.</li>
-      </td>
-      <td>
-         CALL sys.rewrite_file_index(table => "t")<br/>
-         CALL sys.rewrite_file_index(table => "t", where => "day = '2025-08-17'")<br/>
-      </td>
-   </tr>
-   <tr>
-      <td>create_global_index</td>
-      <td>
-         To create global index files for a given column. The table must have <code>row-tracking.enabled=true</code>. Arguments:
-            <li>table: the target table identifier. Cannot be empty.</li>
-            <li>index_column: the name of the column to index. Cannot be empty.</li>
-            <li>index_type: type of the index to build, e.g. 'btree', 'bitmap', or 'fm'. Cannot be empty.</li>
-            <li>partitions: partition filter to limit the partitions on which to build the index. The comma (",") represents "AND", the semicolon (";") represents "OR". Left empty for all partitions.</li>
-            <li>options: additional dynamic options of the table. It prioritizes higher than original `tableProp` and lower than `procedureArg`.</li>
-      </td>
-      <td>
-         CALL sys.create_global_index(table => 'default.T', index_column => 'name', index_type => 'btree')<br/><br/>
-         CALL sys.create_global_index(table => 'default.T', index_column => 'tag', index_type => 'bitmap', options => 'sorted-index.records-per-range=1000000')<br/><br/>
-         CALL sys.create_global_index(table => 'default.T', index_column => 'content', index_type => 'fm')<br/><br/>
-         CALL sys.create_global_index(table => 'default.T', index_column => 'name', index_type => 'btree', partitions => 'pt=p1;pt=p2')<br/><br/>
-         CALL sys.create_global_index(table => 'default.T', index_column => 'content', index_type => 'full-text', options => 'full-text.tokenizer=ngram,full-text.ngram.min-gram=2,full-text.ngram.max-gram=2')<br/><br/>
-         CALL sys.create_global_index(table => 'default.T', index_column => 'content', index_type => 'full-text', options => 'full-text.tokenizer=jieba')<br/><br/>
-         CALL sys.create_global_index(table => 'default.T', index_column => 'content', index_type => 'full-text', options => 'full-text.tokenizer=simple,full-text.stem=true,full-text.remove-stop-words=true')
-      </td>
-   </tr>
-   <tr>
-      <td>drop_global_index</td>
-      <td>
-         To drop global index files for a given column. Arguments:
-            <li>table: the target table identifier. Cannot be empty.</li>
-            <li>index_column: the name of the indexed column. Cannot be empty.</li>
-            <li>index_type: type of the index to drop, e.g. 'btree'. Cannot be empty.</li>
-            <li>partitions: partition filter to limit the partitions from which to drop the index. The comma (",") represents "AND", the semicolon (";") represents "OR". Left empty for all partitions.</li>
-            <li>dry_run: when true, return the number of index files that would be dropped without committing any change. Default is false.</li>
-      </td>
-      <td>
-         CALL sys.drop_global_index(table => 'default.T', index_column => 'name', index_type => 'btree', partitions => 'pt=p1')<br/><br/>
-         -- Preview what would be dropped without deleting<br/>
-         CALL sys.drop_global_index(table => 'default.T', index_column => 'name', index_type => 'btree', dry_run => true)
-      </td>
-   </tr>
-   <tr>
-      <td>reassign_row_id</td>
-      <td>
-         To reassign row IDs for a data evolution table when partition row-id ranges overlap. The table must have <code>row-tracking.enabled=true</code> and <code>data-evolution.enabled=true</code>. Arguments:
-            <li>table: the target table identifier. Cannot be empty.</li>
-            <li>partitions: partition filter to limit the partitions to reassign. The comma (",") represents "AND", the semicolon (";") represents "OR". Left empty for all partitions.</li>
-      </td>
-      <td>
-         CALL sys.reassign_row_id(table => 'default.T')<br/><br/>
-         CALL sys.reassign_row_id(table => 'default.T', partitions => 'dt=2026-05-19')
-      </td>
-   </tr>
-   <tr>
-      <td>copy</td>
-      <td>
-         copy table files. Arguments:
-            <li>source_table: the source table identifier. Cannot be empty.</li>
-            <li>target_table: the target table identifier. Cannot be empty.</li>
-            <li>where: partition predicate. Left empty for all partitions.</li>
-      </td>
-      <td>
-         CALL sys.copy(source_table => "t1", target_table => "t1_copy")<br/>
-         CALL sys.copy(source_table => "t1", target_table => "t1_copy", where => "day = '2025-08-17'")<br/>
-      </td>
-   </tr>
-   <tr>
-      <td>rescale</td>
-      <td>
-         Rescale partitions of a table by changing the bucket number. Arguments:
-            <li>table: the target table identifier. Cannot be empty.</li>
-            <li>bucket_num: resulting bucket number after rescale. The default value is the current bucket number of the table. Cannot be empty for postpone bucket tables.</li>
-            <li>partitions: partition filter. Left empty for all partitions. (Can't be used together with "where")</li>
-            <li>where: partition predicate. Left empty for all partitions. (Can't be used together with "partitions")</li>
-      </td>
-      <td>
-         CALL sys.rescale(table => 'default.T', bucket_num => 16, partitions => 'dt=20250217,hh=08;dt=20250217,hh=09')<br/>
-      </td>
-   </tr>
-   </tbody>
-</table>
+```sql
+-- Select a Paimon catalog, then use its sys namespace.
+USE paimon.default;
+CALL sys.compact(table => 'default.T');
+
+-- Or qualify the catalog explicitly.
+CALL paimon.sys.compact(table => 'default.T');
+```
+
+Examples below assume the named tables already exist. Named arguments (`name => value`) make
+optional parameters explicit; identifiers passed as arguments are SQL string literals.
+Parameter types and required/optional labels below follow the procedure signatures. An optional
+argument can still be required by a particular mode or combination; those constraints are
+listed in its description. Examples under one procedure are alternative calls, not a script to
+run in sequence.
+
+## Find a Procedure
+
+Choose a group, then use the page contents to jump to a procedure:
+
+| Group | Operations |
+| --- | --- |
+| [Compaction and cleanup](./procedures/maintenance) | Compact files and manifests, rescale buckets, expire history, and repair metadata. |
+| [Tags, branches, and rollback](./procedures/versions) | Create and manage versions, merge branches, or restore table state. |
+| [Migration and copy](./procedures/migration) | Migrate Hive tables or copy Paimon files. |
+| [Indexes and row IDs](./procedures/indexes) | Build or drop indexes and reassign row IDs. |
+| [Consumers, views, and functions](./procedures/metadata) | Manage reader progress, partition completion, and catalog objects. |
+
+## Procedure Index
+
+### Compaction and Cleanup
+
+[`compact`](./procedures/maintenance#compact),
+[`compact_database`](./procedures/maintenance#compact_database),
+[`compact_chain_table`](./procedures/maintenance#compact_chain_table),
+[`compact_manifest`](./procedures/maintenance#compact_manifest),
+[`materialize_deletion_vectors`](./procedures/maintenance#materialize_deletion_vectors),
+[`rescale`](./procedures/maintenance#rescale),
+[`expire_snapshots`](./procedures/maintenance#expire_snapshots),
+[`expire_partitions`](./procedures/maintenance#expire_partitions),
+[`remove_orphan_files`](./procedures/maintenance#remove_orphan_files),
+[`remove_unexisting_files`](./procedures/maintenance#remove_unexisting_files),
+[`purge_files`](./procedures/maintenance#purge_files),
+[`repair`](./procedures/maintenance#repair),
+[`repair_earliest_snapshot`](./procedures/maintenance#repair_earliest_snapshot)
+
+### Tags, Branches, and Rollback
+
+[`create_tag`](./procedures/versions#create_tag),
+[`create_tag_from_timestamp`](./procedures/versions#create_tag_from_timestamp),
+[`replace_tag`](./procedures/versions#replace_tag),
+[`rename_tag`](./procedures/versions#rename_tag),
+[`delete_tag`](./procedures/versions#delete_tag),
+[`expire_tags`](./procedures/versions#expire_tags),
+[`trigger_tag_automatic_creation`](./procedures/versions#trigger_tag_automatic_creation),
+[`create_branch`](./procedures/versions#create_branch),
+[`delete_branch`](./procedures/versions#delete_branch),
+[`rename_branch`](./procedures/versions#rename_branch),
+[`fast_forward`](./procedures/versions#fast_forward),
+[`merge_branch`](./procedures/versions#merge_branch),
+[`rollback`](./procedures/versions#rollback),
+[`rollback_to_timestamp`](./procedures/versions#rollback_to_timestamp),
+[`rollback_to_watermark`](./procedures/versions#rollback_to_watermark)
+
+### Migration and Copy
+
+[`migrate_database`](./procedures/migration#migrate_database),
+[`migrate_table`](./procedures/migration#migrate_table),
+[`copy`](./procedures/migration#copy)
+
+### Indexes and Row IDs
+
+[`rewrite_file_index`](./procedures/indexes#rewrite_file_index),
+[`create_global_index`](./procedures/indexes#create_global_index),
+[`drop_global_index`](./procedures/indexes#drop_global_index),
+[`reassign_row_id`](./procedures/indexes#reassign_row_id)
+
+### Consumers, Views, and Functions
+
+[`reset_consumer`](./procedures/metadata#reset_consumer),
+[`clear_consumers`](./procedures/metadata#clear_consumers),
+[`mark_partition_done`](./procedures/metadata#mark_partition_done),
+[`alter_view_dialect`](./procedures/metadata#alter_view_dialect),
+[`create_function`](./procedures/metadata#create_function),
+[`alter_function`](./procedures/metadata#alter_function),
+[`drop_function`](./procedures/metadata#drop_function)
+
+## Permissions and Policies
+
+REST catalog access management is documented with its resource scopes and parameter contracts:
+
+| Procedure | Reference |
+| --- | --- |
+| `grant_permission` | [Grant permissions](../concepts/rest/management-api#grant-permissions) |
+| `revoke_permission` | [Revoke permissions](../concepts/rest/management-api#revoke-permissions) |
+| `list_permissions` | [List permissions](../concepts/rest/management-api#list-permissions) |
+| `create_policy` | [Row filters](../concepts/rest/management-api#create-row-filter-policies) and [column masks](../concepts/rest/management-api#create-column-masking-policies) |
+| `drop_policy` | [Drop policies](../concepts/rest/management-api#drop-policies) |
+| `list_policies` | [List policies](../concepts/rest/management-api#list-policies) |

--- a/docs/docs/spark/procedures/indexes.md
+++ b/docs/docs/spark/procedures/indexes.md
@@ -1,0 +1,143 @@
+---
+title: "Indexes and Row IDs"
+---
+
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+# Indexes and Row IDs
+
+Build or remove indexes and maintain row IDs. Read the table-specific requirements in
+[Global Indexes](../../multimodal-table/global-index) and
+[Data Evolution](../../multimodal-table/data-evolution) before choosing an operation.
+
+For catalog selection and invocation syntax, see [Procedures](../procedures).
+
+## rewrite_file_index
+
+Rewrite the file index for the table.
+
+**Arguments**
+
+- `table` (`STRING`, required): the target table identifier.
+- `where` (`STRING`, optional): partition predicate. Omit for all partitions.
+
+```sql
+CALL sys.rewrite_file_index(table => "t");
+
+CALL sys.rewrite_file_index(table => "t", where => "day = '2025-08-17'");
+```
+
+## create_global_index
+
+Create global index files for a given column. The table must have `row-tracking.enabled=true`.
+
+**Arguments**
+
+- `table` (`STRING`, required): the target table identifier.
+- `index_column` (`STRING`, required): the name of the column to index.
+- `index_type` (`STRING`, required): type of the index to build, e.g. 'btree', 'bitmap', or 'fm'.
+- `partitions` (`STRING`, optional): partition filter to limit the partitions on which to build the index. The comma (",") represents "AND", the semicolon (";") represents "OR". Omit for all partitions.
+- `options` (`STRING`, optional): additional dynamic options of the table. These override stored table properties and are overridden by explicit procedure arguments.
+
+```sql
+CALL sys.create_global_index(table => 'default.T', index_column => 'name', index_type => 'btree');
+
+CALL sys.create_global_index(
+  table => 'default.T',
+  index_column => 'tag',
+  index_type => 'bitmap',
+  options => 'sorted-index.records-per-range=1000000'
+);
+
+CALL sys.create_global_index(table => 'default.T', index_column => 'content', index_type => 'fm');
+
+CALL sys.create_global_index(
+  table => 'default.T',
+  index_column => 'name',
+  index_type => 'btree',
+  partitions => 'pt=p1;pt=p2'
+);
+
+CALL sys.create_global_index(
+  table => 'default.T',
+  index_column => 'content',
+  index_type => 'full-text',
+  options => 'full-text.tokenizer=ngram,full-text.ngram.min-gram=2,full-text.ngram.max-gram=2'
+);
+
+CALL sys.create_global_index(
+  table => 'default.T',
+  index_column => 'content',
+  index_type => 'full-text',
+  options => 'full-text.tokenizer=jieba'
+);
+
+CALL sys.create_global_index(
+  table => 'default.T',
+  index_column => 'content',
+  index_type => 'full-text',
+  options => 'full-text.tokenizer=simple,full-text.stem=true,full-text.remove-stop-words=true'
+);
+```
+
+## drop_global_index
+
+Drop global index files for a given column.
+
+**Arguments**
+
+- `table` (`STRING`, required): the target table identifier.
+- `index_column` (`STRING`, required): the name of the indexed column.
+- `index_type` (`STRING`, required): type of the index to drop, e.g. 'btree'.
+- `partitions` (`STRING`, optional): partition filter to limit the partitions from which to drop the index. The comma (",") represents "AND", the semicolon (";") represents "OR". Omit for all partitions.
+- `dry_run` (`BOOLEAN`, optional): when true, return the number of index files that would be dropped without committing any change. Default is false.
+
+```sql
+CALL sys.drop_global_index(
+  table => 'default.T',
+  index_column => 'name',
+  index_type => 'btree',
+  partitions => 'pt=p1'
+);
+
+-- Preview what would be dropped without deleting
+CALL sys.drop_global_index(
+  table => 'default.T',
+  index_column => 'name',
+  index_type => 'btree',
+  dry_run => true
+);
+```
+
+## reassign_row_id
+
+Reassign row IDs for a data evolution table when partition row-id ranges overlap. The table must
+have `row-tracking.enabled=true` and `data-evolution.enabled=true`.
+
+**Arguments**
+
+- `table` (`STRING`, required): the target table identifier.
+- `partitions` (`STRING`, optional): partition filter to limit the partitions to reassign. The comma (",") represents "AND", the semicolon (";") represents "OR". Omit for all partitions.
+
+```sql
+CALL sys.reassign_row_id(table => 'default.T');
+
+CALL sys.reassign_row_id(table => 'default.T', partitions => 'dt=2026-05-19');
+```

--- a/docs/docs/spark/procedures/maintenance.md
+++ b/docs/docs/spark/procedures/maintenance.md
@@ -1,0 +1,317 @@
+---
+title: "Compaction and Cleanup"
+---
+
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+# Compaction and Cleanup
+
+Compact data and manifests, expire unused history, or repair file metadata.
+See [Dedicated Compaction](../../maintenance/dedicated-compaction) and
+[Manage Snapshots](../../maintenance/manage-snapshots) for operational context.
+
+For catalog selection and invocation syntax, see [Procedures](../procedures).
+
+## compact
+
+Compact files.
+
+**Arguments**
+
+- `table` (`STRING`, required): the target table identifier.
+- `partitions` (`STRING`, optional): partition filter. a comma (",") represents AND; a semicolon (";") represents OR. If you want to compact one partition with date=01 and day=01, you need to write 'date=01,day=01'. Omit for all partitions. (Can't be used together with "where")
+- `where` (`STRING`, optional): partition predicate. Omit for all partitions. (Can't be used together with "partitions")
+- `order_strategy` (`STRING`, optional): 'order' or 'zorder' or 'hilbert' or 'none'. Omit for 'none'.
+- `order_by` (`STRING`, optional): the columns to sort. Omit if 'order_strategy' is 'none'.
+- `options` (`STRING`, optional): additional dynamic options of the table. These override stored table properties and are overridden by explicit procedure arguments.
+- `partition_idle_time` (`STRING`, optional): this is used to do a full compaction for partition which had not received any new data for 'partition_idle_time'. And only these partitions will be compacted. This argument can not be used with order compact.
+- `compact_strategy` (`STRING`, optional): `full` selects all candidate files in the chosen scope; `minor` selects files according to the compaction policy. Defaults to `minor` when incremental clustering is enabled, otherwise `full`.
+- `buckets` (`STRING`, optional): fixed-bucket IDs, comma-separated IDs, or inclusive ranges, for example `'0-3,7'`. Omit to include all buckets. Valid only for fixed-bucket tables without sort compaction.
+
+```sql
+SET spark.sql.shuffle.partitions=10; --set the compact parallelism
+
+CALL sys.compact(table => 'T', partitions => 'p=0;p=1',  order_strategy => 'zorder', order_by => 'a,b');
+
+CALL sys.compact(table => 'T', where => 'p>0 and p<3', order_strategy => 'zorder', order_by => 'a,b');
+
+CALL sys.compact(
+  table => 'T',
+  where => 'dt>10 and h<20',
+  order_strategy => 'zorder',
+  order_by => 'a,b',
+  options => 'target-file-size=128m'
+);
+
+CALL sys.compact(table => 'T', partition_idle_time => '60s');
+
+CALL sys.compact(table => 'T', compact_strategy => 'minor');
+
+-- Limit full compaction to these buckets of a fixed-bucket table with at least 8 buckets.
+CALL sys.compact(table => 'T', compact_strategy => 'full', buckets => '0-3,7');
+```
+
+## compact_database
+
+Compact all tables across one or more databases.
+
+**Arguments**
+
+- `including_databases` (`STRING`, optional): regular expression to match databases to compact. Omit to match all databases (i.e. '.*').
+- `including_tables` (`STRING`, optional): regular expression to match table identifiers (in 'db.table' form) to compact. Omit to match all tables (i.e. '.*').
+- `excluding_tables` (`STRING`, optional): regular expression to match table identifiers to exclude from compaction.
+- `options` (`STRING`, optional): additional dynamic options of the table. These override stored table properties and are overridden by explicit procedure arguments.
+
+```sql
+-- compact all databases
+CALL sys.compact_database();
+
+-- compact some databases (accept regular expression)
+CALL sys.compact_database(including_databases => 'db1|db2');
+
+-- compact some tables (accept regular expression)
+CALL sys.compact_database(including_databases => 'db1', including_tables => 'db1.table1|db1.table2');
+
+-- exclude some tables (accept regular expression)
+CALL sys.compact_database(
+  including_databases => 'db1',
+  including_tables => '.*',
+  excluding_tables => '.*ignore_table'
+);
+
+-- set table options
+CALL sys.compact_database(including_databases => 'db1', options => 'target-file-size=128m');
+```
+
+## compact_chain_table
+
+Compact chain table by merging snapshot and delta branches into the snapshot branch.
+
+**Arguments**
+
+- `table` (`STRING`, required): The target chain table identifier.
+- `partition` (`STRING`, required): Partition specification format (e.g., 'dt="20250810",hour="22"').
+- `overwrite` (`BOOLEAN`, optional): Whether to overwrite if the partition already exists in the snapshot branch. Default is false.
+
+```sql
+CALL sys.compact_chain_table(table => 'default.T', partition => 'dt="20250810",hour="22"');
+```
+
+## compact_manifest
+
+Compact manifest files.
+
+**Arguments**
+
+- `table` (`STRING`, required): the target table identifier.
+- `options` (`STRING`, optional): the additional dynamic options of the table. These override stored table properties and are overridden by explicit procedure arguments.
+- `dry_run` (`BOOLEAN`, optional): when true, logs manifest metadata statistics without actually compacting. When manifest sort is enabled, the log also contains the number of manifest files in each level built by manifest sort. The result is printed to the application log; the SQL return value is still `true`.
+- `manifest_sort_enabled` (`BOOLEAN`, optional): whether to use manifest sort rewrite for this invocation.
+- `manifest_sort_partition_field` (`STRING`, optional): partition field used to sort manifest entries. Defaults to the first partition field.
+- `manifest_sort_max_rewrite_size` (`STRING`, optional): maximum manifest size rewritten by one sort pass.
+
+```sql
+CALL sys.compact_manifest(`table` => 'default.T');
+
+CALL sys.compact_manifest(`table` => 'default.T', dry_run => true);
+
+CALL sys.compact_manifest(
+  `table` => 'default.T',
+  manifest_sort_enabled => true,
+  manifest_sort_partition_field => 'dt',
+  manifest_sort_max_rewrite_size => '1 gb'
+);
+```
+
+## materialize_deletion_vectors
+
+Applies deletion vectors to the latest state of an unaware-bucket Data Evolution table and assigns
+new row IDs to surviving rows. Affected global indexes are dropped. Spark processes bounded batches
+until all matching deletion vectors are materialized. Historical snapshots and tags can retain the
+replaced files until snapshot expiration.
+
+**Arguments**
+
+- `table` (`STRING`, required): the target table identifier.
+- `partitions` (`STRING`, optional): partition filter. Cannot be used together with where.
+- `options` (`STRING`, optional): additional dynamic table options.
+- `where` (`STRING`, optional): partition predicate. Cannot be used together with partitions.
+
+```sql
+CALL sys.materialize_deletion_vectors(table => 'T');
+
+CALL sys.materialize_deletion_vectors(table => 'T', partitions => 'dt=2026-08-12');
+```
+
+## rescale
+
+Rescale partitions of a table by changing the bucket number.
+
+**Arguments**
+
+- `table` (`STRING`, required): the target table identifier.
+- `bucket_num` (`INT`, optional): resulting bucket number after rescale. The default value is the current bucket number of the table. Cannot be empty for postpone bucket tables.
+- `partitions` (`STRING`, optional): partition filter. Omit for all partitions. (Can't be used together with "where")
+- `where` (`STRING`, optional): partition predicate. Omit for all partitions. (Can't be used together with "partitions")
+
+```sql
+CALL sys.rescale(
+  table => 'default.T',
+  bucket_num => 16,
+  partitions => 'dt=20250217,hh=08;dt=20250217,hh=09'
+);
+```
+
+## expire_snapshots
+
+Expire snapshots.
+
+**Arguments**
+
+- `table` (`STRING`, required): the target table identifier.
+- `retain_max` (`INT`, optional): the maximum number of completed snapshots to retain.
+- `retain_min` (`INT`, optional): the minimum number of completed snapshots to retain.
+- `older_than` (`STRING`, optional): timestamp before which snapshots will be removed.
+- `max_deletes` (`INT`, optional): the maximum number of snapshots that can be deleted at once.
+- `options` (`STRING`, optional): the additional dynamic options of the table. These override stored table properties and are overridden by explicit procedure arguments.
+
+```sql
+CALL sys.expire_snapshots(table => 'default.T', retain_max => 10, options => 'snapshot.expire.limit=1');
+```
+
+## expire_partitions
+
+Expire partitions.
+
+**Arguments**
+
+- `table` (`STRING`, required): the target table identifier.
+- `expiration_time` (`STRING`, optional): the expiration interval of a partition. A partition will be expired if it's lifetime is over this value. Partition time is extracted from the partition value.
+- `timestamp_formatter` (`STRING`, optional): the formatter to format timestamp from string.
+- `timestamp_pattern` (`STRING`, optional): the pattern to get a timestamp from partitions.
+- `expire_strategy` (`STRING`, optional): specifies the expiration strategy for partition expiration, possible values: 'values-time' or 'update-time' , 'values-time' as default.
+- `max_expires` (`INT`, optional): The maximum of limited expired partitions, it is optional.
+- `options` (`STRING`, optional): the additional dynamic options of the table. These override stored table properties and are overridden by explicit procedure arguments.
+
+```sql
+CALL sys.expire_partitions(
+  table => 'default.T',
+  expiration_time => '1 d',
+  timestamp_formatter => 'yyyy-MM-dd',
+  timestamp_pattern => '$dt',
+  expire_strategy => 'values-time',
+  options => 'partition.expiration-max-num=2'
+);
+```
+
+## remove_orphan_files
+
+Remove the orphan data files and metadata files.
+
+**Arguments**
+
+- `table` (`STRING`, required): the target table identifier. Use `database_name.*` to process the whole database.
+- `older_than` (`STRING`, optional): to avoid deleting newly written files, this procedure only deletes orphan files older than 1 day by default. This argument can modify the interval.
+- `dry_run` (`BOOLEAN`, optional): when true, view only orphan files, don't actually remove files. Default is false.
+- `parallelism` (`INT`, optional): The maximum number of concurrent deleting files. By default is the number of processors available to the Java virtual machine.
+- `mode` (`STRING`, optional): The mode of remove orphan clean procedure (local or distributed) . By default is distributed.
+
+```sql
+CALL sys.remove_orphan_files(table => 'default.T', older_than => '2023-10-31 12:00:00');
+
+CALL sys.remove_orphan_files(table => 'default.*', older_than => '2023-10-31 12:00:00');
+
+CALL sys.remove_orphan_files(table => 'default.T', older_than => '2023-10-31 12:00:00', dry_run => true);
+
+CALL sys.remove_orphan_files(
+  table => 'default.T',
+  older_than => '2023-10-31 12:00:00',
+  dry_run => true,
+  parallelism => 5
+);
+
+CALL sys.remove_orphan_files(
+  table => 'default.T',
+  older_than => '2023-10-31 12:00:00',
+  dry_run => true,
+  parallelism => 5,
+  mode => 'local'
+);
+```
+
+## remove_unexisting_files
+
+Procedure to remove unexisting data files from manifest entries. See [Java docs](https://paimon.apac
+he.org/docs/master/api/java/org/apache/paimon/flink/action/RemoveUnexistingFilesAction.html) for
+detailed use cases. Note that user is on his own risk using this procedure, which may cause data
+loss when used outside from the use cases listed in Java docs.
+
+**Arguments**
+
+- `table` (`STRING`, required): the target table identifier. Use `database_name.*` to process the whole database.
+- `dry_run` (`BOOLEAN`, optional): only check what files will be removed, but not really remove them. Default is false.
+- `parallelism` (`INT`, optional): number of parallelisms to check files in the manifests.
+
+```sql
+-- remove unexisting data files in the table `mydb.myt`
+CALL sys.remove_unexisting_files(table => 'mydb.myt');
+
+-- only check what files will be removed, but not really remove them (dry run)
+CALL sys.remove_unexisting_files(table => 'mydb.myt', dry_run => true);
+```
+
+## purge_files
+
+Clear table with purge files.
+
+**Arguments**
+
+- `table` (`STRING`, required): the target table identifier.
+
+```sql
+CALL sys.purge_files(table => 'default.T');
+```
+
+## repair
+
+Synchronize information from the file system to Metastore.
+
+**Arguments**
+
+- `database_or_table` (`STRING`, required): empty or the target database name or the target table identifier, if you specify multiple tags, delimiter is ','
+
+```sql
+CALL sys.repair('test_db.T');
+
+CALL sys.repair('test_db.T,test_db01,test_db.T2');
+```
+
+## repair_earliest_snapshot
+
+Repair the earliest snapshot hint for a table.
+
+**Arguments**
+
+- `table` (`STRING`, required): the target table identifier.
+- `snapshot_id` (`BIGINT`, required): the snapshot ID to set as the earliest snapshot.
+
+```sql
+CALL sys.repair_earliest_snapshot(table => 'test_db.T', snapshot_id => 10);
+```

--- a/docs/docs/spark/procedures/metadata.md
+++ b/docs/docs/spark/procedures/metadata.md
@@ -1,0 +1,177 @@
+---
+title: "Consumers, Views, and Functions"
+---
+
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+# Consumers, Views, and Functions
+
+Manage consumer positions, partition completion, view dialects, and stored functions.
+See [Streaming Recovery](../streaming-recovery), [SQL Functions](../sql-functions), and
+[Views](../../concepts/views) for the corresponding feature guides.
+
+For catalog selection and invocation syntax, see [Procedures](../procedures).
+
+## reset_consumer
+
+Reset or delete consumer.
+
+**Arguments**
+
+- `table` (`STRING`, required): the target table identifier.
+- `consumerId` (`STRING`, required): consumer to be reset or deleted.
+- `nextSnapshotId` (`BIGINT`, optional): the new next snapshot id of the consumer.
+
+```sql
+-- reset the new next snapshot id in the consumer
+CALL sys.reset_consumer(table => 'default.T', consumerId => 'myid', nextSnapshotId => 10);
+
+-- delete consumer
+CALL sys.reset_consumer(table => 'default.T', consumerId => 'myid');
+```
+
+## clear_consumers
+
+Clear consumers.
+
+**Arguments**
+
+- `table` (`STRING`, required): the target table identifier.
+- `includingConsumers` (`STRING`, optional): consumers to be cleared.
+- `excludingConsumers` (`STRING`, optional): consumers which not to be cleared.
+
+```sql
+-- clear all consumers in the table
+CALL sys.clear_consumers(table => 'default.T');
+
+-- clear some consumers in the table (accept regular expression)
+CALL sys.clear_consumers(table => 'default.T', includingConsumers => 'myid.*');
+
+-- clear all consumers except excludingConsumers in the table (accept regular expression)
+CALL sys.clear_consumers(
+  table => 'default.T',
+  includingConsumers => '',
+  excludingConsumers => 'myid1.*'
+);
+
+-- clear all consumers with includingConsumers and excludingConsumers (accept regular expression)
+CALL sys.clear_consumers(
+  table => 'default.T',
+  includingConsumers => 'myid.*',
+  excludingConsumers => 'myid1.*'
+);
+```
+
+## mark_partition_done
+
+Mark partitions as done.
+
+**Arguments**
+
+- `table` (`STRING`, required): the target table identifier.
+- `partitions` (`STRING`, required): partitions need to be mark done, If you specify multiple partitions, delimiter is ';'.
+
+```sql
+-- mark single partition done
+CALL sys.mark_partition_done(table => 'default.T', partitions => 'day=2024-07-01');
+
+-- mark multiple partitions done
+CALL sys.mark_partition_done(table => 'default.T', partitions => 'day=2024-07-01;day=2024-07-02');
+```
+
+## alter_view_dialect
+
+Alter view dialect.
+
+**Arguments**
+
+- `view` (`STRING`, required): the target view identifier.
+- `action` (`STRING`, required): define change action like: add, update, drop.
+- `engine` (`STRING`, optional): when engine which is not spark need define it.
+- `query` (`STRING`, optional): query for the dialect when action is add and update it couldn't be empty.
+
+```sql
+-- add dialect in the view
+CALL sys.alter_view_dialect('view_identifier', 'add', 'spark', 'query');
+
+CALL sys.alter_view_dialect(`view` => 'view_identifier', `action` => 'add', `query` => 'query');
+
+-- update dialect in the view
+CALL sys.alter_view_dialect('view_identifier', 'update', 'spark', 'query');
+
+CALL sys.alter_view_dialect(`view` => 'view_identifier', `action` => 'update', `query` => 'query');
+
+-- drop dialect in the view
+CALL sys.alter_view_dialect('view_identifier', 'drop', 'spark');
+
+CALL sys.alter_view_dialect(`view` => 'view_identifier', `action` => 'drop');
+```
+
+## create_function
+
+Create a function.
+
+**Arguments**
+
+- `function` (`STRING`, required): the target function identifier.
+- `inputParams` (`STRING`, required): inputParams of the function.
+- `returnParams` (`STRING`, required): returnParams of the function.
+- `deterministic` (`BOOLEAN`, optional): Whether the function is deterministic.
+- `comment` (`STRING`, optional): The comment for the function.
+- `options` (`STRING`, optional): the additional dynamic options of the function.
+
+```sql
+CALL sys.create_function(
+  `function` => 'function_identifier',
+  `inputParams` => '[{"id": 0, "name":"length", "type":"INT"}, {"id": 1, "name":"width", "type":"INT"}]',
+  `returnParams` => '[{"id": 0, "name":"area", "type":"BIGINT"}]',
+  `deterministic` => true,
+  `comment` => 'comment',
+  `options` => 'k1=v1,k2=v2'
+);
+```
+
+## alter_function
+
+Alter a function.
+
+**Arguments**
+
+- `function` (`STRING`, required): the target function identifier.
+- `change` (`STRING`, required): change of the function.
+
+```sql
+CALL sys.alter_function(
+  `function` => 'function_identifier',
+  `change` => '{"action" : "addDefinition", "name" : "spark", "definition" : {"type" : "lambda", "definition" : "(Integer length, Integer width) -> { return (long) length * width; }", "language": "JAVA" } }'
+);
+```
+
+## drop_function
+
+Drop a function.
+
+**Arguments**
+
+- `function` (`STRING`, required): the target function identifier.
+
+```sql
+CALL sys.drop_function(`function` => 'function_identifier');
+```

--- a/docs/docs/spark/procedures/migration.md
+++ b/docs/docs/spark/procedures/migration.md
@@ -1,0 +1,92 @@
+---
+title: "Migration and Copy"
+---
+
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+# Migration and Copy
+
+Migrate Hive tables or copy existing Paimon table files. See
+[Migration from Hive](../../migration/migration-from-hive) for migration prerequisites.
+Import CSV, JSON, or Parquet files, use [COPY INTO](../copy-into).
+
+For catalog selection and invocation syntax, see [Procedures](../procedures).
+
+## migrate_database
+
+Migrate all hive tables in database to paimon tables.
+
+**Arguments**
+
+- `source_type` (`STRING`, required): the origin database's type to be migrated, such as hive.
+- `database` (`STRING`, required): name of the origin database to be migrated.
+- `options` (`STRING`, optional): the table options of the paimon table to migrate.
+- `options_map` (`MAP<STRING, STRING>`, optional): Options map for adding key-value options which is a map.
+- `parallelism` (`INT`, optional): the parallelism for migrate process, default is core numbers of machine.
+
+```sql
+CALL sys.migrate_database(
+  source_type => 'hive',
+  database => 'db01',
+  options => 'file.format=parquet',
+  options_map => map('k1','v1'),
+  parallelism => 6
+);
+```
+
+## migrate_table
+
+Migrate hive table to a paimon table.
+
+**Arguments**
+
+- `source_type` (`STRING`, required): the origin table's type to be migrated, such as hive.
+- `table` (`STRING`, required): name of the origin table to be migrated.
+- `options` (`STRING`, optional): the table options of the paimon table to migrate.
+- `target_table` (`STRING`, optional): name of the target paimon table to migrate. If not set would keep the same name with origin table
+- `delete_origin` (`BOOLEAN`, optional): If had set target_table, can set delete_origin to decide whether delete the origin table metadata from hms after migrate. Default is true
+- `options_map` (`MAP<STRING, STRING>`, optional): Options map for adding key-value options which is a map.
+- `parallelism` (`INT`, optional): the parallelism for migrate process, default is core numbers of machine.
+
+```sql
+CALL sys.migrate_table(
+  source_type => 'hive',
+  table => 'default.T',
+  options => 'file.format=parquet',
+  options_map => map('k1','v1'),
+  parallelism => 6
+);
+```
+
+## copy
+
+Copy Paimon table files.
+
+**Arguments**
+
+- `source_table` (`STRING`, required): the source table identifier.
+- `target_table` (`STRING`, required): the target table identifier.
+- `where` (`STRING`, optional): partition predicate. Omit for all partitions.
+
+```sql
+CALL sys.copy(source_table => "t1", target_table => "t1_copy");
+
+CALL sys.copy(source_table => "t1", target_table => "t1_copy", where => "day = '2025-08-17'");
+```

--- a/docs/docs/spark/procedures/versions.md
+++ b/docs/docs/spark/procedures/versions.md
@@ -1,0 +1,267 @@
+---
+title: "Tags, Branches, and Rollback"
+---
+
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+# Tags, Branches, and Rollback
+
+Manage retained versions and branches. For SQL tag DDL, see
+[Create Tables, Views, and Tags](../sql-ddl#tag).
+For retention and branch behavior, see [Manage Tags](../../maintenance/manage-tags) and
+[Manage Branches](../../maintenance/manage-branches).
+
+For catalog selection and invocation syntax, see [Procedures](../procedures).
+
+## create_tag
+
+Create a tag based on given snapshot.
+
+**Arguments**
+
+- `table` (`STRING`, required): the target table identifier.
+- `tag` (`STRING`, required): name of the new tag.
+- `snapshot` (`BIGINT`, optional): id of the snapshot which the new tag is based on.
+- `time_retained` (`STRING`, optional): The maximum time retained for newly created tags.
+
+```sql
+-- based on snapshot 10 with 1d
+CALL sys.create_tag(table => 'default.T', tag => 'my_tag', snapshot => 10, time_retained => '1 d');
+
+-- based on the latest snapshot
+CALL sys.create_tag(table => 'default.T', tag => 'my_tag');
+```
+
+## create_tag_from_timestamp
+
+Create a tag based on given timestamp.
+
+**Arguments**
+
+- `table` (`STRING`, required): the target table identifier.
+- `tag` (`STRING`, required): name of the new tag.
+- `timestamp` (`BIGINT`, optional): Find the first retained snapshot (including tagged snapshots) whose commit time is at or after this Unix timestamp in milliseconds.
+- `time_retained` (`STRING`, optional): The maximum time retained for newly created tags.
+
+```sql
+CALL sys.create_tag_from_timestamp(
+  `table` => 'default.T',
+  `tag` => 'my_tag',
+  `timestamp` => 1724404318750,
+  time_retained => '1 d'
+);
+```
+
+## replace_tag
+
+Replace an existing tag with new tag info.
+
+**Arguments**
+
+- `table` (`STRING`, required): the target table identifier.
+- `tag` (`STRING`, required): name of the existed tag.
+- `snapshot` (`BIGINT`, optional): id of the snapshot which the tag is based on, it is optional.
+- `time_retained` (`STRING`, optional): The maximum time retained for the existing tag, it is optional.
+
+```sql
+CALL sys.replace_tag(table => 'default.T', tag => 'tag1', snapshot => 10, time_retained => '1 d');
+```
+
+## rename_tag
+
+Rename a tag with a new tag name.
+
+**Arguments**
+
+- `table` (`STRING`, required): the target table identifier.
+- `tag` (`STRING`, required): name of the tag.
+- `target_tag` (`STRING`, required): the new tag name to rename.
+
+```sql
+CALL sys.rename_tag(table => 'default.T', tag => 'tag1', target_tag => 'tag2');
+```
+
+## delete_tag
+
+Delete a tag.
+
+**Arguments**
+
+- `table` (`STRING`, required): the target table identifier.
+- `tag` (`STRING`, required): name of the tag to be deleted. If you specify multiple tags, delimiter is ','.
+
+```sql
+CALL sys.delete_tag(table => 'default.T', tag => 'my_tag');
+```
+
+## expire_tags
+
+Expire tags by time.
+
+**Arguments**
+
+- `table` (`STRING`, required): the target table identifier.
+- `older_than` (`STRING`, optional): tagCreateTime before which tags will be removed.
+
+```sql
+CALL sys.expire_tags(table => 'default.T', older_than => '2024-09-06 11:00:00');
+```
+
+## trigger_tag_automatic_creation
+
+Trigger the tag automatic creation.
+
+**Arguments**
+
+- `table` (`STRING`, required): the target table identifier.
+
+```sql
+CALL sys.trigger_tag_automatic_creation(table => 'default.T');
+```
+
+## create_branch
+
+Create an empty branch, or create a branch from an existing tag. Without `tag`, the new branch
+contains the table schema and no data.
+
+**Arguments**
+
+- `table` (`STRING`, required): the source table or branch identifier.
+- `branch` (`STRING`, required): the name of the new branch.
+- `tag` (`STRING`, optional): an existing tag in the source table or branch to start from.
+- `ignoreIfExists` (`STRING`, optional): STRING parsed as a boolean. Use 'true' to ignore an existing branch. Default is 'false'.
+
+```sql
+CALL sys.create_branch(table => 'test_db.T', branch => 'test_branch');
+
+CALL sys.create_branch(table => 'test_db.T', branch => 'test_branch', tag => 'my_tag');
+
+CALL sys.create_branch(
+  table => 'test_db.T$branch_existBranchName',
+  branch => 'test_branch',
+  tag => 'my_tag'
+);
+```
+
+## delete_branch
+
+Delete one or more branches.
+
+**Arguments**
+
+- `table` (`STRING`, required): the target table identifier.
+- `branch` (`STRING`, required): names of the branches to delete, separated by commas.
+
+```sql
+CALL sys.delete_branch(table => 'test_db.T', branch => 'test_branch');
+```
+
+## rename_branch
+
+Rename a branch.
+
+**Arguments**
+
+- `table` (`STRING`, required): the target table identifier.
+- `from_branch` (`STRING`, required): name of the branch to be renamed.
+- `to_branch` (`STRING`, required): new name of the branch.
+
+```sql
+CALL sys.rename_branch(table => 'test_db.T', from_branch => 'test_branch', to_branch => 'new_branch');
+```
+
+## fast_forward
+
+Fast_forward a branch to main branch.
+
+**Arguments**
+
+- `table` (`STRING`, required): the target table identifier.
+- `branch` (`STRING`, required): name of the branch to be merged.
+
+```sql
+CALL sys.fast_forward(table => 'test_db.T', branch => 'test_branch');
+```
+
+## merge_branch
+
+Merge data files from source branch into target branch for append-only tables. The table must be
+created with `'branch-merge.enabled' = 'true'`. This option enforces a pure-append table history by
+rejecting compaction and INSERT OVERWRITE, and it is incompatible with deletion vectors. Requires
+compatible schema history and consistent row-tracking settings between source and target.
+
+**Arguments**
+
+- `table` (`STRING`, required): the table identifier.
+- `source_branch` (`STRING`, required): name of the source branch to merge from.
+- `target_branch` (`STRING`, optional): name of the target branch to merge into. Default is 'main'.
+
+```sql
+CALL sys.merge_branch(table => 'test_db.T', source_branch => 'branch1');
+
+CALL sys.merge_branch(table => 'test_db.T', source_branch => 'branch1', target_branch => 'branch2');
+```
+
+## rollback
+
+Roll back to a retained snapshot or tag. Specify exactly one of `snapshot`, `tag`, or the legacy
+`version` argument.
+
+**Arguments**
+
+- `table` (`STRING`, required): the target table identifier.
+- `version` (`STRING`, optional): Legacy snapshot ID or tag name. Prefer `snapshot` or `tag` for new calls.
+- `snapshot` (`BIGINT`, optional): snapshot that will roll back to.
+- `tag` (`STRING`, optional): tag that will roll back to.
+
+```sql
+CALL sys.rollback(table => 'default.T', version => 'my_tag');
+
+CALL sys.rollback(table => 'default.T', version => 10);
+
+CALL sys.rollback(table => 'default.T', tag => 'tag1');
+CALL sys.rollback(table => 'default.T', snapshot => 2);
+```
+
+## rollback_to_timestamp
+
+Rollback to the snapshot which earlier or equal than timestamp.
+
+**Arguments**
+
+- `table` (`STRING`, required): the target table identifier.
+- `timestamp` (`BIGINT`, required): roll back to the snapshot which earlier or equal than timestamp.
+
+```sql
+CALL sys.rollback_to_timestamp(table => 'default.T', timestamp => 1730292023000);
+```
+
+## rollback_to_watermark
+
+Rollback to the snapshot which earlier or equal than watermark.
+
+**Arguments**
+
+- `table` (`STRING`, required): the target table identifier.
+- `watermark` (`BIGINT`, required): roll back to the snapshot which earlier or equal than watermark.
+
+```sql
+CALL sys.rollback_to_watermark(table => 'default.T', watermark => 1730292023000);
+```

--- a/docs/docs/spark/quick-start.mdx
+++ b/docs/docs/spark/quick-start.mdx
@@ -1,12 +1,6 @@
 ---
 title: "Quick Start"
-sidebar_position: 1
 ---
-
-import Tabs from '@theme/Tabs';
-import TabItem from '@theme/TabItem';
-import Stable from '@site/src/components/Stable';
-import Unstable from '@site/src/components/Unstable';
 
 <!--
 Licensed to the Apache Software Foundation (ASF) under one
@@ -29,373 +23,84 @@ under the License.
 
 # Quick Start
 
+Run a local Spark SQL session, create a primary key table, and read an update back.
+The examples use Spark 3.5 with Scala 2.12. Choose the matching connector for another version in
+[Installation](./installation).
+
 ## Preparation
 
-Paimon supports the following Spark versions with their respective Java and Scala compatibility. We recommend using the latest Spark version for a better experience.
-
-- Spark 4.x (including 4.1, 4.0) : Pre-built with Java 17 and Scala 2.13
-
-- Spark 3.x (including 3.5, 3.4, 3.3, 3.2) : Pre-built with Java 8 and Scala 2.12/2.13
-
-Download the jar file with corresponding version.
-
-<Stable>
-
-
-
-| Version   | Jar (Scala 2.12)                                                                                                                                                                    | Jar (Scala 2.13)                                                                                                                                                                    |
-|-----------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| Spark 4.1 | -                                                                                                                                                                                   | [paimon-spark-4.1_2.13-@@VERSION@@.jar](https://repo.maven.apache.org/maven2/org/apache/paimon/paimon-spark-4.1_2.13/@@VERSION@@/paimon-spark-4.1_2.13-@@VERSION@@.jar) |
-| Spark 4.0 | -                                                                                                                                                                                   | [paimon-spark-4.0_2.13-@@VERSION@@.jar](https://repo.maven.apache.org/maven2/org/apache/paimon/paimon-spark-4.0_2.13/@@VERSION@@/paimon-spark-4.0_2.13-@@VERSION@@.jar) |
-| Spark 3.5 | [paimon-spark-3.5_2.12-@@VERSION@@.jar](https://repo.maven.apache.org/maven2/org/apache/paimon/paimon-spark-3.5_2.12/@@VERSION@@/paimon-spark-3.5_2.12-@@VERSION@@.jar) | [paimon-spark-3.5_2.13-@@VERSION@@.jar](https://repo.maven.apache.org/maven2/org/apache/paimon/paimon-spark-3.5_2.13/@@VERSION@@/paimon-spark-3.5_2.13-@@VERSION@@.jar) |
-| Spark 3.4 | [paimon-spark-3.4_2.12-@@VERSION@@.jar](https://repo.maven.apache.org/maven2/org/apache/paimon/paimon-spark-3.4_2.12/@@VERSION@@/paimon-spark-3.4_2.12-@@VERSION@@.jar) | [paimon-spark-3.4_2.13-@@VERSION@@.jar](https://repo.maven.apache.org/maven2/org/apache/paimon/paimon-spark-3.4_2.13/@@VERSION@@/paimon-spark-3.4_2.13-@@VERSION@@.jar) |
-| Spark 3.3 | [paimon-spark-3.3_2.12-@@VERSION@@.jar](https://repo.maven.apache.org/maven2/org/apache/paimon/paimon-spark-3.3_2.12/@@VERSION@@/paimon-spark-3.3_2.12-@@VERSION@@.jar) | [paimon-spark-3.3_2.13-@@VERSION@@.jar](https://repo.maven.apache.org/maven2/org/apache/paimon/paimon-spark-3.3_2.13/@@VERSION@@/paimon-spark-3.3_2.13-@@VERSION@@.jar) |
-| Spark 3.2 | [paimon-spark-3.2_2.12-@@VERSION@@.jar](https://repo.maven.apache.org/maven2/org/apache/paimon/paimon-spark-3.2_2.12/@@VERSION@@/paimon-spark-3.2_2.12-@@VERSION@@.jar) | [paimon-spark-3.2_2.13-@@VERSION@@.jar](https://repo.maven.apache.org/maven2/org/apache/paimon/paimon-spark-3.2_2.13/@@VERSION@@/paimon-spark-3.2_2.13-@@VERSION@@.jar) |
-
-
-
-</Stable>
-
-<Unstable>
-
-
-
-| Version   | Jar (Scala 2.12)                                                                                                                              | Jar (Scala 2.13)                                                                                                                              |
-|-----------|-----------------------------------------------------------------------------------------------------------------------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------|
-| Spark 4.1 | -                                                                                                                                             | [paimon-spark-4.1_2.13-@@VERSION@@.jar](https://repository.apache.org/snapshots/org/apache/paimon/paimon-spark-4.1_2.13/@@VERSION@@/) |
-| Spark 4.0 | -                                                                                                                                             | [paimon-spark-4.0_2.13-@@VERSION@@.jar](https://repository.apache.org/snapshots/org/apache/paimon/paimon-spark-4.0_2.13/@@VERSION@@/) |
-| Spark 3.5 | [paimon-spark-3.5_2.12-@@VERSION@@.jar](https://repository.apache.org/snapshots/org/apache/paimon/paimon-spark-3.5_2.12/@@VERSION@@/) | [paimon-spark-3.5_2.13-@@VERSION@@.jar](https://repository.apache.org/snapshots/org/apache/paimon/paimon-spark-3.5_2.13/@@VERSION@@/) |
-| Spark 3.4 | [paimon-spark-3.4_2.12-@@VERSION@@.jar](https://repository.apache.org/snapshots/org/apache/paimon/paimon-spark-3.4_2.12/@@VERSION@@/) | [paimon-spark-3.4_2.13-@@VERSION@@.jar](https://repository.apache.org/snapshots/org/apache/paimon/paimon-spark-3.4_2.13/@@VERSION@@/) |
-| Spark 3.3 | [paimon-spark-3.3_2.12-@@VERSION@@.jar](https://repository.apache.org/snapshots/org/apache/paimon/paimon-spark-3.3_2.12/@@VERSION@@/) | [paimon-spark-3.3_2.13-@@VERSION@@.jar](https://repository.apache.org/snapshots/org/apache/paimon/paimon-spark-3.3_2.13/@@VERSION@@/) |
-| Spark 3.2 | [paimon-spark-3.2_2.12-@@VERSION@@.jar](https://repository.apache.org/snapshots/org/apache/paimon/paimon-spark-3.2_2.12/@@VERSION@@/) | [paimon-spark-3.2_2.13-@@VERSION@@.jar](https://repository.apache.org/snapshots/org/apache/paimon/paimon-spark-3.2_2.13/@@VERSION@@/) |
-
-
-
-</Unstable>
-
-You can also manually build bundled jar from the source code.
-
-To build from source code, [clone the git repository](@@GITHUB_REPO@@), then build the bundled jar with the following command.
-
-```bash
-# build paimon spark 3.5 with scala 2.12
-mvn clean package -DskipTests -pl paimon-spark/paimon-spark-3.5 -am
-
-# build paimon spark 3.5 with scala 2.13
-mvn clean package -DskipTests -pl paimon-spark/paimon-spark-3.5 -am -Pscala-2.13
-
-# build paimon spark 4.0
-mvn clean package -DskipTests -pl paimon-spark/paimon-spark-4.0 -am -Pspark4
-
-# build paimon spark 4.1
-mvn clean package -DskipTests -pl paimon-spark/paimon-spark-4.1 -am -Pspark4
-```
-
-For Spark 3.5, you can find the bundled jar in `./paimon-spark/paimon-spark-3.5/target/paimon-spark-3.5_2.12-@@VERSION@@.jar`.
+Install Spark and download the matching Paimon JAR from [Installation](./installation#download-the-connector).
+The connector's Spark minor version and Scala binary version must match your Spark distribution.
 
 ## Setup
 
-:::info
-
-If you are using HDFS, make sure that the environment variable `HADOOP_HOME` or `HADOOP_CONF_DIR` is set.
-
-:::
-
-**Step 1: Specify Paimon Jar File**
-
-Append path to paimon jar file to the `--jars` argument when starting `spark-sql`.
+Start a local session with the connector, catalog, and SQL extensions configured together:
 
 ```bash
-spark-sql ... --jars /path/to/paimon-spark-3.5_2.12-@@VERSION@@.jar
+spark-sql --master 'local[2]' \
+  --jars /path/to/paimon-spark-3.5_2.12-@@VERSION@@.jar \
+  --conf spark.sql.catalog.paimon=org.apache.paimon.spark.SparkCatalog \
+  --conf spark.sql.catalog.paimon.warehouse=file:/tmp/paimon \
+  --conf spark.sql.extensions=org.apache.paimon.spark.extensions.PaimonSparkSessionExtensions
 ```
 
-OR use the `--packages` option.
+Replace the JAR path with your downloaded file. The local warehouse is for this single-machine
+example; a cluster needs storage accessible to the driver and every executor. See
+[Catalogs](./catalogs) for Hive, JDBC, REST, and `SparkGenericCatalog` setup.
 
-```bash
-spark-sql ... --packages org.apache.paimon:paimon-spark-3.5_2.12:@@VERSION@@
-```
-
-Alternatively, you can copy `paimon-spark-3.5_2.12-@@VERSION@@.jar` under `spark/jars` in your Spark installation directory.
-
-**Step 2: Specify Paimon Catalog**
-
-<Tabs groupId="specify-paimon-catalog">
-
-<TabItem value="catalog" label="Catalog">
-
-When starting `spark-sql`, use the following command to register Paimon's Spark catalog with the name `paimon`. Table files of the warehouse is stored under `/tmp/paimon`.
-
-```bash
-spark-sql ... \
-    --conf spark.sql.catalog.paimon=org.apache.paimon.spark.SparkCatalog \
-    --conf spark.sql.catalog.paimon.warehouse=file:/tmp/paimon \
-    --conf spark.sql.extensions=org.apache.paimon.spark.extensions.PaimonSparkSessionExtensions
-```
-
-Catalogs are configured using properties under spark.sql.catalog.(catalog_name). In above case, 'paimon' is the
-catalog name, you can change it to your own favorite catalog name.
-
-After `spark-sql` command line has started, run the following SQL to create and switch to database `default`.
+Select the catalog and database:
 
 ```sql
-USE paimon;
-USE default;
+USE paimon.default;
 ```
 
-After switching to the catalog (`'USE paimon'`), Spark's existing tables will not be directly accessible, you
-can use the `spark_catalog.${database_name}.${table_name}` to access Spark tables.
-
-</TabItem>
-
-<TabItem value="generic-catalog" label="Generic Catalog">
-
-When starting `spark-sql`, use the following command to register Paimon's Spark Generic catalog to replace Spark
-default catalog `spark_catalog`. (default warehouse is Spark `spark.sql.warehouse.dir`)
-
-Currently, it is only recommended to use `SparkGenericCatalog` in the case of Hive metastore, Paimon will infer
-Hive conf from Spark session, you just need to configure Spark's Hive conf.
-
-```bash
-spark-sql ... \
-    --conf spark.sql.catalog.spark_catalog=org.apache.paimon.spark.SparkGenericCatalog \
-    --conf spark.sql.extensions=org.apache.paimon.spark.extensions.PaimonSparkSessionExtensions
-```
-
-Using `SparkGenericCatalog`, you can use Paimon tables in this Catalog or non-Paimon tables such as Spark's csv,
-parquet, Hive tables, etc.
-
-</TabItem>
-
-</Tabs>
+Use a fully qualified name such as `spark_catalog.default.other_table` to access a table in
+Spark's built-in catalog while `paimon` is selected.
 
 ## Create Table
 
-<Tabs groupId="create-paimon-table">
-
-<TabItem value="catalog" label="Catalog">
-
 ```sql
-create table my_table (
-    k int,
-    v string
-) tblproperties (
-    'primary-key' = 'k'
+CREATE TABLE my_table (
+    k INT,
+    v STRING
+) TBLPROPERTIES (
+    'primary-key' = 'k',
+    'bucket' = '1'
 );
 ```
 
-</TabItem>
-
-<TabItem value="generic-catalog" label="Generic Catalog">
-
-```sql
-create table my_table (
-    k int,
-    v string
-) USING paimon
-tblproperties (
-    'primary-key' = 'k'
-);
-
-```
-
-</TabItem>
-
-</Tabs>
+A primary key table merges records with the same key. Without the `primary-key` property,
+Paimon creates an append table. See [Create Tables, Views, and Tags](./sql-ddl) for partitioned
+and external tables.
 
 ## Insert Table
 
-<Tabs groupId="insert-paimon-table">
-
-<TabItem value="sql" label="SQL">
-
 ```sql
 INSERT INTO my_table VALUES (1, 'Hi'), (2, 'Hello');
+INSERT INTO my_table VALUES (1, 'Hello Paimon');
 ```
 
-</TabItem>
-
-<TabItem value="dataframe" label="DataFrame">
-
-```scala
--- you can use
-Seq((1, "Hi"), (2, "Hello")).toDF("k", "v")
-  .write.format("paimon").mode("append").saveAsTable("my_table")
-
--- or
-Seq((1, "Hi"), (2, "Hello")).toDF("k", "v")
-  .write.format("paimon").mode("append").save("file:/tmp/paimon/default.db/my_table")
-```
-
-</TabItem>
-
-</Tabs>
+The second write updates key `1` under the default deduplicate merge engine.
 
 ## Query Table
 
-<Tabs groupId="query-paimon-table">
-
-<TabItem value="sql" label="SQL">
-
 ```sql
-SELECT * FROM my_table;
-
-/*
-1	Hi
-2	Hello
-*/
+SELECT * FROM my_table ORDER BY k;
+-- 1  Hello Paimon
+-- 2  Hello
 ```
 
-</TabItem>
+## Next Steps
 
-<TabItem value="dataframe" label="DataFrame">
-
-```scala
--- you can use
-spark.read.format("paimon").table("my_table").show()
-
--- or
-spark.read.format("paimon").load("file:/tmp/paimon/default.db/my_table").show()
-
-/*
-+---+------+
-| k |     v|
-+---+------+
-|  1|    Hi|
-|  2| Hello|
-+---+------+
-*/
-```
-
-</TabItem>
-
-</Tabs>
+| Task | Guide |
+| --- | --- |
+| Read and write from Scala | [DataFrame API](./dataframe) |
+| Filter data or query an older snapshot | [SQL Queries](./sql-query) |
+| Overwrite partitions, update, or merge rows | [SQL Writes](./sql-write) |
+| Consume or produce streaming data | [Structured Streaming](./structured-streaming) |
+| Tune the connector or table options | [Configuration](./configuration) |
 
 ## Spark Type Conversion
 
-This section lists all supported type conversion between Spark and Paimon.
-All Spark's data types are available in package `org.apache.spark.sql.types`.
-
-<table className="table table-bordered">
-    <thead>
-    <tr>
-      <th className="text-left" style={{width: "10%"}}>Spark Data Type</th>
-      <th className="text-left" style={{width: "10%"}}>Paimon Data Type</th>
-      <th className="text-left" style={{width: "5%"}}>Atomic Type</th>
-    </tr>
-    </thead>
-    <tbody>
-    <tr>
-      <td><code>StructType</code></td>
-      <td><code>RowType</code></td>
-      <td>false</td>
-    </tr>
-    <tr>
-      <td><code>MapType</code></td>
-      <td><code>MapType</code></td>
-      <td>false</td>
-    </tr>
-    <tr>
-      <td><code>ArrayType</code></td>
-      <td><code>ArrayType</code></td>
-      <td>false</td>
-    </tr>
-    <tr>
-      <td><code>BooleanType</code></td>
-      <td><code>BooleanType</code></td>
-      <td>true</td>
-    </tr>
-    <tr>
-      <td><code>ByteType</code></td>
-      <td><code>TinyIntType</code></td>
-      <td>true</td>
-    </tr>
-    <tr>
-      <td><code>ShortType</code></td>
-      <td><code>SmallIntType</code></td>
-      <td>true</td>
-    </tr>
-    <tr>
-      <td><code>IntegerType</code></td>
-      <td><code>IntType</code></td>
-      <td>true</td>
-    </tr>
-    <tr>
-      <td><code>LongType</code></td>
-      <td><code>BigIntType</code></td>
-      <td>true</td>
-    </tr>
-    <tr>
-      <td><code>FloatType</code></td>
-      <td><code>FloatType</code></td>
-      <td>true</td>
-    </tr>
-    <tr>
-      <td><code>DoubleType</code></td>
-      <td><code>DoubleType</code></td>
-      <td>true</td>
-    </tr>
-    <tr>
-      <td><code>StringType</code></td>
-      <td><code>VarCharType(Integer.MAX_VALUE)</code></td>
-      <td>true</td>
-    </tr>
-    <tr>
-      <td><code>VarCharType(length)</code></td>
-      <td><code>VarCharType(length)</code></td>
-      <td>true</td>
-    </tr>
-    <tr>
-      <td><code>CharType(length)</code></td>
-      <td><code>CharType(length)</code></td>
-      <td>true</td>
-    </tr>
-    <tr>
-      <td><code>DateType</code></td>
-      <td><code>DateType</code></td>
-      <td>true</td>
-    </tr>
-    <tr>
-      <td><code>TimestampType</code></td>
-      <td><code>LocalZonedTimestamp</code></td>
-      <td>true</td>
-    </tr>
-    <tr>
-      <td><code>TimestampNTZType(Spark3.4+)</code></td>
-      <td><code>TimestampType</code></td>
-      <td>true</td>
-    </tr>
-    <tr>
-      <td><code>DecimalType(precision, scale)</code></td>
-      <td><code>DecimalType(precision, scale)</code></td>
-      <td>true</td>
-    </tr>
-    <tr>
-      <td><code>BinaryType</code></td>
-      <td><code>VarBinaryType</code>, <code>BinaryType</code></td>
-      <td>true</td>
-    </tr>
-    <tr>
-      <td><code>GeometryType (Spark 4.1)</code></td>
-      <td><code>GeometryType</code></td>
-      <td>true</td>
-    </tr>
-    <tr>
-      <td><code>GeographyType (Spark 4.1)</code></td>
-      <td><code>GeographyType</code></td>
-      <td>true</td>
-    </tr>
-    <tr>
-      <td><code>VariantType(Spark4.0+)</code></td>
-      <td><code>VariantType</code></td>
-      <td>true</td>
-    </tr>
-    </tbody>
-</table>
-
-Due to the previous design, in Spark3.3 and below, Paimon will map both Paimon's TimestampType and LocalZonedTimestamp to Spark's TimestampType, and only correctly handle with TimestampType.
-
-Therefore, when using Spark3.3 and below, reads Paimon table with LocalZonedTimestamp type written by other engines, such as Flink, the query result of LocalZonedTimestamp type will have time zone offset, which needs to be adjusted manually.
-
-When using Spark3.4 and above, all timestamp types can be parsed correctly.
-
-Native `GeometryType` and `GeographyType` conversion is supported only in Spark 4.1 and only for CRSs recognized by Spark. Enable it explicitly in production with `--conf spark.sql.geospatial.enabled=true`; Spark enables it automatically only in its test environment. Spark 4.1 supports only the `spherical` geography edge algorithm, so Paimon geography types using `vincenty`, `thomas`, `andoyer`, or `karney` cannot be converted. Spark 3.x and Spark 4.0 reject Paimon geospatial columns instead of exposing them as `BinaryType`, which would lose the CRS or edge algorithm. Paimon does not support Spark geospatial types with mixed SRIDs.
+The mapping table and timestamp, variant, and geospatial compatibility notes are in
+[Data Types](./data-types).

--- a/docs/docs/spark/schema-evolution.md
+++ b/docs/docs/spark/schema-evolution.md
@@ -1,0 +1,100 @@
+---
+title: "Schema Evolution on Write"
+---
+
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+# Schema Evolution on Write
+
+When `write.merge-schema` is enabled, Paimon automatically evolves the table schema during write to accommodate new columns in the incoming data, while preserving data integrity.
+
+:::info
+
+Since the table schema may be updated during writing, catalog caching needs to be disabled to use this feature. Configure `spark.sql.catalog.<catalogName>.cache-enabled` to `false`.
+
+:::
+
+## How It Evolves the Schema
+
+Three options control how aggressively the schema evolves; each only takes effect when the previous one is enabled:
+
+| Option | Description |
+| --- | --- |
+| `write.merge-schema` | If true, evolve the table schema to accept new columns from the incoming data. Existing column types are preserved and incoming values are cast to them; to also widen existing types, enable `write.merge-schema.type-widening`. |
+| `write.merge-schema.type-widening` | Only effective when `write.merge-schema` is true. If true, widen an existing column type when the incoming data has a wider compatible type (e.g. INT -> BIGINT, DECIMAL precision increase). Lossy changes are still rejected unless `write.merge-schema.explicit-cast` is also true. |
+| `write.merge-schema.explicit-cast` | Only effective when `write.merge-schema.type-widening` is true. If true, also allow lossy type changes between compatible types (e.g. BIGINT -> INT, STRING -> DATE). |
+
+## Examples
+
+DataFrame batch write:
+
+```scala
+data.write
+  .format("paimon")
+  .mode("append")
+  .option("write.merge-schema", "true")
+  .saveAsTable("t")
+```
+
+Spark SQL (requires Spark 3.5+ for `BY NAME`):
+
+```sql
+SET `spark.paimon.write.merge-schema` = true;
+
+CREATE TABLE t (a INT, b STRING);
+INSERT INTO t VALUES (1, '1'), (2, '2');
+
+INSERT INTO t BY NAME SELECT 3 AS a, '3' AS b, 3 AS c;
+```
+
+Streaming write (use the existing table's actual location):
+
+```scala
+// input is a streaming DataFrame whose columns match or extend table t.
+input
+  .writeStream
+  .format("paimon")
+  .option("checkpointLocation", "/path/to/checkpoint")
+  .option("write.merge-schema", "true")
+  .start("/path/to/warehouse/default.db/t")
+```
+
+## Column Alignment by Write Path
+
+When the source schema doesn't match the target schema exactly, the behavior depends on both `write.merge-schema` and the write path. For nested struct fields, all byName paths behave the same; at the top level, `MERGE INTO *` differs from regular byName `INSERT` because `*` expansion only references target columns.
+
+| Write path | Scenario | `merge-schema=false` (default) | `merge-schema=true` |
+|------------|----------|-------------------------------|---------------------|
+| **byName `INSERT`** (`INSERT INTO ... BY NAME` / `saveAsTable` / `writeTo`) | Top-level source-extra columns | Throws | Evolved into the target schema |
+| | Top-level target columns missing from source | NULL-filled | NULL-filled |
+| | Nested struct source-extra fields | Throws | Evolved into the target schema |
+| | Nested struct target-missing fields | Throws | NULL-filled |
+| **`MERGE INTO *`** (`UPDATE *` / `INSERT *`) | Top-level source-extra columns | Silently dropped (`*` only covers target columns) | Evolved into the target schema |
+| | Top-level target columns missing from source | Throws | `UPDATE *` preserves current value; `INSERT *` fills `CURRENT_DEFAULT` (or NULL when no default) |
+| | Nested struct source-extra fields | Throws | Evolved into the target schema |
+| | Nested struct target-missing fields | Throws | `UPDATE *` preserves current value; `INSERT *` fills `CURRENT_DEFAULT` (or NULL when no default) |
+
+Notes:
+- Position-based writes (e.g. `INSERT INTO t VALUES (...)` without `BY NAME`) require an exact column count match and don't engage schema evolution; only byName writes are covered above.
+- Top-level target-missing under `merge-schema=false` for byName `INSERT` mirrors Spark's `INSERT FILL` semantics — only nested missing fields throw.
+- Under strict mode (`merge-schema=false`), nested source-extra fields throw to avoid silent data loss; for `MERGE INTO *` at the top level, source-extras are silently dropped because `*` never references them.
+
+For explicit DDL changes, see [Alter Tables](./sql-alter). For default expressions, see
+[Default Values](./default-value).

--- a/docs/docs/spark/sql-alter.md
+++ b/docs/docs/spark/sql-alter.md
@@ -1,5 +1,5 @@
 ---
-title: "SQL Alter"
+title: "Alter Tables"
 sidebar_position: 6
 ---
 
@@ -22,9 +22,25 @@ specific language governing permissions and limitations
 under the License.
 -->
 
-# Altering Tables
+# Alter Tables
 
-## Changing/Adding Table Properties
+Change table properties and schemas with explicit DDL. For automatic schema changes during
+a write, see [Schema Evolution on Write](./schema-evolution). For default expressions, see
+[Default Values](./default-value).
+
+| Change | Guide |
+| --- | --- |
+| Properties and comments | [Set properties](#changingadding-table-properties), [unset properties](#removing-table-properties), [comments](#changingadding-table-comment) |
+| Table identity | [Rename a table](#rename-table-name) |
+| Schema | [Add](#adding-new-columns), [rename](#renaming-column-name), [drop](#dropping-columns), [reorder](#changing-column-position), or [change types](#changing-column-type) |
+| Data partitions | [Drop partitions](#dropping-partitions), or [manage Format Table partitions](./format-table) |
+| Database metadata | [Alter a database](#alter-database) |
+
+Examples are independent: run the form that matches your existing table schema. For nested
+fields, `v.f1` addresses a struct field, `v.element.f1` an array element's struct field, and
+`v.value.f1` a map value's struct field.
+
+## Set Table Properties {#changingadding-table-properties}
 
 The following SQL sets `write-buffer-size` table property to `256 MB`.
 
@@ -34,7 +50,7 @@ ALTER TABLE my_table SET TBLPROPERTIES (
 );
 ```
 
-## Removing Table Properties
+## Unset Table Properties {#removing-table-properties}
 
 The following SQL removes `write-buffer-size` table property.
 
@@ -42,17 +58,17 @@ The following SQL removes `write-buffer-size` table property.
 ALTER TABLE my_table UNSET TBLPROPERTIES ('write-buffer-size');
 ```
 
-##  Changing/Adding Table Comment
+## Set a Table Comment {#changingadding-table-comment}
 
 The following SQL changes comment of table `my_table` to `table comment`.
 
 ```sql
 ALTER TABLE my_table SET TBLPROPERTIES (
     'comment' = 'table comment'
-    );
+);
 ```
 
-## Removing Table Comment
+## Remove a Table Comment {#removing-table-comment}
 
 The following SQL removes table comment.
 
@@ -60,23 +76,21 @@ The following SQL removes table comment.
 ALTER TABLE my_table UNSET TBLPROPERTIES ('comment');
 ```
 
-## Rename Table Name
+## Rename a Table {#rename-table-name}
 
-The following SQL rename the table name to new name.
-
-The simplest sql to call is:
+Rename a table within the current catalog:
 ```sql
 ALTER TABLE my_table RENAME TO my_table_new;
 ```
 
-Note that: we can rename paimon table in spark this way:
+The source may be catalog-qualified, but the destination must not include a catalog name:
+
 ```sql
-ALTER TABLE [catalog.[database.]]test1 RENAME to [database.]test2;
+ALTER TABLE paimon.default.my_table RENAME TO default.my_table_new;
 ```
-But we can't put catalog name before the renamed-to table, it will throw an error if we write sql like this:
-```sql
-ALTER TABLE catalog.database.test1 RENAME to catalog.database.test2;
-```
+
+A destination such as `paimon.default.my_table_new` is rejected. This operation does not move a
+table between catalogs.
 
 :::info
 
@@ -84,7 +98,7 @@ If you use object storage without REST Catalog, such as S3 or OSS, please use th
 
 :::
 
-## Adding New Columns
+## Add Columns {#adding-new-columns}
 
 The following SQL adds two columns `c1` and `c2` to table `my_table`.
 
@@ -116,7 +130,7 @@ The following SQL adds a nested column `f3` to a struct type, which is the value
 ALTER TABLE my_table ADD COLUMN v.value.f3 STRING;
 ```
 
-## Renaming Column Name
+## Rename Columns {#renaming-column-name}
 
 The following SQL renames column `c0` in table `my_table` to `c1`.
 
@@ -145,7 +159,7 @@ The following SQL renames a nested column `f1` to `f100` in a struct type, which
 ALTER TABLE my_table RENAME COLUMN v.value.f1 to f100;
 ```
 
-## Dropping Columns
+## Drop Columns {#dropping-columns}
 
 The following SQL drops two columns `c1` and `c2` from table `my_table`.
 
@@ -186,18 +200,19 @@ See [HIVE-17832](https://issues.apache.org/jira/browse/HIVE-17832) for the histo
 
 :::
 
-Otherwise this operation may fail, throws an exception like `The following columns have types incompatible with the
+Otherwise, the operation can fail with `The following columns have types incompatible with the
 existing columns in their respective positions`.
 
-## Dropping Partitions
+## Drop Partitions {#dropping-partitions}
 
-The following SQL drops the partitions of the paimon table. For spark sql, you need to specify all the partition columns.
+For a Paimon snapshot table, supply every partition column. For example, on a table partitioned
+by `(id, name)`:
 
 ```sql
 ALTER TABLE my_table DROP PARTITION (`id` = 1, `name` = 'paimon');
 ```
 
-## Changing Column Comment
+## Set a Column Comment {#changing-column-comment}
 
 The following SQL changes comment of column `buy_count` to `buy count`.
 
@@ -205,7 +220,7 @@ The following SQL changes comment of column `buy_count` to `buy count`.
 ALTER TABLE my_table ALTER COLUMN buy_count COMMENT 'buy count';
 ```
 
-## Adding Column Position
+## Choose a New Column Position {#adding-column-position}
 
 ```sql
 ALTER TABLE my_table ADD COLUMN c INT FIRST;
@@ -213,7 +228,7 @@ ALTER TABLE my_table ADD COLUMN c INT FIRST;
 ALTER TABLE my_table ADD COLUMN c INT AFTER b;
 ```
 
-## Changing Column Position
+## Reorder Columns {#changing-column-position}
 
 ```sql
 ALTER TABLE my_table ALTER COLUMN col_a FIRST;
@@ -221,7 +236,7 @@ ALTER TABLE my_table ALTER COLUMN col_a FIRST;
 ALTER TABLE my_table ALTER COLUMN col_a AFTER col_b;
 ```
 
-## Changing Column Type
+## Change Column Types {#changing-column-type}
 
 ```sql
 ALTER TABLE my_table ALTER COLUMN col_a TYPE DOUBLE;
@@ -248,20 +263,19 @@ The following SQL changes the type of a nested column `f2` to `BIGINT` in a stru
 ALTER TABLE my_table ALTER COLUMN v.value.f2 TYPE BIGINT;
 ```
 
+## Alter a Database {#alter-database}
 
-# ALTER DATABASE
-
-The following SQL sets one or more properties in the specified database. If a particular property is already set in the database, override the old value with the new one.
+Set database properties; an existing value for the same key is replaced. `SCHEMA` and
+`NAMESPACE` are aliases for `DATABASE` in this syntax.
 
 ```sql
-ALTER { DATABASE | SCHEMA | NAMESPACE } my_database
-    SET { DBPROPERTIES | PROPERTIES } ( property_name = property_value [ , ... ] )
+ALTER DATABASE my_database SET DBPROPERTIES ('owner' = 'analytics');
 ```
 
-## Altering Database Location
+### Altering Database Location
 
 The following SQL sets the location of the specified database to `file:/temp/my_database.db`.
 
 ```sql
-ALTER DATABASE my_database SET LOCATION 'file:/temp/my_database.db'
+ALTER DATABASE my_database SET LOCATION 'file:/temp/my_database.db';
 ```

--- a/docs/docs/spark/sql-ddl.md
+++ b/docs/docs/spark/sql-ddl.md
@@ -1,6 +1,5 @@
 ---
-title: "SQL DDL"
-sidebar_position: 2
+title: "Create Tables, Views, and Tags"
 ---
 
 <!--
@@ -22,166 +21,48 @@ specific language governing permissions and limitations
 under the License.
 -->
 
-# SQL DDL
+# Create Tables, Views, and Tags
+
+Create tables, views, and tags after selecting a [Paimon catalog](./catalogs). Use
+[Alter Tables](./sql-alter) to evolve an existing schema and [Format Table Partitions](./format-table)
+for catalog-managed partition DDL.
+
+| Command | Creates data? | Use it for |
+| --- | --- | --- |
+| `CREATE TABLE` | No | Define an empty table with explicit columns and properties. |
+| `CREATE TABLE ... AS SELECT` | Yes | Create and populate a table from query results. |
+| `CREATE TABLE ... LIKE` | No | Copy a source table definition; requires Spark 3.4+. |
+| `REPLACE TABLE` | Only with `AS SELECT` | Replace an existing table definition; requires Spark 3.4+ for the behavior below. |
+| `CREATE OR REPLACE TABLE` | Only with `AS SELECT` | Create a missing table or replace one that exists. |
+
+The examples assume `USE paimon.default` with a configured [catalog](./catalogs). In
+`SparkGenericCatalog`, include `USING paimon` when creating or replacing a Paimon table.
 
 ## Catalog
 
-### Create Catalog
+<span id="create-catalog"></span>
+<span id="create-filesystem-catalog"></span>
+<span id="creating-hive-catalog"></span>
+<span id="creating-jdbc-catalog"></span>
+<span id="creating-rest-catalog"></span>
+<span id="bear-token"></span>
+<span id="dlf-ak"></span>
+<span id="dlf-sts-token"></span>
 
-Paimon catalogs currently support three types of metastores:
-
-* `filesystem` metastore (default), which stores both metadata and table files in filesystems.
-* `hive` metastore, which additionally stores metadata in Hive metastore. Users can directly access the tables from Hive.
-* `jdbc` metastore, which additionally stores metadata in relational databases such as MySQL, Postgres, etc.
-
-See [CatalogOptions](../maintenance/configurations#catalogoptions) for detailed options when creating a catalog.
-
-#### Create Filesystem Catalog
-
-The following Spark SQL registers and uses a Paimon catalog named `my_catalog`. Metadata and table files are stored under `hdfs:///path/to/warehouse`.
-
-The following shell command registers a paimon catalog named `paimon`. Metadata and table files are stored under `hdfs:///path/to/warehouse`.
-
-```bash
-spark-sql ... \
-    --conf spark.sql.catalog.paimon=org.apache.paimon.spark.SparkCatalog \
-    --conf spark.sql.catalog.paimon.warehouse=hdfs:///path/to/warehouse
-```
-
-You can define any default table options with the prefix `spark.sql.catalog.paimon.table-default.` for tables created in the catalog.
-
-After `spark-sql` is started, you can switch to the `default` database of the `paimon` catalog with the following SQL.
-
-```sql
-USE paimon.default;
-```
-
-#### Creating Hive Catalog
-
-By using Paimon Hive catalog, changes to the catalog will directly affect the corresponding Hive metastore. Tables created in such catalog can also be accessed directly from Hive.
-
-To use Hive catalog, Database name, Table name and Field names should be **lower** case.
-
-Your Spark installation should be able to detect, or already contains Hive dependencies. See [here](https://spark.apache.org/docs/latest/sql-data-sources-hive-tables.html) for more information.
-
-The following shell command registers a Paimon Hive catalog named `paimon`. Metadata and table files are stored under `hdfs:///path/to/warehouse`. In addition, metadata is also stored in Hive metastore.
-
-```bash
-spark-sql ... \
-    --conf spark.sql.catalog.paimon=org.apache.paimon.spark.SparkCatalog \
-    --conf spark.sql.catalog.paimon.warehouse=hdfs:///path/to/warehouse \
-    --conf spark.sql.catalog.paimon.metastore=hive \
-    --conf spark.sql.catalog.paimon.uri=thrift://<hive-metastore-host-name>:<port>
-```
-
-You can define any default table options with the prefix `spark.sql.catalog.paimon.table-default.` for tables created in the catalog.
-
-After `spark-sql` is started, you can switch to the `default` database of the `paimon` catalog with the following SQL.
-
-```sql
-USE paimon.default;
-```
-
-Also, you can create [SparkGenericCatalog](./quick-start).
-
-**Synchronizing Partitions into Hive Metastore**
-
-By default, Paimon does not synchronize newly created partitions into Hive metastore. Users will see an unpartitioned table in Hive. Partition push-down will be carried out by filter push-down instead.
-
-If you want to see a partitioned table in Hive and also synchronize newly created partitions into Hive metastore, please set the table property `metastore.partitioned-table` to true. Also see [CoreOptions](../maintenance/configurations#coreoptions).
-
-#### Creating JDBC Catalog
-
-By using the Paimon JDBC catalog, changes to the catalog will be directly stored in relational databases such as SQLite, MySQL, postgres, etc.
-
-Currently, lock configuration is only supported for MySQL and SQLite. If you are using a different type of database for catalog storage, please do not configure `lock.enabled`.
-
-Paimon JDBC Catalog in Spark needs to correctly add the corresponding jar package for connecting to the database. You should first download JDBC  connector bundled jar and add it to classpath. such as MySQL, postgres
-
-| database type | Bundle Name          | SQL Client JAR                                                             |
-|:--------------|:---------------------|:---------------------------------------------------------------------------|
-| mysql         | mysql-connector-java | [Download](https://mvnrepository.com/artifact/mysql/mysql-connector-java)  |
-| postgres      | postgresql           | [Download](https://mvnrepository.com/artifact/org.postgresql/postgresql)   |
-
-JDBC catalog supports persistent Paimon views. View metadata is stored in the automatically created
-`paimon_views` table in the catalog database.
-
-Within a single database, a name cannot be used by both a table and a view; all writers
-(`createTable`, `renameTable`, `createView`, `renameView`) reject conflicting identifiers. See
-[Views](../concepts/views#jdbc-catalog-notes) for upgrade-time permissions, single-process locking
-semantics, and database visibility details.
-
-```bash
-spark-sql ... \
-    --conf spark.sql.catalog.paimon=org.apache.paimon.spark.SparkCatalog \
-    --conf spark.sql.catalog.paimon.warehouse=hdfs:///path/to/warehouse \
-    --conf spark.sql.catalog.paimon.metastore=jdbc \
-    --conf spark.sql.catalog.paimon.uri=jdbc:mysql://<host>:<port>/<databaseName> \
-    --conf spark.sql.catalog.paimon.jdbc.user=... \
-    --conf spark.sql.catalog.paimon.jdbc.password=...
-    
-```
-
-```sql
-USE paimon.default;
-```
-#### Creating REST Catalog
-
-By using the Paimon REST catalog, changes to the catalog will be directly stored in remote server.
-
-##### bear token
-```bash
-spark-sql ... \
-    --conf spark.sql.catalog.paimon=org.apache.paimon.spark.SparkCatalog \
-    --conf spark.sql.catalog.paimon.metastore=rest \
-    --conf spark.sql.catalog.paimon.uri=<catalog server url> \
-    --conf spark.sql.catalog.paimon.token.provider=bear \
-    --conf spark.sql.catalog.paimon.token=<token>
-    
-```
-
-##### dlf ak
-```bash
-spark-sql ... \
-    --conf spark.sql.catalog.paimon=org.apache.paimon.spark.SparkCatalog \
-    --conf spark.sql.catalog.paimon.metastore=rest \
-    --conf spark.sql.catalog.paimon.uri=<catalog server url> \
-    --conf spark.sql.catalog.paimon.token.provider=dlf \
-    --conf spark.sql.catalog.paimon.dlf.access-key-id=<access-key-id> \
-    --conf spark.sql.catalog.paimon.dlf.access-key-secret=<security-token>
-    
-```
-
-##### dlf sts token
-```bash
-spark-sql ... \
-    --conf spark.sql.catalog.paimon=org.apache.paimon.spark.SparkCatalog \
-    --conf spark.sql.catalog.paimon.metastore=rest \
-    --conf spark.sql.catalog.paimon.uri=<catalog server url> \
-    --conf spark.sql.catalog.paimon.token.provider=dlf \
-    --conf spark.sql.catalog.paimon.dlf.access-key-id=<access-key-id> \
-    --conf spark.sql.catalog.paimon.dlf.access-key-secret=<access-key-secret> \
-    --conf spark.sql.catalog.paimon.dlf.security-token=<security-token>
-    
-    
-```
-
-```sql
-USE paimon.default;
-```
+See [Catalogs](./catalogs) for filesystem, Hive, JDBC, REST, and `SparkGenericCatalog` setup.
 
 ## Table
 
 ### Create Table
 
-After use Paimon catalog, you can create and drop tables. Tables created in Paimon Catalogs are managed by the catalog.
-When the table is dropped from catalog, its table files will also be deleted.
+Tables created without an external location are managed by the catalog. Dropping a managed
+table also deletes its files. See [Create External Table](#create-external-table) for Hive
+catalog ownership rules.
 
-The following SQL assumes that you have registered and are using a Paimon catalog. It creates a managed table named 
-`my_table` with five columns in the catalog's `default` database, where `dt`, `hh` and `user_id` are the primary keys.
+Create an unpartitioned primary key table:
 
 ```sql
-CREATE TABLE my_table (
+CREATE TABLE events (
     user_id BIGINT,
     item_id BIGINT,
     behavior STRING,
@@ -192,187 +73,98 @@ CREATE TABLE my_table (
 );
 ```
 
-You can create partitioned table:
+To partition the data by date and hour, declare `PARTITIONED BY`. For a primary key table,
+the primary key must include every partition column:
 
 ```sql
-CREATE TABLE my_table (
+CREATE TABLE partitioned_events (
     user_id BIGINT,
     item_id BIGINT,
     behavior STRING,
     dt STRING,
     hh STRING
-) PARTITIONED BY (dt, hh) TBLPROPERTIES (
-    'primary-key' = 'dt,hh,user_id'
-);
+) PARTITIONED BY (dt, hh)
+TBLPROPERTIES ('primary-key' = 'dt,hh,user_id');
 ```
+
+Omit `primary-key` to create an append table. For storage layout and table options, see
+[Primary Key Tables](../primary-key-table/) and [Append Tables](../append-table/).
 
 ### Manage Format Table Partitions
 
-For a Format Table whose `metastore.partitioned-table` option is `true`, the catalog holds the
-partitions and Spark supports the standard partition DDL:
-
-```sql
-ALTER TABLE my_table ADD PARTITION (dt='2025-01-01');
-ALTER TABLE my_table ADD PARTITION (dt='2024-12-31')
-    LOCATION 'oss://archive-bucket/events/dt=2024-12-31';
-ALTER TABLE my_table DROP PARTITION (dt='2025-01-01');
-MSCK REPAIR TABLE my_table;
-SHOW PARTITIONS my_table;
-ANALYZE TABLE my_table PARTITION (dt='2025-01-01') COMPUTE STATISTICS NOSCAN;
-```
-
-On a Format Table whose partitions are discovered from the filesystem, `ADD PARTITION`,
-`DROP PARTITION`, `MSCK REPAIR TABLE` and `ANALYZE TABLE` fail with an error.
-
-`ADD PARTITION` creates the partition directory and registers the partition; querying a newly
-added partition before any data is written returns no rows. `DROP PARTITION` unregisters the
-partition and deletes its directory.
-
-`ADD PARTITION ... LOCATION` registers a custom absolute URI without moving data and requires a
-compatible REST catalog. Paimon can read the partition but does not write, delete, or analyze its
-data. `DROP PARTITION` only unregisters it, and `MSCK REPAIR TABLE` leaves it unchanged.
-
-A partition value that is empty or all whitespace is rejected by `ADD PARTITION`, `DROP PARTITION`
-and `TRUNCATE PARTITION`. Such a value is written to the partition named by
-`partition.default-name` (`__DEFAULT_PARTITION__` unless configured otherwise), the same partition
-a `NULL` is written to, so it names that partition rather than one of its own - name it directly
-instead. Writing one through `INSERT` is unaffected and still lands there.
-
-`ANALYZE TABLE` measures partitions. A Format Table has no snapshot to carry a table-level
-statistic and no column statistics, so `COMPUTE STATISTICS FOR COLUMNS` and `FOR ALL COLUMNS` are
-not supported on it; what the statement writes back to the catalog is the file count, byte size,
-last file creation time and row count of the partitions it measured. Each measured field replaces
-the one the catalog held, so running it twice reports the same numbers as running it once, while a
-field it could not measure leaves the stored one as it was. It never adds or removes a partition —
-use `MSCK REPAIR TABLE` for that.
-
-`NOSCAN` stops at the directory listing, which gives everything except the row count. Without it,
-the row count is read from each file's footer, so it is exact for the formats that carry one
-(Parquet, ORC) and a partition holding no files counts as zero, while a format that carries none
-(CSV, TEXT, JSON) leaves the row count the catalog already held rather than guessing one. Reading
-footers costs one open per file, so it runs on the executors and `NOSCAN` is the cheaper of the
-two.
-
-A `PARTITION (...)` clause must give values for a leading run of the partition columns, because
-that is the shape the catalog can select on. On a table partitioned by `(dt, hh)`,
-`PARTITION (dt='2025-01-01')` and `PARTITION (dt='2025-01-01', hh)` both measure every hour of
-that day, while `PARTITION (hh='01')` is rejected rather than widened to every day. Naming a
-partition that is not registered is an error too, rather than a statement that reports success for
-having measured nothing.
-
-:::info
-
-`metastore.partitioned-table = true` enables catalog-managed partitions, which requires an
-internal Format Table in a catalog that supports it (currently the REST catalog) and cannot be
-combined with `format-table.implementation = engine`. The REST catalog validates this
-combination on `CREATE TABLE`, with catalog-level table defaults
-(`spark.sql.catalog.paimon.table-default.*`) participating in the effective options: a default
-that makes the combination invalid fails the DDL.
-
-In a REST catalog, asking for catalog-managed partitions on a table that cannot have them — an
-external table, or `format-table.implementation = engine` — fails, rather than handing back a
-table whose options say one thing and whose partitions come from somewhere else. Remove the option
-with `ALTER TABLE my_table UNSET TBLPROPERTIES ('metastore.partitioned-table')`.
-
-In any other catalog the option keeps the meaning it has always had on a Format Table — none. Such
-a table loads and reads its partitions from the filesystem, so on a Format Table it
-only takes effect in a REST catalog; elsewhere partitions are discovered from the filesystem.
-On a REST catalog, an existing Format Table whose partitions were never registered reads as empty
-until you register them with `MSCK REPAIR TABLE my_table`.
-
-Mixed-version note: only writers that support catalog-managed partitions register the partitions
-they produce. During a rolling upgrade, upgrade all writers before relying on catalog-managed
-partitions, or run `MSCK REPAIR TABLE` afterwards, since data written by an older writer is not
-visible until its partitions are registered.
-
-For a Format Table, `metastore.partitioned-table` only changes where partitions come from; it does not
-change the table's managed/external ownership.
-
-:::
+See [Format Table Partitions](./format-table) for partition registration, custom locations,
+statistics, and mixed-version writer requirements.
 
 ### Create External Table
 
-When the catalog's `metastore` type is `hive`, if the `location` is specified when creating a table, that table will be considered an external table; otherwise, it will be a managed table. 
-
-When you drop an external table, only the metadata in Hive will be removed, and the actual data files will not be deleted; whereas dropping a managed table will also delete the data.
+In a Hive catalog, specifying `LOCATION` creates an external table. Dropping that table removes
+its Hive metadata and keeps the data files. Without `LOCATION`, the table is managed and dropping
+it also deletes its files.
 
 ```sql
-CREATE TABLE my_table (
+CREATE TABLE external_events (
     user_id BIGINT,
     item_id BIGINT,
     behavior STRING,
     dt STRING,
     hh STRING
-) PARTITIONED BY (dt, hh) TBLPROPERTIES (
-    'primary-key' = 'dt,hh,user_id'
-) LOCATION '/path/to/table';
+) PARTITIONED BY (dt, hh)
+TBLPROPERTIES ('primary-key' = 'dt,hh,user_id')
+LOCATION '/path/to/external_events';
 ```
 
-Furthermore, if there is already data stored in the specified location, you can create the table without explicitly specifying the fields, partitions and props or other information. 
-In this case, the new table will inherit them all from the existing table's metadata.
-
-However, if you manually specify them, you need to ensure that they are consistent with those of the existing table (props can be a subset). Therefore, it is strongly recommended not to specify them.
+To register an existing Paimon table at a location, let Paimon load its schema, partitioning,
+and properties from that location:
 
 ```sql
-CREATE TABLE my_table LOCATION '/path/to/table';
+CREATE TABLE registered_events LOCATION '/path/to/existing_paimon_table';
 ```
+
+If you specify columns or partitioning, they must match the existing table. Supplied table
+properties may be a subset of the existing properties. Omitting those declarations avoids
+repeating metadata already stored with the table.
 
 ### Create Table As Select
 
-Table can be created and populated by the results of a query, for example, we have a sql like this: `CREATE TABLE table_b AS SELECT id, name FORM table_a`,
-The resulting table `table_b` will be equivalent to create the table and insert the data with the following statement:
-`CREATE TABLE table_b (id INT, name STRING); INSERT INTO table_b SELECT id, name FROM table_a;`
+`CREATE TABLE ... AS SELECT` (CTAS) derives the schema from a query and writes its result to
+a new table. Declare the target partitioning, primary key, and storage properties on the new
+table as needed.
 
-We can specify the primary key or partition when use `CREATE TABLE AS SELECT`, for syntax, please refer to the following sql.
+Create a small source table for the following examples:
 
 ```sql
-CREATE TABLE my_table (
-     user_id BIGINT,
-     item_id BIGINT
-);
-CREATE TABLE my_table_as AS SELECT * FROM my_table;
-
-/* partitioned table*/
-CREATE TABLE my_table_partition (
-      user_id BIGINT,
-      item_id BIGINT,
-      behavior STRING,
-      dt STRING,
-      hh STRING
-) PARTITIONED BY (dt, hh);
-CREATE TABLE my_table_partition_as PARTITIONED BY (dt) AS SELECT * FROM my_table_partition;
-
-/* change TBLPROPERTIES */
-CREATE TABLE my_table_options (
-       user_id BIGINT,
-       item_id BIGINT
-) TBLPROPERTIES ('file.format' = 'orc');
-CREATE TABLE my_table_options_as TBLPROPERTIES ('file.format' = 'parquet') AS SELECT * FROM my_table_options;
-
-
-/* primary key */
-CREATE TABLE my_table_pk (
-     user_id BIGINT,
-     item_id BIGINT,
-     behavior STRING,
-     dt STRING,
-     hh STRING
-) TBLPROPERTIES (
-    'primary-key' = 'dt,hh,user_id'
-);
-CREATE TABLE my_table_pk_as TBLPROPERTIES ('primary-key' = 'dt') AS SELECT * FROM my_table_pk;
-
-/* primary key + partition */
-CREATE TABLE my_table_all (
+CREATE TABLE source_events (
     user_id BIGINT,
     item_id BIGINT,
     behavior STRING,
     dt STRING,
     hh STRING
-) PARTITIONED BY (dt, hh) TBLPROPERTIES (
-    'primary-key' = 'dt,hh,user_id'
 );
-CREATE TABLE my_table_all_as PARTITIONED BY (dt) TBLPROPERTIES ('primary-key' = 'dt,hh') AS SELECT * FROM my_table_all;
+INSERT INTO source_events VALUES (1, 10, 'pv', '2025-01-01', '00');
+```
+
+Each statement below creates a separate target:
+
+```sql
+-- Copy query results into an append table.
+CREATE TABLE events_copy AS SELECT * FROM source_events;
+
+-- Partition the target by date.
+CREATE TABLE events_by_date PARTITIONED BY (dt)
+AS SELECT * FROM source_events;
+
+-- Choose a file format for the target.
+CREATE TABLE events_parquet TBLPROPERTIES ('file.format' = 'parquet')
+AS SELECT * FROM source_events;
+
+-- Create a primary key table.
+CREATE TABLE events_by_user TBLPROPERTIES ('primary-key' = 'user_id')
+AS SELECT * FROM source_events;
+
+-- Combine partitioning and a primary key.
+CREATE TABLE events_by_date_user PARTITIONED BY (dt)
+TBLPROPERTIES ('primary-key' = 'dt,user_id')
+AS SELECT * FROM source_events;
 ```
 
 ### Replace Table
@@ -415,8 +207,9 @@ SELECT * FROM my_table VERSION AS OF 1;
 `REPLACE TABLE` requires the table to exist. If the table does not exist, use
 `CREATE OR REPLACE TABLE` instead.
 
-`REPLACE TABLE` does not accept `AS SELECT`. To replace a table and populate it with query results,
-use `CREATE OR REPLACE TABLE ... AS SELECT`.
+Both `REPLACE TABLE ... AS SELECT` and `CREATE OR REPLACE TABLE ... AS SELECT` are supported.
+The former requires an existing target; the latter also creates the target when it is missing.
+For example, given a source table with columns `(user_id BIGINT, item_id BIGINT, behavior STRING)`:
 
 ```sql
 CREATE OR REPLACE TABLE my_table
@@ -427,9 +220,28 @@ TBLPROPERTIES (
 AS SELECT user_id, item_id, behavior FROM source_table;
 ```
 
-When the existing table and target table use different table types,
-uses its fallback drop+create behavior instead of snapshot-preserving replace
-behavior.
+Snapshot preservation depends on the replacement path and catalog support. Keep the provider,
+table type, and partitioning unchanged to use the in-place path. A replacement that changes
+these can fall back to dropping and recreating the table, losing its snapshot history. A catalog
+that does not support in-place replacement can also fall back to drop-and-create.
+
+When a replacement query reads its own target, Paimon pins the source read to the existing
+snapshot. On a partitioned table, restate the partitioning:
+
+```sql
+CREATE TABLE replace_example (id INT, dt STRING) PARTITIONED BY (dt);
+INSERT INTO replace_example VALUES (1, 'a'), (2, 'b');
+
+REPLACE TABLE replace_example PARTITIONED BY (dt)
+AS SELECT * FROM replace_example WHERE dt = 'a';
+
+SELECT * FROM replace_example;
+-- 1  a
+```
+
+A self-referencing replacement that would change the provider, table type, or partitioning
+is rejected before the table is dropped. Write the query result to a separate table first if
+that change is needed.
 
 ### Create Table Like
 
@@ -466,36 +278,47 @@ CREATE TABLE target_tbl LIKE source_tbl;
 
 ## View
 
-Views are based on the result-set of an SQL query, when using `org.apache.paimon.spark.SparkCatalog`, views are managed by paimon itself. 
-And in this case, views are supported when the `metastore` type is `hive`, `rest` or `jdbc`.
+A persistent view stores a query definition in the Paimon catalog. With `SparkCatalog`,
+persistent views are supported by Hive, REST, and JDBC metastores. Temporary views belong to
+the Spark session and use an unqualified name.
 
 ### Create Or Replace View
 
-CREATE VIEW constructs a virtual table that has no physical data.
+These examples read the `events` table from [Create Table](#create-table):
 
 ```sql
--- create a view or a temporary view. (temporary view should not specify database name)
-CREATE [TEMPORARY] VIEW <mydb>.v1 AS SELECT * FROM t1;
+-- Persistent view in the selected catalog and database.
+CREATE VIEW event_view AS SELECT user_id, behavior FROM events;
+CREATE OR REPLACE VIEW event_view
+AS SELECT user_id, behavior FROM events WHERE behavior = 'pv';
 
--- create a view or a temporary view, if a view of same name already exists, it will be replaced. (temporary view should not specify database name)
-CREATE OR REPLACE [TEMPORARY] VIEW <mydb>.v1 AS SELECT * FROM t1;
+-- Session-scoped view; do not qualify the temporary view name with a database.
+CREATE TEMPORARY VIEW temporary_events AS SELECT * FROM events;
+CREATE OR REPLACE TEMPORARY VIEW temporary_events
+AS SELECT * FROM events WHERE behavior = 'pv';
 ```
+
+See [Views](../concepts/views) for catalog-specific behavior and
+[`alter_view_dialect`](./procedures/metadata#alter_view_dialect) for dialect management.
 
 ### Drop View
 
-DROP VIEW removes the metadata associated with a specified view from the catalog.
-
 ```sql
--- drop a view or a temporary view.
-DROP VIEW <mydb>.v1;
+DROP VIEW event_view;
+DROP VIEW temporary_events;
 ```
 
 ## Tag
+
+Tags retain named snapshots for later reads. The examples below assume `T` has committed data
+and snapshots `1` and `2` exist. See [Manage Tags](../maintenance/manage-tags) for retention and
+[Time Travel](./sql-query#batch-time-travel) for reading a tag.
+
 ### Create Or Replace Tag
-Create or replace a tag syntax with the following options.
-- Create a tag with or without the snapshot id and time retention.
-- Create an existed tag is not failed if using `IF NOT EXISTS` syntax.
-- Update a tag using `REPLACE TAG` or `CREATE OR REPLACE TAG` syntax.
+
+Specify a snapshot and retention period, or omit them to tag the latest snapshot without an
+explicit retention period. `IF NOT EXISTS` leaves an existing tag unchanged; `REPLACE TAG`
+updates an existing tag.
 
 ```sql
 -- create a tag based on the latest snapshot and no retention.
@@ -513,13 +336,13 @@ ALTER TABLE T CREATE TAG `TAG-3` AS OF VERSION 1;
 -- create a tag based on snapshot-2 and retain it for 12 hour.
 ALTER TABLE T CREATE TAG `TAG-4` AS OF VERSION 2 RETAIN 12 HOURS;
 
--- replace a existed tag with new snapshot id and new retention
+-- replace an existing tag with new snapshot id and new retention
 ALTER TABLE T REPLACE TAG `TAG-4` AS OF VERSION 2 RETAIN 24 HOURS;
 
--- create or replace a tag, create tag if it not exist, replace tag if it exists.
+-- Create the tag if missing, or replace it if it exists.
 ALTER TABLE T CREATE OR REPLACE TAG `TAG-5` AS OF VERSION 2 RETAIN 24 HOURS;
 ```
-NOTE: If tag.automatic-creation is set, only one auto-tag could be created for one snapshot.
+When `tag.automatic-creation` is enabled, only one automatic tag can be created per snapshot.
 
 ### Delete Tag
 Delete a tag or multiple tags of a table.
@@ -528,7 +351,7 @@ Delete a tag or multiple tags of a table.
 ALTER TABLE T DELETE TAG `TAG-1`;
 
 -- delete a tag if it exists.
-ALTER TABLE T DELETE TAG IF EXISTS `TAG-1`
+ALTER TABLE T DELETE TAG IF EXISTS `TAG-1`;
 
 -- delete multiple tags, delimiter is ','.
 ALTER TABLE T DELETE TAG `TAG-1,TAG-2`;

--- a/docs/docs/spark/sql-functions.md
+++ b/docs/docs/spark/sql-functions.md
@@ -24,7 +24,16 @@ under the License.
 
 # SQL Functions
 
-This section introduce all available Paimon Spark functions.
+Use built-in functions for partitions and blob descriptors, or define functions in a REST
+catalog. Configure the [catalog and extensions](./quick-start#setup) first.
+
+| Task | Function or guide |
+| --- | --- |
+| Find the latest nonempty top-level partition | [`max_pt`](#max_pt) |
+| Reference an external blob | [`path_to_descriptor`](#path_to_descriptor) |
+| Inspect blob metadata | [`descriptor_to_string`](#descriptor_to_string) |
+| Create a temporary OSS download URL | [`descriptor_to_presigned_url`](#descriptor_to_presigned_url) |
+| Define reusable logic | [User-defined functions](#user-defined-function) |
 
 ## Built-in Function
 
@@ -46,7 +55,7 @@ It would throw exception when:
 ```sql
 SELECT sys.max_pt('t');
 -- 20250101
- 
+
 SELECT * FROM t where pt = sys.max_pt('t');
 -- a, 20250101
 ```
@@ -131,19 +140,25 @@ for Java and Flink examples, caching behavior, and current limitations.
 
 ## User-defined Function
 
-Paimon Spark supports three types of user-defined functions: lambda functions, file-based functions, and SQL functions.
+Paimon-managed function definitions require a REST catalog. Choose a definition format:
 
-This feature currently only supports the REST catalog.
+| Definition | Use it for | Requirement |
+| --- | --- | --- |
+| [Java lambda](#lambda-function) | A small Java expression stored in the catalog | Register metadata and a Spark definition with procedures. |
+| [JAR implementation](#file-function) | Existing Spark or Hive UDF/UDAF classes | Spark 3.4+ and the implementation JAR. |
+| [SQL body](#sql-function) | Reusable scalar SQL logic | Spark 4.0+. |
+
+The examples assume the REST catalog and its `default` database are selected.
 
 ### Lambda Function
 
-Empowering users to define functions using Java lambda expressions, enabling inline, concise, and functional-style operations.
+Define the function signature, then attach a Java lambda as its Spark implementation.
 
 **Example**
 
 ```sql
 -- Create Function
-CALL sys.create_function(`function` => 'my_db.area_func',
+CALL sys.create_function(`function` => 'default.area_func',
   `inputParams` => '[{"id": 0, "name":"length", "type":"INT"}, {"id": 1, "name":"width", "type":"INT"}]',
   `returnParams` => '[{"id": 0, "name":"area", "type":"BIGINT"}]',
   `deterministic` => true,
@@ -152,41 +167,47 @@ CALL sys.create_function(`function` => 'my_db.area_func',
 );
 
 -- Alter Function
-CALL sys.alter_function(`function` => 'my_db.area_func',
+CALL sys.alter_function(`function` => 'default.area_func',
   `change` => '{"action" : "addDefinition", "name" : "spark", "definition" : {"type" : "lambda", "definition" : "(Integer length, Integer width) -> { return (long) length * width; }", "language": "JAVA" } }'
 );
 
 -- Drop Function
-CALL sys.drop_function(`function` => 'my_db.area_func');
+CALL sys.drop_function(`function` => 'default.area_func');
 ```
 
 ### File Function
 
-Users can define functions within a file, providing flexibility and modular support for function definition, only supports jar files now.
+Register a Spark or Hive UDF/UDAF implementation packaged in a JAR.
 
 Currently, supports Spark or Hive implementations of UDFs and UDAFs, see [Spark UDFs](https://spark.apache.org/docs/latest/sql-ref-functions.html#udfs-user-defined-functions)
 
 This feature requires Spark 3.4 or higher.
 
-**Example**
+Replace the class name and JAR path with your implementation. Permanent and temporary
+functions use different names here so that the examples can coexist:
 
 ```sql
--- Create Function or Temporary Function (Temporary function should not specify database name)
-CREATE [TEMPORARY] FUNCTION <mydb>.simple_udf
-AS 'com.example.SimpleUdf' 
-USING JAR '/tmp/SimpleUdf.jar' [, JAR '/tmp/SimpleUdfR.jar'];
-
--- Create or Replace Temporary Function (Temporary function should not specify database name)
-CREATE OR REPLACE [TEMPORARY] FUNCTION <mydb>.simple_udf 
+-- Persistent function in the current REST catalog.
+CREATE FUNCTION default.simple_udf
 AS 'com.example.SimpleUdf'
-USING JAR '/tmp/SimpleUdf.jar';
-       
--- Describe Function
-DESCRIBE FUNCTION [EXTENDED] <mydb>.simple_udf;
+USING JAR '/path/to/SimpleUdf.jar';
 
--- Drop Function
-DROP [TEMPORARY] FUNCTION <mydb>.simple_udf;
+-- Session-scoped function: no database prefix on its name.
+CREATE TEMPORARY FUNCTION temporary_udf
+AS 'com.example.SimpleUdf'
+USING JAR '/path/to/SimpleUdf.jar';
+
+CREATE OR REPLACE TEMPORARY FUNCTION temporary_udf
+AS 'com.example.SimpleUdf'
+USING JAR '/path/to/SimpleUdf.jar';
+
+DESCRIBE FUNCTION EXTENDED default.simple_udf;
+DROP FUNCTION default.simple_udf;
+DROP TEMPORARY FUNCTION temporary_udf;
 ```
+
+To attach more than one JAR, separate resources with commas:
+`USING JAR '/path/to/udf.jar', JAR '/path/to/dependency.jar'`.
 
 ### SQL Function
 
@@ -202,7 +223,10 @@ CREATE FUNCTION area(width DOUBLE, height DOUBLE)
 RETURNS DOUBLE
 RETURN width * height;
 
--- Create Function (query body)
+SELECT area(3.0, 4.0);
+-- 12.0
+
+-- Query body: assumes emp has columns salary and dept_id.
 CREATE FUNCTION dept_total(d INT) RETURNS INT
 RETURN SELECT SUM(salary) FROM emp WHERE dept_id = d;
 
@@ -214,7 +238,7 @@ CREATE OR REPLACE FUNCTION inc(x INT) RETURNS INT RETURN x + 100;
 CREATE FUNCTION IF NOT EXISTS inc(x INT) RETURNS INT RETURN x + 1;
 
 -- Describe / Show / Drop Function
-DESCRIBE FUNCTION [EXTENDED] area;
+DESCRIBE FUNCTION EXTENDED area;
 SHOW USER FUNCTIONS;
-DROP FUNCTION [IF EXISTS] area;
+DROP FUNCTION IF EXISTS area;
 ```

--- a/docs/docs/spark/sql-query.md
+++ b/docs/docs/spark/sql-query.md
@@ -1,5 +1,5 @@
 ---
-title: "SQL Query"
+title: "SQL Queries"
 sidebar_position: 4
 ---
 
@@ -22,9 +22,19 @@ specific language governing permissions and limitations
 under the License.
 -->
 
-# SQL Query
+# SQL Queries
 
-Just like all other tables, Paimon tables can be queried with `SELECT` statement.
+Query Paimon tables with `SELECT` after selecting a [Paimon catalog](./catalogs).
+Choose the read scope before adding filters:
+
+| Read scope | Use it for | Entry point |
+| --- | --- | --- |
+| Latest snapshot | Current table state | [`SELECT`](#batch-query) |
+| Historical snapshot or tag | Reproduce a past table state | [Time travel](#batch-time-travel) |
+| Bounded changes | Process an interval of updates | [Batch incremental](#batch-incremental) |
+| Continuous changes | Keep consuming new commits | [Structured Streaming](./structured-streaming) |
+
+![A snapshot read returns one table state; an incremental read selects changes in a bounded interval; a streaming read continues to later snapshots.](/img/spark-read-scopes.svg)
 
 ## Batch Query
 
@@ -63,7 +73,7 @@ you can use `VERSION AS OF` and `TIMESTAMP AS OF` in query to do time travel:
 -- read the snapshot with id 1L (use snapshot id as version)
 SELECT * FROM t VERSION AS OF 1;
 
--- read the snapshot from specified timestamp 
+-- read the snapshot from specified timestamp
 SELECT * FROM t TIMESTAMP AS OF '2023-06-01 00:00:00.123';
 
 -- read the snapshot from specified timestamp in unix seconds
@@ -87,22 +97,24 @@ instead of snapshot 1.
 
 ### Batch Incremental
 
-Read incremental changes between start snapshot (exclusive) and end snapshot.
+Read incremental changes between a start snapshot (exclusive) and an end snapshot (inclusive).
 
 For example:
 - '5,10' means changes between snapshot 5 and snapshot 10.
 - 'TAG1,TAG3' means changes between TAG1 and TAG3.
 
-By default, will scan changelog files for the table which produces changelog files. Otherwise, scan newly changed files.
-You can also force specifying `'incremental-between-scan-mode'`.
+For snapshot-ID and timestamp ranges, the default scan uses changelog files when the table
+has a changelog producer; otherwise it scans newly changed files. Tag-to-tag ranges default to
+a snapshot diff. Use `incremental-between-scan-mode` to select a supported scan mode explicitly.
 
-Paimon supports that use Spark SQL to do the incremental query that implemented by Spark Table Valued Function.
+Paimon provides table-valued functions for incremental SQL queries. These require the
+[Paimon SQL extensions](./quick-start#setup).
 
 ```sql
 -- read the incremental data between snapshot id 12 and snapshot id 20.
 SELECT * FROM paimon_incremental_query('tableName', 12, 20);
 
--- read the incremental data between ts 1692169900000 and ts 1692169900000.
+-- read the incremental data between timestamps 1692169000000 and 1692169900000.
 SELECT * FROM paimon_incremental_between_timestamp('tableName', '1692169000000', '1692169900000');
 SELECT * FROM paimon_incremental_between_timestamp('tableName', '2025-03-12 00:00:00', '2025-03-12 00:08:00');
 
@@ -113,7 +125,7 @@ SELECT * FROM paimon_incremental_to_auto_tag('tableName', '2024-12-04');
 ```
 
 In Batch SQL, the `DELETE` records are not allowed to be returned, so records of `-D` will be dropped.
-If you want see `DELETE` records, you can query audit_log table.
+To inspect row kinds, including deletes, query the [`audit_log` system table](../concepts/system-tables#audit-log-table).
 
 ## Query Optimization
 
@@ -141,7 +153,7 @@ Suppose that a table has the following specification:
 CREATE TABLE orders (
     catalog_id BIGINT,
     order_id BIGINT,
-    .....,
+    amount DECIMAL(10, 2)
 ) TBLPROPERTIES (
     'primary-key' = 'catalog_id,order_id'
 );

--- a/docs/docs/spark/sql-write.md
+++ b/docs/docs/spark/sql-write.md
@@ -1,6 +1,5 @@
 ---
-title: "SQL Write"
-sidebar_position: 2
+title: "SQL Writes"
 ---
 
 <!--
@@ -22,7 +21,20 @@ specific language governing permissions and limitations
 under the License.
 -->
 
-# SQL Write
+# SQL Writes
+
+Choose a write operation according to what should happen to existing rows:
+
+| Operation | Effect |
+| --- | --- |
+| `INSERT INTO` | Append rows, or merge records by key in a primary key table. |
+| `INSERT OVERWRITE` | Replace the table or selected partitions; scope depends on overwrite mode. |
+| `UPDATE` / `DELETE` | Modify or remove rows matching a predicate. |
+| `MERGE INTO` | Apply conditional updates, inserts, and deletes from a source. |
+| [`COPY INTO`](./copy-into) | Import CSV, JSON, or Parquet files, or export query results. |
+
+Configure the [catalog and SQL extensions](./quick-start#setup) before running these statements.
+For new columns arriving with a write, see [Schema Evolution on Write](./schema-evolution).
 
 ## Insert Table
 
@@ -35,7 +47,7 @@ INSERT { INTO | OVERWRITE } table_identifier [ part_spec ] [ column_list ] { val
 ```
 **Parameters**
 
-- **table_identifier**: Specifies a table name, which may be optionally qualified with a database name. 
+- **table_identifier**: Specifies a table name, which may be optionally qualified with a database name.
 
 - **part_spec**: An optional parameter that specifies a comma-separated list of key and value pairs for partitions.
 
@@ -57,7 +69,8 @@ INSERT INTO my_table SELECT ...
 
 ### Insert Overwrite
 
-Use `INSERT OVERWRITE` to overwrite the whole table.
+In static mode, `INSERT OVERWRITE` without a partition filter replaces the whole table.
+In dynamic mode, it replaces only partitions represented by the input rows.
 
 ```sql
 INSERT OVERWRITE my_table SELECT ...
@@ -73,7 +86,11 @@ INSERT OVERWRITE my_table PARTITION (key1 = value1, key2 = value2, ...) SELECT .
 
 #### Dynamic Overwrite Partition
 
-Spark's default overwrite mode is `static` partition overwrite. To enable dynamic overwritten you need to set the Spark session configuration `spark.sql.sources.partitionOverwriteMode` to `dynamic`
+Spark defaults to `static` partition overwrite. Set
+`spark.sql.sources.partitionOverwriteMode=dynamic` to replace only the partitions written by the
+input. Each case below resets the table to the same two rows before overwriting.
+
+![Static overwrite replaces the whole table; an explicit partition or dynamic overwrite preserves untouched partitions.](/img/spark-partition-overwrite.svg)
 
 For example:
 
@@ -81,9 +98,10 @@ For example:
 CREATE TABLE my_table (id INT, pt STRING) PARTITIONED BY (pt);
 INSERT INTO my_table VALUES (1, 'p1'), (2, 'p2');
 
--- Static overwrite (Overwrite the whole table)
+-- Static overwrite (overwrite the whole table)
+SET spark.sql.sources.partitionOverwriteMode=static;
 INSERT OVERWRITE my_table VALUES (3, 'p1');
--- or 
+-- or
 INSERT OVERWRITE my_table PARTITION (pt) VALUES (3, 'p1');
 
 SELECT * FROM my_table;
@@ -95,7 +113,10 @@ SELECT * FROM my_table;
 +---+---+
 */
 
--- Static overwrite with specified partitions (Only overwrite pt='p1')
+-- Restore the initial rows before the next case.
+INSERT OVERWRITE my_table VALUES (1, 'p1'), (2, 'p2');
+
+-- Static overwrite with specified partitions (only overwrite pt='p1')
 INSERT OVERWRITE my_table PARTITION (pt='p1') VALUES (3);
 
 SELECT * FROM my_table;
@@ -107,8 +128,11 @@ SELECT * FROM my_table;
 |  3| p1|
 +---+---+
 */
-  
--- Dynamic overwrite (Only overwrite pt='p1')
+
+-- Restore the initial rows while still in static mode.
+INSERT OVERWRITE my_table VALUES (1, 'p1'), (2, 'p2');
+
+-- Dynamic overwrite (only overwrite pt='p1')
 SET spark.sql.sources.partitionOverwriteMode=dynamic;
 INSERT OVERWRITE my_table VALUES (3, 'p1');
 
@@ -151,7 +175,7 @@ the table does not have is an error.
 
 ## Update Table
 
-Updates the column values for the rows that match a predicate. When no predicate is provided, update the column values for all rows. 
+Updates the column values for the rows that match a predicate. When no predicate is provided, update the column values for all rows.
 
 Note:
 
@@ -168,11 +192,11 @@ Spark supports update PrimitiveType and StructType, for example:
 UPDATE table_identifier SET column1 = value1, column2 = value2, ... WHERE condition;
 
 CREATE TABLE t (
-  id INT, 
-  s STRUCT<c1: INT, c2: STRING>, 
+  id INT,
+  s STRUCT<c1: INT, c2: STRING>,
   name STRING)
 TBLPROPERTIES (
-  'primary-key' = 'id', 
+  'primary-key' = 'id',
   'merge-engine' = 'deduplicate'
 );
 
@@ -243,424 +267,32 @@ WHEN NOT MATCHED THEN INSERT *
 Assignments are aligned to the target table by **column name**.
 
 - **Explicit clauses** (`UPDATE SET col = expr` / `INSERT (col list) VALUES ...`) — only the mentioned columns are written. Unmentioned target columns preserve their current value for `UPDATE`, or get NULL / `CURRENT_DEFAULT` for `INSERT`.
-- **Star clauses** (`UPDATE SET *` / `INSERT *`) — `*` expands against the **target** columns. When source and target columns don't match exactly, the behavior depends on `spark.paimon.write.merge-schema`; see [Column Alignment by Write Path](#column-alignment-by-write-path) under Write Merge Schema for the full table covering both `MERGE INTO *` and byName `INSERT` paths.
+- **Star clauses** (`UPDATE SET *` / `INSERT *`) — `*` expands against the **target** columns. When source and target columns don't match exactly, the behavior depends on `spark.paimon.write.merge-schema`; see [Column Alignment by Write Path](./schema-evolution#column-alignment-by-write-path) under Write Merge Schema for the full table covering both `MERGE INTO *` and byName `INSERT` paths.
 
 ## Write Merge Schema
 
-When `write.merge-schema` is enabled, Paimon automatically evolves the table schema during write to accommodate new columns in the incoming data, while preserving data integrity.
+<span id="how-it-evolves-the-schema"></span>
+<span id="examples-1"></span>
+<span id="column-alignment-by-write-path"></span>
 
-:::info
-
-Since the table schema may be updated during writing, catalog caching needs to be disabled to use this feature. Configure `spark.sql.catalog.<catalogName>.cache-enabled` to `false`.
-
-:::
-
-### How It Evolves the Schema
-
-Three options control how aggressively the schema evolves; each only takes effect when the previous one is enabled:
-
-<table class="configuration table table-bordered">
-    <thead>
-        <tr>
-            <th class="text-left" style="width: 30%">Option</th>
-            <th class="text-left" style="width: 70%">Description</th>
-        </tr>
-    </thead>
-    <tbody>
-        <tr>
-            <td><h5>write.merge-schema</h5></td>
-            <td>If true, evolve the table schema to accept new columns from the incoming data. Existing column types are preserved and incoming values are cast to them; to also widen existing types, enable <code>write.merge-schema.type-widening</code>.</td>
-        </tr>
-        <tr>
-            <td><h5>write.merge-schema.type-widening</h5></td>
-            <td>Only effective when <code>write.merge-schema</code> is true. If true, widen an existing column type when the incoming data has a wider compatible type (e.g. INT -> BIGINT, DECIMAL precision increase). Lossy changes are still rejected unless <code>write.merge-schema.explicit-cast</code> is also true.</td>
-        </tr>
-        <tr>
-            <td><h5>write.merge-schema.explicit-cast</h5></td>
-            <td>Only effective when <code>write.merge-schema.type-widening</code> is true. If true, also allow lossy type changes between compatible types (e.g. BIGINT -> INT, STRING -> DATE).</td>
-        </tr>
-    </tbody>
-</table>
-
-### Examples
-
-DataFrame batch write:
-
-```scala
-data.write
-  .format("paimon")
-  .mode("append")
-  .option("write.merge-schema", "true")
-  .saveAsTable("t")
-```
-
-Spark SQL (requires Spark 3.5+ for `BY NAME`):
-
-```sql
-SET `spark.paimon.write.merge-schema` = true;
-
-CREATE TABLE t (a INT, b STRING);
-INSERT INTO t VALUES (1, '1'), (2, '2');
-
-INSERT INTO t BY NAME SELECT 3 AS a, '3' AS b, 3 AS c;
-```
-
-Streaming write:
-
-```scala
-val inputData = MemoryStream[(Int, String)]
-inputData
-  .toDS()
-  .toDF("col1", "col2")
-  .writeStream
-  .format("paimon")
-  .option("checkpointLocation", "/path/to/checkpoint")
-  .option("write.merge-schema", "true")
-  .toTable("t")
-```
-
-### Column Alignment by Write Path
-
-When the source schema doesn't match the target schema exactly, the behavior depends on both `write.merge-schema` and the write path. For nested struct fields, all byName paths behave the same; at the top level, `MERGE INTO *` differs from regular byName `INSERT` because `*` expansion only references target columns.
-
-| Write path | Scenario | `merge-schema=false` (default) | `merge-schema=true` |
-|------------|----------|-------------------------------|---------------------|
-| **byName `INSERT`** (`INSERT INTO ... BY NAME` / `saveAsTable` / `writeTo`) | Top-level source-extra columns | Throws | Evolved into the target schema |
-| | Top-level target columns missing from source | NULL-filled | NULL-filled |
-| | Nested struct source-extra fields | Throws | Evolved into the target schema |
-| | Nested struct target-missing fields | Throws | NULL-filled |
-| **`MERGE INTO *`** (`UPDATE *` / `INSERT *`) | Top-level source-extra columns | Silently dropped (`*` only covers target columns) | Evolved into the target schema |
-| | Top-level target columns missing from source | Throws | `UPDATE *` preserves current value; `INSERT *` fills `CURRENT_DEFAULT` (or NULL when no default) |
-| | Nested struct source-extra fields | Throws | Evolved into the target schema |
-| | Nested struct target-missing fields | Throws | `UPDATE *` preserves current value; `INSERT *` fills `CURRENT_DEFAULT` (or NULL when no default) |
-
-Notes:
-- Position-based writes (e.g. `INSERT INTO t VALUES (...)` without `BY NAME`) require an exact column count match and don't engage schema evolution; only byName writes are covered above.
-- Top-level target-missing under `merge-schema=false` for byName `INSERT` mirrors Spark's `INSERT FILL` semantics — only nested missing fields throw.
-- Under strict mode (`merge-schema=false`), nested source-extra fields throw to avoid silent data loss; for `MERGE INTO *` at the top level, source-extras are silently dropped because `*` never references them.
+See [Schema Evolution on Write](./schema-evolution) for options, examples, and the
+[column alignment reference](./schema-evolution#column-alignment-by-write-path).
 
 ## COPY INTO
 
-`COPY INTO` provides a SQL command for bulk loading data files into Paimon tables and exporting table data to files. Supported formats: **CSV**, **JSON**, and **Parquet**.
-
-:::info
-**SQL dialect:** Paimon's `COPY INTO` is a Snowflake-style extension (`FILE_FORMAT = (TYPE = ...)`, `PATTERN`, `FORCE`, `ON_ERROR`), not the Databricks `COPY INTO` form (`FILEFORMAT` + `FORMAT_OPTIONS (...)` / `COPY_OPTIONS (...)`). It implements only a subset of the Snowflake syntax. In particular, `ON_ERROR` supports `ABORT_STATEMENT` (default), `CONTINUE`, and `SKIP_FILE`; the Snowflake variants `SKIP_FILE_<num>` and `SKIP_FILE_<num>%` are **not** supported.
-:::
-
-#### CSV Import
-
-```sql
-COPY INTO table_name [(col1, col2, ...)]
-FROM 'source_path'
-FILE_FORMAT = (TYPE = CSV [, option = value, ...])
-[PATTERN = 'regex']
-[FORCE = TRUE|FALSE]
-[ON_ERROR = { ABORT_STATEMENT | CONTINUE | SKIP_FILE }]
-```
-
-**Basic import:**
-
-```sql
-COPY INTO my_db.my_table
-FROM '/data/csv_files/'
-FILE_FORMAT = (TYPE = CSV);
-```
-
-**Import with explicit column mapping:**
-
-```sql
--- Only load into specified columns; omitted columns use their DEFAULT value or NULL
-COPY INTO my_db.users (id, name)
-FROM '/data/new_users/'
-FILE_FORMAT = (TYPE = CSV, SKIP_HEADER = 1);
-```
-
-**Import with NULL_IF and PATTERN:**
-
-```sql
-COPY INTO my_db.events
-FROM '/data/logs/'
-FILE_FORMAT = (TYPE = CSV, FIELD_DELIMITER = '|', NULL_IF = ('NULL', '\\N', ''))
-PATTERN = '.*\.csv'
-FORCE = FALSE;
-```
-
-#### JSON Import
-
-```sql
-COPY INTO table_name [(col1, col2, ...)]
-FROM 'source_path'
-FILE_FORMAT = (TYPE = JSON [, option = value, ...])
-[PATTERN = 'regex']
-[FORCE = TRUE|FALSE]
-[ON_ERROR = { ABORT_STATEMENT | CONTINUE | SKIP_FILE }]
-```
-
-**Basic import:**
-
-```sql
-COPY INTO my_db.my_table
-FROM '/data/json_files/'
-FILE_FORMAT = (TYPE = JSON);
-```
-
-**Import multi-line JSON array:**
-
-```sql
-COPY INTO my_db.events
-FROM '/data/events/'
-FILE_FORMAT = (TYPE = JSON, MULTI_LINE = TRUE);
-```
-
-JSON columns are matched **by column name** (not by position), so source field order does not matter.
-
-#### Parquet Import
-
-```sql
-COPY INTO table_name [(col1, col2, ...)]
-FROM 'source_path'
-FILE_FORMAT = (TYPE = PARQUET [, option = value, ...])
-[PATTERN = 'regex']
-[FORCE = TRUE|FALSE]
-[ON_ERROR = { ABORT_STATEMENT | CONTINUE | SKIP_FILE }]
-```
-
-**Basic import:**
-
-```sql
-COPY INTO my_db.my_table
-FROM '/data/parquet_files/'
-FILE_FORMAT = (TYPE = PARQUET);
-```
-
-**Import with PATTERN:**
-
-```sql
-COPY INTO my_db.events
-FROM '/data/lake/'
-FILE_FORMAT = (TYPE = PARQUET)
-PATTERN = '.*\.parquet'
-FORCE = FALSE;
-```
-
-Parquet columns are matched **by column name** (not by position). Extra columns in the source files are ignored; missing columns become NULL.
-
-#### Write CSV Files
-
-```sql
-COPY INTO 'target_path'
-FROM { table_name | (SELECT ...) }
-FILE_FORMAT = (TYPE = CSV [, option = value, ...])
-[OVERWRITE = TRUE|FALSE]
-```
-
-**Write with header and overwrite:**
-
-```sql
-COPY INTO '/export/users_backup/'
-FROM my_db.users
-FILE_FORMAT = (TYPE = CSV, HEADER = TRUE, FIELD_DELIMITER = ',')
-OVERWRITE = TRUE;
-```
-
-**Write from query:**
-
-```sql
-COPY INTO '/export/active_users/'
-FROM (SELECT id, name FROM my_db.users WHERE active = TRUE)
-FILE_FORMAT = (TYPE = CSV, HEADER = TRUE);
-```
-
-#### Write JSON Files
-
-```sql
-COPY INTO 'target_path'
-FROM { table_name | (SELECT ...) }
-FILE_FORMAT = (TYPE = JSON [, option = value, ...])
-[OVERWRITE = TRUE|FALSE]
-```
-
-**Basic JSON export:**
-
-```sql
-COPY INTO '/export/events_backup/'
-FROM my_db.events
-FILE_FORMAT = (TYPE = JSON)
-OVERWRITE = TRUE;
-```
-
-**JSON export from query:**
-
-```sql
-COPY INTO '/export/recent_events/'
-FROM (SELECT * FROM my_db.events WHERE event_date > '2024-01-01')
-FILE_FORMAT = (TYPE = JSON);
-```
-
-#### Write Parquet Files
-
-```sql
-COPY INTO 'target_path'
-FROM { table_name | (SELECT ...) }
-FILE_FORMAT = (TYPE = PARQUET [, option = value, ...])
-[OVERWRITE = TRUE|FALSE]
-```
-
-**Basic Parquet export:**
-
-```sql
-COPY INTO '/export/data_backup/'
-FROM my_db.events
-FILE_FORMAT = (TYPE = PARQUET)
-OVERWRITE = TRUE;
-```
-
-**Export with compression:**
-
-```sql
-COPY INTO '/export/data_compressed/'
-FROM my_db.events
-FILE_FORMAT = (TYPE = PARQUET, COMPRESSION = GZIP)
-OVERWRITE = TRUE;
-```
-
-**Parquet export from aggregation query:**
-
-```sql
-COPY INTO '/export/summary/'
-FROM (SELECT dept, COUNT(*) AS cnt FROM my_db.employees GROUP BY dept)
-FILE_FORMAT = (TYPE = PARQUET);
-```
-
-#### FILE_FORMAT Options
-
-`FILE_FORMAT` is required and must include `TYPE = CSV`, `TYPE = JSON`, or `TYPE = PARQUET`.
-
-**CSV import options:**
-
-| Option | Description | Default |
-|--------|-------------|---------|
-| TYPE | File format type. `CSV`, `JSON`, or `PARQUET`. | (required) |
-| FIELD_DELIMITER | Column delimiter character. | `,` |
-| SKIP_HEADER | Skip the first line as header. Only `0` or `1`. | `0` |
-| QUOTE | Quote character for enclosing fields. | `"` |
-| ESCAPE | Escape character within quoted fields. | `\` |
-| NULL_IF | List of string values to interpret as NULL, e.g. `('NULL', '\\N')`. | (none) |
-| EMPTY_FIELD_AS_NULL | Treat empty fields as NULL. `TRUE` or `FALSE`. | `FALSE` |
-| COMPRESSION | Compression codec (e.g. `GZIP`). | `NONE` |
-
-**JSON import options:**
-
-| Option | Description | Default |
-|--------|-------------|---------|
-| TYPE | File format type. `CSV`, `JSON`, or `PARQUET`. | (required) |
-| MULTI_LINE | Parse multi-line JSON (e.g. JSON arrays or pretty-printed objects). | `FALSE` |
-| NULL_IF | List of string values to interpret as NULL. | (none) |
-| EMPTY_FIELD_AS_NULL | Treat empty string values as NULL. | `FALSE` |
-| COMPRESSION | Compression codec (e.g. `GZIP`). | `NONE` |
-
-**Parquet import options:**
-
-| Option | Description | Default |
-|--------|-------------|---------|
-| TYPE | File format type. `CSV`, `JSON`, or `PARQUET`. | (required) |
-| COMPRESSION | Compression codec. Usually auto-detected; rarely needed for import. | (auto) |
-
-**CSV write options:**
-
-| Option | Description | Default |
-|--------|-------------|---------|
-| TYPE | File format type. `CSV`, `JSON`, or `PARQUET`. | (required) |
-| FIELD_DELIMITER | Column delimiter character. | `,` |
-| HEADER | Write column names as the first line. `TRUE` or `FALSE`. | `FALSE` |
-| QUOTE | Quote character for enclosing fields. | `"` |
-| ESCAPE | Escape character within quoted fields. | `\` |
-| COMPRESSION | Compression codec (e.g. `GZIP`). | `NONE` |
-
-**JSON write options:**
-
-| Option | Description | Default |
-|--------|-------------|---------|
-| TYPE | File format type. `CSV`, `JSON`, or `PARQUET`. | (required) |
-| DATE_FORMAT | Custom date format pattern. | Spark default |
-| TIMESTAMP_FORMAT | Custom timestamp format pattern. | Spark default |
-| COMPRESSION | Compression codec (e.g. `GZIP`). | `NONE` |
-
-**Parquet write options:**
-
-| Option | Description | Default |
-|--------|-------------|---------|
-| TYPE | File format type. `CSV`, `JSON`, or `PARQUET`. | (required) |
-| COMPRESSION | Compression codec (`SNAPPY`, `GZIP`, `NONE`, etc.). | `SNAPPY` |
-
-#### Import Options
-
-| Option | Description | Default |
-|--------|-------------|---------|
-| PATTERN | Regex to filter source files by base file name. Only matching files are loaded. | (all files) |
-| FORCE | `FALSE`: skip files already loaded (idempotent). `TRUE`: reload all files. | `FALSE` |
-| ON_ERROR | Error handling strategy. `ABORT_STATEMENT`: abort on any error. `CONTINUE`: skip bad rows and continue loading. `SKIP_FILE`: skip files that contain errors. | `ABORT_STATEMENT` |
-
-#### File Write Options
-
-| Option | Description | Default |
-|--------|-------------|---------|
-| OVERWRITE | `FALSE`: fail if target path exists. `TRUE`: overwrite existing files. | `FALSE` |
-
-#### Column Mapping
-
-When an explicit column list is provided (e.g., `COPY INTO t (col1, col2) FROM ...`):
-
-- **CSV**: Columns are mapped **positionally** to the specified column list.
-- **JSON**: Columns are matched **by name** to the specified column list.
-- **Parquet**: Columns are matched **by name** to the specified column list.
-- The number of source columns must match the column list length (CSV). For JSON and Parquet, missing fields in the source become NULL.
-- Columns not in the list are filled with their **DEFAULT value** (if defined in the table schema) or **NULL**.
-- Non-nullable columns without a default value that are not in the list will cause an error.
-
-When no column list is provided:
-
-- **CSV**: Columns are mapped positionally to all writable columns in the target table. The number of CSV columns must match the number of writable columns.
-- **JSON**: Columns are matched by name to the writable columns. Missing fields in JSON become NULL.
-
-#### Repeated Imports
-
-By default (`FORCE = FALSE`), COPY INTO tracks which files have been successfully loaded. A file is identified by its path, size, and last-modified timestamp.
-
-- Re-running the same COPY INTO command will **skip** already-loaded files and return status `SKIPPED`.
-- If a source file is modified (size or timestamp changes), it becomes eligible for re-loading.
-- `FORCE = TRUE` bypasses load history and always re-imports all matching files.
-
-#### Result Output
-
-**Import** returns one row per source file:
-
-| Column | Type | Description |
-|--------|------|-------------|
-| file_name | STRING | Source file name |
-| status | STRING | `LOADED`, `PARTIALLY_LOADED`, `LOAD_FAILED`, or `SKIPPED` |
-| rows_loaded | BIGINT | Number of rows written |
-| rows_parsed | BIGINT | Number of rows parsed from the file |
-| errors_seen | BIGINT | Number of error rows (parse or cast failures) |
-| first_error | STRING | First error message encountered (NULL if no errors) |
-
-**File write** returns a single row:
-
-| Column | Type | Description |
-|--------|------|-------------|
-| output_path | STRING | Target output path |
-| file_count | INT | Number of files written |
-| rows_written | BIGINT | Total rows written |
-
-#### Limitations
-
-- **CSV column-count mismatch**: Rows with fewer or more columns than the target schema are treated as malformed records. With `ON_ERROR = CONTINUE`, these rows are skipped and counted as errors.
-- Only **CSV**, **JSON**, and **Parquet** formats are supported.
-- `SINGLE = TRUE` (single-file output) is not supported.
-- File format options must be specified inline in `FILE_FORMAT = (...)`.
-- File listing is **non-recursive**: only direct files under the source path are processed. Subdirectories are ignored.
-- `PATTERN` matches the **base file name** only (not the full path).
-- Concurrent COPY INTO commands targeting the same table may produce duplicate data.
-- `SKIP_HEADER` only supports values `0` or `1`.
-- `FROM (...)` accepts any read-only query (e.g. `SELECT`, `WITH ... SELECT`, `VALUES`); statements with side effects (e.g. `INSERT`, `INSERT OVERWRITE DIRECTORY`, DDL) are rejected.
-- For a `FROM (...)` export, `rows_written` is an execution-time statistic counted by a separate pass before the files are written. Because the DataFrame is lazy and not cached, writing re-executes the query a second time; if the query is non-deterministic (e.g. uses `rand()`, `current_timestamp()`, or reads a volatile source), the two runs can produce different rows, so `rows_written` may not match the actual file contents. The result is intentionally not staged, so the export does not consume extra executor disk.
+<span id="csv-import"></span>
+<span id="json-import"></span>
+<span id="parquet-import"></span>
+<span id="write-csv-files"></span>
+<span id="write-json-files"></span>
+<span id="write-parquet-files"></span>
+<span id="file_format-options"></span>
+<span id="import-options"></span>
+<span id="file-write-options"></span>
+<span id="column-mapping"></span>
+<span id="repeated-imports"></span>
+<span id="result-output"></span>
+<span id="limitations"></span>
+
+See [COPY INTO](./copy-into) for CSV, JSON, and Parquet import/export syntax, options,
+column mapping, load history, and limitations.

--- a/docs/docs/spark/streaming-recovery.md
+++ b/docs/docs/spark/streaming-recovery.md
@@ -1,0 +1,130 @@
+---
+title: "Streaming Recovery"
+---
+
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+# Streaming Recovery
+
+Spark checkpoints and Paimon Consumers solve different parts of recovery. Keep the checkpoint
+for precise micro-batch recovery; use a Consumer to record a conservative table-side position
+and protect data needed by that reader.
+
+![Spark checkpoints restore micro-batches, while a Paimon Consumer records a conservative snapshot position and protects retained history.](/img/spark-streaming-recovery.svg)
+
+## Configure a Consumer
+
+You can assign a Paimon Consumer to a streaming query. The Consumer records a
+table-side, snapshot-level recovery position and acts as a fence during normal
+snapshot expiration. For tables with a decoupled changelog lifecycle, enabling
+`consumer.changelog-only` makes the Consumer protect long-lived changelogs
+instead of snapshots.
+
+Configure the Consumer lifetime as a table property before starting the query:
+
+```sql
+ALTER TABLE table_name SET TBLPROPERTIES (
+  'consumer.expiration-time' = '1 d'
+);
+```
+
+```scala
+val query = spark.readStream
+  .format("paimon")
+  .option("consumer-id", "my-consumer")
+  .table("table_name")
+  .writeStream
+  .format("console")
+  .option("checkpointLocation", "/path/to/spark/checkpoint")
+  .start()
+```
+
+## Recovery Position
+
+Spark checkpoint and Paimon Consumer progress have different granularities:
+
+- When the Spark checkpoint is available, Spark uses it for precise micro-batch
+  recovery.
+- A new query without that checkpoint starts from the Consumer position. This
+  recovery is conservative and may replay a completed snapshot if the query
+  failed after processing it but before updating the Consumer.
+
+Paimon updates the Consumer only from Spark's successful micro-batch commit
+callback. When a micro-batch ends partway through a delta snapshot, the Consumer
+may be created or refreshed at that snapshot so that the whole snapshot remains
+protected and can be replayed. The Consumer advances past a snapshot only after
+the micro-batch containing its last split is committed. A Consumer update failure
+is propagated, fails the running query, and leaves the Consumer at its previous
+conservative position.
+
+Spark never advances Consumer progress past an incomplete snapshot. An incomplete
+initial full snapshot does not create a Consumer because Consumer recovery from
+that snapshot would use a delta scan. `consumer.mode` does not select a different
+Spark source implementation.
+
+Offsets restored from an older Spark checkpoint do not contain snapshot
+completion metadata. Spark logs a warning and leaves the Consumer unchanged for
+those offsets rather than advancing it without proof that the snapshot finished.
+
+If the Consumer does not exist, the configured startup options are used. For
+example, the default `latest-full` mode first reads the full snapshot and creates
+the Consumer only after that snapshot is completely committed. If the Consumer
+already exists, its next snapshot takes precedence over startup options and is
+read incrementally, unless `consumer.ignore-progress` is enabled.
+
+:::note
+
+Spark can invoke the source commit callback while constructing a later
+micro-batch. Therefore the Consumer may temporarily lag behind the latest
+successful batch, especially while a query is idle or after its final available
+batch. This is safe and can only cause conservative replay.
+
+:::
+
+## Retention and Query Ownership
+
+Consumer files are scoped to the branch being read. Use one active Spark query
+for each `(table, branch, consumer-id)` combination. Concurrent queries sharing
+the same Consumer are unsupported because a faster query could move the shared
+position past data still needed by a slower query.
+
+Configure `consumer.expiration-time` according to the longest expected snapshot
+processing time, failure recovery time, and idle interval. Eligible Spark source
+commit callbacks refresh the Consumer file, but there is no separate timer-based
+Spark heartbeat. Expired Consumer files are cleaned by non-write-only table
+commits. A write-only writer does not perform Consumer expiration, so stale
+Consumer IDs must be managed explicitly or by a separate non-write-only
+maintenance process.
+
+An initial full scan has no Consumer retention fence until it completes, so
+snapshot retention should be long enough for that scan. If its snapshot expires
+first, a restart without a Spark checkpoint performs a new initial full scan
+according to the startup options.
+
+When expired data would force recovery of a logged Spark batch to switch between
+a full and an incremental scan, Paimon fails the query instead of combining the
+two plans. Start a new query with a new checkpoint to apply the startup options
+again.
+
+## Manage Consumer Records
+
+See [`reset_consumer`](./procedures/metadata#reset_consumer) and
+[`clear_consumers`](./procedures/metadata#clear_consumers) for explicit maintenance.
+Return to [Structured Streaming](./structured-streaming) for startup modes and trigger examples.

--- a/docs/docs/spark/structured-streaming.md
+++ b/docs/docs/spark/structured-streaming.md
@@ -1,6 +1,5 @@
 ---
 title: "Structured Streaming"
-sidebar_position: 11
 ---
 
 <!--
@@ -24,37 +23,48 @@ under the License.
 
 # Structured Streaming
 
-Paimon supports streaming data processing with [Spark Structured Streaming](https://spark.apache.org/docs/latest/streaming/index.html), enabling both streaming write and streaming query.
+Read or write Paimon tables with Spark Structured Streaming. Configure the
+[catalog and extensions](./quick-start#setup) first. Streaming reads require **Spark 3.3 or later**.
+The examples use Scala and micro-batch execution.
 
 ## Streaming Write
 
-:::info
-
-Paimon Structured Streaming only supports the two `append` and `complete` modes.
-
-:::
+The sink supports `append` and `complete` output modes. The following example uses Spark's
+public `rate` source and writes to the location of a catalog table; run it in `spark-shell` configured as in
+[Quick Start](./quick-start#setup).
 
 ```scala
-// Create a paimon table if not exists.
-spark.sql(s"""
-           |CREATE TABLE T (k INT, v STRING)
-           |TBLPROPERTIES ('primary-key'='k', 'bucket'='3')
-           |""".stripMargin)
+import org.apache.spark.sql.functions.col
 
-// Here we use MemoryStream to fake a streaming source.
-val inputData = MemoryStream[(Int, String)]
-val df = inputData.toDS().toDF("k", "v")
+spark.sql("USE paimon.default")
+spark.sql("""
+  CREATE TABLE IF NOT EXISTS stream_events (id BIGINT, event_time TIMESTAMP)
+  TBLPROPERTIES ('bucket' = '-1')
+""")
 
-// Streaming Write to paimon table.
-val stream = df
-  .writeStream
-  .outputMode("append")
-  .option("checkpointLocation", "/path/to/checkpoint")
+val input = spark.readStream
+  .format("rate")
+  .option("rowsPerSecond", "10")
+  .load()
+  .select(col("value").as("id"), col("timestamp").as("event_time"))
+
+val writer = input.writeStream
   .format("paimon")
-  .start("/path/to/paimon/sink/table")
+  .outputMode("append")
+  .option("checkpointLocation", "/tmp/paimon-checkpoints/stream-events-writer")
+  .start("file:/tmp/paimon/default.db/stream_events")
 ```
 
-Streaming write also supports [Write merge schema](./sql-write#write-merge-schema).
+The sink uses `.start(tableLocation)` to access an existing table. `writeStream.toTable(...)` is
+not supported for Paimon catalog tables. This path matches the local warehouse in Quick Start;
+replace it with your table's actual location for another warehouse.
+
+`append` applies each batch to the table. `complete` overwrites the table with each batch
+and should be used only when the input represents the complete result.
+
+Use a durable checkpoint location accessible to the cluster for deployed jobs. Give each query
+its own checkpoint directory. Stop this example with `writer.stop()`.
+Streaming writes also support [Schema Evolution on Write](./schema-evolution).
 
 ## Streaming Query
 
@@ -64,220 +74,80 @@ Paimon currently supports Spark 3.3+ for streaming read.
 
 :::
 
-Paimon supports rich scan mode for streaming read. There is a list:
-<table class="configuration table table-bordered">
-    <thead>
-        <tr>
-            <th class="text-left" style="width: 20%">Scan Mode</th>
-            <th class="text-left" style="width: 60%">Description</th>
-        </tr>
-    </thead>
-    <tbody>
-        <tr>
-            <td><h5>latest</h5></td>
-            <td>For streaming sources, continuously reads latest changes without producing a snapshot at the beginning. </td>
-        </tr>
-        <tr>
-            <td><h5>latest-full</h5></td>
-            <td>For streaming sources, produces the latest snapshot on the table upon first startup, and continue to read the latest changes.</td>
-        </tr>
-        <tr>
-            <td><h5>from-timestamp</h5></td>
-            <td>For streaming sources, continuously reads changes starting from timestamp specified by "scan.timestamp-millis", without producing a snapshot at the beginning. </td>
-        </tr>
-        <tr>
-            <td><h5>from-snapshot</h5></td>
-            <td>For streaming sources, continuously reads changes starting from snapshot specified by "scan.snapshot-id", without producing a snapshot at the beginning. </td>
-        </tr>
-        <tr>
-            <td><h5>from-snapshot-full</h5></td>
-            <td>For streaming sources, produces from snapshot specified by "scan.snapshot-id" on the table upon first startup, and continuously reads changes.</td>
-        </tr>
-        <tr>
-            <td><h5>default</h5></td>
-            <td>It is equivalent to from-snapshot if "scan.snapshot-id" is specified. It is equivalent to from-timestamp if "timestamp-millis" is specified. Or, It is equivalent to latest-full.</td>
-        </tr>
-    </tbody>
-</table>
+Choose the startup scan mode for a new query. Once a Spark checkpoint or Consumer position
+exists, recovery follows [Streaming Recovery](./streaming-recovery).
+
+| `scan.mode` | Initial read | Then |
+| --- | --- | --- |
+| `latest` | No initial snapshot | Read new changes. |
+| `latest-full` | Read the latest full snapshot | Read subsequent changes. |
+| `from-timestamp` | Changes starting from `scan.timestamp-millis` | Continue reading changes. |
+| `from-snapshot` | Changes starting from `scan.snapshot-id` | Continue reading changes. |
+| `from-snapshot-full` | Full snapshot at `scan.snapshot-id` | Read subsequent changes. |
+| `default` | Infer from `scan.snapshot-id`, `scan.timestamp-millis`, or `scan.timestamp`; otherwise use `latest-full` | Continue reading changes. |
 
 A simple example with default scan mode:
 
 ```scala
-// no any scan-related configs are provided, that will use latest-full scan mode.
+// With no startup options or saved progress, use latest-full.
 val query = spark.readStream
   .format("paimon")
   // by table name
-  .table("table_name") 
+  .table("paimon.default.stream_events")
   // or by location
   // .load("/path/to/paimon/source/table")
   .writeStream
   .format("console")
+  .option("checkpointLocation", "/tmp/paimon-checkpoints/stream-events-reader")
   .start()
 ```
+
+For primary key changes that include row kinds, see [Read Changelogs](#read-changelogs).
 
 ### Consumer progress
 
-You can assign a Paimon Consumer to a streaming query. The Consumer records a
-table-side, snapshot-level recovery position and acts as a fence during normal
-snapshot expiration. For tables with a decoupled changelog lifecycle, enabling
-`consumer.changelog-only` makes the Consumer protect long-lived changelogs
-instead of snapshots.
+See [Streaming Recovery](./streaming-recovery) for checkpoints, Consumer positions, replay, and
+retention. A Consumer is not a replacement for a Spark checkpoint.
 
-Configure the Consumer lifetime as a table property before starting the query:
+## Triggers and Read Limits
 
-```sql
-ALTER TABLE table_name SET TBLPROPERTIES (
-  'consumer.expiration-time' = '1 d'
-);
-```
+Limit the amount of input admitted to each micro-batch with these source options. Admission
+works on whole Paimon splits: a split can contain multiple files, and the byte or row threshold
+can be exceeded by the last admitted split. These settings do not impose exact output row or
+memory limits.
 
-```scala
-val query = spark.readStream
-  .format("paimon")
-  .option("consumer-id", "my-consumer")
-  .table("table_name")
-  .writeStream
-  .format("console")
-  .option("checkpointLocation", "/path/to/spark/checkpoint")
-  .start()
-```
+| Source option | Default | Meaning |
+| --- | --- | --- |
+| `read.stream.maxFilesPerTrigger` | Unset | Maximum admitted splits; the option name refers to files. |
+| `read.stream.maxBytesPerTrigger` | Unset | Soft threshold on admitted file bytes. |
+| `read.stream.maxRowsPerTrigger` | Unset | Soft threshold on admitted file row counts. |
+| `read.stream.minRowsPerTrigger` | Unset | Row-count target for delaying admission; use with `read.stream.maxTriggerDelayMs`. |
+| `read.stream.maxTriggerDelayMs` | Unset | Maximum waiting time in milliseconds when using the minimum-row limit. |
 
-Spark checkpoint and Paimon Consumer progress have different granularities:
+### Process Available Data and Stop
 
-- When the Spark checkpoint is available, Spark uses it for precise micro-batch
-  recovery.
-- A new query without that checkpoint starts from the Consumer position. This
-  recovery is conservative and may replay a completed snapshot if the query
-  failed after processing it but before updating the Consumer.
-
-Paimon updates the Consumer only from Spark's successful micro-batch commit
-callback. When a micro-batch ends partway through a delta snapshot, the Consumer
-may be created or refreshed at that snapshot so that the whole snapshot remains
-protected and can be replayed. The Consumer advances past a snapshot only after
-the micro-batch containing its last split is committed. A Consumer update failure
-is propagated, fails the running query, and leaves the Consumer at its previous
-conservative position.
-
-Spark never advances Consumer progress past an incomplete snapshot. An incomplete
-initial full snapshot does not create a Consumer because Consumer recovery from
-that snapshot would use a delta scan. `consumer.mode` does not select a different
-Spark source implementation.
-
-Offsets restored from an older Spark checkpoint do not contain snapshot
-completion metadata. Spark logs a warning and leaves the Consumer unchanged for
-those offsets rather than advancing it without proof that the snapshot finished.
-
-If the Consumer does not exist, the configured startup options are used. For
-example, the default `latest-full` mode first reads the full snapshot and creates
-the Consumer only after that snapshot is completely committed. If the Consumer
-already exists, its next snapshot takes precedence over startup options and is
-read incrementally, unless `consumer.ignore-progress` is enabled.
-
-:::note
-
-Spark can invoke the source commit callback while constructing a later
-micro-batch. Therefore the Consumer may temporarily lag behind the latest
-successful batch, especially while a query is idle or after its final available
-batch. This is safe and can only cause conservative replay.
-
-:::
-
-Consumer files are scoped to the branch being read. Use one active Spark query
-for each `(table, branch, consumer-id)` combination. Concurrent queries sharing
-the same Consumer are unsupported because a faster query could move the shared
-position past data still needed by a slower query.
-
-Configure `consumer.expiration-time` according to the longest expected snapshot
-processing time, failure recovery time, and idle interval. Eligible Spark source
-commit callbacks refresh the Consumer file, but there is no separate timer-based
-Spark heartbeat. Expired Consumer files are cleaned by non-write-only table
-commits. A write-only writer does not perform Consumer expiration, so stale
-Consumer IDs must be managed explicitly or by a separate non-write-only
-maintenance process.
-
-An initial full scan has no Consumer retention fence until it completes, so
-snapshot retention should be long enough for that scan. If its snapshot expires
-first, a restart without a Spark checkpoint performs a new initial full scan
-according to the startup options.
-
-When expired data would force recovery of a logged Spark batch to switch between
-a full and an incremental scan, Paimon fails the query instead of combining the
-two plans. Start a new query with a new checkpoint to apply the startup options
-again.
-
-Paimon Structured Streaming also supports a variety of streaming read modes, it can support many triggers and many read limits.
-
-These read limits are supported:
-
-<table class="configuration table table-bordered">
-    <thead>
-        <tr>
-            <th class="text-left" style="width: 20%">Key</th>
-            <th class="text-left" style="width: 15%">Default</th>
-            <th class="text-left" style="width: 10%">Type</th>
-            <th class="text-left" style="width: 55%">Description</th>
-        </tr>
-    </thead>
-    <tbody>
-        <tr>
-            <td><h5>read.stream.maxFilesPerTrigger</h5></td>
-            <td style="word-wrap: break-word;">(none)</td>
-            <td>Integer</td>
-            <td>The maximum number of files returned in a single batch.</td>
-        </tr>
-        <tr>
-            <td><h5>read.stream.maxBytesPerTrigger</h5></td>
-            <td style="word-wrap: break-word;">(none)</td>
-            <td>Long</td>
-            <td>The maximum number of bytes returned in a single batch.</td>
-        </tr>
-        <tr>
-            <td><h5>read.stream.maxRowsPerTrigger</h5></td>
-            <td style="word-wrap: break-word;">(none)</td>
-            <td>Long</td>
-            <td>The maximum number of rows returned in a single batch.</td>
-        </tr>
-        <tr>
-            <td><h5>read.stream.minRowsPerTrigger</h5></td>
-            <td style="word-wrap: break-word;">(none)</td>
-            <td>Long</td>
-            <td>The minimum number of rows returned in a single batch, which used to create MinRowsReadLimit with read.stream.maxTriggerDelayMs together.</td>
-        </tr>
-        <tr>
-            <td><h5>read.stream.maxTriggerDelayMs</h5></td>
-            <td style="word-wrap: break-word;">(none)</td>
-            <td>Long</td>
-            <td>The maximum delay between two adjacent batches, which used to create MinRowsReadLimit with read.stream.minRowsPerTrigger together.</td>
-        </tr>
-    </tbody>
-</table>
-
-**Example: One**
-
-Use `org.apache.spark.sql.streaming.Trigger.AvailableNow()` and `maxBytesPerTrigger` defined by paimon.
+`Trigger.AvailableNow()` processes data available when the query starts, in one or more batches,
+then stops. This example uses a 128 MiB admission threshold; a batch may exceed it by a split.
 
 ```scala
-// Trigger.AvailableNow()) processes all available data at the start
-// of the query in one or multiple batches, then terminates the query.
-// That set read.stream.maxBytesPerTrigger to 128M means that each
-// batch processes a maximum of 128 MB of data.
+import org.apache.spark.sql.streaming.Trigger
+
 val query = spark.readStream
   .format("paimon")
   .option("read.stream.maxBytesPerTrigger", "134217728")
   .table("table_name")
   .writeStream
   .format("console")
+  .option("checkpointLocation", "/path/to/checkpoints/available-now")
   .trigger(Trigger.AvailableNow())
   .start()
 ```
 
-**Example: Two**
+### Wait for More Rows
 
-Use `org.apache.spark.sql.connector.read.streaming.ReadMinRows`.
+Use a 5,000-row target with a maximum delay of 300 seconds:
 
 ```scala
-// It will not trigger a batch until there are more than 5,000 pieces of data,
-// unless the interval between the two batches is more than 300 seconds.
 val query = spark.readStream
   .format("paimon")
   .option("read.stream.minRowsPerTrigger", "5000")
@@ -285,10 +155,11 @@ val query = spark.readStream
   .table("table_name")
   .writeStream
   .format("console")
+  .option("checkpointLocation", "/path/to/checkpoints/min-rows")
   .start()
 ```
 
-### Written Columns of a Micro-Batch
+## Written Columns of a Micro-Batch
 
 `foreachBatch` consumers can inspect which Paimon field IDs were written by the data files admitted to the current micro-batch. Call `PaimonSparkMicroBatchMetadata.writtenColumnIds` with the raw `Dataset` passed to `foreachBatch`. Paimon resolves the file metadata lazily when this method is called.
 
@@ -317,34 +188,29 @@ A present `Optional` contains the complete, immutable list of written field IDs 
 
 An empty `Optional` means that metadata is unavailable, for example because a file or schema cannot be resolved, the micro-batch is empty, the `Dataset` is not the raw batch from a query with exactly one distinct Paimon streaming source, or its lineage is incomplete or ambiguous. An empty `Optional` does not mean that no columns were written; callers must fall back to processing all columns.
 
-Paimon Structured Streaming supports read row in the form of changelog (add rowkind column in row to represent its
-change type) in two ways:
+## Read Changelogs
 
-- Direct streaming read with the system audit_log table
-- Set `read.changelog` to true (default is false), then streaming read with table location
-
-**Example:**
+Expose a row-kind column to distinguish inserts, updates, and deletes. Use either the system
+`$audit_log` table through the catalog, or `read.changelog=true` when reading by table location.
+Choose one source form:
 
 ```scala
-// Option 1
-val query1 = spark.readStream
+// Catalog table: use the audit_log system table.
+val changesByName = spark.readStream
   .format("paimon")
   .table("`table_name$audit_log`")
-  .writeStream
-  .format("console")
-  .start()
 
-// Option 2
-val query2 = spark.readStream
+// Table location: read.changelog is applied by the path-based source.
+val changesByPath = spark.readStream
   .format("paimon")
   .option("read.changelog", "true")
-  .table("table_name")
-  .writeStream
-  .format("console")
-  .start()
+  .load("/path/to/paimon/source/table")
 
-/*
-+I   1  Hi
-+I   2  Hello
-*/
+val query = changesByName.writeStream
+  .format("console")
+  .option("checkpointLocation", "/path/to/checkpoints/changelog")
+  .start()
 ```
+
+This exposes the available changes; it does not configure the table to produce a complete
+changelog. See [Changelog Producers](../primary-key-table/changelog-producer) for production modes.

--- a/docs/sidebars.js
+++ b/docs/sidebars.js
@@ -248,16 +248,68 @@ const sidebars = {
     },
     "items": [
       "spark/quick-start",
-      "spark/sql-ddl",
-      "spark/sql-functions",
-      "spark/sql-write",
-      "spark/sql-query",
-      "spark/sql-alter",
-      "spark/auxiliary",
-      "spark/default-value",
-      "spark/dataframe",
-      "spark/structured-streaming",
-      "spark/procedures"
+      {
+        "type": "category",
+        "label": "Setup and Configuration",
+        "items": [
+          "spark/installation",
+          "spark/catalogs",
+          "spark/configuration"
+        ]
+      },
+      {
+        "type": "category",
+        "label": "Tables and Schemas",
+        "items": [
+          "spark/sql-ddl",
+          "spark/sql-alter",
+          "spark/format-table",
+          "spark/data-types",
+          "spark/default-value"
+        ]
+      },
+      {
+        "type": "category",
+        "label": "Reading and Writing",
+        "items": [
+          "spark/sql-query",
+          "spark/sql-write",
+          "spark/dataframe",
+          "spark/copy-into",
+          "spark/schema-evolution",
+          "spark/sql-functions"
+        ]
+      },
+      {
+        "type": "category",
+        "label": "Streaming",
+        "items": [
+          "spark/structured-streaming",
+          "spark/streaming-recovery"
+        ]
+      },
+      {
+        "type": "category",
+        "label": "Operations",
+        "items": [
+          "spark/auxiliary",
+          {
+            "type": "category",
+            "label": "Procedures",
+            "link": {
+              "type": "doc",
+              "id": "spark/procedures"
+            },
+            "items": [
+              "spark/procedures/maintenance",
+              "spark/procedures/versions",
+              "spark/procedures/migration",
+              "spark/procedures/indexes",
+              "spark/procedures/metadata"
+            ]
+          }
+        ]
+      }
     ]
   },
   {

--- a/docs/static/img/spark-dataframe-alignment.svg
+++ b/docs/static/img/spark-dataframe-alignment.svg
@@ -1,0 +1,43 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="900" height="485" viewBox="0 0 900 485" role="img" aria-labelledby="title desc">
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+<title id="title">Column names or column positions?</title>
+<desc id="desc">A source row has columns b and a, with values B and A. Inserting it into target columns a and b by position stores B and A. Appending with saveAsTable aligns names and stores A and B. Select target columns explicitly before positional writes.</desc>
+<defs><marker id="arrow" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto"><path d="M 0 0 L 10 5 L 0 10 z" fill="#526277"/></marker></defs>
+<g font-family="Arial, Helvetica, sans-serif">
+<rect x="1" y="1" width="898" height="483" rx="12" fill="#ffffff" stroke="#d7dfeb" stroke-width="1.5"/>
+<text x="28" y="43" font-size="27" fill="#172b4d" font-weight="700" text-anchor="start">Column names or column positions?</text>
+<text x="28" y="77" font-size="18" fill="#526277" font-weight="400" text-anchor="start">The same source row can produce different results in a table with columns (a, b)</text>
+<rect x="260" y="103" width="380" height="90" rx="8" fill="#f5f7fb" stroke="#d7dfeb" stroke-width="1.5"/>
+<text x="450" y="133" font-size="21" fill="#172b4d" font-weight="700" text-anchor="middle">Source DataFrame</text>
+<text x="450" y="169" font-size="23" fill="#2463b4" font-weight="700" text-anchor="middle">b = &quot;B&quot;     |     a = &quot;A&quot;</text>
+<path d="M 360 193 V 217 H 225 V 248" fill="none" stroke="#526277" stroke-width="2" marker-end="url(#arrow)"/>
+<path d="M 540 193 V 217 H 675 V 248" fill="none" stroke="#526277" stroke-width="2" marker-end="url(#arrow)"/>
+<rect x="28" y="257" width="394" height="142" rx="8" fill="#fff7e6" stroke="#946200" stroke-width="1.5"/>
+<text x="225" y="293" font-size="23" fill="#946200" font-weight="700" text-anchor="middle">insertInto</text>
+<text x="225" y="321" font-size="18" fill="#526277" font-weight="400" text-anchor="middle">By position</text>
+<text x="225" y="367" font-size="23" fill="#172b4d" font-weight="700" text-anchor="middle">a = &quot;B&quot;     |     b = &quot;A&quot;</text>
+<rect x="478" y="257" width="394" height="142" rx="8" fill="#e8f7f2" stroke="#087f6e" stroke-width="1.5"/>
+<text x="675" y="293" font-size="23" fill="#087f6e" font-weight="700" text-anchor="middle">saveAsTable · append</text>
+<text x="675" y="321" font-size="18" fill="#526277" font-weight="400" text-anchor="middle">By name</text>
+<text x="675" y="367" font-size="23" fill="#172b4d" font-weight="700" text-anchor="middle">a = &quot;A&quot;     |     b = &quot;B&quot;</text>
+<text x="28" y="439" font-size="18" fill="#526277" font-weight="400" text-anchor="start">Before insertInto or a default V1 path write, select columns in the target table order.</text>
+<text x="28" y="466" font-size="17" fill="#526277" font-weight="400" text-anchor="start">Example: source.select(&quot;a&quot;, &quot;b&quot;).write.mode(&quot;append&quot;).insertInto(&quot;target&quot;)</text>
+</g>
+</svg>

--- a/docs/static/img/spark-integration.svg
+++ b/docs/static/img/spark-integration.svg
@@ -1,0 +1,53 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="900" height="490" viewBox="0 0 900 490" role="img" aria-labelledby="title desc">
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+<title id="title">Spark and Paimon</title>
+<desc id="desc">Spark SQL, the DataFrame API, and Structured Streaming use the Paimon connector. The catalog resolves tables and metadata. Spark reads and writes table files in the warehouse.</desc>
+<defs><marker id="arrow" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto"><path d="M 0 0 L 10 5 L 0 10 z" fill="#526277"/></marker></defs>
+<g font-family="Arial, Helvetica, sans-serif">
+<rect x="1" y="1" width="898" height="488" rx="12" fill="#ffffff" stroke="#d7dfeb" stroke-width="1.5"/>
+<text x="28" y="43" font-size="27" fill="#172b4d" font-weight="700" text-anchor="start">Spark and Paimon</text>
+<text x="28" y="76" font-size="18" fill="#526277" font-weight="400" text-anchor="start">One connector · three entry points · a shared table format</text>
+<rect x="28" y="110" width="268" height="82" rx="8" fill="#eaf2ff" stroke="#2463b4" stroke-width="1.5"/>
+<text x="162" y="144" font-size="22" fill="#2463b4" font-weight="700" text-anchor="middle">Spark SQL</text>
+<text x="162" y="174" font-size="17" fill="#526277" font-weight="400" text-anchor="middle">DDL, queries, writes</text>
+<path d="M 162 192 V 230" fill="none" stroke="#526277" stroke-width="2" marker-end="url(#arrow)"/>
+<rect x="316" y="110" width="268" height="82" rx="8" fill="#eaf2ff" stroke="#2463b4" stroke-width="1.5"/>
+<text x="450" y="144" font-size="22" fill="#2463b4" font-weight="700" text-anchor="middle">DataFrame API</text>
+<text x="450" y="174" font-size="17" fill="#526277" font-weight="400" text-anchor="middle">Scala reads and writes</text>
+<path d="M 450 192 V 230" fill="none" stroke="#526277" stroke-width="2" marker-end="url(#arrow)"/>
+<rect x="604" y="110" width="268" height="82" rx="8" fill="#eaf2ff" stroke="#2463b4" stroke-width="1.5"/>
+<text x="738" y="144" font-size="22" fill="#2463b4" font-weight="700" text-anchor="middle">Structured Streaming</text>
+<text x="738" y="174" font-size="17" fill="#526277" font-weight="400" text-anchor="middle">Micro-batch sources and sinks</text>
+<path d="M 738 192 V 230" fill="none" stroke="#526277" stroke-width="2" marker-end="url(#arrow)"/>
+<rect x="28" y="238" width="844" height="85" rx="8" fill="#e8f7f2" stroke="#087f6e" stroke-width="1.5"/>
+<text x="450" y="272" font-size="24" fill="#087f6e" font-weight="700" text-anchor="middle">Paimon Spark connector</text>
+<text x="450" y="301" font-size="19" fill="#526277" font-weight="400" text-anchor="middle">SQL extensions · planning · scans · writes · commits</text>
+<path d="M 222 323 V 371" fill="none" stroke="#526277" stroke-width="2" marker-end="url(#arrow)"/>
+<path d="M 676 323 V 371" fill="none" stroke="#526277" stroke-width="2" marker-end="url(#arrow)"/>
+<text x="237" y="354" font-size="17" fill="#526277" font-weight="400" text-anchor="start">resolve tables</text>
+<text x="691" y="354" font-size="17" fill="#526277" font-weight="400" text-anchor="start">read / write</text>
+<rect x="28" y="380" width="390" height="82" rx="8" fill="#f5f7fb" stroke="#d7dfeb" stroke-width="1.5"/>
+<text x="223" y="412" font-size="22" fill="#172b4d" font-weight="700" text-anchor="middle">Catalog</text>
+<text x="223" y="441" font-size="18" fill="#526277" font-weight="400" text-anchor="middle">Filesystem · Hive · JDBC · REST</text>
+<rect x="448" y="380" width="424" height="82" rx="8" fill="#f5f7fb" stroke="#d7dfeb" stroke-width="1.5"/>
+<text x="660" y="412" font-size="22" fill="#172b4d" font-weight="700" text-anchor="middle">Warehouse</text>
+<text x="660" y="441" font-size="17" fill="#526277" font-weight="400" text-anchor="middle">Table metadata, snapshots, and data files</text>
+</g>
+</svg>

--- a/docs/static/img/spark-partition-overwrite.svg
+++ b/docs/static/img/spark-partition-overwrite.svg
@@ -1,0 +1,58 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="900" height="485" viewBox="0 0 900 485" role="img" aria-labelledby="title desc">
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+<title id="title">Partition overwrite scope</title>
+<desc id="desc">Every example starts with row 1 in partition p1 and row 2 in partition p2, then writes row 3 to p1. Static overwrite without a partition filter removes p2. Static overwrite for p1 and dynamic overwrite both preserve p2.</desc>
+<defs><marker id="arrow" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto"><path d="M 0 0 L 10 5 L 0 10 z" fill="#526277"/></marker></defs>
+<g font-family="Arial, Helvetica, sans-serif">
+<rect x="1" y="1" width="898" height="483" rx="12" fill="#ffffff" stroke="#d7dfeb" stroke-width="1.5"/>
+<text x="28" y="43" font-size="27" fill="#172b4d" font-weight="700" text-anchor="start">Partition overwrite scope</text>
+<text x="28" y="77" font-size="18" fill="#526277" font-weight="400" text-anchor="start">Each case starts with the same table and writes one new row to p1</text>
+<rect x="28" y="103" width="844" height="70" rx="8" fill="#f5f7fb" stroke="#d7dfeb" stroke-width="1.5"/>
+<text x="48" y="145" font-size="19" fill="#172b4d" font-weight="700" text-anchor="start">Before:</text>
+<text x="137" y="145" font-size="20" fill="#526277" font-weight="400" text-anchor="start">p1 → row 1   |   p2 → row 2</text>
+<text x="540" y="145" font-size="20" fill="#2463b4" font-weight="700" text-anchor="start">Input: p1 → row 3</text>
+<path d="M 162 173 V 213" fill="none" stroke="#526277" stroke-width="2" marker-end="url(#arrow)"/>
+<rect x="28" y="222" width="268" height="183" rx="8" fill="#f5f7fb" stroke="#d7dfeb" stroke-width="1.5"/>
+<text x="162" y="254" font-size="22" fill="#172b4d" font-weight="700" text-anchor="middle">Static</text>
+<text x="162" y="282" font-size="17" fill="#526277" font-weight="400" text-anchor="middle">No partition filter</text>
+<rect x="46" y="300" width="232" height="39" rx="8" fill="#e8f7f2" stroke="#b8dcd2" stroke-width="1.5"/>
+<text x="162" y="326" font-size="20" fill="#087f6e" font-weight="700" text-anchor="middle">p1 → row 3</text>
+<rect x="46" y="350" width="232" height="39" rx="8" fill="#fff7e6" stroke="#e4cb92" stroke-width="1.5"/>
+<text x="162" y="376" font-size="20" fill="#946200" font-weight="700" text-anchor="middle">p2 removed</text>
+<path d="M 450 173 V 213" fill="none" stroke="#526277" stroke-width="2" marker-end="url(#arrow)"/>
+<rect x="316" y="222" width="268" height="183" rx="8" fill="#f5f7fb" stroke="#d7dfeb" stroke-width="1.5"/>
+<text x="450" y="254" font-size="22" fill="#172b4d" font-weight="700" text-anchor="middle">Static</text>
+<text x="450" y="282" font-size="17" fill="#526277" font-weight="400" text-anchor="middle">PARTITION (pt = &#x27;p1&#x27;)</text>
+<rect x="334" y="300" width="232" height="39" rx="8" fill="#e8f7f2" stroke="#b8dcd2" stroke-width="1.5"/>
+<text x="450" y="326" font-size="20" fill="#087f6e" font-weight="700" text-anchor="middle">p1 → row 3</text>
+<rect x="334" y="350" width="232" height="39" rx="8" fill="#eaf2ff" stroke="#bfd2ed" stroke-width="1.5"/>
+<text x="450" y="376" font-size="20" fill="#2463b4" font-weight="700" text-anchor="middle">p2 → row 2</text>
+<path d="M 738 173 V 213" fill="none" stroke="#526277" stroke-width="2" marker-end="url(#arrow)"/>
+<rect x="604" y="222" width="268" height="183" rx="8" fill="#f5f7fb" stroke="#d7dfeb" stroke-width="1.5"/>
+<text x="738" y="254" font-size="22" fill="#172b4d" font-weight="700" text-anchor="middle">Dynamic</text>
+<text x="738" y="282" font-size="17" fill="#526277" font-weight="400" text-anchor="middle">Partitions present in input</text>
+<rect x="622" y="300" width="232" height="39" rx="8" fill="#e8f7f2" stroke="#b8dcd2" stroke-width="1.5"/>
+<text x="738" y="326" font-size="20" fill="#087f6e" font-weight="700" text-anchor="middle">p1 → row 3</text>
+<rect x="622" y="350" width="232" height="39" rx="8" fill="#eaf2ff" stroke="#bfd2ed" stroke-width="1.5"/>
+<text x="738" y="376" font-size="20" fill="#2463b4" font-weight="700" text-anchor="middle">p2 → row 2</text>
+<text x="28" y="443" font-size="17" fill="#526277" font-weight="400" text-anchor="start">Empty input: static overwrite clears its selected scope; dynamic overwrite replaces no partitions.</text>
+<text x="28" y="467" font-size="17" fill="#526277" font-weight="400" text-anchor="start">Set spark.sql.sources.partitionOverwriteMode explicitly when switching between these cases.</text>
+</g>
+</svg>

--- a/docs/static/img/spark-read-scopes.svg
+++ b/docs/static/img/spark-read-scopes.svg
@@ -1,0 +1,73 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="900" height="490" viewBox="0 0 900 490" role="img" aria-labelledby="title desc">
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+<title id="title">Choose the scope of a read</title>
+<desc id="desc">A snapshot query reads the complete table state at one snapshot. A bounded incremental query uses an exclusive start and inclusive end. A latest-full stream reads initial state and subsequent changes. Incremental output depends on scan mode and commit kind.</desc>
+<defs><marker id="arrow" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto"><path d="M 0 0 L 10 5 L 0 10 z" fill="#526277"/></marker></defs>
+<g font-family="Arial, Helvetica, sans-serif">
+<rect x="1" y="1" width="898" height="488" rx="12" fill="#ffffff" stroke="#d7dfeb" stroke-width="1.5"/>
+<text x="28" y="43" font-size="27" fill="#172b4d" font-weight="700" text-anchor="start">Choose the scope of a read</text>
+<text x="28" y="76" font-size="18" fill="#526277" font-weight="400" text-anchor="start">Table state and change intervals answer different questions</text>
+<text x="28" y="144" font-size="22" fill="#172b4d" font-weight="700" text-anchor="start">Snapshot</text>
+<text x="28" y="173" font-size="17" fill="#526277" font-weight="400" text-anchor="start">One table state</text>
+<text x="28" y="254" font-size="22" fill="#172b4d" font-weight="700" text-anchor="start">Incremental</text>
+<text x="28" y="283" font-size="17" fill="#526277" font-weight="400" text-anchor="start">Bounded changes</text>
+<text x="28" y="364" font-size="22" fill="#172b4d" font-weight="700" text-anchor="start">Streaming</text>
+<text x="28" y="393" font-size="17" fill="#526277" font-weight="400" text-anchor="start">latest-full startup</text>
+<path d="M 250 143 H 858" fill="none" stroke="#526277" stroke-width="2" marker-end="url(#arrow)"/>
+<path d="M 250 253 H 858" fill="none" stroke="#526277" stroke-width="2" marker-end="url(#arrow)"/>
+<path d="M 250 363 H 858" fill="none" stroke="#526277" stroke-width="2" marker-end="url(#arrow)"/>
+<rect x="250" y="119" width="66" height="48" rx="8" fill="#f5f7fb" stroke="#d7dfeb" stroke-width="1.5"/>
+<text x="283" y="149" font-size="20" fill="#526277" font-weight="400" text-anchor="middle">S5</text>
+<rect x="382" y="119" width="66" height="48" rx="8" fill="#f5f7fb" stroke="#d7dfeb" stroke-width="1.5"/>
+<text x="415" y="149" font-size="20" fill="#526277" font-weight="400" text-anchor="middle">S6</text>
+<rect x="514" y="119" width="66" height="48" rx="8" fill="#f5f7fb" stroke="#d7dfeb" stroke-width="1.5"/>
+<text x="547" y="149" font-size="20" fill="#526277" font-weight="400" text-anchor="middle">S7</text>
+<rect x="646" y="119" width="66" height="48" rx="8" fill="#e8f7f2" stroke="#087f6e" stroke-width="1.5"/>
+<text x="679" y="149" font-size="20" fill="#087f6e" font-weight="700" text-anchor="middle">S8</text>
+<rect x="778" y="119" width="66" height="48" rx="8" fill="#f5f7fb" stroke="#d7dfeb" stroke-width="1.5"/>
+<text x="811" y="149" font-size="20" fill="#526277" font-weight="400" text-anchor="middle">S9</text>
+<text x="679" y="194" font-size="17" fill="#087f6e" font-weight="700" text-anchor="middle">full state</text>
+<rect x="375" y="225" width="344" height="55" rx="8" fill="#e8f7f2" stroke="#b8dcd2" stroke-width="1.5"/>
+<rect x="250" y="229" width="66" height="48" rx="8" fill="#ffffff" stroke="#d7dfeb" stroke-width="1.5"/>
+<text x="283" y="259" font-size="20" fill="#526277" font-weight="400" text-anchor="middle">S5</text>
+<rect x="382" y="229" width="66" height="48" rx="8" fill="#ffffff" stroke="#087f6e" stroke-width="1.5"/>
+<text x="415" y="259" font-size="20" fill="#087f6e" font-weight="400" text-anchor="middle">S6</text>
+<rect x="514" y="229" width="66" height="48" rx="8" fill="#ffffff" stroke="#087f6e" stroke-width="1.5"/>
+<text x="547" y="259" font-size="20" fill="#087f6e" font-weight="400" text-anchor="middle">S7</text>
+<rect x="646" y="229" width="66" height="48" rx="8" fill="#ffffff" stroke="#087f6e" stroke-width="1.5"/>
+<text x="679" y="259" font-size="20" fill="#087f6e" font-weight="400" text-anchor="middle">S8</text>
+<rect x="778" y="229" width="66" height="48" rx="8" fill="#ffffff" stroke="#d7dfeb" stroke-width="1.5"/>
+<text x="811" y="259" font-size="20" fill="#526277" font-weight="400" text-anchor="middle">S9</text>
+<text x="283" y="308" font-size="16" fill="#526277" font-weight="400" text-anchor="middle">start excluded</text>
+<text x="679" y="308" font-size="16" fill="#087f6e" font-weight="400" text-anchor="middle">end included</text>
+<rect x="250" y="339" width="66" height="48" rx="8" fill="#e8f7f2" stroke="#087f6e" stroke-width="1.5"/>
+<text x="283" y="369" font-size="20" fill="#087f6e" font-weight="700" text-anchor="middle">S8</text>
+<rect x="382" y="339" width="66" height="48" rx="8" fill="#eaf2ff" stroke="#2463b4" stroke-width="1.5"/>
+<text x="415" y="369" font-size="20" fill="#2463b4" font-weight="700" text-anchor="middle">S9</text>
+<rect x="514" y="339" width="66" height="48" rx="8" fill="#eaf2ff" stroke="#2463b4" stroke-width="1.5"/>
+<text x="547" y="369" font-size="20" fill="#2463b4" font-weight="700" text-anchor="middle">S10</text>
+<rect x="646" y="339" width="66" height="48" rx="8" fill="#eaf2ff" stroke="#2463b4" stroke-width="1.5"/>
+<text x="679" y="369" font-size="20" fill="#2463b4" font-weight="700" text-anchor="middle">S11</text>
+<text x="811" y="369" font-size="24" fill="#2463b4" font-weight="700" text-anchor="middle">…</text>
+<text x="283" y="418" font-size="16" fill="#087f6e" font-weight="400" text-anchor="middle">initial full state</text>
+<text x="546" y="418" font-size="17" fill="#2463b4" font-weight="400" text-anchor="middle">then keep reading changes</text>
+<text x="28" y="460" font-size="17" fill="#526277" font-weight="400" text-anchor="start">Incremental output depends on scan mode and commit kind; it is not a replay of every commit.</text>
+</g>
+</svg>

--- a/docs/static/img/spark-streaming-recovery.svg
+++ b/docs/static/img/spark-streaming-recovery.svg
@@ -1,0 +1,49 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="900" height="540" viewBox="0 0 900 540" role="img" aria-labelledby="title desc">
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+<title id="title">Two recovery positions</title>
+<desc id="desc">A Spark checkpoint restores micro-batch progress. Without that checkpoint, an existing Paimon Consumer starts from a conservative snapshot position and may replay data. Without either, startup options apply. Partial delta snapshots remain protected, and an incomplete initial full snapshot has no Consumer fence.</desc>
+<defs><marker id="arrow" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto"><path d="M 0 0 L 10 5 L 0 10 z" fill="#526277"/></marker></defs>
+<g font-family="Arial, Helvetica, sans-serif">
+<rect x="1" y="1" width="898" height="538" rx="12" fill="#ffffff" stroke="#d7dfeb" stroke-width="1.5"/>
+<text x="28" y="43" font-size="27" fill="#172b4d" font-weight="700" text-anchor="start">Two recovery positions</text>
+<text x="28" y="76" font-size="18" fill="#526277" font-weight="400" text-anchor="start">Checkpoints record micro-batch progress; Consumers protect a conservative snapshot position</text>
+<rect x="300" y="105" width="300" height="60" rx="8" fill="#eaf2ff" stroke="#2463b4" stroke-width="1.5"/>
+<text x="450" y="143" font-size="21" fill="#2463b4" font-weight="700" text-anchor="middle">Restart a streaming query</text>
+<path d="M 380 165 V 189 H 225 V 225" fill="none" stroke="#526277" stroke-width="2" marker-end="url(#arrow)"/>
+<path d="M 520 165 V 189 H 675 V 225" fill="none" stroke="#526277" stroke-width="2" marker-end="url(#arrow)"/>
+<text x="225" y="182" font-size="18" fill="#2463b4" font-weight="700" text-anchor="middle">Checkpoint available</text>
+<text x="675" y="182" font-size="18" fill="#087f6e" font-weight="700" text-anchor="middle">New checkpoint</text>
+<rect x="28" y="234" width="394" height="93" rx="8" fill="#eaf2ff" stroke="#2463b4" stroke-width="1.5"/>
+<text x="225" y="268" font-size="23" fill="#2463b4" font-weight="700" text-anchor="middle">Restore Spark progress</text>
+<text x="225" y="299" font-size="18" fill="#526277" font-weight="400" text-anchor="middle">Use saved micro-batch offsets</text>
+<rect x="478" y="234" width="394" height="93" rx="8" fill="#e8f7f2" stroke="#087f6e" stroke-width="1.5"/>
+<text x="675" y="268" font-size="23" fill="#087f6e" font-weight="700" text-anchor="middle">Read Paimon Consumer</text>
+<text x="675" y="299" font-size="17" fill="#526277" font-weight="400" text-anchor="middle">If present and progress is not ignored</text>
+<path d="M 675 327 V 357" fill="none" stroke="#526277" stroke-width="2" marker-end="url(#arrow)"/>
+<rect x="478" y="366" width="394" height="79" rx="8" fill="#f5f7fb" stroke="#d7dfeb" stroke-width="1.5"/>
+<text x="675" y="398" font-size="21" fill="#172b4d" font-weight="700" text-anchor="middle">Resume at a snapshot boundary</text>
+<text x="675" y="427" font-size="18" fill="#526277" font-weight="400" text-anchor="middle">Conservative replay is possible</text>
+<rect x="28" y="366" width="394" height="79" rx="8" fill="#f5f7fb" stroke="#d7dfeb" stroke-width="1.5"/>
+<text x="225" y="398" font-size="21" fill="#172b4d" font-weight="700" text-anchor="middle">No saved position?</text>
+<text x="225" y="427" font-size="17" fill="#526277" font-weight="400" text-anchor="middle">Apply the configured startup scan mode</text>
+<text x="28" y="480" font-size="18" fill="#526277" font-weight="400" text-anchor="start">A partial delta snapshot stays protected until its final split is committed.</text>
+<text x="28" y="509" font-size="17" fill="#526277" font-weight="400" text-anchor="start">An incomplete initial full scan has no Consumer fence: size snapshot retention for that scan.</text>
+</g>
+</svg>


### PR DESCRIPTION
### Purpose

The Spark documentation has an empty landing page and mixes setup, schema evolution, streaming recovery, and procedure reference material into long pages. Organize the guides around setup, tables and schemas, reading and writing, streaming, and operations, with a runnable quick start and dedicated reference pages. Preserve existing page routes and section anchors when moving content.

Replace the procedure HTML table with categorized Markdown references, index all 48 registered procedures, and document parameter types and requiredness. Clarify SQL and DataFrame examples against the implementation and existing tests, including column alignment, overwrite scope, table replacement, default values, and streaming recovery. Add five editable SVG diagrams covering integration, read scopes, partition overwrite, DataFrame column alignment, and recovery.

### Tests

- Docusaurus production build passed with Node.js 22 after rebasing onto the latest master.
- REST OpenAPI validation passed: 56 catalog operations and 6 management operations.
- Local documentation validation checked 1,490 page, image, and anchor references; all original Spark section anchors and 42 procedure references were preserved.
- Audited all 48 registered procedure signatures and visually checked the rendered documentation and SVG diagrams.
- Focused Spark 3.5.8 smoke validation reproduced the reported complex string-default limitation, then executed all 17 SQL statements and verified the five result sets in `default-value.md`. This used the existing local connector artifact with the current default-value parsers recompiled from source. Explicit complex string inputs and preservation of stored values after `ALTER DEFAULT` also passed.
- `git diff --check` passed. No runtime code changes; the full Spark integration test suite was not run.
