### PR TITLE
[core] Add interrupt coverage for snapshot existence retries

### DIFF
--- a/paimon-core/src/test/java/org/apache/paimon/utils/SnapshotManagerTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/utils/SnapshotManagerTest.java
@@ -121,6 +121,25 @@ public class SnapshotManagerTest {
         Mockito.verify(fileIO, Mockito.times(3)).exists(Mockito.any(Path.class));
     }
 
+    @Test
+    public void testSnapshotExistsRestoresInterruptedStatus() throws IOException {
+        FileIO fileIO = Mockito.mock(FileIO.class);
+        Mockito.when(fileIO.exists(Mockito.any(Path.class)))
+                .thenThrow(new IOException("Temporary failure"));
+        SnapshotManager snapshotManager = newSnapshotManager(fileIO, new Path(tempDir.toString()));
+
+        Thread.currentThread().interrupt();
+        try {
+            assertThatThrownBy(() -> snapshotManager.snapshotExists(2))
+                    .hasMessageContaining("Interrupted while checking whether snapshot #2 exists")
+                    .hasCauseInstanceOf(InterruptedException.class);
+            assertThat(Thread.currentThread().isInterrupted()).isTrue();
+            Mockito.verify(fileIO).exists(Mockito.any(Path.class));
+        } finally {
+            Thread.interrupted();
+        }
+    }
+
     @ParameterizedTest
     @ValueSource(booleans = {true, false})
     public void testEarliestSnapshot(boolean isRaceCondition) throws IOException {


### PR DESCRIPTION
### Purpose

Follow-up to #9707.

#9707 added bounded retries for snapshot existence checks. During review, interrupt-path coverage was also requested.

The production failure was observed on HDFS during a lookup join refresh. `FileIO#exists` threw an `IOException`, which `SnapshotManager` wrapped in a `RuntimeException`. The snapshot was confirmed to exist, and the same lookup succeeded without data or code changes after HDFS recovered. The available log excerpt did not include the concrete `IOException` subtype.

This change verifies that interrupting the retry wait preserves the `InterruptedException` as the cause, restores the thread interrupt status, and stops the retry loop after the initial existence check. It does not change production behavior.

### Tests

- `SnapshotManagerTest` (42 tests, all passed)

### API and Format

No API or format changes.

### Documentation

No documentation changes.