### PR TITLE
[mosaic] Prefetch row groups and read with one input stream per concurrent read

### DIFF
--- a/docs/docs/concepts/spec/fileformat.md
+++ b/docs/docs/concepts/spec/fileformat.md
@@ -285,6 +285,7 @@ Format Options:
 | --- | --- | --- | --- |
 | `mosaic.num-buckets` | auto | Integer | Number of column buckets for parallel I/O. When set to 0 or not specified, the format auto-determines the bucket count. |
 | `mosaic.stats-columns` | (empty) | String | Comma-separated column names to collect min/max statistics for filter pushdown. Empty means no statistics are collected. |
+| `mosaic.read.prefetch-row-groups` | 8 | Integer | Number of row groups a reader opens ahead of the one being consumed. Opening a row group issues several dependent range reads, so prefetching overlaps that latency with decoding. 0 disables prefetching. |
 
 Limitations:
 1. Mosaic does not support complex types: ARRAY, MAP, MULTISET, ROW, VARIANT, BLOB, VECTOR.

--- a/docs/docs/concepts/spec/fileformat.md
+++ b/docs/docs/concepts/spec/fileformat.md
@@ -285,7 +285,8 @@ Format Options:
 | --- | --- | --- | --- |
 | `mosaic.num-buckets` | auto | Integer | Number of column buckets for parallel I/O. When set to 0 or not specified, the format auto-determines the bucket count. |
 | `mosaic.stats-columns` | (empty) | String | Comma-separated column names to collect min/max statistics for filter pushdown. Empty means no statistics are collected. |
-| `mosaic.read.prefetch-row-groups` | 8 | Integer | Number of row groups a reader opens ahead of the one being consumed. Opening a row group issues several dependent range reads, so prefetching overlaps that latency with decoding. 0 disables prefetching. |
+| `mosaic.read.prefetch-row-groups` | 8 | Integer | Number of row groups a reader opens ahead of the one being consumed. Opening a row group issues several dependent range reads, so prefetching overlaps that latency with decoding. Each row group ahead keeps its decoded batch in memory and uses its own input stream, see `mosaic.read.prefetch-max-bytes`. 0 disables prefetching. |
+| `mosaic.read.prefetch-max-bytes` | 64 mb | MemorySize | Upper bound on the file bytes of the row groups a reader opens ahead, estimated from the file size divided by its row group count. Large row groups therefore lower the effective `mosaic.read.prefetch-row-groups`. |
 
 Limitations:
 1. Mosaic does not support complex types: ARRAY, MAP, MULTISET, ROW, VARIANT, BLOB, VECTOR.

--- a/docs/docs/concepts/spec/fileformat.md
+++ b/docs/docs/concepts/spec/fileformat.md
@@ -286,7 +286,7 @@ Format Options:
 | `mosaic.num-buckets` | auto | Integer | Number of column buckets for parallel I/O. When set to 0 or not specified, the format auto-determines the bucket count. |
 | `mosaic.stats-columns` | (empty) | String | Comma-separated column names to collect min/max statistics for filter pushdown. Empty means no statistics are collected. |
 | `mosaic.read.prefetch-row-groups` | 8 | Integer | Number of row groups a reader opens ahead of the one being consumed. Opening a row group issues several dependent range reads, so prefetching overlaps that latency with decoding. Each row group ahead keeps its decoded batch in memory and uses its own input stream, see `mosaic.read.prefetch-max-bytes`. 0 disables prefetching. |
-| `mosaic.read.prefetch-max-bytes` | 64 mb | MemorySize | Upper bound on the file bytes of the row groups a reader opens ahead, estimated from the file size divided by its row group count. Large row groups therefore lower the effective `mosaic.read.prefetch-row-groups`. |
+| `mosaic.read.prefetch-max-bytes` | 64 mb | MemorySize | Upper bound on the estimated decoded size of the row groups a reader keeps ahead, from their row counts and the projected column types. Wide projections or large row groups therefore lower the effective `mosaic.read.prefetch-row-groups`. |
 
 Limitations:
 1. Mosaic does not support complex types: ARRAY, MAP, MULTISET, ROW, VARIANT, BLOB, VECTOR.

