### PR TITLE
[core] Push partition and bucket filters into the uncached manifest read path

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/manifest/ManifestEntryCache.java
+++ b/paimon-core/src/main/java/org/apache/paimon/manifest/ManifestEntryCache.java
@@ -65,13 +65,49 @@ import static org.apache.paimon.manifest.ManifestEntrySerializer.totalBucketGett
 @ThreadSafe
 public class ManifestEntryCache extends ObjectsCache<Path, ManifestEntry, ManifestEntrySegments> {
 
+    @Nullable private final FilteredReader filteredReader;
+
     public ManifestEntryCache(
             SegmentsCache<Path> cache,
             ObjectSerializer<ManifestEntry> projectedSerializer,
             RowType formatSchema,
             FunctionWithIOException<Path, Long> fileSizeFunction,
             BiFunctionWithIOE<Path, Long, CloseableIterator<InternalRow>> reader) {
+        this(cache, projectedSerializer, formatSchema, fileSizeFunction, reader, null);
+    }
+
+    public ManifestEntryCache(
+            SegmentsCache<Path> cache,
+            ObjectSerializer<ManifestEntry> projectedSerializer,
+            RowType formatSchema,
+            FunctionWithIOException<Path, Long> fileSizeFunction,
+            BiFunctionWithIOE<Path, Long, CloseableIterator<InternalRow>> reader,
+            @Nullable FilteredReader filteredReader) {
         super(cache, projectedSerializer, formatSchema, fileSizeFunction, reader);
+        this.filteredReader = filteredReader;
+    }
+
+    /** Uncached reads skip non-matching partitions and buckets before decoding their stats. */
+    @Override
+    protected CloseableIterator<InternalRow> createFilteredIterator(
+            Path path, @Nullable Long fileSize, Filters<ManifestEntry> filters) throws IOException {
+        if (filteredReader != null && filters instanceof ManifestEntryFilters) {
+            ManifestEntryFilters manifestFilters = (ManifestEntryFilters) filters;
+            return filteredReader.read(
+                    path, fileSize, manifestFilters.partitionFilter, manifestFilters.bucketFilter);
+        }
+        return super.createFilteredIterator(path, fileSize, filters);
+    }
+
+    /** Reader of manifest rows which can skip entries by partition and bucket while decoding. */
+    @FunctionalInterface
+    public interface FilteredReader {
+        CloseableIterator<InternalRow> read(
+                Path path,
+                @Nullable Long fileSize,
+                @Nullable PartitionPredicate partitionFilter,
+                @Nullable BucketFilter bucketFilter)
+                throws IOException;
     }
 
     @Override

--- a/paimon-core/src/main/java/org/apache/paimon/manifest/ManifestFile.java
+++ b/paimon-core/src/main/java/org/apache/paimon/manifest/ManifestFile.java
@@ -91,7 +91,18 @@ public class ManifestFile extends ObjectsFile<ManifestEntry> {
     protected ManifestEntryCache createCache(
             @Nullable SegmentsCache<Path> cache, RowType formatType) {
         return new ManifestEntryCache(
-                cache, serializer, formatType, super::fileSize, this::createIterator);
+                cache,
+                serializer,
+                formatType,
+                super::fileSize,
+                this::createIterator,
+                (path, fileSize, partitionFilter, bucketFilter) ->
+                        createManifestIterator(
+                                fileIO,
+                                path,
+                                ManifestEntry.MANIFEST_ROW_TYPE,
+                                partitionFilter,
+                                bucketFilter));
     }
 
     @Override

--- a/paimon-core/src/main/java/org/apache/paimon/utils/ObjectsCache.java
+++ b/paimon-core/src/main/java/org/apache/paimon/utils/ObjectsCache.java
@@ -90,13 +90,19 @@ public abstract class ObjectsCache<K, V, S extends Segments> {
                 return readFromSegments(segments, filters, convertor);
             } else {
                 return readFromIterator(
-                        reader.apply(key, fileSize),
+                        createFilteredIterator(key, fileSize, filters),
                         projectedSerializer,
                         filters.readFilter(),
                         filters.readVFilter(),
                         convertor);
             }
         }
