### PR TITLE
[benchmark] Include parameter axes in lookup benchmark names

### DIFF
--- a/paimon-benchmark/paimon-micro-benchmarks/src/test/java/org/apache/paimon/benchmark/lookup/LookupReaderBenchmark.java
+++ b/paimon-benchmark/paimon-micro-benchmarks/src/test/java/org/apache/paimon/benchmark/lookup/LookupReaderBenchmark.java
@@ -81,7 +81,13 @@ public class LookupReaderBenchmark extends AbstractLookupBenchmark {
     private void readLookupDataBenchmark(byte[][] inputs, byte[][] randomInputs, boolean nullResult)
             throws IOException {
         Benchmark benchmark =
-                new Benchmark("reader-" + randomInputs.length, randomInputs.length)
+                new Benchmark(
+                                String.format(
+                                        "reader-%d-records-bloom-%s-%s",
+                                        recordCount,
+                                        bloomFilterEnabled,
+                                        nullResult ? "miss" : "hit"),
+                                randomInputs.length)
                         .setNumWarmupIters(1)
                         .setOutputPerIteration(true);
         for (int valueLength : VALUE_LENGTHS) {

--- a/paimon-benchmark/paimon-micro-benchmarks/src/test/java/org/apache/paimon/benchmark/lookup/LookupWriterBenchmark.java
+++ b/paimon-benchmark/paimon-micro-benchmarks/src/test/java/org/apache/paimon/benchmark/lookup/LookupWriterBenchmark.java
@@ -61,7 +61,13 @@ public class LookupWriterBenchmark extends AbstractLookupBenchmark {
 
     private void writeLookupDataBenchmark(byte[][] inputs, boolean sameValue) {
         Benchmark benchmark =
-                new Benchmark("writer-" + inputs.length, inputs.length)
+                new Benchmark(
+                                String.format(
+                                        "writer-%d-records-bloom-%s-%s",
+                                        inputs.length,
+                                        bloomFilterEnabled,
+                                        sameValue ? "same-value" : "diff-value"),
+                                inputs.length)
                         .setNumWarmupIters(1)
                         .setOutputPerIteration(true);
         for (int valueLength : VALUE_LENGTHS) {


### PR DESCRIPTION

### Purpose

- `mvn -pl paimon-benchmark/paimon-micro-benchmarks -Dtest=LookupReaderBenchmark test` prints 20 result tables (5 record counts x bloom on/off x hit/miss) whose header and every row read identically: `reader-10000` / `OPERATORTEST_reader-10000_read-<n>B-value-10000-num`. The JUnit display name `countBloom-[...]` only reaches the surefire XML/txt reports, so the console gives no way to tell which table is which.
- `LookupWriterBenchmark` likewise collapses its bloom on/off and same/diff-value tables into one label per record count.
- The `Benchmark` name now carries record count, bloom flag and hit/miss or same/diff-value, following `LocalKvDbBenchmark.benchmarkDescription()` (`%d-records-...-bloom-%s`) in the same package.

### Tests

- Label-only change: case labels, `valuesPerIteration`, iteration counts and the measured code path are unchanged, so no test is added. `mvn spotless:check -pl paimon-benchmark/paimon-micro-benchmarks` and `mvn -pl paimon-benchmark/paimon-micro-benchmarks -DskipTests clean verify` (JDK 11) passed; benchmarks were not executed (each parameter set writes up to 15M records).
