### PR TITLE
[codegen] Fix map equaliser for keys without value-based Java equality

### DIFF
--- a/paimon-codegen/src/main/scala/org/apache/paimon/codegen/ScalarOperatorGens.scala
+++ b/paimon-codegen/src/main/scala/org/apache/paimon/codegen/ScalarOperatorGens.scala
@@ -337,7 +337,7 @@ object ScalarOperatorGens {
         val mapDataUtil = className[InternalMapSerializer]
 
         val stmt =
-          if (containsFloatingPoint(keyType)) {
+          if (requiresElementWiseKeyMatch(keyType)) {
             val leftKeyArrayTerm = newName("leftKeyArray")
             val rightKeyArrayTerm = newName("rightKeyArray")
             val leftValueArrayTerm = newName("leftValueArray")
@@ -471,6 +471,19 @@ object ScalarOperatorGens {
       getNestedTypes(t).asScala.exists(containsFloatingPoint)
     case _ => false
   }
+
+  /**
+   * Whether map keys of the given type must be matched pairwise with the generated key equality
+   * instead of being looked up through a [[java.util.Map]].
+   *
+   * A [[java.util.Map]] lookup is only correct when the internal representation of the key has
+   * value-based `equals`/`hashCode`, which holds for numeric, character string, decimal and
+   * temporal keys. Binary keys are `byte[]` and compare by identity; composite keys may be columnar
+   * views without `hashCode` support or mix generic and binary representations across the two maps;
+   * floating-point keys need `Float.compare`/`Double.compare` semantics.
+   */
+  private def requiresElementWiseKeyMatch(keyType: DataType): Boolean =
+    containsFloatingPoint(keyType) || isBinaryString(keyType) || !isComparable(keyType)
 
   // ----------------------------------------------------------------------------------------------
 }

--- a/paimon-codegen/src/test/java/org/apache/paimon/codegen/EqualiserCodeGeneratorTest.java
+++ b/paimon-codegen/src/test/java/org/apache/paimon/codegen/EqualiserCodeGeneratorTest.java
@@ -50,6 +50,7 @@ import org.junit.jupiter.params.provider.EnumSource;
 
 import java.util.Arrays;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.ThreadLocalRandom;
@@ -418,6 +419,180 @@ public class EqualiserCodeGeneratorTest {
         assertThat(equaliser.equals(toBinaryRow.apply(left), toBinaryRow.apply(right)))
                 .as("equals(binary %s, binary %s)", left, right)
                 .isEqualTo(equal);
+    }
+
+    @Test
+    public void testBinaryKeyMapEqualiser() {
+        DataType mapType = DataTypes.MAP(DataTypes.BYTES(), DataTypes.INT());
+        RecordEqualiser equaliser =
+                new EqualiserCodeGenerator(new DataType[] {mapType})
+                        .generateRecordEqualiser("binaryKeyMapFieldEquals")
+                        .newInstance(Thread.currentThread().getContextClassLoader());
+
+        // byte[] keys with equal content but distinct identity must compare equal
+        assertMapEqualiser(
+                equaliser,
+                mapType,
+                new GenericMap(singletonMap("k1".getBytes(), 1)),
+                new GenericMap(singletonMap("k1".getBytes(), 1)),
+                true);
+        assertMapEqualiser(
+                equaliser,
+                mapType,
+                new GenericMap(singletonMap("k1".getBytes(), 1)),
+                new GenericMap(singletonMap("k2".getBytes(), 1)),
+                false);
+        assertMapEqualiser(
+                equaliser,
+                mapType,
+                new GenericMap(singletonMap("k1".getBytes(), 1)),
+                new GenericMap(singletonMap("k1".getBytes(), 2)),
+                false);
+
+        // multiple keys: same insertion order on both sides so that the serialized
+        // BinaryRow bytes are identical for the BinaryRow/BinaryRow fast path
+        Map<Object, Object> leftMap = new LinkedHashMap<>();
+        leftMap.put("k1".getBytes(), 1);
+        leftMap.put("k2".getBytes(), 2);
+        Map<Object, Object> rightMap = new LinkedHashMap<>();
+        rightMap.put("k1".getBytes(), 1);
+        rightMap.put("k2".getBytes(), 2);
+        assertMapEqualiser(
+                equaliser, mapType, new GenericMap(leftMap), new GenericMap(rightMap), true);
+
+        // entry order must not matter for the element-wise comparison
+        Map<Object, Object> reversedMap = new LinkedHashMap<>();
+        reversedMap.put("k2".getBytes(), 2);
+        reversedMap.put("k1".getBytes(), 1);
+        assertThat(
+                        equaliser.equals(
+                                GenericRow.of(new GenericMap(leftMap)),
+                                GenericRow.of(new GenericMap(reversedMap))))
+                .isTrue();
+
+        Map<Object, Object> differentValueMap = new LinkedHashMap<>();
+        differentValueMap.put("k1".getBytes(), 1);
+        differentValueMap.put("k2".getBytes(), 3);
+        assertMapEqualiser(
+                equaliser,
+                mapType,
+                new GenericMap(leftMap),
+                new GenericMap(differentValueMap),
+                false);
+    }
+
+    @Test
+    public void testBinaryElementMultisetEqualiser() {
+        DataType multisetType = DataTypes.MULTISET(DataTypes.BYTES());
+        RecordEqualiser equaliser =
+                new EqualiserCodeGenerator(new DataType[] {multisetType})
+                        .generateRecordEqualiser("binaryMultisetFieldEquals")
+                        .newInstance(Thread.currentThread().getContextClassLoader());
+
+        assertMapEqualiser(
+                equaliser,
+                multisetType,
+                new GenericMap(singletonMap("e1".getBytes(), 2)),
+                new GenericMap(singletonMap("e1".getBytes(), 2)),
+                true);
+        assertMapEqualiser(
+                equaliser,
+                multisetType,
+                new GenericMap(singletonMap("e1".getBytes(), 2)),
+                new GenericMap(singletonMap("e2".getBytes(), 2)),
+                false);
+        assertMapEqualiser(
+                equaliser,
+                multisetType,
+                new GenericMap(singletonMap("e1".getBytes(), 2)),
+                new GenericMap(singletonMap("e1".getBytes(), 3)),
+                false);
+    }
+
+    @Test
+    public void testRowKeyMapEqualiserAcrossRowRepresentations() {
+        DataType mapType = DataTypes.MAP(DataTypes.ROW(DataTypes.INT()), DataTypes.INT());
+        RecordEqualiser equaliser =
+                new EqualiserCodeGenerator(new DataType[] {mapType})
+                        .generateRecordEqualiser("rowKeyMapFieldEquals")
+                        .newInstance(Thread.currentThread().getContextClassLoader());
+
+        // a binary side yields NestedRow keys while the generic side yields GenericRow keys
+        assertMapEqualiser(
+                equaliser,
+                mapType,
+                new GenericMap(singletonMap(GenericRow.of(1), 10)),
+                new GenericMap(singletonMap(GenericRow.of(1), 10)),
+                true);
+        assertMapEqualiser(
+                equaliser,
+                mapType,
+                new GenericMap(singletonMap(GenericRow.of(1), 10)),
+                new GenericMap(singletonMap(GenericRow.of(2), 10)),
+                false);
+        assertMapEqualiser(
+                equaliser,
+                mapType,
+                new GenericMap(singletonMap(GenericRow.of(1), 10)),
+                new GenericMap(singletonMap(GenericRow.of(1), 11)),
+                false);
+    }
+
+    @Test
+    public void testIntKeyMapEqualiserIgnoresEntryOrder() {
+        DataType mapType = DataTypes.MAP(DataTypes.INT(), DataTypes.INT());
+        RecordEqualiser equaliser =
+                new EqualiserCodeGenerator(new DataType[] {mapType})
+                        .generateRecordEqualiser("intKeyMapFieldEquals")
+                        .newInstance(Thread.currentThread().getContextClassLoader());
+
+        Map<Object, Object> leftMap = new LinkedHashMap<>();
+        leftMap.put(1, 10);
+        leftMap.put(2, 20);
+        Map<Object, Object> reversedMap = new LinkedHashMap<>();
+        reversedMap.put(2, 20);
+        reversedMap.put(1, 10);
+        assertThat(
+                        equaliser.equals(
+                                GenericRow.of(new GenericMap(leftMap)),
+                                GenericRow.of(new GenericMap(reversedMap))))
+                .isTrue();
+        assertMapEqualiser(
+                equaliser, mapType, new GenericMap(leftMap), new GenericMap(leftMap), true);
+
+        Map<Object, Object> differentValueMap = new LinkedHashMap<>();
+        differentValueMap.put(1, 10);
+        differentValueMap.put(2, 21);
+        assertMapEqualiser(
+                equaliser,
+                mapType,
+                new GenericMap(leftMap),
+                new GenericMap(differentValueMap),
+                false);
+    }
+
+    private static Map<Object, Object> singletonMap(Object key, Object value) {
+        Map<Object, Object> map = new HashMap<>();
+        map.put(key, value);
+        return map;
+    }
+
+    private static void assertMapEqualiser(
+            RecordEqualiser equaliser,
+            DataType mapType,
+            GenericMap left,
+            GenericMap right,
+            boolean equal) {
+        Serializer<?> serializer = InternalSerializers.create(mapType);
+        Function<GenericMap, BinaryRow> toBinaryRow =
+                value -> {
+                    BinaryRow row = new BinaryRow(1);
+                    BinaryRowWriter writer = new BinaryRowWriter(row);
+                    BinaryWriter.write(writer, 0, value, mapType, serializer);
+                    writer.complete();
+                    return row;
+                };
+        assertBoolean(equaliser, toBinaryRow, left, right, equal);
     }
 
     @RepeatedTest(100)


### PR DESCRIPTION
### Purpose

fix #9737

- The generated map/multiset equality returned `false` for equal maps with BINARY/VARBINARY/GEOMETRY/GEOGRAPHY or composite (ROW/ARRAY) keys, so `changelog-producer.row-deduplicate` emitted `-U`/`+U` for unchanged rows.
- Cause: `generateMapComparison` only matched keys pairwise for floating-point keys and otherwise used `java.util.HashMap` lookups, where `byte[]` keys compare by identity.
- Fix: extend the element-wise key matching introduced in #8534 to binary and non-comparable key types (`requiresElementWiseKeyMatch`); generated code and the `BinaryRow` fast path are unchanged.
- Composite keys go pairwise too: the two maps may mix generic/binary representations (`GenericRow` vs `NestedRow`), and `ColumnarRow` has no `hashCode`.

### Tests

- Added `EqualiserCodeGeneratorTest#testBinaryKeyMapEqualiser`, `#testBinaryElementMultisetEqualiser`, `#testRowKeyMapEqualiserAcrossRowRepresentations` (fail before the fix) and `#testIntKeyMapEqualiserIgnoresEntryOrder` (regression control for the `HashMap` path).
- `mvn -pl paimon-codegen -DfailIfNoTests=false clean install` — checkstyle, spotless-check, enforcer and surefire passed; 231 tests, 0 failures.
- Cross-module: rebuilt `paimon-codegen-loader` with the fix; `paimon-core` `CodeGenUtilsTest` and `LookupChangelogMergeFunctionWrapperTest` — 23 tests, 0 failures.