+    }
+
+    /** Iterator for a file too large to cache; subclasses may push {@code filters} into it. */
+    protected CloseableIterator<InternalRow> createFilteredIterator(
+            K key, @Nullable Long fileSize, Filters<V> filters) throws IOException {
+        return reader.apply(key, fileSize);
     }
 
     protected abstract <R> List<R> readFromSegments(

--- a/paimon-core/src/test/java/org/apache/paimon/manifest/ManifestFileTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/manifest/ManifestFileTest.java
@@ -31,6 +31,7 @@ import org.apache.paimon.fs.PositionOutputStream;
 import org.apache.paimon.fs.local.LocalFileIO;
 import org.apache.paimon.io.DataFileMeta;
 import org.apache.paimon.io.DataFileMetaWriteColsLegacySerializer;
+import org.apache.paimon.options.MemorySize;
 import org.apache.paimon.options.Options;
 import org.apache.paimon.partition.PartitionPredicate;
 import org.apache.paimon.schema.FileSystemSchemaManager;
@@ -40,6 +41,8 @@ import org.apache.paimon.types.RowType;
 import org.apache.paimon.utils.CloseableIterator;
 import org.apache.paimon.utils.FailingFileIO;
 import org.apache.paimon.utils.FileStorePathFactory;
+import org.apache.paimon.utils.Filter;
+import org.apache.paimon.utils.SegmentsCache;
 
 import org.junit.jupiter.api.RepeatedTest;
 import org.junit.jupiter.api.Test;
@@ -47,6 +50,8 @@ import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
+
+import javax.annotation.Nullable;
 
 import java.io.IOException;
 import java.io.UncheckedIOException;
@@ -1224,6 +1229,11 @@ public class ManifestFileTest {
     }
 
     private ManifestFile createManifestFile(String pathStr, long suggestedFileSize) {
+        return createManifestFile(pathStr, suggestedFileSize, null);
+    }
+
+    private ManifestFile createManifestFile(
+            String pathStr, long suggestedFileSize, @Nullable SegmentsCache<Path> cache) {
         Path path = new Path(pathStr);
         FileStorePathFactory pathFactory =
                 new FileStorePathFactory(
@@ -1251,8 +1261,54 @@ public class ManifestFileTest {
                         "zstd",
                         pathFactory,
                         suggestedFileSize,
-                        null)
+                        cache)
                 .create();
+    }
+
+    @Test
+    void testBucketFilterPushedDownWhenManifestExceedsCacheElementSize() throws Exception {
+        List<ManifestEntry> entries = generateData();
+        Set<Integer> buckets =
+                entries.stream().map(ManifestEntry::bucket).collect(Collectors.toSet());
+        assertThat(buckets.size()).isGreaterThan(1);
+
+        // A manifest above the cache element size limit is read uncached; the bucket filter must
+        // still reach the Avro reader instead of being applied after decoding every entry.
+        SegmentsCache<Path> tinyElementCache =
+                new SegmentsCache<>(1024, MemorySize.ofMebiBytes(8), 1L);
+        ManifestFile manifestFile =
+                createManifestFile(tempDir.toString(), Long.MAX_VALUE, tinyElementCache);
+        List<ManifestFileMeta> metas = manifestFile.write(entries);
+        assertThat(metas).hasSize(1);
+        ManifestFileMeta meta = metas.get(0);
+
+        for (int bucket : buckets) {
+            BucketFilter bucketFilter = BucketFilter.create(false, bucket, null, null);
+            List<ManifestEntry> actual =
+                    manifestFile.read(
+                            meta.fileName(),
+                            meta.fileSize(),
+                            null,
+                            bucketFilter,
+                            Filter.alwaysTrue(),
+                            Filter.alwaysTrue());
+            List<ManifestEntry> expected =
+                    entries.stream()
+                            .filter(entry -> entry.bucket() == bucket)
+                            .collect(Collectors.toList());
+            assertThat(actual).isEqualTo(expected);
+        }
+
+        // Without any pushdown filter every entry must still be returned.
+        assertThat(
+                        manifestFile.read(
+                                meta.fileName(),
+                                meta.fileSize(),
+                                null,
+                                null,
+                                Filter.alwaysTrue(),
+                                Filter.alwaysTrue()))
+                .isEqualTo(entries);
     }
 
     private ManifestFileMeta writeSingleManifest(


### PR DESCRIPTION
### Purpose

`ManifestAvroReader` can skip a manifest entry as soon as its partition or bucket cannot match, before the (potentially large) file stats are decoded. That pushdown is only wired for the path without a manifest cache: `ManifestFile` hands the cache layer an iterator factory with `null` filters, and `ObjectsCache.read` uses that factory whenever a manifest file is larger than `cache.manifest.small-file-threshold` (1 MiB by default). Wide tables exceed that limit on every manifest, so every planning of such a table decodes the stats of every entry and filters afterwards. This restores what #7392 introduced as `loadFilter`, which was lost when the cache read path was reorganised.

Measured on a table with 11,374 columns and 240 buckets: a query with an equality predicate on the bucket key used to decode ~267 MB of Avro manifests and allocate ~10 GB per planning; with this change the entries of the 239 non-matching buckets are skipped with `BinaryDecoder.skipBytes`/`skipArray` and the JFR profile moves from `FieldReaderFactory$ArrayReader.read` to `ArrayReader.skip`.

Changes:

- `ObjectsCache`: new `createFilteredIterator(key, fileSize, filters)` hook used by the uncached fallback; default behaviour unchanged.
- `ManifestEntryCache`: optional `FilteredReader` that receives the partition and bucket filters carried by `ManifestEntryFilters`.
- `ManifestFile`: passes a filter-aware `createManifestIterator` to the cache.

`createSegments` (files below the threshold) stays unfiltered on purpose: the cached segments are shared by queries with different predicates.

### Tests

- `ManifestFileTest#testBucketFilterPushedDownWhenManifestExceedsCacheElementSize` (new): with a cache whose element size limit forces the uncached path, reading with a bucket filter returns only that bucket's entries; without a filter every entry is returned.
- `ManifestFileTest` and `ObjectsCacheTest` pass locally.

### API and Format

No public API or format change.

### Documentation

None.
