### PR TITLE
[mosaic] Push row selection down to row-group reads

### DIFF
--- a/paimon-mosaic/src/main/java/org/apache/paimon/format/mosaic/MosaicReaderFactory.java
+++ b/paimon-mosaic/src/main/java/org/apache/paimon/format/mosaic/MosaicReaderFactory.java
@@ -55,6 +55,7 @@ public class MosaicReaderFactory implements FormatReaderFactory {
                 dataSchemaRowType,
                 projectedRowType,
                 predicates,
-                context.filePath());
+                context.filePath(),
+                context.selection());
     }
 }

--- a/paimon-mosaic/src/main/java/org/apache/paimon/format/mosaic/MosaicRecordsReader.java
+++ b/paimon-mosaic/src/main/java/org/apache/paimon/format/mosaic/MosaicRecordsReader.java
@@ -31,6 +31,7 @@ import org.apache.paimon.reader.FileRecordReader;
 import org.apache.paimon.types.DataField;
 import org.apache.paimon.types.DataType;
 import org.apache.paimon.types.RowType;
+import org.apache.paimon.utils.RoaringBitmap32;
 
 import org.apache.arrow.memory.BufferAllocator;
 import org.apache.arrow.memory.RootAllocator;
@@ -63,8 +64,11 @@ public class MosaicRecordsReader implements FileRecordReader<InternalRow> {
     private final int projectedFieldCount;
     private final boolean allProjectedColumnsMissing;
     @Nullable private final List<Predicate> predicates;
+    @Nullable private final RoaringBitmap32 selection;
 
     private int currentRowGroup;
+    // Unlike returnedPosition, this always advances by the full physical row-group size.
+    private long nextRowGroupStart;
     private long returnedPosition = -1;
     private VectorSchemaRoot currentVsr;
 
@@ -82,6 +86,27 @@ public class MosaicRecordsReader implements FileRecordReader<InternalRow> {
                 projectedRowType,
                 predicates,
                 filePath,
+                null,
+                new RootAllocator(),
+                MosaicReader::open);
+    }
+
+    MosaicRecordsReader(
+            MosaicInputFileAdapter inputFileAdapter,
+            long fileSize,
+            RowType dataSchemaRowType,
+            RowType projectedRowType,
+            @Nullable List<Predicate> predicates,
+            Path filePath,
+            @Nullable RoaringBitmap32 selection) {
+        this(
+                inputFileAdapter,
+                fileSize,
+                dataSchemaRowType,
+                projectedRowType,
+                predicates,
+                filePath,
+                selection,
                 new RootAllocator(),
                 MosaicReader::open);
     }