--- a/paimon-mosaic/src/main/java/org/apache/paimon/format/mosaic/MosaicFileFormat.java
+++ b/paimon-mosaic/src/main/java/org/apache/paimon/format/mosaic/MosaicFileFormat.java
@@ -93,10 +93,10 @@ public class MosaicFileFormat extends FileFormat {
                     .memoryType()
                     .defaultValue(MemorySize.ofMebiBytes(64))
                     .withDescription(
-                            "Upper bound on the file bytes of the row groups a reader opens ahead, "
-                                    + "estimated from the file size divided by its row group count. "
-                                    + "Large row groups therefore lower the effective "
-                                    + "'mosaic.read.prefetch-row-groups'.");
+                            "Upper bound on the estimated decoded size of the row groups a reader "
+                                    + "keeps ahead, from their row counts and the projected column "
+                                    + "types. Wide projections or large row groups therefore lower "
+                                    + "the effective 'mosaic.read.prefetch-row-groups'.");
 
     static {
         System.setProperty("arrow.enable_unsafe_memory_access", "true");

--- a/paimon-mosaic/src/main/java/org/apache/paimon/format/mosaic/MosaicFileFormat.java
+++ b/paimon-mosaic/src/main/java/org/apache/paimon/format/mosaic/MosaicFileFormat.java
@@ -75,6 +75,16 @@ public class MosaicFileFormat extends FileFormat {
                     .noDefaultValue()
                     .withDescription("Number of column buckets for parallel IO.");
 
+    public static final ConfigOption<Integer> READ_PREFETCH_ROW_GROUPS =
+            ConfigOptions.key("mosaic.read.prefetch-row-groups")
+                    .intType()
+                    .defaultValue(8)
+                    .withDescription(
+                            "Number of row groups a reader opens ahead of the one being consumed. "
+                                    + "Opening a row group issues several dependent range reads, "
+                                    + "so prefetching overlaps that latency with decoding. "
+                                    + "0 disables prefetching.");
+
     static {
         System.setProperty("arrow.enable_unsafe_memory_access", "true");
     }
@@ -91,7 +101,11 @@ public class MosaicFileFormat extends FileFormat {
             RowType dataSchemaRowType,
             RowType projectedRowType,
             @Nullable List<Predicate> predicates) {
-        return new MosaicReaderFactory(dataSchemaRowType, projectedRowType, predicates);
+        return new MosaicReaderFactory(
+                dataSchemaRowType,
+                projectedRowType,
+                predicates,
+                Math.max(0, formatContext.options().get(READ_PREFETCH_ROW_GROUPS)));
     }
 
     @Override

--- a/paimon-mosaic/src/main/java/org/apache/paimon/format/mosaic/MosaicFileFormat.java
+++ b/paimon-mosaic/src/main/java/org/apache/paimon/format/mosaic/MosaicFileFormat.java
@@ -25,6 +25,7 @@ import org.apache.paimon.format.FormatWriterFactory;
 import org.apache.paimon.format.SimpleStatsExtractor;
 import org.apache.paimon.options.ConfigOption;
 import org.apache.paimon.options.ConfigOptions;
+import org.apache.paimon.options.MemorySize;
 import org.apache.paimon.predicate.Predicate;
 import org.apache.paimon.statistics.SimpleColStatsCollector;
 import org.apache.paimon.types.ArrayType;
@@ -82,8 +83,20 @@ public class MosaicFileFormat extends FileFormat {
                     .withDescription(
                             "Number of row groups a reader opens ahead of the one being consumed. "
                                     + "Opening a row group issues several dependent range reads, "
-                                    + "so prefetching overlaps that latency with decoding. "
+                                    + "so prefetching overlaps that latency with decoding. Each "
+                                    + "row group ahead keeps its decoded batch in memory and uses "
+                                    + "its own input stream, see 'mosaic.read.prefetch-max-bytes'. "
                                     + "0 disables prefetching.");
+
+    public static final ConfigOption<MemorySize> READ_PREFETCH_MAX_BYTES =
+            ConfigOptions.key("mosaic.read.prefetch-max-bytes")
+                    .memoryType()
+                    .defaultValue(MemorySize.ofMebiBytes(64))
+                    .withDescription(
+                            "Upper bound on the file bytes of the row groups a reader opens ahead, "
+                                    + "estimated from the file size divided by its row group count. "
+                                    + "Large row groups therefore lower the effective "
+                                    + "'mosaic.read.prefetch-row-groups'.");
 
     static {
         System.setProperty("arrow.enable_unsafe_memory_access", "true");
@@ -105,7 +118,8 @@ public class MosaicFileFormat extends FileFormat {
                 dataSchemaRowType,
                 projectedRowType,
                 predicates,
-                Math.max(0, formatContext.options().get(READ_PREFETCH_ROW_GROUPS)));
+                formatContext.options().get(READ_PREFETCH_ROW_GROUPS),
+                formatContext.options().get(READ_PREFETCH_MAX_BYTES).getBytes());
     }
 
     @Override

--- a/paimon-mosaic/src/main/java/org/apache/paimon/format/mosaic/MosaicInputFileAdapter.java
+++ b/paimon-mosaic/src/main/java/org/apache/paimon/format/mosaic/MosaicInputFileAdapter.java
@@ -27,53 +27,173 @@ import org.apache.paimon.mosaic.InputFile;
 import java.io.Closeable;
 import java.io.EOFException;
 import java.io.IOException;
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicLong;
 
 /**
- * Adapts Paimon's {@link FileIO} to Mosaic's {@link InputFile} interface.
- *
- * <p>Maintains a single {@link SeekableInputStream}. If the stream implements {@link
- * VectoredReadable}, reads use {@link VectoredReadable#preadFully} which is thread-safe. Otherwise,
- * reads are synchronized to protect seek+read sequences.
+ * Adapts Paimon's {@link FileIO} to Mosaic's {@link InputFile}; each concurrent read borrows its
+ * own {@link SeekableInputStream} from a pool because streams serialize concurrent reads.
  */
 public class MosaicInputFileAdapter implements InputFile, Closeable {
 
+    private final FileIO fileIO;
     private final Path path;
-    private final SeekableInputStream in;
-    private final VectoredReadable vectoredReadable;
+
+    private final ArrayDeque<SeekableInputStream> idleStreams = new ArrayDeque<>();
+    private final List<SeekableInputStream> allStreams = new ArrayList<>();
+    private boolean closed;
+
+    // I/O counters (diagnostics; see MosaicRecordsReader#close).
+    private final AtomicLong readCount = new AtomicLong();
+    private final AtomicLong smallReadCount = new AtomicLong();
+    private final AtomicLong mediumReadCount = new AtomicLong(); // [4 KiB, 256 KiB)
+    private final AtomicLong largeReadCount = new AtomicLong(); // [256 KiB, 1 MiB)
+    private final AtomicLong hugeReadCount = new AtomicLong(); // >= 1 MiB
+    private final AtomicLong readBytes = new AtomicLong();
+    private final AtomicLong readNanos = new AtomicLong();
+    private final AtomicLong maxReadNanos = new AtomicLong();
 
     public MosaicInputFileAdapter(FileIO fileIO, Path path) throws IOException {
+        this.fileIO = fileIO;
         this.path = path;
-        this.in = fileIO.newInputStream(path);
-        this.vectoredReadable = in instanceof VectoredReadable ? (VectoredReadable) in : null;
+        // Open eagerly so that a missing file fails here rather than in a native callback.
+        release(fileIO.newInputStream(path));
+    }
+
+    public String ioStats() {
+        return "reads="
+                + readCount.get()
+                + "|small_reads="
+                + smallReadCount.get()
+                + "|medium_reads="
+                + mediumReadCount.get()
+                + "|large_reads="
+                + largeReadCount.get()
+                + "|huge_reads="
+                + hugeReadCount.get()
+                + "|bytes="
+                + readBytes.get()
+                + "|read_ms="
+                + readNanos.get() / 1_000_000
+                + "|max_read_ms="
+                + maxReadNanos.get() / 1_000_000
+                + "|streams="
+                + streamCount();
     }
 
     @Override
     public void readFully(long position, byte[] buffer, int offset, int length) throws IOException {
-        if (vectoredReadable != null) {
-            vectoredReadable.preadFully(position, buffer, offset, length);
-        } else {
-            synchronized (in) {
-                in.seek(position);
-                int remaining = length;
-                int off = offset;
-                while (remaining > 0) {
-                    int read = in.read(buffer, off, remaining);
-                    if (read < 0) {
-                        throw new EOFException(
-                                "Reached end of file while reading "
-                                        + path
-                                        + " at position "
-                                        + position);
-                    }
-                    off += read;
-                    remaining -= read;
-                }
+        long start = System.nanoTime();
+        SeekableInputStream in = borrow();
+        try {
+            doReadFully(in, position, buffer, offset, length);
+        } finally {
+            release(in);
+            long nanos = System.nanoTime() - start;
+            readCount.incrementAndGet();
+            if (length < 4096) {
+                smallReadCount.incrementAndGet();
+            } else if (length < 256 * 1024) {
+                mediumReadCount.incrementAndGet();
+            } else if (length < 1024 * 1024) {
+                largeReadCount.incrementAndGet();
+            } else {
+                hugeReadCount.incrementAndGet();
+            }
+            readBytes.addAndGet(length);
+            readNanos.addAndGet(nanos);
+            maxReadNanos.accumulateAndGet(nanos, Math::max);
+        }
+    }
+
+    private void doReadFully(
+            SeekableInputStream in, long position, byte[] buffer, int offset, int length)
+            throws IOException {
+        if (in instanceof VectoredReadable) {
+            ((VectoredReadable) in).preadFully(position, buffer, offset, length);
+            return;
+        }
+        // The stream is borrowed exclusively, so seek + read needs no extra locking.
+        in.seek(position);
+        int remaining = length;
+        int off = offset;
+        while (remaining > 0) {
+            int read = in.read(buffer, off, remaining);
+            if (read < 0) {
+                throw new EOFException(
+                        "Reached end of file while reading " + path + " at position " + position);
+            }
+            off += read;
+            remaining -= read;
+        }
+    }
+
+    private SeekableInputStream borrow() throws IOException {
+        synchronized (this) {
+            if (closed) {
+                throw new IOException("Input file " + path + " is closed");
+            }
+            SeekableInputStream idle = idleStreams.poll();
+            if (idle != null) {
+                return idle;
             }
         }
+        SeekableInputStream opened = fileIO.newInputStream(path);
+        synchronized (this) {
+            if (closed) {
+                opened.close();
+                throw new IOException("Input file " + path + " is closed");
+            }
+            allStreams.add(opened);
+        }
+        return opened;
+    }
+
+    private void release(SeekableInputStream in) throws IOException {
+        synchronized (this) {
+            if (!closed) {
+                if (!allStreams.contains(in)) {
+                    allStreams.add(in);
+                }
+                idleStreams.push(in);
+                return;
+            }
+        }
+        in.close();
+    }
+
+    private synchronized int streamCount() {
+        return allStreams.size();
     }
 
     @Override
     public void close() throws IOException {
-        in.close();
+        List<SeekableInputStream> toClose;
+        synchronized (this) {
+            if (closed) {
+                return;
+            }
+            closed = true;
+            toClose = new ArrayList<>(allStreams);
+            allStreams.clear();
+            idleStreams.clear();
+        }
+        IOException failure = null;
+        for (SeekableInputStream in : toClose) {
+            try {
+                in.close();
+            } catch (IOException e) {
+                if (failure == null) {
+                    failure = e;
+                } else {
+                    failure.addSuppressed(e);
+                }
+            }
+        }
+        if (failure != null) {
+            throw failure;
+        }
     }
 }

--- a/paimon-mosaic/src/main/java/org/apache/paimon/format/mosaic/MosaicInputFileAdapter.java
+++ b/paimon-mosaic/src/main/java/org/apache/paimon/format/mosaic/MosaicInputFileAdapter.java
@@ -27,84 +27,49 @@ import org.apache.paimon.mosaic.InputFile;
 import java.io.Closeable;
 import java.io.EOFException;
 import java.io.IOException;
+import java.io.InterruptedIOException;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.concurrent.atomic.AtomicLong;
 
 /**
- * Adapts Paimon's {@link FileIO} to Mosaic's {@link InputFile}; each concurrent read borrows its
- * own {@link SeekableInputStream} from a pool because streams serialize concurrent reads.
+ * Adapter that exposes a Paimon {@link SeekableInputStream} as a Mosaic {@link InputFile}.
+ *
+ * <p>Each read borrows one of at most {@code maxStreams} input streams, so concurrent reads do not
+ * serialize on a single stream; a read that finds every stream busy waits for one.
  */
 public class MosaicInputFileAdapter implements InputFile, Closeable {
 
     private final FileIO fileIO;
     private final Path path;
+    private final int maxStreams;
 
     private final ArrayDeque<SeekableInputStream> idleStreams = new ArrayDeque<>();
     private final List<SeekableInputStream> allStreams = new ArrayList<>();
+    private int openingStreams;
     private boolean closed;
 
-    // I/O counters (diagnostics; see MosaicRecordsReader#close).
-    private final AtomicLong readCount = new AtomicLong();
-    private final AtomicLong smallReadCount = new AtomicLong();
-    private final AtomicLong mediumReadCount = new AtomicLong(); // [4 KiB, 256 KiB)
-    private final AtomicLong largeReadCount = new AtomicLong(); // [256 KiB, 1 MiB)
-    private final AtomicLong hugeReadCount = new AtomicLong(); // >= 1 MiB
-    private final AtomicLong readBytes = new AtomicLong();
-    private final AtomicLong readNanos = new AtomicLong();
-    private final AtomicLong maxReadNanos = new AtomicLong();
-
     public MosaicInputFileAdapter(FileIO fileIO, Path path) throws IOException {
-        this.fileIO = fileIO;
-        this.path = path;
-        // Open eagerly so that a missing file fails here rather than in a native callback.
-        release(fileIO.newInputStream(path));
+        this(fileIO, path, 1);
     }
 
-    public String ioStats() {
-        return "reads="
-                + readCount.get()
-                + "|small_reads="
-                + smallReadCount.get()
-                + "|medium_reads="
-                + mediumReadCount.get()
-                + "|large_reads="
-                + largeReadCount.get()
-                + "|huge_reads="
-                + hugeReadCount.get()
-                + "|bytes="
-                + readBytes.get()
-                + "|read_ms="
-                + readNanos.get() / 1_000_000
-                + "|max_read_ms="
-                + maxReadNanos.get() / 1_000_000
-                + "|streams="
-                + streamCount();
+    public MosaicInputFileAdapter(FileIO fileIO, Path path, int maxStreams) throws IOException {
+        this.fileIO = fileIO;
+        this.path = path;
+        this.maxStreams = Math.max(1, maxStreams);
+        // Open eagerly so that a missing file fails here rather than in a native callback.
+        SeekableInputStream first = fileIO.newInputStream(path);
+        allStreams.add(first);
+        idleStreams.push(first);
     }
 
     @Override
     public void readFully(long position, byte[] buffer, int offset, int length) throws IOException {
-        long start = System.nanoTime();
         SeekableInputStream in = borrow();
         try {
             doReadFully(in, position, buffer, offset, length);
         } finally {
             release(in);
-            long nanos = System.nanoTime() - start;
-            readCount.incrementAndGet();
-            if (length < 4096) {
-                smallReadCount.incrementAndGet();
-            } else if (length < 256 * 1024) {
-                mediumReadCount.incrementAndGet();
-            } else if (length < 1024 * 1024) {
-                largeReadCount.incrementAndGet();
-            } else {
-                hugeReadCount.incrementAndGet();
-            }
-            readBytes.addAndGet(length);
-            readNanos.addAndGet(nanos);
-            maxReadNanos.accumulateAndGet(nanos, Math::max);
         }
     }
 
@@ -132,21 +97,43 @@ public class MosaicInputFileAdapter implements InputFile, Closeable {
 
     private SeekableInputStream borrow() throws IOException {
         synchronized (this) {
-            if (closed) {
-                throw new IOException("Input file " + path + " is closed");
-            }
-            SeekableInputStream idle = idleStreams.poll();
-            if (idle != null) {
-                return idle;
+            while (true) {
+                if (closed) {
+                    throw new IOException("Input file " + path + " is closed");
+                }
+                SeekableInputStream idle = idleStreams.poll();
+                if (idle != null) {
+                    return idle;
+                }
+                if (allStreams.size() + openingStreams < maxStreams) {
+                    openingStreams++;
+                    break;
+                }
+                try {
+                    wait();
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                    throw new InterruptedIOException(
+                            "Interrupted while waiting for an input stream of " + path);
+                }
             }
         }
-        SeekableInputStream opened = fileIO.newInputStream(path);
-        synchronized (this) {
-            if (closed) {
-                opened.close();
-                throw new IOException("Input file " + path + " is closed");
+        SeekableInputStream opened = null;
+        try {
+            opened = fileIO.newInputStream(path);
+        } finally {
+            synchronized (this) {
+                openingStreams--;
+                if (opened != null && !closed) {
+                    allStreams.add(opened);
+                } else {
+                    notifyAll();
+                }
             }
-            allStreams.add(opened);
+        }
+        if (closed) {
+            opened.close();
+            throw new IOException("Input file " + path + " is closed");
         }
         return opened;
     }
@@ -154,18 +141,12 @@ public class MosaicInputFileAdapter implements InputFile, Closeable {
     private void release(SeekableInputStream in) throws IOException {
         synchronized (this) {
             if (!closed) {
-                if (!allStreams.contains(in)) {
-                    allStreams.add(in);
-                }
                 idleStreams.push(in);
+                notifyAll();
                 return;
             }
         }
         in.close();
-    }
-
-    private synchronized int streamCount() {
-        return allStreams.size();
     }
 
     @Override
@@ -179,6 +160,7 @@ public class MosaicInputFileAdapter implements InputFile, Closeable {
             toClose = new ArrayList<>(allStreams);
             allStreams.clear();
             idleStreams.clear();
+            notifyAll();
         }
         IOException failure = null;
         for (SeekableInputStream in : toClose) {

--- a/paimon-mosaic/src/main/java/org/apache/paimon/format/mosaic/MosaicReaderFactory.java
+++ b/paimon-mosaic/src/main/java/org/apache/paimon/format/mosaic/MosaicReaderFactory.java
@@ -36,33 +36,27 @@ public class MosaicReaderFactory implements FormatReaderFactory {
     private final RowType projectedRowType;
     @Nullable private final List<Predicate> predicates;
     private final int prefetchRowGroups;
-
-    public MosaicReaderFactory(
-            RowType dataSchemaRowType,
-            RowType projectedRowType,
-            @Nullable List<Predicate> predicates) {
-        this(
-                dataSchemaRowType,
-                projectedRowType,
-                predicates,
-                MosaicFileFormat.READ_PREFETCH_ROW_GROUPS.defaultValue());
-    }
+    private final long prefetchMaxBytes;
 
     public MosaicReaderFactory(
             RowType dataSchemaRowType,
             RowType projectedRowType,
             @Nullable List<Predicate> predicates,
-            int prefetchRowGroups) {
+            int prefetchRowGroups,
+            long prefetchMaxBytes) {
         this.dataSchemaRowType = dataSchemaRowType;
         this.projectedRowType = projectedRowType;
         this.predicates = predicates;
-        this.prefetchRowGroups = prefetchRowGroups;
+        this.prefetchRowGroups = Math.max(0, prefetchRowGroups);
+        this.prefetchMaxBytes = prefetchMaxBytes;
     }
 
     @Override
     public FileRecordReader<InternalRow> createReader(Context context) throws IOException {
+        // One stream per row group being opened, plus one for the consumer's own reads.
         MosaicInputFileAdapter inputFile =
-                new MosaicInputFileAdapter(context.fileIO(), context.filePath());
+                new MosaicInputFileAdapter(
+                        context.fileIO(), context.filePath(), prefetchRowGroups + 1);
         return new MosaicRecordsReader(
                 inputFile,
                 context.fileSize(),
@@ -70,6 +64,7 @@ public class MosaicReaderFactory implements FormatReaderFactory {
                 projectedRowType,
                 predicates,
                 context.filePath(),
-                prefetchRowGroups);
+                prefetchRowGroups,
+                prefetchMaxBytes);
     }
 }

--- a/paimon-mosaic/src/main/java/org/apache/paimon/format/mosaic/MosaicReaderFactory.java
+++ b/paimon-mosaic/src/main/java/org/apache/paimon/format/mosaic/MosaicReaderFactory.java
@@ -35,14 +35,28 @@ public class MosaicReaderFactory implements FormatReaderFactory {
     private final RowType dataSchemaRowType;
     private final RowType projectedRowType;
     @Nullable private final List<Predicate> predicates;
+    private final int prefetchRowGroups;
 
     public MosaicReaderFactory(
             RowType dataSchemaRowType,
             RowType projectedRowType,
             @Nullable List<Predicate> predicates) {
+        this(
+                dataSchemaRowType,
+                projectedRowType,
+                predicates,
+                MosaicFileFormat.READ_PREFETCH_ROW_GROUPS.defaultValue());
+    }
+
+    public MosaicReaderFactory(
+            RowType dataSchemaRowType,
+            RowType projectedRowType,
+            @Nullable List<Predicate> predicates,
+            int prefetchRowGroups) {
         this.dataSchemaRowType = dataSchemaRowType;
         this.projectedRowType = projectedRowType;
         this.predicates = predicates;
+        this.prefetchRowGroups = prefetchRowGroups;
     }
 
     @Override
@@ -55,6 +69,7 @@ public class MosaicReaderFactory implements FormatReaderFactory {
                 dataSchemaRowType,
                 projectedRowType,
                 predicates,
-                context.filePath());
+                context.filePath(),
+                prefetchRowGroups);
     }
 }

--- a/paimon-mosaic/src/main/java/org/apache/paimon/format/mosaic/MosaicRecordsReader.java
+++ b/paimon-mosaic/src/main/java/org/apache/paimon/format/mosaic/MosaicRecordsReader.java
@@ -100,25 +100,9 @@ public class MosaicRecordsReader implements FileRecordReader<InternalRow> {
             RowType dataSchemaRowType,
             RowType projectedRowType,
             @Nullable List<Predicate> predicates,
-            Path filePath) {
-        this(
-                inputFileAdapter,
-                fileSize,
-                dataSchemaRowType,
-                projectedRowType,
-                predicates,
-                filePath,
-                MosaicFileFormat.READ_PREFETCH_ROW_GROUPS.defaultValue());
-    }
-
-    public MosaicRecordsReader(
-            MosaicInputFileAdapter inputFileAdapter,
-            long fileSize,
-            RowType dataSchemaRowType,
-            RowType projectedRowType,
-            @Nullable List<Predicate> predicates,
             Path filePath,
-            int prefetchRowGroups) {
+            int prefetchRowGroups,
+            long prefetchMaxBytes) {
         this(
                 inputFileAdapter,
                 fileSize,
@@ -128,7 +112,8 @@ public class MosaicRecordsReader implements FileRecordReader<InternalRow> {
                 filePath,
                 new RootAllocator(),
                 MosaicReader::open,
-                prefetchRowGroups);
+                prefetchRowGroups,
+                prefetchMaxBytes);
     }
 
     MosaicRecordsReader(
@@ -149,7 +134,8 @@ public class MosaicRecordsReader implements FileRecordReader<InternalRow> {
                 filePath,
                 allocator,
                 nativeReaderOpener,
-                MosaicFileFormat.READ_PREFETCH_ROW_GROUPS.defaultValue());
+                MosaicFileFormat.READ_PREFETCH_ROW_GROUPS.defaultValue(),
+                MosaicFileFormat.READ_PREFETCH_MAX_BYTES.defaultValue().getBytes());
     }
 
     MosaicRecordsReader(
@@ -161,14 +147,14 @@ public class MosaicRecordsReader implements FileRecordReader<InternalRow> {
             Path filePath,
             BufferAllocator allocator,
             NativeReaderOpener nativeReaderOpener,
-            int prefetchRowGroups) {
+            int prefetchRowGroups,
+            long prefetchMaxBytes) {
         this.filePath = filePath;
         this.inputFileAdapter = inputFileAdapter;
         this.dataSchemaRowType = dataSchemaRowType;
         this.projectedFieldCount = projectedRowType.getFieldCount();
         this.predicates = predicates;
         this.allocator = allocator;
-        this.prefetchDepth = Math.max(0, prefetchRowGroups);
 
         MosaicReader createdReader = null;
         int createdNumRowGroups;
@@ -203,8 +189,25 @@ public class MosaicRecordsReader implements FileRecordReader<InternalRow> {
 
         this.reader = createdReader;
         this.numRowGroups = createdNumRowGroups;
+        this.prefetchDepth =
+                boundedPrefetchDepth(
+                        prefetchRowGroups, prefetchMaxBytes, fileSize, createdNumRowGroups);
         this.allProjectedColumnsMissing = createdAllProjectedColumnsMissing;
         this.arrowBatchReader = createdArrowBatchReader;
+    }
+
+    /** Caps the depth so the row groups ahead, by their average file size, fit the byte budget. */
+    static int boundedPrefetchDepth(int rowGroups, long maxBytes, long fileSize, int numRowGroups) {
+        int depth = Math.max(0, rowGroups);
+        if (depth == 0 || fileSize <= 0 || numRowGroups <= 0) {
+            return depth;
+        }
+        long rowGroupBytes = Math.max(1, fileSize / numRowGroups);
+        return (int) Math.min(depth, Math.max(0, maxBytes) / rowGroupBytes);
+    }
+
+    int prefetchDepth() {
+        return prefetchDepth;
     }
 
     @Nullable
@@ -459,19 +462,6 @@ public class MosaicRecordsReader implements FileRecordReader<InternalRow> {
     public void close() throws IOException {
         Throwable throwable = null;
 
-        if (LOG.isDebugEnabled()) {
-            LOG.debug(
-                    "Closing mosaic reader for {}: row groups {} (opened {}), rows {}, "
-                            + "waited {} ms for row groups, lifetime {} ms, {}",
-                    filePath.getName(),
-                    numRowGroups,
-                    openedRowGroups,
-                    rowsReturned,
-                    openNanos / 1_000_000,
-                    (System.nanoTime() - createdNanos) / 1_000_000,
-                    inputFileAdapter.ioStats());
-        }
-
         try {
             releaseCurrentVsr();
         } catch (Throwable t) {
@@ -508,6 +498,18 @@ public class MosaicRecordsReader implements FileRecordReader<InternalRow> {
             throwable = addSuppressed(throwable, t);
         }
 
+        if (LOG.isDebugEnabled()) {
+            LOG.debug(
+                    "Closed mosaic reader for {}: row groups {} (opened {}, prefetch depth {}), "
+                            + "rows {}, waited {} ms for row groups, lifetime {} ms",
+                    filePath.getName(),
+                    numRowGroups,
+                    openedRowGroups,
+                    prefetchDepth,
+                    rowsReturned,
+                    openNanos / 1_000_000,
+                    (System.nanoTime() - createdNanos) / 1_000_000);
+        }
         if (interrupted) {
             Thread.currentThread().interrupt();
         }

--- a/paimon-mosaic/src/main/java/org/apache/paimon/format/mosaic/MosaicRecordsReader.java
+++ b/paimon-mosaic/src/main/java/org/apache/paimon/format/mosaic/MosaicRecordsReader.java
@@ -79,6 +79,9 @@ public class MosaicRecordsReader implements FileRecordReader<InternalRow> {
             Executors.newCachedThreadPool(new ExecutorThreadFactory("mosaic-row-group-prefetch"));
 
     private final int prefetchDepth;
+    private final long prefetchMaxBytes;
+    private final long estimatedRowBytes;
+    private long pendingBytes;
     private final ArrayDeque<RowGroupBatch> pending = new ArrayDeque<>();
     private int nextRowGroupToSchedule;
     private long scheduledRowCount;
@@ -189,21 +192,51 @@ public class MosaicRecordsReader implements FileRecordReader<InternalRow> {
 
         this.reader = createdReader;
         this.numRowGroups = createdNumRowGroups;
-        this.prefetchDepth =
-                boundedPrefetchDepth(
-                        prefetchRowGroups, prefetchMaxBytes, fileSize, createdNumRowGroups);
+        this.prefetchDepth = Math.max(0, prefetchRowGroups);
+        this.prefetchMaxBytes = Math.max(0, prefetchMaxBytes);
+        this.estimatedRowBytes = estimatedRowBytes(projectedRowType);
         this.allProjectedColumnsMissing = createdAllProjectedColumnsMissing;
         this.arrowBatchReader = createdArrowBatchReader;
     }
 
-    /** Caps the depth so the row groups ahead, by their average file size, fit the byte budget. */
-    static int boundedPrefetchDepth(int rowGroups, long maxBytes, long fileSize, int numRowGroups) {
-        int depth = Math.max(0, rowGroups);
-        if (depth == 0 || fileSize <= 0 || numRowGroups <= 0) {
-            return depth;
+    /** Rough decoded size of one row of the projected columns, used for the prefetch budget. */
+    static long estimatedRowBytes(RowType projectedRowType) {
+        long bytes = 0;
+        for (DataField field : projectedRowType.getFields()) {
+            switch (field.type().getTypeRoot()) {
+                case BOOLEAN:
+                case TINYINT:
+                    bytes += 2;
+                    break;
+                case SMALLINT:
+                    bytes += 3;
+                    break;
+                case INTEGER:
+                case FLOAT:
+                case DATE:
+                case TIME_WITHOUT_TIME_ZONE:
+                    bytes += 5;
+                    break;
+                case BIGINT:
+                case DOUBLE:
+                case TIMESTAMP_WITHOUT_TIME_ZONE:
+                case TIMESTAMP_WITH_LOCAL_TIME_ZONE:
+                    bytes += 9;
+                    break;
+                case DECIMAL:
+                    bytes += 17;
+                    break;
+                case CHAR:
+                case VARCHAR:
+                case BINARY:
+                case VARBINARY:
+                    bytes += 40;
+                    break;
+                default:
+                    bytes += 128;
+            }
         }
-        long rowGroupBytes = Math.max(1, fileSize / numRowGroups);
-        return (int) Math.min(depth, Math.max(0, maxBytes) / rowGroupBytes);
+        return Math.max(1, bytes);
     }
 
     int prefetchDepth() {
@@ -273,6 +306,7 @@ public class MosaicRecordsReader implements FileRecordReader<InternalRow> {
         openNanos += System.nanoTime() - waitStart;
         openedRowGroups++;
         pending.poll();
+        pendingBytes -= head.bytes;
         currentVsr = vsr;
         if (prefetchDepth > 0) {
             // currentVsr is owned by this reader, so a failure here leaves nothing unreleased.
@@ -281,16 +315,24 @@ public class MosaicRecordsReader implements FileRecordReader<InternalRow> {
         return head;
     }
 
-    /** Schedules matching row groups until {@code wanted} of them are queued. */
+    /** Schedules matching row groups until {@code wanted} are queued or the byte budget is used. */
     private void fillPrefetchQueue(int wanted) {
         while (pending.size() < wanted && nextRowGroupToSchedule < numRowGroups) {
-            int index = nextRowGroupToSchedule++;
+            int index = nextRowGroupToSchedule;
             int numRows = reader.rowGroupNumRows(index);
             long startPosition = scheduledRowCount;
-            scheduledRowCount += numRows;
             if (!matchesRowGroup(index, numRows)) {
+                nextRowGroupToSchedule++;
+                scheduledRowCount += numRows;
                 continue;
             }
+            long bytes = numRows * estimatedRowBytes;
+            // The first queued row group is always read; the rest must fit the decoded budget.
+            if (!pending.isEmpty() && pendingBytes + bytes > prefetchMaxBytes) {
+                return;
+            }
+            nextRowGroupToSchedule++;
+            scheduledRowCount += numRows;
             Future<VectorSchemaRoot> future = null;
             if (!allProjectedColumnsMissing) {
                 FutureTask<VectorSchemaRoot> task =
@@ -302,7 +344,8 @@ public class MosaicRecordsReader implements FileRecordReader<InternalRow> {
                 }
                 future = task;
             }
-            pending.add(new RowGroupBatch(index, numRows, startPosition, future));
+            pending.add(new RowGroupBatch(index, numRows, startPosition, bytes, future));
+            pendingBytes += bytes;
         }
     }
 
@@ -311,16 +354,19 @@ public class MosaicRecordsReader implements FileRecordReader<InternalRow> {
         final int index;
         final int numRows;
         final long startPosition;
+        final long bytes;
         @Nullable private final Future<VectorSchemaRoot> future;
 
         RowGroupBatch(
                 int index,
                 int numRows,
                 long startPosition,
+                long bytes,
                 @Nullable Future<VectorSchemaRoot> future) {
             this.index = index;
             this.numRows = numRows;
             this.startPosition = startPosition;
+            this.bytes = bytes;
             this.future = future;
         }
 
@@ -473,6 +519,7 @@ public class MosaicRecordsReader implements FileRecordReader<InternalRow> {
         boolean interrupted = false;
         RowGroupBatch batch;
         while ((batch = pending.poll()) != null) {
+            pendingBytes -= batch.bytes;
             try {
                 interrupted |= batch.discard();
             } catch (Throwable t) {

--- a/paimon-mosaic/src/main/java/org/apache/paimon/format/mosaic/MosaicRecordsReader.java
+++ b/paimon-mosaic/src/main/java/org/apache/paimon/format/mosaic/MosaicRecordsReader.java
@@ -31,22 +31,30 @@ import org.apache.paimon.reader.FileRecordReader;
 import org.apache.paimon.types.DataField;
 import org.apache.paimon.types.DataType;
 import org.apache.paimon.types.RowType;
+import org.apache.paimon.utils.ExecutorThreadFactory;
 
 import org.apache.arrow.memory.BufferAllocator;
 import org.apache.arrow.memory.RootAllocator;
 import org.apache.arrow.vector.VectorSchemaRoot;
 import org.apache.arrow.vector.types.pojo.Field;
 import org.apache.arrow.vector.types.pojo.Schema;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nullable;
 
 import java.io.IOException;
+import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
 
 import static org.apache.paimon.format.mosaic.MosaicObjects.convertStatsValue;
 
@@ -64,9 +72,25 @@ public class MosaicRecordsReader implements FileRecordReader<InternalRow> {
     private final boolean allProjectedColumnsMissing;
     @Nullable private final List<Predicate> predicates;
 
-    private int currentRowGroup;
+    /** Opens upcoming row groups while the current one is consumed; opens are thread-safe. */
+    private static final ExecutorService PREFETCH_POOL =
+            Executors.newCachedThreadPool(new ExecutorThreadFactory("mosaic-row-group-prefetch"));
+
+    private final int prefetchDepth;
+    private final ArrayDeque<RowGroupBatch> pending = new ArrayDeque<>();
+    private int nextRowGroupToSchedule;
+    private long scheduledRowCount;
+
     private long returnedPosition = -1;
     private VectorSchemaRoot currentVsr;
+
+    private static final Logger LOG = LoggerFactory.getLogger(MosaicRecordsReader.class);
+
+    // Read statistics reported at debug level when the reader closes.
+    private int openedRowGroups;
+    private long openNanos;
+    private long rowsReturned;
+    private final long createdNanos = System.nanoTime();
 
     public MosaicRecordsReader(
             MosaicInputFileAdapter inputFileAdapter,
@@ -82,8 +106,27 @@ public class MosaicRecordsReader implements FileRecordReader<InternalRow> {
                 projectedRowType,
                 predicates,
                 filePath,
+                MosaicFileFormat.READ_PREFETCH_ROW_GROUPS.defaultValue());
+    }
+
+    public MosaicRecordsReader(
+            MosaicInputFileAdapter inputFileAdapter,
+            long fileSize,
+            RowType dataSchemaRowType,
+            RowType projectedRowType,
+            @Nullable List<Predicate> predicates,
+            Path filePath,
+            int prefetchRowGroups) {
+        this(
+                inputFileAdapter,
+                fileSize,
+                dataSchemaRowType,
+                projectedRowType,
+                predicates,
+                filePath,
                 new RootAllocator(),
-                MosaicReader::open);
+                MosaicReader::open,
+                prefetchRowGroups);
     }
 
     MosaicRecordsReader(
@@ -95,12 +138,35 @@ public class MosaicRecordsReader implements FileRecordReader<InternalRow> {
             Path filePath,
             BufferAllocator allocator,
             NativeReaderOpener nativeReaderOpener) {
+        this(
+                inputFileAdapter,
+                fileSize,
+                dataSchemaRowType,
+                projectedRowType,
+                predicates,
+                filePath,
+                allocator,
+                nativeReaderOpener,
+                MosaicFileFormat.READ_PREFETCH_ROW_GROUPS.defaultValue());
+    }
+
+    MosaicRecordsReader(
+            MosaicInputFileAdapter inputFileAdapter,
+            long fileSize,
+            RowType dataSchemaRowType,
+            RowType projectedRowType,
+            @Nullable List<Predicate> predicates,
+            Path filePath,
+            BufferAllocator allocator,
+            NativeReaderOpener nativeReaderOpener,
+            int prefetchRowGroups) {
         this.filePath = filePath;
         this.inputFileAdapter = inputFileAdapter;
         this.dataSchemaRowType = dataSchemaRowType;
         this.projectedFieldCount = projectedRowType.getFieldCount();
         this.predicates = predicates;
         this.allocator = allocator;
+        this.prefetchDepth = Math.max(0, prefetchRowGroups);
 
         MosaicReader createdReader = null;
         int createdNumRowGroups;
@@ -136,62 +202,151 @@ public class MosaicRecordsReader implements FileRecordReader<InternalRow> {
         this.reader = createdReader;
         this.numRowGroups = createdNumRowGroups;
         this.allProjectedColumnsMissing = createdAllProjectedColumnsMissing;
-        this.currentRowGroup = 0;
         this.arrowBatchReader = createdArrowBatchReader;
     }
 
     @Nullable
     @Override
     public FileRecordIterator<InternalRow> readBatch() throws IOException {
-        while (currentRowGroup < numRowGroups) {
-            int numRows = reader.rowGroupNumRows(currentRowGroup);
-            if (!matchesRowGroup(currentRowGroup, numRows)) {
-                returnedPosition += numRows;
-                currentRowGroup++;
+        releaseCurrentVsr();
+
+        RowGroupBatch batch = nextRowGroup();
+        if (batch == null) {
+            return null;
+        }
+        // Rows of skipped row groups still count towards the file position.
+        returnedPosition = batch.startPosition - 1;
+        rowsReturned += batch.numRows;
+
+        if (allProjectedColumnsMissing) {
+            return allNullIterator(batch.numRows);
+        }
+
+        VectorSchemaRoot vsr = batch.vsr;
+        this.currentVsr = vsr;
+
+        Iterator<InternalRow> rows = arrowBatchReader.readBatch(vsr).iterator();
+
+        return new FileRecordIterator<InternalRow>() {
+            @Override
+            public long returnedPosition() {
+                return returnedPosition;
+            }
+
+            @Override
+            public Path filePath() {
+                return filePath;
+            }
+
+            @Nullable
+            @Override
+            public InternalRow next() {
+                if (rows.hasNext()) {
+                    returnedPosition++;
+                    return rows.next();
+                }
+                return null;
+            }
+
+            @Override
+            public void releaseBatch() {
+                releaseCurrentVsr();
+            }
+        };
+    }
+
+    /** Returns the next matching row group with its data ready, or null at end of file. */
+    @Nullable
+    private RowGroupBatch nextRowGroup() throws IOException {
+        fillPrefetchQueue();
+        RowGroupBatch head = pending.poll();
+        if (head == null) {
+            return null;
+        }
+        // Keep the pipeline full while waiting for the head to arrive.
+        fillPrefetchQueue();
+        long waitStart = System.nanoTime();
+        head.await();
+        openNanos += System.nanoTime() - waitStart;
+        openedRowGroups++;
+        return head;
+    }
+
+    /** Schedules matching row groups until the queue holds the head plus {@code prefetchDepth}. */
+    private void fillPrefetchQueue() {
+        int wanted = prefetchDepth + 1;
+        while (pending.size() < wanted && nextRowGroupToSchedule < numRowGroups) {
+            int index = nextRowGroupToSchedule++;
+            int numRows = reader.rowGroupNumRows(index);
+            long startPosition = scheduledRowCount;
+            scheduledRowCount += numRows;
+            if (!matchesRowGroup(index, numRows)) {
                 continue;
             }
-
-            releaseCurrentVsr();
-
+            RowGroupBatch batch = new RowGroupBatch(index, numRows, startPosition);
             if (allProjectedColumnsMissing) {
-                currentRowGroup++;
-                return allNullIterator(numRows);
+                // Nothing to read from the file for this batch.
+            } else if (prefetchDepth == 0) {
+                batch.vsr = reader.readRowGroup(index, allocator);
+            } else {
+                batch.future = PREFETCH_POOL.submit(() -> reader.readRowGroup(index, allocator));
             }
-
-            VectorSchemaRoot vsr = reader.readRowGroup(currentRowGroup, allocator);
-            currentRowGroup++;
-            this.currentVsr = vsr;
-
-            Iterator<InternalRow> rows = arrowBatchReader.readBatch(vsr).iterator();
-
-            return new FileRecordIterator<InternalRow>() {
-                @Override
-                public long returnedPosition() {
-                    return returnedPosition;
-                }
-
-                @Override
-                public Path filePath() {
-                    return filePath;
-                }
-
-                @Nullable
-                @Override
-                public InternalRow next() {
-                    if (rows.hasNext()) {
-                        returnedPosition++;
-                        return rows.next();
-                    }
-                    return null;
-                }
-
-                @Override
-                public void releaseBatch() {
-                    releaseCurrentVsr();
-                }
-            };
+            pending.add(batch);
         }
-        return null;
+    }
+
+    /** A row group whose data is being, or has been, loaded. */
+    private static final class RowGroupBatch {
+        final int index;
+        final int numRows;
+        final long startPosition;
+        @Nullable Future<VectorSchemaRoot> future;
+        @Nullable VectorSchemaRoot vsr;
+
+        RowGroupBatch(int index, int numRows, long startPosition) {
+            this.index = index;
+            this.numRows = numRows;
+            this.startPosition = startPosition;
+        }
+
+        void await() throws IOException {
+            if (future == null) {
+                return;
+            }
+            try {
+                vsr = future.get();
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                throw new IOException("Interrupted while opening row group " + index, e);
+            } catch (ExecutionException e) {
+                Throwable cause = e.getCause();
+                if (cause instanceof IOException) {
+                    throw (IOException) cause;
+                }
+                if (cause instanceof RuntimeException) {
+                    throw (RuntimeException) cause;
+                }
+                if (cause instanceof Error) {
+                    throw (Error) cause;
+                }
+                throw new IOException("Failed to open row group " + index, cause);
+            } finally {
+                future = null;
+            }
+        }
+
+        /** Releases data that was loaded but never consumed. */
+        void discard() {
+            try {
+                await();
+            } catch (Throwable ignored) {
+                // The reader is being closed; the failure has no consumer anymore.
+            }
+            if (vsr != null) {
+                vsr.close();
+                vsr = null;
+            }
+        }
     }
 
     private FileRecordIterator<InternalRow> allNullIterator(int numRows) {
@@ -277,10 +432,34 @@ public class MosaicRecordsReader implements FileRecordReader<InternalRow> {
     public void close() throws IOException {
         Throwable throwable = null;
 
+        if (LOG.isDebugEnabled()) {
+            LOG.debug(
+                    "Closing mosaic reader for {}: row groups {} (opened {}), rows {}, "
+                            + "waited {} ms for row groups, lifetime {} ms, {}",
+                    filePath.getName(),
+                    numRowGroups,
+                    openedRowGroups,
+                    rowsReturned,
+                    openNanos / 1_000_000,
+                    (System.nanoTime() - createdNanos) / 1_000_000,
+                    inputFileAdapter.ioStats());
+        }
+
         try {
             releaseCurrentVsr();
         } catch (Throwable t) {
             throwable = t;
+        }
+
+        // Prefetched row groups must finish and be released before the native reader and the
+        // allocator go away.
+        RowGroupBatch batch;
+        while ((batch = pending.poll()) != null) {
+            try {
+                batch.discard();
+            } catch (Throwable t) {
+                throwable = addSuppressed(throwable, t);
+            }
         }
 
         try {

--- a/paimon-mosaic/src/main/java/org/apache/paimon/format/mosaic/MosaicRecordsReader.java
+++ b/paimon-mosaic/src/main/java/org/apache/paimon/format/mosaic/MosaicRecordsReader.java
@@ -44,6 +44,7 @@ import org.slf4j.LoggerFactory;
 import javax.annotation.Nullable;
 
 import java.io.IOException;
+import java.io.InterruptedIOException;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.HashSet;
@@ -55,6 +56,7 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
+import java.util.concurrent.FutureTask;
 
 import static org.apache.paimon.format.mosaic.MosaicObjects.convertStatsValue;
 
@@ -222,10 +224,7 @@ public class MosaicRecordsReader implements FileRecordReader<InternalRow> {
             return allNullIterator(batch.numRows);
         }
 
-        VectorSchemaRoot vsr = batch.vsr;
-        this.currentVsr = vsr;
-
-        Iterator<InternalRow> rows = arrowBatchReader.readBatch(vsr).iterator();
+        Iterator<InternalRow> rows = arrowBatchReader.readBatch(currentVsr).iterator();
 
         return new FileRecordIterator<InternalRow>() {
             @Override
@@ -258,23 +257,29 @@ public class MosaicRecordsReader implements FileRecordReader<InternalRow> {
     /** Returns the next matching row group with its data ready, or null at end of file. */
     @Nullable
     private RowGroupBatch nextRowGroup() throws IOException {
-        fillPrefetchQueue();
-        RowGroupBatch head = pending.poll();
+        if (pending.isEmpty()) {
+            fillPrefetchQueue(Math.max(1, prefetchDepth));
+        }
+        RowGroupBatch head = pending.peek();
         if (head == null) {
             return null;
         }
-        // Keep the pipeline full while waiting for the head to arrive.
-        fillPrefetchQueue();
+        // The head stays queued until its data has arrived, so close() can still wait for it.
         long waitStart = System.nanoTime();
-        head.await();
+        VectorSchemaRoot vsr = head.await();
         openNanos += System.nanoTime() - waitStart;
         openedRowGroups++;
+        pending.poll();
+        currentVsr = vsr;
+        if (prefetchDepth > 0) {
+            // currentVsr is owned by this reader, so a failure here leaves nothing unreleased.
+            fillPrefetchQueue(prefetchDepth);
+        }
         return head;
     }
 
-    /** Schedules matching row groups until the queue holds the head plus {@code prefetchDepth}. */
-    private void fillPrefetchQueue() {
-        int wanted = prefetchDepth + 1;
+    /** Schedules matching row groups until {@code wanted} of them are queued. */
+    private void fillPrefetchQueue(int wanted) {
         while (pending.size() < wanted && nextRowGroupToSchedule < numRowGroups) {
             int index = nextRowGroupToSchedule++;
             int numRows = reader.rowGroupNumRows(index);
@@ -283,15 +288,18 @@ public class MosaicRecordsReader implements FileRecordReader<InternalRow> {
             if (!matchesRowGroup(index, numRows)) {
                 continue;
             }
-            RowGroupBatch batch = new RowGroupBatch(index, numRows, startPosition);
-            if (allProjectedColumnsMissing) {
-                // Nothing to read from the file for this batch.
-            } else if (prefetchDepth == 0) {
-                batch.vsr = reader.readRowGroup(index, allocator);
-            } else {
-                batch.future = PREFETCH_POOL.submit(() -> reader.readRowGroup(index, allocator));
+            Future<VectorSchemaRoot> future = null;
+            if (!allProjectedColumnsMissing) {
+                FutureTask<VectorSchemaRoot> task =
+                        new FutureTask<>(() -> reader.readRowGroup(index, allocator));
+                if (prefetchDepth == 0) {
+                    task.run();
+                } else {
+                    PREFETCH_POOL.execute(task);
+                }
+                future = task;
             }
-            pending.add(batch);
+            pending.add(new RowGroupBatch(index, numRows, startPosition, future));
         }
     }
 
@@ -300,24 +308,33 @@ public class MosaicRecordsReader implements FileRecordReader<InternalRow> {
         final int index;
         final int numRows;
         final long startPosition;
-        @Nullable Future<VectorSchemaRoot> future;
-        @Nullable VectorSchemaRoot vsr;
+        @Nullable private final Future<VectorSchemaRoot> future;
 
-        RowGroupBatch(int index, int numRows, long startPosition) {
+        RowGroupBatch(
+                int index,
+                int numRows,
+                long startPosition,
+                @Nullable Future<VectorSchemaRoot> future) {
             this.index = index;
             this.numRows = numRows;
             this.startPosition = startPosition;
+            this.future = future;
         }
 
-        void await() throws IOException {
+        /** Waits for the data; the batch is not released here even when the wait fails. */
+        @Nullable
+        VectorSchemaRoot await() throws IOException {
             if (future == null) {
-                return;
+                return null;
             }
             try {
-                vsr = future.get();
+                return future.get();
             } catch (InterruptedException e) {
                 Thread.currentThread().interrupt();
-                throw new IOException("Interrupted while opening row group " + index, e);
+                InterruptedIOException interrupted =
+                        new InterruptedIOException("Interrupted while opening row group " + index);
+                interrupted.initCause(e);
+                throw interrupted;
             } catch (ExecutionException e) {
                 Throwable cause = e.getCause();
                 if (cause instanceof IOException) {
@@ -330,21 +347,31 @@ public class MosaicRecordsReader implements FileRecordReader<InternalRow> {
                     throw (Error) cause;
                 }
                 throw new IOException("Failed to open row group " + index, cause);
-            } finally {
-                future = null;
             }
         }
 
-        /** Releases data that was loaded but never consumed. */
-        void discard() {
-            try {
-                await();
-            } catch (Throwable ignored) {
-                // The reader is being closed; the failure has no consumer anymore.
+        /**
+         * Waits for the read to finish, even if the current thread is interrupted, and releases its
+         * data. Returns whether an interrupt was swallowed while waiting.
+         */
+        boolean discard() {
+            if (future == null) {
+                return false;
             }
-            if (vsr != null) {
-                vsr.close();
-                vsr = null;
+            boolean interrupted = false;
+            while (true) {
+                try {
+                    VectorSchemaRoot vsr = future.get();
+                    if (vsr != null) {
+                        vsr.close();
+                    }
+                    return interrupted;
+                } catch (InterruptedException e) {
+                    // The native read still uses the reader handle; it must complete first.
+                    interrupted = true;
+                } catch (ExecutionException e) {
+                    return interrupted;
+                }
             }
         }
     }
@@ -452,11 +479,12 @@ public class MosaicRecordsReader implements FileRecordReader<InternalRow> {
         }
 
         // Prefetched row groups must finish and be released before the native reader and the
-        // allocator go away.
+        // allocator go away, even if this thread is interrupted.
+        boolean interrupted = false;
         RowGroupBatch batch;
         while ((batch = pending.poll()) != null) {
             try {
-                batch.discard();
+                interrupted |= batch.discard();
             } catch (Throwable t) {
                 throwable = addSuppressed(throwable, t);
             }
@@ -480,6 +508,9 @@ public class MosaicRecordsReader implements FileRecordReader<InternalRow> {
             throwable = addSuppressed(throwable, t);
         }
 
+        if (interrupted) {
+            Thread.currentThread().interrupt();
+        }
         if (throwable != null) {
             rethrow(throwable);
         }

--- a/paimon-mosaic/src/test/java/org/apache/paimon/format/mosaic/MosaicInputFileAdapterTest.java
+++ b/paimon-mosaic/src/test/java/org/apache/paimon/format/mosaic/MosaicInputFileAdapterTest.java
@@ -1,0 +1,162 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.format.mosaic;
+
+import org.apache.paimon.fs.Path;
+import org.apache.paimon.fs.SeekableInputStream;
+import org.apache.paimon.fs.local.LocalFileIO;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Tests for the stream pool of {@link MosaicInputFileAdapter}. */
+class MosaicInputFileAdapterTest {
+
+    @Test
+    void testConcurrentReadsAreCappedAtMaxStreams() throws Exception {
+        CountDownLatch readsStarted = new CountDownLatch(2);
+        CountDownLatch releaseReads = new CountDownLatch(1);
+        AtomicInteger opened = new AtomicInteger();
+        LocalFileIO fileIO =
+                new LocalFileIO() {
+                    @Override
+                    public SeekableInputStream newInputStream(Path path) {
+                        opened.incrementAndGet();
+                        return new BlockingStream(readsStarted, releaseReads);
+                    }
+                };
+        MosaicInputFileAdapter adapter =
+                new MosaicInputFileAdapter(fileIO, new Path("file:/tmp/mosaic-adapter-test"), 2);
+
+        List<Thread> readers = new ArrayList<>();
+        AtomicReference<Throwable> failure = new AtomicReference<>();
+        for (int i = 0; i < 3; i++) {
+            Thread thread =
+                    new Thread(
+                            () -> {
+                                try {
+                                    adapter.readFully(0, new byte[4], 0, 4);
+                                } catch (Throwable t) {
+                                    failure.set(t);
+                                }
+                            });
+            thread.start();
+            readers.add(thread);
+        }
+        readsStarted.await();
+        // Two reads hold the two streams; the third must wait instead of opening another one.
+        readers.get(0).join(200);
+        assertThat(opened.get()).isEqualTo(2);
+        assertThat(readers.stream().filter(Thread::isAlive).count()).isEqualTo(3);
+
+        releaseReads.countDown();
+        for (Thread thread : readers) {
+            thread.join();
+        }
+        assertThat(failure.get()).isNull();
+        assertThat(opened.get()).isEqualTo(2);
+        adapter.close();
+    }
+
+    @Test
+    void testCloseWakesWaitingReader() throws Exception {
+        CountDownLatch readsStarted = new CountDownLatch(1);
+        CountDownLatch releaseReads = new CountDownLatch(1);
+        LocalFileIO fileIO =
+                new LocalFileIO() {
+                    @Override
+                    public SeekableInputStream newInputStream(Path path) {
+                        return new BlockingStream(readsStarted, releaseReads);
+                    }
+                };
+        MosaicInputFileAdapter adapter =
+                new MosaicInputFileAdapter(fileIO, new Path("file:/tmp/mosaic-adapter-test"), 1);
+        AtomicReference<Throwable> first = new AtomicReference<>();
+        AtomicReference<Throwable> second = new AtomicReference<>();
+        Thread holder = new Thread(() -> read(adapter, first));
+        holder.start();
+        readsStarted.await();
+        Thread waiter = new Thread(() -> read(adapter, second));
+        waiter.start();
+        waiter.join(200);
+        assertThat(waiter.isAlive()).isTrue();
+
+        adapter.close();
+        waiter.join();
+        assertThat(second.get()).isInstanceOf(IOException.class);
+        releaseReads.countDown();
+        holder.join();
+    }
+
+    private static void read(MosaicInputFileAdapter adapter, AtomicReference<Throwable> failure) {
+        try {
+            adapter.readFully(0, new byte[4], 0, 4);
+        } catch (Throwable t) {
+            failure.set(t);
+        }
+    }
+
+    /** A stream whose reads block until released, to hold a pooled stream busy. */
+    private static class BlockingStream extends SeekableInputStream {
+
+        private final CountDownLatch started;
+        private final CountDownLatch release;
+
+        private BlockingStream(CountDownLatch started, CountDownLatch release) {
+            this.started = started;
+            this.release = release;
+        }
+
+        @Override
+        public void seek(long desired) {}
+
+        @Override
+        public long getPos() {
+            return 0;
+        }
+
+        @Override
+        public int read(byte[] b, int off, int len) throws IOException {
+            started.countDown();
+            try {
+                release.await();
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                throw new IOException(e);
+            }
+            return len;
+        }
+
+        @Override
+        public int read() {
+            return -1;
+        }
+
+        @Override
+        public void close() {}
+    }
+}

--- a/paimon-mosaic/src/test/java/org/apache/paimon/format/mosaic/MosaicReaderWriterTest.java
+++ b/paimon-mosaic/src/test/java/org/apache/paimon/format/mosaic/MosaicReaderWriterTest.java
@@ -56,6 +56,7 @@ import java.util.List;
 import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
@@ -393,8 +394,7 @@ class MosaicReaderWriterTest {
         }
         writeRows(rowType, path, new Options(), MemorySize.ofKibiBytes(32), rows);
 
-        MosaicFileFormat format = createFormat();
-        FormatReaderFactory readerFactory = new MosaicReaderFactory(rowType, rowType, null, 4);
+        FormatReaderFactory readerFactory = createReaderFactory(rowType, null, 4);
         LocalFileIO fileIO = new LocalFileIO();
         RecordReader<InternalRow> reader =
                 readerFactory.createReader(
@@ -403,8 +403,7 @@ class MosaicReaderWriterTest {
         // Consume one batch only; the prefetched row groups are still in flight or buffered.
         assertThat(reader.readBatch()).isNotNull();
         // Closing must wait for and release them (an Arrow allocator leak would throw here).
-        reader.close();
-        assertThat(format).isNotNull();
+        assertThatCode(reader::close).doesNotThrowAnyException();
     }
 
     private void writeRows(
@@ -431,7 +430,7 @@ class MosaicReaderWriterTest {
             List<Long> positions)
             throws IOException {
         FormatReaderFactory readerFactory =
-                new MosaicReaderFactory(rowType, rowType, predicates, prefetchRowGroups);
+                createReaderFactory(rowType, predicates, prefetchRowGroups);
         LocalFileIO fileIO = new LocalFileIO();
         RecordReader<InternalRow> reader =
                 readerFactory.createReader(
@@ -490,6 +489,16 @@ class MosaicReaderWriterTest {
         reader.forEachRemaining(row -> result.add(serializer.copy(row)));
         reader.close();
         return result;
+    }
+
+    private static FormatReaderFactory createReaderFactory(
+            RowType rowType, List<Predicate> predicates, int prefetchRowGroups) {
+        return new MosaicReaderFactory(
+                rowType,
+                rowType,
+                predicates,
+                prefetchRowGroups,
+                MosaicFileFormat.READ_PREFETCH_MAX_BYTES.defaultValue().getBytes());
     }
 
     private static MosaicFileFormat createFormat() {

--- a/paimon-mosaic/src/test/java/org/apache/paimon/format/mosaic/MosaicReaderWriterTest.java
+++ b/paimon-mosaic/src/test/java/org/apache/paimon/format/mosaic/MosaicReaderWriterTest.java
@@ -32,6 +32,7 @@ import org.apache.paimon.format.FormatWriter;
 import org.apache.paimon.format.FormatWriterFactory;
 import org.apache.paimon.fs.Path;
 import org.apache.paimon.fs.local.LocalFileIO;
+import org.apache.paimon.options.MemorySize;
 import org.apache.paimon.options.Options;
 import org.apache.paimon.predicate.Predicate;
 import org.apache.paimon.predicate.PredicateBuilder;
@@ -338,6 +339,118 @@ class MosaicReaderWriterTest {
         }
         writer.close();
         assertThat(reached).isTrue();
+    }
+
+    @Test
+    void testPrefetchedReadMatchesSequentialRead() throws IOException {
+        RowType rowType = DataTypes.ROW(DataTypes.INT(), DataTypes.STRING());
+        Path path = newPath();
+        int numRows = 20_000;
+        GenericRow[] rows = new GenericRow[numRows];
+        for (int i = 0; i < numRows; i++) {
+            rows[i] = GenericRow.of(i, BinaryString.fromString("value_" + i + "_padding"));
+        }
+        // A tiny row group size produces many row groups, so prefetching is exercised.
+        Options writeOptions = new Options();
+        writeOptions.set(MosaicFileFormat.STATS_COLUMNS, "f0");
+        writeRows(rowType, path, writeOptions, MemorySize.ofKibiBytes(32), rows);
+
+        List<Long> sequentialPositions = new ArrayList<>();
+        List<InternalRow> sequential =
+                readAllWithPrefetch(rowType, path, null, 0, sequentialPositions);
+        assertThat(sequential).hasSize(numRows);
+
+        List<Long> prefetchedPositions = new ArrayList<>();
+        List<InternalRow> prefetched =
+                readAllWithPrefetch(rowType, path, null, 3, prefetchedPositions);
+        assertThat(prefetched).hasSize(numRows);
+        assertThat(prefetchedPositions).isEqualTo(sequentialPositions);
+        for (int i = 0; i < numRows; i++) {
+            assertThat(prefetched.get(i).getInt(0)).isEqualTo(sequential.get(i).getInt(0));
+            assertThat(prefetched.get(i).getString(1)).isEqualTo(sequential.get(i).getString(1));
+        }
+
+        // Row groups skipped by the predicate must still advance the returned position.
+        Predicate predicate = new PredicateBuilder(rowType).greaterOrEqual(0, numRows - 1000);
+        List<Long> filteredPositions = new ArrayList<>();
+        List<InternalRow> filtered =
+                readAllWithPrefetch(
+                        rowType, path, Collections.singletonList(predicate), 3, filteredPositions);
+        assertThat(filtered).isNotEmpty();
+        assertThat(filtered.size()).isLessThan(numRows);
+        assertThat(filteredPositions.get(0)).isEqualTo((long) filtered.get(0).getInt(0));
+        assertThat(filteredPositions.get(filteredPositions.size() - 1))
+                .isEqualTo((long) numRows - 1);
+    }
+
+    @Test
+    void testClosingReaderWithPendingPrefetchReleasesResources() throws IOException {
+        RowType rowType = DataTypes.ROW(DataTypes.INT(), DataTypes.STRING());
+        Path path = newPath();
+        GenericRow[] rows = new GenericRow[20_000];
+        for (int i = 0; i < rows.length; i++) {
+            rows[i] = GenericRow.of(i, BinaryString.fromString("value_" + i + "_padding"));
+        }
+        writeRows(rowType, path, new Options(), MemorySize.ofKibiBytes(32), rows);
+
+        MosaicFileFormat format = createFormat();
+        FormatReaderFactory readerFactory = new MosaicReaderFactory(rowType, rowType, null, 4);
+        LocalFileIO fileIO = new LocalFileIO();
+        RecordReader<InternalRow> reader =
+                readerFactory.createReader(
+                        new FormatReaderContext(
+                                fileIO, path, fileIO.getFileSize(path), null, null));
+        // Consume one batch only; the prefetched row groups are still in flight or buffered.
+        assertThat(reader.readBatch()).isNotNull();
+        // Closing must wait for and release them (an Arrow allocator leak would throw here).
+        reader.close();
+        assertThat(format).isNotNull();
+    }
+
+    private void writeRows(
+            RowType rowType, Path path, Options options, MemorySize blockSize, GenericRow... rows)
+            throws IOException {
+        MosaicFileFormat format =
+                new MosaicFileFormat(
+                        new FileFormatFactory.FormatContext(
+                                options, 1024, 1024, MemorySize.VALUE_128_MB, 1, blockSize));
+        FormatWriterFactory writerFactory = format.createWriterFactory(rowType);
+        LocalFileIO fileIO = new LocalFileIO();
+        FormatWriter writer = writerFactory.create(fileIO.newOutputStream(path, false), "zstd");
+        for (GenericRow row : rows) {
+            writer.addElement(row);
+        }
+        writer.close();
+    }
+
+    private List<InternalRow> readAllWithPrefetch(
+            RowType rowType,
+            Path path,
+            List<Predicate> predicates,
+            int prefetchRowGroups,
+            List<Long> positions)
+            throws IOException {
+        FormatReaderFactory readerFactory =
+                new MosaicReaderFactory(rowType, rowType, predicates, prefetchRowGroups);
+        LocalFileIO fileIO = new LocalFileIO();
+        RecordReader<InternalRow> reader =
+                readerFactory.createReader(
+                        new FormatReaderContext(
+                                fileIO, path, fileIO.getFileSize(path), null, null));
+        InternalRowSerializer serializer = new InternalRowSerializer(rowType);
+        List<InternalRow> result = new ArrayList<>();
+        RecordReader.RecordIterator<InternalRow> batch;
+        while ((batch = reader.readBatch()) != null) {
+            FileRecordIterator<InternalRow> fileIterator = (FileRecordIterator<InternalRow>) batch;
+            InternalRow row;
+            while ((row = fileIterator.next()) != null) {
+                positions.add(fileIterator.returnedPosition());
+                result.add(serializer.copy(row));
+            }
+            batch.releaseBatch();
+        }
+        reader.close();
+        return result;
     }
 
     private Path newPath() {

--- a/paimon-mosaic/src/test/java/org/apache/paimon/format/mosaic/MosaicRecordsReaderTest.java
+++ b/paimon-mosaic/src/test/java/org/apache/paimon/format/mosaic/MosaicRecordsReaderTest.java
@@ -55,6 +55,7 @@ import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.timeout;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -369,40 +370,38 @@ class MosaicRecordsReaderTest {
     }
 
     @Test
-    void testPrefetchDepthIsBoundedByRowGroupBytes() throws IOException {
-        long mb = 1024 * 1024;
-        // 100 MB row groups against a 64 MB budget: nothing is read ahead.
-        assertThat(MosaicRecordsReader.boundedPrefetchDepth(8, 64 * mb, 400 * mb, 4)).isEqualTo(0);
-        // 100 MB row groups against a 250 MB budget: two ahead.
-        assertThat(MosaicRecordsReader.boundedPrefetchDepth(8, 250 * mb, 400 * mb, 4)).isEqualTo(2);
-        // 1 MB row groups: the configured depth applies.
-        assertThat(MosaicRecordsReader.boundedPrefetchDepth(8, 64 * mb, 400 * mb, 400))
-                .isEqualTo(8);
-        // Unknown file size keeps the configured depth; depth 0 stays 0.
-        assertThat(MosaicRecordsReader.boundedPrefetchDepth(8, 64 * mb, 0, 4)).isEqualTo(8);
-        assertThat(MosaicRecordsReader.boundedPrefetchDepth(0, 64 * mb, 400 * mb, 4)).isEqualTo(0);
-
-        CloseCountingSeekableInputStream inputStream = new CloseCountingSeekableInputStream();
-        MosaicInputFileAdapter inputFileAdapter = createInputFileAdapter(inputStream);
-        CloseCountingRootAllocator allocator = new CloseCountingRootAllocator();
-        MosaicReader reader = createProjectedReader(allocator, 4);
-        MosaicRecordsReader recordsReader =
-                new MosaicRecordsReader(
-                        inputFileAdapter,
-                        400 * mb,
-                        rowType(),
-                        rowType(),
-                        null,
-                        new Path("file:/tmp/mosaic-reader-test"),
-                        allocator,
-                        (inputFile, fileSize, bufferAllocator) -> reader,
-                        8,
-                        64 * mb);
-        assertThat(recordsReader.prefetchDepth()).isEqualTo(0);
-        assertThat(recordsReader.readBatch()).isNotNull();
-        verify(reader, times(1)).readRowGroup(anyInt(), any());
-        recordsReader.close();
-        assertThat(allocator.closeCount()).isEqualTo(1);
+    void testPrefetchIsBoundedByEstimatedDecodedBytes() throws IOException {
+        // One INT column: 5 bytes per row; 1,000 rows per row group is 5,000 bytes.
+        assertThat(MosaicRecordsReader.estimatedRowBytes(rowType())).isEqualTo(5);
+        for (long budget : new long[] {4_000L, 100_000L}) {
+            CloseCountingSeekableInputStream inputStream = new CloseCountingSeekableInputStream();
+            MosaicInputFileAdapter inputFileAdapter = createInputFileAdapter(inputStream);
+            CloseCountingRootAllocator allocator = new CloseCountingRootAllocator();
+            MosaicReader reader = createProjectedReader(allocator, 4);
+            when(reader.rowGroupNumRows(anyInt())).thenReturn(1000);
+            MosaicRecordsReader recordsReader =
+                    new MosaicRecordsReader(
+                            inputFileAdapter,
+                            0,
+                            rowType(),
+                            rowType(),
+                            null,
+                            new Path("file:/tmp/mosaic-reader-test"),
+                            allocator,
+                            (inputFile, fileSize, bufferAllocator) -> reader,
+                            8,
+                            budget);
+            assertThat(recordsReader.readBatch()).isNotNull();
+            if (budget < 5_000L) {
+                // Below one row group: nothing is read ahead of the batch being consumed.
+                verify(reader, times(1)).readRowGroup(anyInt(), any());
+            } else {
+                // The three remaining row groups fit the budget and are read ahead.
+                verify(reader, timeout(5_000).times(4)).readRowGroup(anyInt(), any());
+            }
+            recordsReader.close();
+            assertThat(allocator.closeCount()).isEqualTo(1);
+        }
     }
 
     private static void closeQuietly(

--- a/paimon-mosaic/src/test/java/org/apache/paimon/format/mosaic/MosaicRecordsReaderTest.java
+++ b/paimon-mosaic/src/test/java/org/apache/paimon/format/mosaic/MosaicRecordsReaderTest.java
@@ -18,6 +18,7 @@
 
 package org.apache.paimon.format.mosaic;
 
+import org.apache.paimon.arrow.ArrowUtils;
 import org.apache.paimon.data.InternalRow;
 import org.apache.paimon.fs.Path;
 import org.apache.paimon.fs.SeekableInputStream;
@@ -27,20 +28,34 @@ import org.apache.paimon.reader.FileRecordIterator;
 import org.apache.paimon.types.DataTypes;
 import org.apache.paimon.types.RowType;
 
+import org.apache.arrow.memory.BufferAllocator;
 import org.apache.arrow.memory.RootAllocator;
+import org.apache.arrow.vector.IntVector;
+import org.apache.arrow.vector.VectorSchemaRoot;
+import org.apache.arrow.vector.types.pojo.ArrowType;
+import org.apache.arrow.vector.types.pojo.Field;
 import org.apache.arrow.vector.types.pojo.Schema;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
+import java.io.InterruptedIOException;
+import java.util.ArrayList;
 import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -186,6 +201,206 @@ class MosaicRecordsReaderTest {
         recordsReader.close();
     }
 
+    @Test
+    void testDisabledPrefetchReadsRowGroupsOnDemand() throws IOException {
+        CloseCountingSeekableInputStream inputStream = new CloseCountingSeekableInputStream();
+        MosaicInputFileAdapter inputFileAdapter = createInputFileAdapter(inputStream);
+        CloseCountingRootAllocator allocator = new CloseCountingRootAllocator();
+        MosaicReader reader = createProjectedReader(allocator, 3);
+
+        MosaicRecordsReader recordsReader =
+                createRecordsReader(inputFileAdapter, allocator, reader, 0);
+
+        FileRecordIterator<InternalRow> first = recordsReader.readBatch();
+        assertThat(first).isNotNull();
+        // Depth 0 must not read the next row group before the first batch is consumed.
+        verify(reader, times(1)).readRowGroup(anyInt(), any());
+        assertThat(first.next().getInt(0)).isEqualTo(0);
+        assertThat(first.next()).isNull();
+        first.releaseBatch();
+
+        List<Integer> values = new ArrayList<>();
+        FileRecordIterator<InternalRow> batch;
+        while ((batch = recordsReader.readBatch()) != null) {
+            InternalRow row;
+            while ((row = batch.next()) != null) {
+                values.add(row.getInt(0));
+            }
+            batch.releaseBatch();
+        }
+        assertThat(values).containsExactly(1, 2);
+        verify(reader, times(3)).readRowGroup(anyInt(), any());
+
+        recordsReader.close();
+        assertThat(allocator.closeCount()).isEqualTo(1);
+    }
+
+    @Test
+    void testInterruptedReadKeepsInFlightRowGroupUntilClose() throws Exception {
+        CloseCountingSeekableInputStream inputStream = new CloseCountingSeekableInputStream();
+        MosaicInputFileAdapter inputFileAdapter = createInputFileAdapter(inputStream);
+        CloseCountingRootAllocator allocator = new CloseCountingRootAllocator();
+        MosaicReader reader = createProjectedReader(allocator, 1);
+        CountDownLatch readStarted = new CountDownLatch(1);
+        CountDownLatch releaseRead = new CountDownLatch(1);
+        List<String> events = Collections.synchronizedList(new ArrayList<>());
+        doAnswer(
+                        invocation -> {
+                            readStarted.countDown();
+                            releaseRead.await();
+                            events.add("read-finished");
+                            return rowGroup(allocator, 0);
+                        })
+                .when(reader)
+                .readRowGroup(eq(0), any());
+        doAnswer(
+                        invocation -> {
+                            events.add("reader-closed");
+                            return null;
+                        })
+                .when(reader)
+                .close();
+
+        MosaicRecordsReader recordsReader =
+                createRecordsReader(inputFileAdapter, allocator, reader, 2);
+        AtomicReference<Throwable> readFailure = new AtomicReference<>();
+        Thread consumer =
+                new Thread(
+                        () -> {
+                            try {
+                                recordsReader.readBatch();
+                            } catch (Throwable t) {
+                                readFailure.set(t);
+                            }
+                        });
+        consumer.start();
+        readStarted.await();
+        consumer.interrupt();
+        consumer.join();
+        assertThat(readFailure.get()).isInstanceOf(InterruptedIOException.class);
+
+        // The interrupted read is still running natively: close() has to wait for it.
+        AtomicReference<Throwable> closeFailure = new AtomicReference<>();
+        Thread closer = new Thread(() -> closeQuietly(recordsReader, closeFailure));
+        closer.start();
+        closer.join(200);
+        assertThat(closer.isAlive()).isTrue();
+        assertThat(events).isEmpty();
+        releaseRead.countDown();
+        closer.join();
+
+        assertThat(closeFailure.get()).isNull();
+        assertThat(events).containsExactly("read-finished", "reader-closed");
+        assertThat(allocator.closeCount()).isEqualTo(1);
+    }
+
+    @Test
+    void testCloseWithInterruptFlagStillWaitsForInFlightRowGroups() throws Exception {
+        CloseCountingSeekableInputStream inputStream = new CloseCountingSeekableInputStream();
+        MosaicInputFileAdapter inputFileAdapter = createInputFileAdapter(inputStream);
+        CloseCountingRootAllocator allocator = new CloseCountingRootAllocator();
+        MosaicReader reader = createProjectedReader(allocator, 2);
+        CountDownLatch readStarted = new CountDownLatch(1);
+        CountDownLatch releaseRead = new CountDownLatch(1);
+        List<String> events = Collections.synchronizedList(new ArrayList<>());
+        doAnswer(
+                        invocation -> {
+                            readStarted.countDown();
+                            releaseRead.await();
+                            events.add("read-finished");
+                            return rowGroup(allocator, 1);
+                        })
+                .when(reader)
+                .readRowGroup(eq(1), any());
+        doAnswer(
+                        invocation -> {
+                            events.add("reader-closed");
+                            return null;
+                        })
+                .when(reader)
+                .close();
+
+        MosaicRecordsReader recordsReader =
+                createRecordsReader(inputFileAdapter, allocator, reader, 1);
+        // Consuming row group 0 schedules row group 1, which now blocks in the background.
+        assertThat(recordsReader.readBatch()).isNotNull();
+        readStarted.await();
+
+        AtomicReference<Throwable> closeFailure = new AtomicReference<>();
+        AtomicBoolean interruptedAfterClose = new AtomicBoolean();
+        Thread closer =
+                new Thread(
+                        () -> {
+                            Thread.currentThread().interrupt();
+                            closeQuietly(recordsReader, closeFailure);
+                            interruptedAfterClose.set(Thread.currentThread().isInterrupted());
+                        });
+        closer.start();
+        closer.join(200);
+        assertThat(closer.isAlive()).isTrue();
+        assertThat(events).isEmpty();
+        releaseRead.countDown();
+        closer.join();
+
+        assertThat(closeFailure.get()).isNull();
+        assertThat(events).containsExactly("read-finished", "reader-closed");
+        assertThat(interruptedAfterClose).isTrue();
+        assertThat(allocator.closeCount()).isEqualTo(1);
+    }
+
+    @Test
+    void testRefillFailureLeavesCurrentRowGroupReleasable() throws IOException {
+        CloseCountingSeekableInputStream inputStream = new CloseCountingSeekableInputStream();
+        MosaicInputFileAdapter inputFileAdapter = createInputFileAdapter(inputStream);
+        CloseCountingRootAllocator allocator = new CloseCountingRootAllocator();
+        MosaicReader reader = createProjectedReader(allocator, 2);
+        RuntimeException failure = new RuntimeException("row group 1 metadata failed");
+        when(reader.rowGroupNumRows(1)).thenThrow(failure);
+
+        MosaicRecordsReader recordsReader =
+                createRecordsReader(inputFileAdapter, allocator, reader, 1);
+        // Row group 0 was read; scheduling row group 1 fails while refilling the queue.
+        assertThatThrownBy(recordsReader::readBatch).isSameAs(failure);
+
+        // Row group 0 must still be released, otherwise the allocator reports a leak here.
+        recordsReader.close();
+        assertThat(allocator.closeCount()).isEqualTo(1);
+    }
+
+    private static void closeQuietly(
+            MosaicRecordsReader recordsReader, AtomicReference<Throwable> failure) {
+        try {
+            recordsReader.close();
+        } catch (Throwable t) {
+            failure.set(t);
+        }
+    }
+
+    /** A mocked native reader whose file schema contains the projected column. */
+    private static MosaicReader createProjectedReader(BufferAllocator allocator, int numRowGroups) {
+        MosaicReader reader = mock(MosaicReader.class);
+        when(reader.getSchema())
+                .thenReturn(
+                        new Schema(
+                                Collections.singletonList(
+                                        Field.nullable("f0", new ArrowType.Int(32, true)))));
+        when(reader.numRowGroups()).thenReturn(numRowGroups);
+        when(reader.rowGroupNumRows(anyInt())).thenReturn(1);
+        when(reader.readRowGroup(anyInt(), any()))
+                .thenAnswer(invocation -> rowGroup(allocator, invocation.getArgument(0)));
+        return reader;
+    }
+
+    private static VectorSchemaRoot rowGroup(BufferAllocator allocator, int value) {
+        VectorSchemaRoot root = ArrowUtils.createVectorSchemaRoot(rowType(), allocator);
+        IntVector vector = (IntVector) root.getVector(0);
+        vector.allocateNew(1);
+        vector.set(0, value);
+        vector.setValueCount(1);
+        root.setRowCount(1);
+        return root;
+    }
+
     private static MosaicInputFileAdapter createInputFileAdapter(
             CloseCountingSeekableInputStream inputStream) throws IOException {
         return new MosaicInputFileAdapter(
@@ -205,6 +420,23 @@ class MosaicRecordsReaderTest {
                 new Path("file:/tmp/mosaic-reader-test"),
                 allocator,
                 (inputFile, fileSize, bufferAllocator) -> reader);
+    }
+
+    private static MosaicRecordsReader createRecordsReader(
+            MosaicInputFileAdapter inputFileAdapter,
+            CloseCountingRootAllocator allocator,
+            MosaicReader reader,
+            int prefetchRowGroups) {
+        return new MosaicRecordsReader(
+                inputFileAdapter,
+                0,
+                rowType(),
+                rowType(),
+                null,
+                new Path("file:/tmp/mosaic-reader-test"),
+                allocator,
+                (inputFile, fileSize, bufferAllocator) -> reader,
+                prefetchRowGroups);
     }
 
     private static MosaicReader createReader() {

--- a/paimon-mosaic/src/test/java/org/apache/paimon/format/mosaic/MosaicRecordsReaderTest.java
+++ b/paimon-mosaic/src/test/java/org/apache/paimon/format/mosaic/MosaicRecordsReaderTest.java
@@ -353,16 +353,54 @@ class MosaicRecordsReaderTest {
         CloseCountingSeekableInputStream inputStream = new CloseCountingSeekableInputStream();
         MosaicInputFileAdapter inputFileAdapter = createInputFileAdapter(inputStream);
         CloseCountingRootAllocator allocator = new CloseCountingRootAllocator();
-        MosaicReader reader = createProjectedReader(allocator, 2);
-        RuntimeException failure = new RuntimeException("row group 1 metadata failed");
-        when(reader.rowGroupNumRows(1)).thenThrow(failure);
+        MosaicReader reader = createProjectedReader(allocator, 3);
+        RuntimeException failure = new RuntimeException("row group 2 metadata failed");
+        when(reader.rowGroupNumRows(2)).thenThrow(failure);
 
         MosaicRecordsReader recordsReader =
                 createRecordsReader(inputFileAdapter, allocator, reader, 1);
-        // Row group 0 was read; scheduling row group 1 fails while refilling the queue.
+        // Row group 0 is handed over; scheduling row group 2 fails while refilling behind it.
+        assertThat(recordsReader.readBatch()).isNotNull();
         assertThatThrownBy(recordsReader::readBatch).isSameAs(failure);
 
         // Row group 0 must still be released, otherwise the allocator reports a leak here.
+        recordsReader.close();
+        assertThat(allocator.closeCount()).isEqualTo(1);
+    }
+
+    @Test
+    void testPrefetchDepthIsBoundedByRowGroupBytes() throws IOException {
+        long mb = 1024 * 1024;
+        // 100 MB row groups against a 64 MB budget: nothing is read ahead.
+        assertThat(MosaicRecordsReader.boundedPrefetchDepth(8, 64 * mb, 400 * mb, 4)).isEqualTo(0);
+        // 100 MB row groups against a 250 MB budget: two ahead.
+        assertThat(MosaicRecordsReader.boundedPrefetchDepth(8, 250 * mb, 400 * mb, 4)).isEqualTo(2);
+        // 1 MB row groups: the configured depth applies.
+        assertThat(MosaicRecordsReader.boundedPrefetchDepth(8, 64 * mb, 400 * mb, 400))
+                .isEqualTo(8);
+        // Unknown file size keeps the configured depth; depth 0 stays 0.
+        assertThat(MosaicRecordsReader.boundedPrefetchDepth(8, 64 * mb, 0, 4)).isEqualTo(8);
+        assertThat(MosaicRecordsReader.boundedPrefetchDepth(0, 64 * mb, 400 * mb, 4)).isEqualTo(0);
+
+        CloseCountingSeekableInputStream inputStream = new CloseCountingSeekableInputStream();
+        MosaicInputFileAdapter inputFileAdapter = createInputFileAdapter(inputStream);
+        CloseCountingRootAllocator allocator = new CloseCountingRootAllocator();
+        MosaicReader reader = createProjectedReader(allocator, 4);
+        MosaicRecordsReader recordsReader =
+                new MosaicRecordsReader(
+                        inputFileAdapter,
+                        400 * mb,
+                        rowType(),
+                        rowType(),
+                        null,
+                        new Path("file:/tmp/mosaic-reader-test"),
+                        allocator,
+                        (inputFile, fileSize, bufferAllocator) -> reader,
+                        8,
+                        64 * mb);
+        assertThat(recordsReader.prefetchDepth()).isEqualTo(0);
+        assertThat(recordsReader.readBatch()).isNotNull();
+        verify(reader, times(1)).readRowGroup(anyInt(), any());
         recordsReader.close();
         assertThat(allocator.closeCount()).isEqualTo(1);
     }
@@ -436,7 +474,8 @@ class MosaicRecordsReaderTest {
                 new Path("file:/tmp/mosaic-reader-test"),
                 allocator,
                 (inputFile, fileSize, bufferAllocator) -> reader,
-                prefetchRowGroups);
+                prefetchRowGroups,
+                MosaicFileFormat.READ_PREFETCH_MAX_BYTES.defaultValue().getBytes());
     }
 
     private static MosaicReader createReader() {


### PR DESCRIPTION
### Purpose

Opening a Mosaic row group is a chain of dependent range reads: the bucket directories first, then the projected column slots. `MosaicRecordsReader` opened one row group at a time and only after the previous one was consumed, so a file with about 120 row groups on object storage paid about 240 sequential round trips of roughly 50 ms each while reading under 5 MB. On a 11,374-column table this was about 12 s per file for a query that keeps 505 rows.

Changes:

- `mosaic.read.prefetch-row-groups` (default 8, 0 disables): while one row group is consumed, the reader keeps up to that many following row groups opening on a shared daemon pool. Skipped row groups still advance the file position. With depth 0 the reader reads strictly on demand.
- `mosaic.read.prefetch-max-bytes` (default 64 MB): further row groups are scheduled only while the estimated decoded size of those in flight (row count times the projected column types) fits this budget; the next row group is always read. Wide projections and large row groups therefore read on demand, while narrow projections of small row groups keep the full depth.
- `MosaicInputFileAdapter` borrows one `SeekableInputStream` per concurrent read from a pool of at most depth + 1 streams; a read that finds every stream busy waits. Positional reads on a single stream are serialized by common implementations, which turned the parallel opens back into a chain; with the pool, per-file scan time dropped from ~12 s to ~1.7 s in the same setup.
- A row group whose wait was interrupted stays owned by the reader, and `close()` waits for every in-flight open (also when the closing thread is interrupted, re-setting the flag afterwards) before it frees the native reader, because Mosaic frees the reader handle on close. Read statistics (row groups opened, wait time, lifetime) are logged at debug level after that drain.

Depth 8 gave the best scan time on an 8-core host reading from OSS; 16 saturated the connections. End to end, the customer query went from 19.3 s to 4.0 s together with the manifest cache configuration, and to 1.7 s on a rebuilt table with lean manifests and `mosaic.stats-columns` (Parquet baseline for the same data: 2.2 s).

### Tests

- `MosaicReaderWriterTest#testPrefetchedReadMatchesSequentialRead` (new): prefetched and sequential reads return the same rows and the same file positions, including across row groups skipped by a predicate.
- `MosaicReaderWriterTest#testClosingReaderWithPendingPrefetchReleasesResources` (new): closing with prefetched batches in flight releases them.
- `MosaicRecordsReaderTest` (new, mocked native reader): `testDisabledPrefetchReadsRowGroupsOnDemand` (depth 0 issues exactly one read before the first batch is consumed), `testInterruptedReadKeepsInFlightRowGroupUntilClose` (an interrupted `readBatch()` keeps the row group owned and `close()` waits for it before closing the native reader), `testCloseWithInterruptFlagStillWaitsForInFlightRowGroups` (entering `close()` interrupted still drains and restores the flag), `testRefillFailureLeavesCurrentRowGroupReleasable` (a failure while scheduling the next row group leaves the current batch releasable), `testPrefetchIsBoundedByEstimatedDecodedBytes` (the decoded-byte budget stops look-ahead below one row group and allows it above).
- `MosaicInputFileAdapterTest` (new): concurrent reads open at most the configured number of streams and the extra reader waits; closing the adapter wakes a waiting reader with an `IOException`.
- All `paimon-mosaic` tests pass locally.

### API and Format

New read options `mosaic.read.prefetch-row-groups` and `mosaic.read.prefetch-max-bytes`. No format change.

### Documentation

Both options are added to the Mosaic section of `docs/docs/concepts/spec/fileformat.md`.
