### PR TITLE
[mosaic] Size the writer's Arrow vectors by write.batch-size

### DIFF
--- a/paimon-mosaic/src/main/java/org/apache/paimon/format/mosaic/MosaicRecordsWriter.java
+++ b/paimon-mosaic/src/main/java/org/apache/paimon/format/mosaic/MosaicRecordsWriter.java
@@ -36,6 +36,7 @@ import org.apache.arrow.memory.RootAllocator;
 import org.apache.arrow.vector.BaseValueVector;
 import org.apache.arrow.vector.FieldVector;
 import org.apache.arrow.vector.VectorSchemaRoot;
+import org.apache.arrow.vector.complex.BaseRepeatedValueVector;
 import org.apache.arrow.vector.types.pojo.Schema;
 
 import javax.annotation.Nullable;
@@ -103,12 +104,12 @@ public class MosaicRecordsWriter implements BundleFormatWriter {
             createdArrowWriter =
                     ArrowFormatWriter.forBorrowedAllocator(
                             rowType, writeBatchSize, true, allocator, writeBatchMemory);
-            // Size vectors by the batch, but never above Arrow's default so that large batch
-            // limits bounded by write.batch-memory do not allocate more up front than before.
-            int initialCapacity =
-                    Math.min(writeBatchSize, BaseValueVector.INITIAL_VALUE_ALLOCATION);
-            for (FieldVector vector : createdArrowWriter.getVectorSchemaRoot().getFieldVectors()) {
-                vector.setInitialCapacity(initialCapacity);
+            // Only batches smaller than Arrow's default allocation are sized by the batch.
+            if (writeBatchSize < BaseValueVector.INITIAL_VALUE_ALLOCATION) {
+                for (FieldVector vector :
+                        createdArrowWriter.getVectorSchemaRoot().getFieldVectors()) {
+                    setInitialCapacity(vector, writeBatchSize);
+                }
             }
             Schema arrowSchema = createdArrowWriter.getVectorSchemaRoot().getSchema();
             createdNativeWriter =
@@ -120,6 +121,15 @@ public class MosaicRecordsWriter implements BundleFormatWriter {
 
         this.arrowFormatWriter = createdArrowWriter;
         this.nativeWriter = createdNativeWriter;
+    }
+
+    private static void setInitialCapacity(FieldVector vector, int capacity) {
+        if (vector instanceof BaseRepeatedValueVector) {
+            // The plain overload would size the element vector for 5 elements per row.
+            ((BaseRepeatedValueVector) vector).setInitialCapacity(capacity, 1.0);
+        } else {
+            vector.setInitialCapacity(capacity);
+        }
     }
 
     @Override

--- a/paimon-mosaic/src/main/java/org/apache/paimon/format/mosaic/MosaicRecordsWriter.java
+++ b/paimon-mosaic/src/main/java/org/apache/paimon/format/mosaic/MosaicRecordsWriter.java
@@ -33,6 +33,7 @@ import org.apache.paimon.types.RowType;
 
 import org.apache.arrow.memory.BufferAllocator;
 import org.apache.arrow.memory.RootAllocator;
+import org.apache.arrow.vector.FieldVector;
 import org.apache.arrow.vector.VectorSchemaRoot;
 import org.apache.arrow.vector.types.pojo.Schema;
 
@@ -101,6 +102,10 @@ public class MosaicRecordsWriter implements BundleFormatWriter {
             createdArrowWriter =
                     ArrowFormatWriter.forBorrowedAllocator(
                             rowType, writeBatchSize, true, allocator, writeBatchMemory);
+            // Arrow otherwise allocates thousands of values per vector; size them by the batch.
+            for (FieldVector vector : createdArrowWriter.getVectorSchemaRoot().getFieldVectors()) {
+                vector.setInitialCapacity(writeBatchSize);
+            }
             Schema arrowSchema = createdArrowWriter.getVectorSchemaRoot().getSchema();
             createdNativeWriter =
                     nativeWriterFactory.create(outputStream, arrowSchema, options, allocator);

--- a/paimon-mosaic/src/main/java/org/apache/paimon/format/mosaic/MosaicRecordsWriter.java
+++ b/paimon-mosaic/src/main/java/org/apache/paimon/format/mosaic/MosaicRecordsWriter.java
@@ -33,6 +33,7 @@ import org.apache.paimon.types.RowType;
 
 import org.apache.arrow.memory.BufferAllocator;
 import org.apache.arrow.memory.RootAllocator;
+import org.apache.arrow.vector.BaseValueVector;
 import org.apache.arrow.vector.FieldVector;
 import org.apache.arrow.vector.VectorSchemaRoot;
 import org.apache.arrow.vector.types.pojo.Schema;
@@ -102,9 +103,12 @@ public class MosaicRecordsWriter implements BundleFormatWriter {
             createdArrowWriter =
                     ArrowFormatWriter.forBorrowedAllocator(
                             rowType, writeBatchSize, true, allocator, writeBatchMemory);
-            // Arrow otherwise allocates thousands of values per vector; size them by the batch.
+            // Size vectors by the batch, but never above Arrow's default so that large batch
+            // limits bounded by write.batch-memory do not allocate more up front than before.
+            int initialCapacity =
+                    Math.min(writeBatchSize, BaseValueVector.INITIAL_VALUE_ALLOCATION);
             for (FieldVector vector : createdArrowWriter.getVectorSchemaRoot().getFieldVectors()) {
-                vector.setInitialCapacity(writeBatchSize);
+                vector.setInitialCapacity(initialCapacity);
             }
             Schema arrowSchema = createdArrowWriter.getVectorSchemaRoot().getSchema();
             createdNativeWriter =

--- a/paimon-mosaic/src/test/java/org/apache/paimon/format/mosaic/MosaicRecordsWriterTest.java
+++ b/paimon-mosaic/src/test/java/org/apache/paimon/format/mosaic/MosaicRecordsWriterTest.java
@@ -20,6 +20,7 @@ package org.apache.paimon.format.mosaic;
 
 import org.apache.paimon.arrow.ArrowBundleRecords;
 import org.apache.paimon.arrow.ArrowUtils;
+import org.apache.paimon.data.GenericRow;
 import org.apache.paimon.format.FileFormatFactory;
 import org.apache.paimon.mosaic.MosaicWriter;
 import org.apache.paimon.options.Options;
@@ -155,6 +156,33 @@ class MosaicRecordsWriterTest {
         writer.close();
 
         verify(nativeWriter).write(any(VectorSchemaRoot.class));
+    }
+
+    @Test
+    void testVectorsAreSizedByWriteBatchSize() throws Exception {
+        // 2,000 columns: Arrow's default per-vector allocation would exceed 60 MB here.
+        RowType.Builder builder = RowType.builder();
+        for (int i = 0; i < 2000; i++) {
+            builder.field("c" + i, DataTypes.DOUBLE());
+        }
+        RowType wideType = builder.build();
+        MosaicWriter nativeWriter = mock(MosaicWriter.class);
+        try (RootAllocator allocator = new RootAllocator()) {
+            MosaicRecordsWriter writer =
+                    new MosaicRecordsWriter(
+                            new ByteArrayOutputStream(),
+                            wideType,
+                            new FileFormatFactory.FormatContext(new Options(), 1024, 4),
+                            Collections.emptyList(),
+                            null,
+                            allocator,
+                            (outputStream, arrowSchema, options, bufferAllocator) -> nativeWriter);
+            GenericRow row = new GenericRow(wideType.getFieldCount());
+            row.setField(0, 1.0d);
+            writer.addElement(row);
+            assertThat(allocator.getAllocatedMemory()).isLessThan(8L * 1024 * 1024);
+            writer.close();
+        }
     }
 
     private static MosaicRecordsWriter createWriter(

--- a/paimon-mosaic/src/test/java/org/apache/paimon/format/mosaic/MosaicRecordsWriterTest.java
+++ b/paimon-mosaic/src/test/java/org/apache/paimon/format/mosaic/MosaicRecordsWriterTest.java
@@ -23,6 +23,7 @@ import org.apache.paimon.arrow.ArrowUtils;
 import org.apache.paimon.data.GenericRow;
 import org.apache.paimon.format.FileFormatFactory;
 import org.apache.paimon.mosaic.MosaicWriter;
+import org.apache.paimon.options.MemorySize;
 import org.apache.paimon.options.Options;
 import org.apache.paimon.types.DataTypes;
 import org.apache.paimon.types.RowType;
@@ -178,6 +179,36 @@ class MosaicRecordsWriterTest {
                             allocator,
                             (outputStream, arrowSchema, options, bufferAllocator) -> nativeWriter);
             GenericRow row = new GenericRow(wideType.getFieldCount());
+            row.setField(0, 1.0d);
+            writer.addElement(row);
+            assertThat(allocator.getAllocatedMemory()).isLessThan(8L * 1024 * 1024);
+            writer.close();
+        }
+    }
+
+    @Test
+    void testLargeBatchSizeWithSmallMemoryBudgetStaysWithinArrowDefaultAllocation()
+            throws Exception {
+        // write.batch-size=65536 with write.batch-memory=128 KiB: the memory budget flushes long
+        // before the row limit, so the first row must not allocate for the whole batch size.
+        RowType.Builder builder = RowType.builder();
+        for (int i = 0; i < 100; i++) {
+            builder.field("c" + i, DataTypes.DOUBLE());
+        }
+        RowType rowType = builder.build();
+        MosaicWriter nativeWriter = mock(MosaicWriter.class);
+        try (RootAllocator allocator = new RootAllocator(16L * 1024 * 1024)) {
+            MosaicRecordsWriter writer =
+                    new MosaicRecordsWriter(
+                            new ByteArrayOutputStream(),
+                            rowType,
+                            new FileFormatFactory.FormatContext(
+                                    new Options(), 1024, 65536, MemorySize.ofKibiBytes(128)),
+                            Collections.emptyList(),
+                            null,
+                            allocator,
+                            (outputStream, arrowSchema, options, bufferAllocator) -> nativeWriter);
+            GenericRow row = new GenericRow(rowType.getFieldCount());
             row.setField(0, 1.0d);
             writer.addElement(row);
             assertThat(allocator.getAllocatedMemory()).isLessThan(8L * 1024 * 1024);

--- a/paimon-mosaic/src/test/java/org/apache/paimon/format/mosaic/MosaicRecordsWriterTest.java
+++ b/paimon-mosaic/src/test/java/org/apache/paimon/format/mosaic/MosaicRecordsWriterTest.java
@@ -20,6 +20,9 @@ package org.apache.paimon.format.mosaic;
 
 import org.apache.paimon.arrow.ArrowBundleRecords;
 import org.apache.paimon.arrow.ArrowUtils;
+import org.apache.paimon.arrow.vector.ArrowFormatWriter;
+import org.apache.paimon.data.BinaryString;
+import org.apache.paimon.data.GenericArray;
 import org.apache.paimon.data.GenericRow;
 import org.apache.paimon.format.FileFormatFactory;
 import org.apache.paimon.mosaic.MosaicWriter;
@@ -187,33 +190,107 @@ class MosaicRecordsWriterTest {
     }
 
     @Test
-    void testLargeBatchSizeWithSmallMemoryBudgetStaysWithinArrowDefaultAllocation()
-            throws Exception {
+    void testLargeBatchSizeWithSmallMemoryBudgetKeepsArrowDefaultAllocation() throws Exception {
         // write.batch-size=65536 with write.batch-memory=128 KiB: the memory budget flushes long
         // before the row limit, so the first row must not allocate for the whole batch size.
-        RowType.Builder builder = RowType.builder();
-        for (int i = 0; i < 100; i++) {
-            builder.field("c" + i, DataTypes.DOUBLE());
-        }
-        RowType rowType = builder.build();
+        RowType rowType = mixedRowType(100);
         MosaicWriter nativeWriter = mock(MosaicWriter.class);
         try (RootAllocator allocator = new RootAllocator(16L * 1024 * 1024)) {
             MosaicRecordsWriter writer =
-                    new MosaicRecordsWriter(
-                            new ByteArrayOutputStream(),
-                            rowType,
-                            new FileFormatFactory.FormatContext(
-                                    new Options(), 1024, 65536, MemorySize.ofKibiBytes(128)),
-                            Collections.emptyList(),
-                            null,
-                            allocator,
-                            (outputStream, arrowSchema, options, bufferAllocator) -> nativeWriter);
-            GenericRow row = new GenericRow(rowType.getFieldCount());
-            row.setField(0, 1.0d);
-            writer.addElement(row);
-            assertThat(allocator.getAllocatedMemory()).isLessThan(8L * 1024 * 1024);
+                    createWriter(
+                            rowType, allocator, nativeWriter, 65536, MemorySize.ofKibiBytes(128));
+            writer.addElement(firstRow(rowType));
+            assertThat(allocator.getAllocatedMemory())
+                    .isEqualTo(baselineFirstRowAllocation(rowType, 65536));
             writer.close();
         }
+    }
+
+    @Test
+    void testInitialCapacityNeverExceedsArrowDefaultAllocation() throws Exception {
+        // DOUBLE, STRING and ARRAY<DOUBLE> columns cover the fixed-width, variable-width and
+        // repeated vector families, whose default sizing differs.
+        RowType rowType = mixedRowType(60);
+        for (int batchSize : new int[] {4, 1024, 3969, 3970, 65536}) {
+            long baseline = baselineFirstRowAllocation(rowType, batchSize);
+            MosaicWriter nativeWriter = mock(MosaicWriter.class);
+            try (RootAllocator allocator = new RootAllocator()) {
+                MosaicRecordsWriter writer =
+                        createWriter(
+                                rowType,
+                                allocator,
+                                nativeWriter,
+                                batchSize,
+                                MemorySize.VALUE_128_MB);
+                try {
+                    writer.addElement(firstRow(rowType));
+                    assertThat(allocator.getAllocatedMemory())
+                            .as("batch size %d", batchSize)
+                            .isLessThanOrEqualTo(baseline);
+                    // Arrow rounds buffers to powers of two, so only clearly smaller batches
+                    // allocate less.
+                    if (batchSize <= 1024) {
+                        assertThat(allocator.getAllocatedMemory())
+                                .as("batch size %d", batchSize)
+                                .isLessThan(baseline);
+                    }
+                } finally {
+                    writer.close();
+                }
+            }
+        }
+    }
+
+    private static RowType mixedRowType(int columnsPerType) {
+        RowType.Builder builder = RowType.builder();
+        for (int i = 0; i < columnsPerType; i++) {
+            builder.field("d" + i, DataTypes.DOUBLE());
+            builder.field("s" + i, DataTypes.STRING());
+            builder.field("a" + i, DataTypes.ARRAY(DataTypes.DOUBLE()));
+        }
+        return builder.build();
+    }
+
+    private static GenericRow firstRow(RowType rowType) {
+        GenericRow row = new GenericRow(rowType.getFieldCount());
+        row.setField(0, 1.0d);
+        row.setField(1, BinaryString.fromString("one"));
+        row.setField(2, new GenericArray(new Object[] {1.0d}));
+        return row;
+    }
+
+    /** First-row allocation of the same writer without the capacity loop. */
+    private static long baselineFirstRowAllocation(RowType rowType, int batchSize) {
+        try (RootAllocator allocator = new RootAllocator()) {
+            ArrowFormatWriter writer =
+                    ArrowFormatWriter.forBorrowedAllocator(
+                            rowType,
+                            batchSize,
+                            true,
+                            allocator,
+                            MemorySize.VALUE_128_MB.getBytes());
+            assertThat(writer.write(firstRow(rowType))).isTrue();
+            long allocated = allocator.getAllocatedMemory();
+            writer.close();
+            return allocated;
+        }
+    }
+
+    private static MosaicRecordsWriter createWriter(
+            RowType rowType,
+            RootAllocator allocator,
+            MosaicWriter nativeWriter,
+            int writeBatchSize,
+            MemorySize writeBatchMemory) {
+        return new MosaicRecordsWriter(
+                new ByteArrayOutputStream(),
+                rowType,
+                new FileFormatFactory.FormatContext(
+                        new Options(), 1024, writeBatchSize, writeBatchMemory),
+                Collections.emptyList(),
+                null,
+                allocator,
+                (outputStream, arrowSchema, options, bufferAllocator) -> nativeWriter);
     }
 
     private static MosaicRecordsWriter createWriter(


### PR DESCRIPTION
### Purpose

`ArrowFormatWriter` creates every vector with Arrow's default initial allocation of 3,970 values, regardless of `write.batch-size` (default 1,024). On a table with 11,374 columns each `MosaicRecordsWriter` therefore reserved about 370 MB of direct memory before writing its first row, and a job with a few bucket writers per task ran out of direct memory while the batch could never hold more than 1,024 rows.

Changes:

- When `write.batch-size` is below Arrow's default allocation, every vector of the writer's root is sized for the batch (`setInitialCapacity`); repeated vectors (ARRAY, MULTISET, MAP) are sized at one element per row, because the plain overload would reserve five per row. Vectors still grow on demand.
- Batches at or above the default keep Arrow's own sizing, so the first-row allocation of large batches is byte-for-byte what it was before (3,970 is not the default for variable-width vectors, which use 3,969, and a larger initial capacity would double their first allocation).

With the default batch size the 11,374-column writer allocates a few MB per writer instead of ~370 MB.

### Tests

- `MosaicRecordsWriterTest#testVectorsAreSizedByWriteBatchSize` (new): 2,000 DOUBLE columns with batch size 4 allocate under 8 MB.
- `MosaicRecordsWriterTest#testLargeBatchSizeWithSmallMemoryBudgetKeepsArrowDefaultAllocation` (new): 100 DOUBLE/STRING/ARRAY columns, `write.batch-size=65536`, `write.batch-memory=128 KiB`, 16 MiB allocator limit: the first row allocates exactly what a writer without the change allocates and no longer throws `OutOfMemoryException`.
- `MosaicRecordsWriterTest#testInitialCapacityNeverExceedsArrowDefaultAllocation` (new): for batch sizes 4, 1024, 3969, 3970 and 65536 the first-row allocation is at most that of a writer without the change, and strictly smaller for batches up to 1024.
- All `paimon-mosaic` tests pass locally.

### API and Format

No public API or format change.

### Documentation

None.