@@ -95,11 +120,34 @@ public class MosaicRecordsReader implements FileRecordReader<InternalRow> {
             Path filePath,
             BufferAllocator allocator,
             NativeReaderOpener nativeReaderOpener) {
+        this(
+                inputFileAdapter,
+                fileSize,
+                dataSchemaRowType,
+                projectedRowType,
+                predicates,
+                filePath,
+                null,
+                allocator,
+                nativeReaderOpener);
+    }
+
+    MosaicRecordsReader(
+            MosaicInputFileAdapter inputFileAdapter,
+            long fileSize,
+            RowType dataSchemaRowType,
+            RowType projectedRowType,
+            @Nullable List<Predicate> predicates,
+            Path filePath,
+            @Nullable RoaringBitmap32 selection,
+            BufferAllocator allocator,
+            NativeReaderOpener nativeReaderOpener) {
         this.filePath = filePath;
         this.inputFileAdapter = inputFileAdapter;
         this.dataSchemaRowType = dataSchemaRowType;
         this.projectedFieldCount = projectedRowType.getFieldCount();
         this.predicates = predicates;
+        this.selection = selection;
         this.allocator = allocator;
 
         MosaicReader createdReader = null;
@@ -145,8 +193,12 @@ public class MosaicRecordsReader implements FileRecordReader<InternalRow> {
     public FileRecordIterator<InternalRow> readBatch() throws IOException {
         while (currentRowGroup < numRowGroups) {
             int numRows = reader.rowGroupNumRows(currentRowGroup);
-            if (!matchesRowGroup(currentRowGroup, numRows)) {
-                returnedPosition += numRows;
+            long rowGroupStart = nextRowGroupStart;
+            returnedPosition = rowGroupStart - 1;
+            if (!matchesSelection(rowGroupStart, numRows)
+                    || !matchesRowGroup(currentRowGroup, numRows)) {
+                nextRowGroupStart += numRows;
+                returnedPosition = nextRowGroupStart - 1;
                 currentRowGroup++;
                 continue;
             }
@@ -154,11 +206,13 @@ public class MosaicRecordsReader implements FileRecordReader<InternalRow> {
             releaseCurrentVsr();
 
             if (allProjectedColumnsMissing) {
+                nextRowGroupStart += numRows;
                 currentRowGroup++;
                 return allNullIterator(numRows);
             }
 
             VectorSchemaRoot vsr = reader.readRowGroup(currentRowGroup, allocator);
+            nextRowGroupStart += numRows;
             currentRowGroup++;
             this.currentVsr = vsr;
 
@@ -192,6 +246,21 @@ public class MosaicRecordsReader implements FileRecordReader<InternalRow> {
             };
         }
         return null;
+    }
+
+    private boolean matchesSelection(long rowGroupStart, long rowCount) {
+        if (selection == null) {
+            return true;
+        }
+        if (rowCount <= 0 || rowGroupStart < 0 || rowGroupStart > RoaringBitmap32.MAX_VALUE) {
+            return false;
+        }
+
+        long maxSupremum = (long) RoaringBitmap32.MAX_VALUE + 1;
+        long remainingAddressableRows = maxSupremum - rowGroupStart;
+        long rowGroupEnd =
+                rowCount > remainingAddressableRows ? maxSupremum : rowGroupStart + rowCount;
+        return selection.intersects(rowGroupStart, rowGroupEnd);
     }
 
     private FileRecordIterator<InternalRow> allNullIterator(int numRows) {

--- a/paimon-mosaic/src/test/java/org/apache/paimon/format/mosaic/MosaicReaderWriterTest.java
+++ b/paimon-mosaic/src/test/java/org/apache/paimon/format/mosaic/MosaicReaderWriterTest.java
@@ -39,6 +39,7 @@ import org.apache.paimon.reader.FileRecordIterator;
 import org.apache.paimon.reader.RecordReader;
 import org.apache.paimon.types.DataTypes;
 import org.apache.paimon.types.RowType;
+import org.apache.paimon.utils.RoaringBitmap32;
 
 import org.apache.arrow.memory.RootAllocator;
 import org.apache.arrow.vector.IntVector;
@@ -242,6 +243,32 @@ class MosaicReaderWriterTest {
         assertThat(fileIter.returnedPosition()).isEqualTo(2);
 
         reader.close();
+    }
+
+    @Test
+    void testEmptySelectionSkipsAllRowGroups() throws IOException {
+        RowType rowType = DataTypes.ROW(DataTypes.INT(), DataTypes.STRING());
+        Path path = newPath();
+
+        writeRows(
+                rowType,
+                path,
+                GenericRow.of(1, BinaryString.fromString("a")),
+                GenericRow.of(2, BinaryString.fromString("b")));
+
+        MosaicFileFormat format = createFormat();
+        FormatReaderFactory readerFactory = format.createReaderFactory(rowType, rowType, null);
+        LocalFileIO fileIO = new LocalFileIO();
+        try (RecordReader<InternalRow> reader =
+                readerFactory.createReader(
+                        new FormatReaderContext(
+                                fileIO,
+                                path,
+                                fileIO.getFileSize(path),
+                                new RoaringBitmap32(),
+                                null))) {
+            assertThat(reader.readBatch()).isNull();
+        }
     }
 
     @Test

--- a/paimon-mosaic/src/test/java/org/apache/paimon/format/mosaic/MosaicRecordsReaderTest.java
+++ b/paimon-mosaic/src/test/java/org/apache/paimon/format/mosaic/MosaicRecordsReaderTest.java
@@ -192,6 +192,72 @@ class MosaicRecordsReaderTest {
     }
 
     @Test
+    void testAllProjectedColumnsMissingPreservesSelectedPositionsAcrossRowGroups()
+            throws IOException {
+        CloseCountingSeekableInputStream inputStream = new CloseCountingSeekableInputStream();
+        MosaicInputFileAdapter inputFileAdapter = createInputFileAdapter(inputStream);
+        CloseCountingRootAllocator allocator = new CloseCountingRootAllocator();
+        MosaicReader reader = createReader();
+        when(reader.numRowGroups()).thenReturn(3);
+        when(reader.rowGroupNumRows(0)).thenReturn(2);
+        when(reader.rowGroupNumRows(1)).thenReturn(2);
+        when(reader.rowGroupNumRows(2)).thenReturn(2);
+
+        Path filePath = new Path("file:/tmp/mosaic-reader-test");
+        RoaringBitmap32 selection = RoaringBitmap32.bitmapOf(1, 5);
+        MosaicRecordsReader recordsReader =
+                new MosaicRecordsReader(
+                        inputFileAdapter,
+                        0,
+                        rowType(),
+                        rowType(),
+                        null,
+                        filePath,
+                        selection,
+                        allocator,
+                        (inputFile, fileSize, bufferAllocator) -> reader);
+        DataFileRecordReader dataFileReader =
+                new DataFileRecordReader(
+                        rowType(),
+                        recordsReader,
+                        false,
+                        false,
+                        null,
+                        null,
+                        null,
+                        false,
+                        null,
+                        0,
+                        Collections.emptyMap(),
+                        selection,
+                        filePath);
+
+        FileRecordIterator<InternalRow> firstBatch = dataFileReader.readBatch();
+        assertThat(firstBatch).isNotNull();
+        InternalRow firstRow = firstBatch.next();
+        assertThat(firstRow).isNotNull();
+        assertThat(firstRow.isNullAt(0)).isTrue();
+        assertThat(firstBatch.returnedPosition()).isEqualTo(1);
+        assertThat(firstBatch.next()).isNull();
+        firstBatch.releaseBatch();
+
+        FileRecordIterator<InternalRow> secondBatch = dataFileReader.readBatch();
+        assertThat(secondBatch).isNotNull();
+        InternalRow secondRow = secondBatch.next();
+        assertThat(secondRow).isNotNull();
+        assertThat(secondRow.isNullAt(0)).isTrue();
+        assertThat(secondBatch.returnedPosition()).isEqualTo(5);
+        assertThat(secondBatch.next()).isNull();
+        secondBatch.releaseBatch();
+
+        assertThat(dataFileReader.readBatch()).isNull();
+        verify(reader, never()).readRowGroup(anyInt(), any());
+
+        dataFileReader.close();
+        assertThat(allocator.getAllocatedMemory()).isZero();
+    }
+
+    @Test
     void testSelectionSkipsUnmatchedRowGroupsAndPreservesPositions() throws IOException {
         CloseCountingSeekableInputStream inputStream = new CloseCountingSeekableInputStream();
         MosaicInputFileAdapter inputFileAdapter = createInputFileAdapter(inputStream);

--- a/paimon-mosaic/src/test/java/org/apache/paimon/format/mosaic/MosaicRecordsReaderTest.java
+++ b/paimon-mosaic/src/test/java/org/apache/paimon/format/mosaic/MosaicRecordsReaderTest.java
@@ -18,16 +18,21 @@
 
 package org.apache.paimon.format.mosaic;
 
+import org.apache.paimon.arrow.ArrowUtils;
 import org.apache.paimon.data.InternalRow;
 import org.apache.paimon.fs.Path;
 import org.apache.paimon.fs.SeekableInputStream;
 import org.apache.paimon.fs.local.LocalFileIO;
+import org.apache.paimon.io.DataFileRecordReader;
 import org.apache.paimon.mosaic.MosaicReader;
 import org.apache.paimon.reader.FileRecordIterator;
 import org.apache.paimon.types.DataTypes;
 import org.apache.paimon.types.RowType;
+import org.apache.paimon.utils.RoaringBitmap32;
 
 import org.apache.arrow.memory.RootAllocator;
+import org.apache.arrow.vector.IntVector;
+import org.apache.arrow.vector.VectorSchemaRoot;
 import org.apache.arrow.vector.types.pojo.Schema;
 import org.junit.jupiter.api.Test;
 
@@ -186,6 +191,120 @@ class MosaicRecordsReaderTest {
         recordsReader.close();
     }
 
+    @Test
+    void testSelectionSkipsUnmatchedRowGroupsAndPreservesPositions() throws IOException {
+        CloseCountingSeekableInputStream inputStream = new CloseCountingSeekableInputStream();
+        MosaicInputFileAdapter inputFileAdapter = createInputFileAdapter(inputStream);
+        CloseCountingRootAllocator allocator = new CloseCountingRootAllocator();
+        MosaicReader reader = mock(MosaicReader.class);
+        VectorSchemaRoot firstRoot = intRoot(allocator, 0, 1);
+        VectorSchemaRoot thirdRoot = intRoot(allocator, 5, 6);
+        VectorSchemaRoot fourthRoot = intRoot(allocator, 7, 8, 9);
+        when(reader.getSchema()).thenReturn(firstRoot.getSchema());
+        when(reader.numRowGroups()).thenReturn(4);
+        when(reader.rowGroupNumRows(0)).thenReturn(2);
+        when(reader.rowGroupNumRows(1)).thenReturn(3);
+        when(reader.rowGroupNumRows(2)).thenReturn(2);
+        when(reader.rowGroupNumRows(3)).thenReturn(3);
+        when(reader.readRowGroup(0, allocator)).thenReturn(firstRoot);
+        when(reader.readRowGroup(2, allocator)).thenReturn(thirdRoot);
+        when(reader.readRowGroup(3, allocator)).thenReturn(fourthRoot);
+
+        Path filePath = new Path("file:/tmp/mosaic-reader-test");
+        RoaringBitmap32 selection = RoaringBitmap32.bitmapOf(1, 5, 9);
+        MosaicRecordsReader recordsReader =
+                new MosaicRecordsReader(
+                        inputFileAdapter,
+                        0,
+                        rowType(),
+                        rowType(),
+                        null,
+                        filePath,
+                        selection,
+                        allocator,
+                        (inputFile, fileSize, bufferAllocator) -> reader);
+        DataFileRecordReader dataFileReader =
+                new DataFileRecordReader(
+                        rowType(),
+                        recordsReader,
+                        false,
+                        false,
+                        null,
+                        null,
+                        null,
+                        false,
+                        null,
+                        0,
+                        Collections.emptyMap(),
+                        selection,
+                        filePath);
+
+        assertSelectedRow(dataFileReader.readBatch(), 1, 1);
+        assertSelectedRow(dataFileReader.readBatch(), 5, 5);
+        assertSelectedRow(dataFileReader.readBatch(), 9, 9);
+        assertThat(dataFileReader.readBatch()).isNull();
+
+        verify(reader).readRowGroup(0, allocator);
+        verify(reader, never()).readRowGroup(1, allocator);
+        verify(reader).readRowGroup(2, allocator);
+        verify(reader).readRowGroup(3, allocator);
+
+        dataFileReader.close();
+        assertThat(allocator.getAllocatedMemory()).isZero();
+    }
+
+    @Test
+    void testRowGroupPositionAfterPartiallyConsumedBatch() throws IOException {
+        CloseCountingSeekableInputStream inputStream = new CloseCountingSeekableInputStream();
+        MosaicInputFileAdapter inputFileAdapter = createInputFileAdapter(inputStream);
+        CloseCountingRootAllocator allocator = new CloseCountingRootAllocator();
+        MosaicReader reader = mock(MosaicReader.class);
+        VectorSchemaRoot secondRoot = intRoot(allocator, 3, 4, 5, 6);
+        VectorSchemaRoot thirdRoot = intRoot(allocator, 7, 8);
+        when(reader.getSchema()).thenReturn(secondRoot.getSchema());
+        when(reader.numRowGroups()).thenReturn(3);
+        when(reader.rowGroupNumRows(0)).thenReturn(3);
+        when(reader.rowGroupNumRows(1)).thenReturn(4);
+        when(reader.rowGroupNumRows(2)).thenReturn(2);
+        when(reader.readRowGroup(1, allocator)).thenReturn(secondRoot);
+        when(reader.readRowGroup(2, allocator)).thenReturn(thirdRoot);
+
+        RoaringBitmap32 selection = RoaringBitmap32.bitmapOf(3, 7);
+        MosaicRecordsReader recordsReader =
+                new MosaicRecordsReader(
+                        inputFileAdapter,
+                        0,
+                        rowType(),
+                        rowType(),
+                        null,
+                        new Path("file:/tmp/mosaic-reader-test"),
+                        selection,
+                        allocator,
+                        (inputFile, fileSize, bufferAllocator) -> reader);
+
+        FileRecordIterator<InternalRow> secondBatch =
+                recordsReader.readBatch().selection(RoaringBitmap32.bitmapOf(3));
+        assertThat(secondBatch.next().getInt(0)).isEqualTo(3);
+        assertThat(secondBatch.returnedPosition()).isEqualTo(3);
+        assertThat(secondBatch.next()).isNull();
+        secondBatch.releaseBatch();
+
+        FileRecordIterator<InternalRow> thirdBatch =
+                recordsReader.readBatch().selection(RoaringBitmap32.bitmapOf(7));
+        assertThat(thirdBatch.next().getInt(0)).isEqualTo(7);
+        assertThat(thirdBatch.returnedPosition()).isEqualTo(7);
+        assertThat(thirdBatch.next()).isNull();
+        thirdBatch.releaseBatch();
+        assertThat(recordsReader.readBatch()).isNull();
+
+        verify(reader, never()).readRowGroup(0, allocator);
+        verify(reader).readRowGroup(1, allocator);
+        verify(reader).readRowGroup(2, allocator);
+
+        recordsReader.close();
+        assertThat(allocator.getAllocatedMemory()).isZero();
+    }
+
     private static MosaicInputFileAdapter createInputFileAdapter(
             CloseCountingSeekableInputStream inputStream) throws IOException {
         return new MosaicInputFileAdapter(
@@ -229,8 +348,29 @@ class MosaicRecordsReaderTest {
         }
     }
 
+    private static void assertSelectedRow(
+            FileRecordIterator<InternalRow> batch, int value, long position) throws IOException {
+        assertThat(batch).isNotNull();
+        assertThat(batch.next().getInt(0)).isEqualTo(value);
+        assertThat(batch.returnedPosition()).isEqualTo(position);
+        assertThat(batch.next()).isNull();
+        batch.releaseBatch();
+    }
+
     private static RowType rowType() {
         return DataTypes.ROW(DataTypes.INT());
+    }
+
+    private static VectorSchemaRoot intRoot(RootAllocator allocator, int... values) {
+        VectorSchemaRoot root = ArrowUtils.createVectorSchemaRoot(rowType(), allocator);
+        IntVector vector = (IntVector) root.getVector(0);
+        vector.allocateNew(values.length);
+        for (int i = 0; i < values.length; i++) {
+            vector.setSafe(i, values[i]);
+        }
+        vector.setValueCount(values.length);
+        root.setRowCount(values.length);
+        return root;
     }
 
     private static class CloseCountingFileIO extends LocalFileIO {


### PR DESCRIPTION
### Purpose

File indexes expose matching row positions through `FormatReaderFactory.Context.selection()`. Exact row filtering remains in `DataFileRecordReader`, while format readers may use the selection for physical pruning. `MosaicReaderFactory` currently drops this selection, so `MosaicRecordsReader` invokes `MosaicReader.readRowGroup` for every predicate-matching row group in a retained file.

This change forwards the selection and skips row groups whose file-relative half-open row range does not intersect the bitmap. It keeps a physical row-group offset separate from `returnedPosition` so pruning stays correct when the outer selection stops a batch early. It does not change exact row filtering, the Mosaic file format, or the native Mosaic library.

This is orthogonal to #9740: that pull request optimizes row-group I/O and prefetch, while this change prevents unmatched row groups from being scheduled or read. If #9740 lands first, the selection check should move ahead of prefetch scheduling during rebase.

In a production-like Spark A/B over identical four-split scans, five alternating pairs returned identical results; median latency decreased from 20.4 s to 5.5 s (about 3.7x).

### Tests

- `mvn -pl paimon-mosaic -am -DskipTests package`
- `mvn -pl paimon-mosaic -am -DfailIfNoTests=false -DwildcardSuites=none -Dtest='org.apache.paimon.format.mosaic.*Test' test` (86 tests)
- Regression coverage verifies factory propagation, unmatched row-group pruning, exact file-relative positions across skipped and partially consumed groups, and Arrow buffer release.
