### PR TITLE
[python] Support linear interpolation in temporal alignment

### DIFF
--- a/docs/docs/pypaimon/multimodal-reading.md
+++ b/docs/docs/pypaimon/multimodal-reading.md
@@ -89,19 +89,12 @@ match delta.
 Inputs are snapshot-pinned (`resolved_snapshots`). Left rows stream, right join
 keys stay in memory, and BLOBs remain descriptors.
 
-Use `interpolate_linear` for numeric state columns. It interpolates between the
-surrounding rows in the same group, does not extrapolate, and requires both rows
-to satisfy `tolerance`. Numeric scalars and fixed-size numeric lists are
-supported.
+Use `interpolate_linear` for numeric scalars or fixed-size numeric lists. It
+requires surrounding rows in the same group and never extrapolates.
 
 ```python
-from pypaimon.multimodal import interpolate_linear
-
-states_at_steps = interpolate_linear(
-    actions.scan(),
+states_at_steps = aligned.interpolate_linear(
     states.scan().select(["joint_position", "velocity"]),
-    on="event_time",
-    by="episode_id",
     tolerance=timedelta(milliseconds=50),
 )
 ```

--- a/docs/docs/pypaimon/multimodal-reading.md
+++ b/docs/docs/pypaimon/multimodal-reading.md
@@ -90,8 +90,10 @@ Inputs are snapshot-pinned (`resolved_snapshots`). Left rows stream, right join
 keys stay in memory, and BLOBs remain descriptors.
 
 Use `interpolate(left, right, ...)` directly or chain `aligned.interpolate(...)`.
-Exact timestamps use the exact right row; otherwise numeric interpolation
-requires surrounding rows in the same `by` group and never extrapolates.
+It supports integer or floating-point scalars and fixed-size lists. Exact
+timestamps use the exact right row; otherwise it requires surrounding rows
+in the same `by` group and never extrapolates. When set, `tolerance` must
+include both surrounding rows.
 
 ```python
 states_at_steps = aligned.interpolate(

--- a/docs/docs/pypaimon/multimodal-reading.md
+++ b/docs/docs/pypaimon/multimodal-reading.md
@@ -89,6 +89,23 @@ match delta.
 Inputs are snapshot-pinned (`resolved_snapshots`). Left rows stream, right join
 keys stay in memory, and BLOBs remain descriptors.
 
+Use `interpolate_linear` for numeric state columns. It interpolates between the
+surrounding rows in the same group, does not extrapolate, and requires both rows
+to satisfy `tolerance`. Numeric scalars and fixed-size numeric lists are
+supported.
+
+```python
+from pypaimon.multimodal import interpolate_linear
+
+states_at_steps = interpolate_linear(
+    actions.scan(),
+    states.scan().select(["joint_position", "velocity"]),
+    on="event_time",
+    by="episode_id",
+    tolerance=timedelta(milliseconds=50),
+)
+```
+
 ### Reading BLOB columns
 
 `scan().read_blobs(column)` bulk-fetches a BLOB column's bytes for the filtered

--- a/docs/docs/pypaimon/multimodal-reading.md
+++ b/docs/docs/pypaimon/multimodal-reading.md
@@ -89,11 +89,11 @@ match delta.
 Inputs are snapshot-pinned (`resolved_snapshots`). Left rows stream, right join
 keys stay in memory, and BLOBs remain descriptors.
 
-Use `interpolate_by` for numeric scalars or fixed-size numeric lists. It
+Use `interpolate_linear` for numeric scalars or fixed-size numeric lists. It
 requires surrounding rows in the same group and never extrapolates.
 
 ```python
-states_at_steps = aligned.interpolate_by(
+states_at_steps = aligned.interpolate_linear(
     states.scan().select(["joint_position", "velocity"]),
     tolerance=timedelta(milliseconds=50),
 )

--- a/docs/docs/pypaimon/multimodal-reading.md
+++ b/docs/docs/pypaimon/multimodal-reading.md
@@ -89,11 +89,11 @@ match delta.
 Inputs are snapshot-pinned (`resolved_snapshots`). Left rows stream, right join
 keys stay in memory, and BLOBs remain descriptors.
 
-Use `interpolate_linear` for numeric scalars or fixed-size numeric lists. It
+Use `interpolate_by` for numeric scalars or fixed-size numeric lists. It
 requires surrounding rows in the same group and never extrapolates.
 
 ```python
-states_at_steps = aligned.interpolate_linear(
+states_at_steps = aligned.interpolate_by(
     states.scan().select(["joint_position", "velocity"]),
     tolerance=timedelta(milliseconds=50),
 )

--- a/docs/docs/pypaimon/multimodal-reading.md
+++ b/docs/docs/pypaimon/multimodal-reading.md
@@ -89,11 +89,12 @@ match delta.
 Inputs are snapshot-pinned (`resolved_snapshots`). Left rows stream, right join
 keys stay in memory, and BLOBs remain descriptors.
 
-Use `interpolate_linear` for numeric scalars or fixed-size numeric lists. It
-requires surrounding rows in the same group and never extrapolates.
+Use `interpolate_by` for numeric scalars or fixed-size numeric lists. It uses
+the `on` time axis within each `by` group, requires surrounding rows, and never
+extrapolates.
 
 ```python
-states_at_steps = aligned.interpolate_linear(
+states_at_steps = aligned.interpolate_by(
     states.scan().select(["joint_position", "velocity"]),
     tolerance=timedelta(milliseconds=50),
 )

--- a/docs/docs/pypaimon/multimodal-reading.md
+++ b/docs/docs/pypaimon/multimodal-reading.md
@@ -89,12 +89,12 @@ match delta.
 Inputs are snapshot-pinned (`resolved_snapshots`). Left rows stream, right join
 keys stay in memory, and BLOBs remain descriptors.
 
-Use `interpolate_by` for numeric scalars or fixed-size numeric lists. It uses
-the `on` time axis within each `by` group, requires surrounding rows, and never
-extrapolates.
+Use `interpolate(left, right, ...)` directly or chain `aligned.interpolate(...)`.
+Exact timestamps use the exact right row; otherwise numeric interpolation
+requires surrounding rows in the same `by` group and never extrapolates.
 
 ```python
-states_at_steps = aligned.interpolate_by(
+states_at_steps = aligned.interpolate(
     states.scan().select(["joint_position", "velocity"]),
     tolerance=timedelta(milliseconds=50),
 )

--- a/paimon-python/pypaimon/multimodal/__init__.py
+++ b/paimon-python/pypaimon/multimodal/__init__.py
@@ -44,7 +44,7 @@ from pypaimon.multimodal.table import (
 )
 from pypaimon.multimodal.temporal import (
     AsOfJoin,
-    interpolate_linear,
+    interpolate_by,
     join_asof,
 )
 from pypaimon.multimodal.video import VideoFrameCollator
@@ -77,7 +77,7 @@ __all__ = [
     "VideoFrameCollator",
     "VideoFrameDescriptor",
     "connect",
-    "interpolate_linear",
+    "interpolate_by",
     "join_asof",
     "lit",
     "source_col",

--- a/paimon-python/pypaimon/multimodal/__init__.py
+++ b/paimon-python/pypaimon/multimodal/__init__.py
@@ -44,7 +44,7 @@ from pypaimon.multimodal.table import (
 )
 from pypaimon.multimodal.temporal import (
     AsOfJoin,
-    interpolate_by,
+    interpolate_linear,
     join_asof,
 )
 from pypaimon.multimodal.video import VideoFrameCollator
@@ -77,7 +77,7 @@ __all__ = [
     "VideoFrameCollator",
     "VideoFrameDescriptor",
     "connect",
-    "interpolate_by",
+    "interpolate_linear",
     "join_asof",
     "lit",
     "source_col",

--- a/paimon-python/pypaimon/multimodal/__init__.py
+++ b/paimon-python/pypaimon/multimodal/__init__.py
@@ -44,6 +44,7 @@ from pypaimon.multimodal.table import (
 )
 from pypaimon.multimodal.temporal import (
     AsOfJoin,
+    interpolate_linear,
     join_asof,
 )
 from pypaimon.multimodal.video import VideoFrameCollator
@@ -76,6 +77,7 @@ __all__ = [
     "VideoFrameCollator",
     "VideoFrameDescriptor",
     "connect",
+    "interpolate_linear",
     "join_asof",
     "lit",
     "source_col",

--- a/paimon-python/pypaimon/multimodal/__init__.py
+++ b/paimon-python/pypaimon/multimodal/__init__.py
@@ -43,8 +43,8 @@ from pypaimon.multimodal.table import (
     vector_route,
 )
 from pypaimon.multimodal.temporal import (
-    AsOfJoin,
-    interpolate_by,
+    TemporalAlignment,
+    interpolate,
     join_asof,
 )
 from pypaimon.multimodal.video import VideoFrameCollator
@@ -56,7 +56,6 @@ from pypaimon.table.data_evolution_merge_into import (
 )
 
 __all__ = [
-    "AsOfJoin",
     "Blob",
     "BlobDescriptor",
     "BlobObject",
@@ -73,11 +72,12 @@ __all__ = [
     "RosbagSource",
     "RosbagStagingConfig",
     "TextRoute",
+    "TemporalAlignment",
     "VectorRoute",
     "VideoFrameCollator",
     "VideoFrameDescriptor",
     "connect",
-    "interpolate_by",
+    "interpolate",
     "join_asof",
     "lit",
     "source_col",

--- a/paimon-python/pypaimon/multimodal/temporal.py
+++ b/paimon-python/pypaimon/multimodal/temporal.py
@@ -425,7 +425,7 @@ class _LinearInterpolationRight(_AsOfJoinRight):
             exact = bisect_right(
                 self._time_keys, target, position, end) - 1
             row_id = self._row_ids[exact].as_py()
-            return row_id, row_id, 0.0
+            return row_id, row_id, 0.0, 0, 1
         if position == start or position == end:
             return None
 
@@ -437,12 +437,10 @@ class _LinearInterpolationRight(_AsOfJoinRight):
                 and max(target - before_time, after_time - target)
                 > self._tolerance_key):
             return None
-        weight = _linear_weight(
-            target, before_time, after_time, self.time_type)
         return (
             self._row_ids[before].as_py(),
             self._row_ids[after].as_py(),
-            weight,
+            *_linear_weight(target, before_time, after_time, self.time_type),
         )
 
     def build_arrays(self, anchor_rows, fetcher):
@@ -468,6 +466,10 @@ class _LinearInterpolationRight(_AsOfJoinRight):
             None if match is None else match[2]
             for match in matches
         ], type=pa.float64())
+        ratios = [
+            None if match is None else match[3:5]
+            for match in matches
+        ]
 
         arrays = []
         for field in self.payload_schema:
@@ -475,6 +477,7 @@ class _LinearInterpolationRight(_AsOfJoinRight):
                 pc.take(values[field.name], before),
                 pc.take(values[field.name], after),
                 weights,
+                ratios,
             )
             array.validate()
             arrays.append(array)
@@ -512,20 +515,26 @@ def _linear_output_type(data_type):
         return pa.list_(
             _linear_output_type(data_type.value_type), data_type.list_size)
     raise TypeError(
-        "Linear interpolation requires numeric scalar or fixed-size list "
-        "columns; got %s." % data_type)
+        "Linear interpolation requires integer or floating-point scalars "
+        "or fixed-size lists; got %s." % data_type)
 
 
 def _linear_weight(target, before, after, data_type):
+    if pa.types.is_integer(data_type) or pa.types.is_timestamp(data_type):
+        numerator = target - before
+        denominator = after - before
+        return numerator / denominator, numerator, denominator
     if pa.types.is_floating(data_type):
         scale = max(abs(target), abs(before), abs(after))
         if scale:
             target, before, after = (
                 target / scale, before / scale, after / scale)
-    return float(target - before) / (after - before)
+    weight = float(target - before) / (after - before)
+    numerator, denominator = weight.as_integer_ratio()
+    return weight, numerator, denominator
 
 
-def _interpolate_array(before, after, weights):
+def _interpolate_array(before, after, weights, ratios):
     if isinstance(before, pa.ChunkedArray):
         before = before.combine_chunks()
     if isinstance(after, pa.ChunkedArray):
@@ -537,17 +546,34 @@ def _interpolate_array(before, after, weights):
         repeated = pa.array([
             weight for weight in weights.to_pylist() for unused in range(size)
         ], type=pa.float64())
+        repeated_ratios = [
+            ratio for ratio in ratios for unused in range(size)
+        ]
         values = _interpolate_array(
             before.values.slice(before.offset * size, len(before) * size),
             after.values.slice(after.offset * size, len(after) * size),
             repeated,
+            repeated_ratios,
         )
         mask = pc.or_(before.is_null(), after.is_null())
         result = pa.FixedSizeListArray.from_arrays(values, size)
         return pc.if_else(mask, pa.scalar(None, type=result.type), result)
 
-    start = pc.cast(before, pa.float64(), safe=False)
-    end = pc.cast(after, pa.float64(), safe=False)
+    if pa.types.is_integer(data_type):
+        result = []
+        for start, end, ratio in zip(
+                before.to_pylist(), after.to_pylist(), ratios):
+            if start is None or end is None or ratio is None:
+                result.append(None)
+                continue
+            numerator, denominator = ratio
+            result.append((
+                start * (denominator - numerator) + end * numerator
+            ) / denominator)
+        return pa.array(result, type=pa.float64())
+
+    start = pc.cast(before, pa.float64())
+    end = pc.cast(after, pa.float64())
     result = pc.add(
         pc.multiply(start, pc.subtract(1.0, weights)),
         pc.multiply(end, weights),

--- a/paimon-python/pypaimon/multimodal/temporal.py
+++ b/paimon-python/pypaimon/multimodal/temporal.py
@@ -54,6 +54,29 @@ _TEMPORAL_ROW_GROUP_CACHE_MAX_SIZE = 64 * 1024 * 1024
 def join_asof(left, right, *, on, by, direction="backward", tolerance=None,
               right_on=None, suffix="_right") -> "AsOfJoin":
     """Join each left row with at most one time-aligned right row."""
+    on, by = _normalize_temporal_keys(on, by)
+    return AsOfJoin(left, on, by).join_asof(
+        right,
+        direction=direction,
+        tolerance=tolerance,
+        right_on=right_on,
+        suffix=suffix,
+    )
+
+
+def interpolate_linear(left, right, *, on, by, tolerance=None,
+                       right_on=None, suffix="_right") -> "AsOfJoin":
+    """Linearly interpolate numeric right values at each left timestamp."""
+    on, by = _normalize_temporal_keys(on, by)
+    return AsOfJoin(left, on, by).interpolate_linear(
+        right,
+        tolerance=tolerance,
+        right_on=right_on,
+        suffix=suffix,
+    )
+
+
+def _normalize_temporal_keys(on, by):
     if not isinstance(on, str) or not on:
         raise ValueError("on must be a non-empty column name.")
     if isinstance(by, str):
@@ -70,13 +93,7 @@ def join_asof(left, right, *, on, by, direction="backward", tolerance=None,
     if (any(not isinstance(name, str) or not name for name in by)
             or len(set(by)) != len(by)):
         raise ValueError("by must contain unique, non-empty column names.")
-    return AsOfJoin(left, on, by).join_asof(
-        right,
-        direction=direction,
-        tolerance=tolerance,
-        right_on=right_on,
-        suffix=suffix,
-    )
+    return on, by
 
 
 class AsOfJoin:
@@ -107,7 +124,24 @@ class AsOfJoin:
             right_on,
             suffix,
         )
+        return self._append(source)
 
+    def interpolate_linear(self, right, *, tolerance=None, right_on=None,
+                           suffix="_right") -> "AsOfJoin":
+        """Append linear interpolation of numeric right-side values."""
+        position = len(self._sources) + 1
+        source = _LinearInterpolationRight(
+            "right source %d" % position,
+            right,
+            self._on,
+            self._by,
+            tolerance,
+            right_on,
+            suffix,
+        )
+        return self._append(source)
+
+    def _append(self, source):
         result = object.__new__(AsOfJoin)
         result._anchor = self._anchor
         result._on = self._on
@@ -218,7 +252,7 @@ class AsOfJoin:
                 else source_fetchers[position].schema
             )
             for name in source.payload_schema.names:
-                field = payload_schema.field(name)
+                field = source.output_field(payload_schema.field(name))
                 output_name = field.name
                 if output_name in names:
                     output_name += source.suffix
@@ -242,21 +276,7 @@ class AsOfJoin:
         arrays = [anchor[name] for name in self._anchor_schema.names]
 
         for source, fetcher in zip(self._sources, source_fetchers):
-            matches = [source.match(row) for row in anchor_rows]
-            matched_ids = [match for match in matches if match is not None]
-            unique_ids = list(dict.fromkeys(matched_ids))
-            values = fetcher.fetch(unique_ids)
-            positions = {
-                row_id: index for index, row_id in enumerate(unique_ids)
-            }
-            take = pa.array([
-                None if match is None else positions[match]
-                for match in matches
-            ], type=pa.int64())
-            for field in source.payload_schema:
-                array = pc.take(values[field.name], take)
-                array.validate()
-                arrays.append(array)
+            arrays.extend(source.build_arrays(anchor_rows, fetcher))
 
         if arrays:
             table = pa.Table.from_arrays(
@@ -347,6 +367,112 @@ class _AsOfJoinRight:
             return None
         return self._row_ids[index].as_py()
 
+    @staticmethod
+    def output_field(field):
+        return field
+
+    def build_arrays(self, anchor_rows, fetcher):
+        matches = [self.match(row) for row in anchor_rows]
+        matched_ids = [match for match in matches if match is not None]
+        unique_ids = list(dict.fromkeys(matched_ids))
+        values = fetcher.fetch(unique_ids)
+        positions = {
+            row_id: index for index, row_id in enumerate(unique_ids)
+        }
+        take = pa.array([
+            None if match is None else positions[match]
+            for match in matches
+        ], type=pa.int64())
+        arrays = []
+        for field in self.payload_schema:
+            array = pc.take(values[field.name], take)
+            array.validate()
+            arrays.append(array)
+        return arrays
+
+
+class _LinearInterpolationRight(_AsOfJoinRight):
+
+    def __init__(self, label, query, anchor_on, by, tolerance,
+                 right_on, suffix):
+        super().__init__(
+            label, query, anchor_on, by, "nearest", tolerance,
+            right_on, suffix)
+        for field in self.payload_schema:
+            self.output_field(field)
+
+    @staticmethod
+    def output_field(field):
+        return pa.field(
+            field.name, _linear_output_type(field.type), nullable=True,
+            metadata=field.metadata)
+
+    def match(self, anchor_row):
+        key = tuple(anchor_row[name] for name in self.by)
+        bounds = self._index.get(key)
+        if bounds is None:
+            return None
+        start, end = bounds
+        target = anchor_row[_TIME_KEY]
+        position = bisect_left(self._time_keys, target, start, end)
+        if position < end and self._time_keys[position] == target:
+            exact = bisect_right(
+                self._time_keys, target, position, end) - 1
+            row_id = self._row_ids[exact].as_py()
+            return row_id, row_id, 0.0
+        if position == start or position == end:
+            return None
+
+        before = position - 1
+        after = position
+        before_time = _python_scalar(self._time_keys[before])
+        after_time = _python_scalar(self._time_keys[after])
+        if (self._tolerance_key is not None
+                and max(target - before_time, after_time - target)
+                > self._tolerance_key):
+            return None
+        weight = float(target - before_time) / (after_time - before_time)
+        return (
+            self._row_ids[before].as_py(),
+            self._row_ids[after].as_py(),
+            weight,
+        )
+
+    def build_arrays(self, anchor_rows, fetcher):
+        matches = [self.match(row) for row in anchor_rows]
+        matched_ids = []
+        for match in matches:
+            if match is not None:
+                matched_ids.extend(match[:2])
+        unique_ids = list(dict.fromkeys(matched_ids))
+        values = fetcher.fetch(unique_ids)
+        positions = {
+            row_id: index for index, row_id in enumerate(unique_ids)
+        }
+        before = pa.array([
+            None if match is None else positions[match[0]]
+            for match in matches
+        ], type=pa.int64())
+        after = pa.array([
+            None if match is None else positions[match[1]]
+            for match in matches
+        ], type=pa.int64())
+        weights = pa.array([
+            None if match is None else match[2]
+            for match in matches
+        ], type=pa.float64())
+
+        arrays = []
+        for field in self.payload_schema:
+            array = _interpolate_array(
+                pc.take(values[field.name], before),
+                pc.take(values[field.name], after),
+                weights,
+            )
+            array.validate()
+            arrays.append(array)
+        return arrays
+
 
 def _validate_join_options(direction, tolerance, right_on, suffix):
     if direction not in ("backward", "forward", "nearest"):
@@ -368,6 +494,47 @@ def _validate_join_options(direction, tolerance, right_on, suffix):
         zero = timedelta(0) if isinstance(tolerance, timedelta) else 0
         if tolerance < zero:
             raise ValueError("tolerance must be non-negative.")
+
+
+def _linear_output_type(data_type):
+    if pa.types.is_integer(data_type):
+        return pa.float64()
+    if pa.types.is_floating(data_type):
+        return data_type
+    if pa.types.is_fixed_size_list(data_type):
+        return pa.list_(
+            _linear_output_type(data_type.value_type), data_type.list_size)
+    raise TypeError(
+        "Linear interpolation requires numeric scalar or fixed-size list "
+        "columns; got %s." % data_type)
+
+
+def _interpolate_array(before, after, weights):
+    if isinstance(before, pa.ChunkedArray):
+        before = before.combine_chunks()
+    if isinstance(after, pa.ChunkedArray):
+        after = after.combine_chunks()
+    data_type = before.type
+    output_type = _linear_output_type(data_type)
+    if pa.types.is_fixed_size_list(data_type):
+        size = data_type.list_size
+        repeated = pa.array([
+            weight for weight in weights.to_pylist() for unused in range(size)
+        ], type=pa.float64())
+        values = _interpolate_array(
+            before.values.slice(before.offset * size, len(before) * size),
+            after.values.slice(after.offset * size, len(after) * size),
+            repeated,
+        )
+        mask = pc.or_(before.is_null(), after.is_null())
+        return pa.FixedSizeListArray.from_arrays(values, size, mask=mask)
+
+    start = pc.cast(before, pa.float64())
+    end = pc.cast(after, pa.float64())
+    result = pc.add(start, pc.multiply(pc.subtract(end, start), weights))
+    if result.type != output_type:
+        result = pc.cast(result, output_type)
+    return result
 
 
 def _require_scan(query, label):

--- a/paimon-python/pypaimon/multimodal/temporal.py
+++ b/paimon-python/pypaimon/multimodal/temporal.py
@@ -52,10 +52,9 @@ _TEMPORAL_ROW_GROUP_CACHE_MAX_SIZE = 64 * 1024 * 1024
 
 
 def join_asof(left, right, *, on, by, direction="backward", tolerance=None,
-              right_on=None, suffix="_right") -> "AsOfJoin":
+              right_on=None, suffix="_right") -> "TemporalAlignment":
     """Join each left row with at most one time-aligned right row."""
-    on, by = _normalize_temporal_keys(on, by)
-    return AsOfJoin(left, on, by).join_asof(
+    return TemporalAlignment(left, on=on, by=by).join_asof(
         right,
         direction=direction,
         tolerance=tolerance,
@@ -64,11 +63,10 @@ def join_asof(left, right, *, on, by, direction="backward", tolerance=None,
     )
 
 
-def interpolate_by(left, right, *, on, by, tolerance=None,
-                   right_on=None, suffix="_right") -> "AsOfJoin":
+def interpolate(left, right, *, on, by, tolerance=None,
+                right_on=None, suffix="_right") -> "TemporalAlignment":
     """Linearly interpolate numeric right values at each left timestamp."""
-    on, by = _normalize_temporal_keys(on, by)
-    return AsOfJoin(left, on, by).interpolate_by(
+    return TemporalAlignment(left, on=on, by=by).interpolate(
         right,
         tolerance=tolerance,
         right_on=right_on,
@@ -89,17 +87,18 @@ def _normalize_temporal_keys(on, by):
                 "by must be a column name or sequence.") from error
     if not by:
         raise ValueError(
-            "join_asof requires at least one grouping column in by.")
+            "Temporal alignment requires a grouping column in by.")
     if (any(not isinstance(name, str) or not name for name in by)
             or len(set(by)) != len(by)):
         raise ValueError("by must contain unique, non-empty column names.")
     return on, by
 
 
-class AsOfJoin:
-    """Lazy, chainable result of :func:`join_asof`."""
+class TemporalAlignment:
+    """Lazy, chainable alignment of table scans by time."""
 
-    def __init__(self, left, on, by):
+    def __init__(self, left, *, on, by):
+        on, by = _normalize_temporal_keys(on, by)
         self._anchor = _pin_scan_to_snapshot(_require_scan(left, "left"))
         self._on = on
         self._by = by
@@ -110,7 +109,7 @@ class AsOfJoin:
         self.schema = self._output_schema()
 
     def join_asof(self, right, *, direction="backward", tolerance=None,
-                  right_on=None, suffix="_right") -> "AsOfJoin":
+                  right_on=None, suffix="_right") -> "TemporalAlignment":
         """Append a right-side as-of join without materializing this scan."""
         position = len(self._sources) + 1
         label = "right source %d" % position
@@ -126,8 +125,8 @@ class AsOfJoin:
         )
         return self._append(source)
 
-    def interpolate_by(self, right, *, tolerance=None, right_on=None,
-                       suffix="_right") -> "AsOfJoin":
+    def interpolate(self, right, *, tolerance=None, right_on=None,
+                    suffix="_right") -> "TemporalAlignment":
         """Append linear interpolation of numeric right-side values."""
         position = len(self._sources) + 1
         source = _LinearInterpolationRight(
@@ -142,7 +141,7 @@ class AsOfJoin:
         return self._append(source)
 
     def _append(self, source):
-        result = object.__new__(AsOfJoin)
+        result = object.__new__(TemporalAlignment)
         result._anchor = self._anchor
         result._on = self._on
         result._by = self._by
@@ -572,12 +571,13 @@ def _pin_scan_to_snapshot(query):
     options = table.options
     if not options.row_tracking_enabled(False):
         raise ValueError(
-            "join_asof requires 'row-tracking.enabled' = 'true'.")
+            "Temporal alignment requires 'row-tracking.enabled' = 'true'.")
     if (options.scan_mode() == StartupMode.INCREMENTAL
             or options.options.contains(
                 CoreOptions.INCREMENTAL_BETWEEN_TIMESTAMP)):
         raise ValueError(
-            "join_asof does not support incremental scans; inputs must "
+            "Temporal alignment does not support incremental scans; "
+            "inputs must "
             "represent a complete point-in-time snapshot.")
     # Validate the original scan configuration before replacing it with a
     # pinned snapshot. Otherwise an invalid or unsupported scan mode can be

--- a/paimon-python/pypaimon/multimodal/temporal.py
+++ b/paimon-python/pypaimon/multimodal/temporal.py
@@ -532,6 +532,7 @@ def _interpolate_array(before, after, weights):
     start = pc.cast(before, pa.float64())
     end = pc.cast(after, pa.float64())
     result = pc.add(start, pc.multiply(pc.subtract(end, start), weights))
+    result = pc.if_else(pc.equal(weights, 0.0), start, result)
     if result.type != output_type:
         result = pc.cast(result, output_type)
     return result

--- a/paimon-python/pypaimon/multimodal/temporal.py
+++ b/paimon-python/pypaimon/multimodal/temporal.py
@@ -525,16 +525,19 @@ def _linear_weight(target, before, after, data_type):
         denominator = after - before
         return numerator / denominator, numerator, denominator
     if pa.types.is_floating(data_type):
+        ratios = [float(value).as_integer_ratio()
+                  for value in (target, before, after)]
+        common_denominator = max(
+            denominator for unused, denominator in ratios)
+        target, before, after = [
+            numerator * (common_denominator // denominator)
+            for numerator, denominator in ratios
+        ]
         numerator = target - before
         denominator = after - before
-        if math.isfinite(numerator) and math.isfinite(denominator):
-            weight = numerator / denominator
-        else:
-            scale = max(abs(target), abs(before), abs(after))
-            weight = ((target / scale - before / scale)
-                      / (after / scale - before / scale))
-    else:
-        weight = float(target - before) / (after - before)
+        weight = numerator / denominator
+        return weight, numerator, denominator
+    weight = float(target - before) / (after - before)
     numerator, denominator = weight.as_integer_ratio()
     return weight, numerator, denominator
 

--- a/paimon-python/pypaimon/multimodal/temporal.py
+++ b/paimon-python/pypaimon/multimodal/temporal.py
@@ -64,11 +64,11 @@ def join_asof(left, right, *, on, by, direction="backward", tolerance=None,
     )
 
 
-def interpolate_by(left, right, *, on, by, tolerance=None,
-                   right_on=None, suffix="_right") -> "AsOfJoin":
+def interpolate_linear(left, right, *, on, by, tolerance=None,
+                       right_on=None, suffix="_right") -> "AsOfJoin":
     """Linearly interpolate numeric right values at each left timestamp."""
     on, by = _normalize_temporal_keys(on, by)
-    return AsOfJoin(left, on, by).interpolate_by(
+    return AsOfJoin(left, on, by).interpolate_linear(
         right,
         tolerance=tolerance,
         right_on=right_on,
@@ -126,8 +126,8 @@ class AsOfJoin:
         )
         return self._append(source)
 
-    def interpolate_by(self, right, *, tolerance=None, right_on=None,
-                       suffix="_right") -> "AsOfJoin":
+    def interpolate_linear(self, right, *, tolerance=None, right_on=None,
+                           suffix="_right") -> "AsOfJoin":
         """Append linear interpolation of numeric right-side values."""
         position = len(self._sources) + 1
         source = _LinearInterpolationRight(

--- a/paimon-python/pypaimon/multimodal/temporal.py
+++ b/paimon-python/pypaimon/multimodal/temporal.py
@@ -64,11 +64,11 @@ def join_asof(left, right, *, on, by, direction="backward", tolerance=None,
     )
 
 
-def interpolate_linear(left, right, *, on, by, tolerance=None,
-                       right_on=None, suffix="_right") -> "AsOfJoin":
+def interpolate_by(left, right, *, on, by, tolerance=None,
+                   right_on=None, suffix="_right") -> "AsOfJoin":
     """Linearly interpolate numeric right values at each left timestamp."""
     on, by = _normalize_temporal_keys(on, by)
-    return AsOfJoin(left, on, by).interpolate_linear(
+    return AsOfJoin(left, on, by).interpolate_by(
         right,
         tolerance=tolerance,
         right_on=right_on,
@@ -126,8 +126,8 @@ class AsOfJoin:
         )
         return self._append(source)
 
-    def interpolate_linear(self, right, *, tolerance=None, right_on=None,
-                           suffix="_right") -> "AsOfJoin":
+    def interpolate_by(self, right, *, tolerance=None, right_on=None,
+                       suffix="_right") -> "AsOfJoin":
         """Append linear interpolation of numeric right-side values."""
         position = len(self._sources) + 1
         source = _LinearInterpolationRight(

--- a/paimon-python/pypaimon/multimodal/temporal.py
+++ b/paimon-python/pypaimon/multimodal/temporal.py
@@ -252,7 +252,10 @@ class AsOfJoin:
                 else source_fetchers[position].schema
             )
             for name in source.payload_schema.names:
-                field = source.output_field(payload_schema.field(name))
+                field = source.output_field(
+                    payload_schema.field(name),
+                    effective=source_fetchers is not None,
+                )
                 output_name = field.name
                 if output_name in names:
                     output_name += source.suffix
@@ -368,7 +371,7 @@ class _AsOfJoinRight:
         return self._row_ids[index].as_py()
 
     @staticmethod
-    def output_field(field):
+    def output_field(field, effective=True):
         return field
 
     def build_arrays(self, anchor_rows, fetcher):
@@ -398,13 +401,17 @@ class _LinearInterpolationRight(_AsOfJoinRight):
         super().__init__(
             label, query, anchor_on, by, "nearest", tolerance,
             right_on, suffix)
-        for field in self.payload_schema:
-            self.output_field(field)
 
     @staticmethod
-    def output_field(field):
+    def output_field(field, effective=True):
+        try:
+            output_type = _linear_output_type(field.type)
+        except TypeError:
+            if effective:
+                raise
+            output_type = field.type
         return pa.field(
-            field.name, _linear_output_type(field.type), nullable=True,
+            field.name, output_type, nullable=True,
             metadata=field.metadata)
 
     def match(self, anchor_row):
@@ -431,7 +438,8 @@ class _LinearInterpolationRight(_AsOfJoinRight):
                 and max(target - before_time, after_time - target)
                 > self._tolerance_key):
             return None
-        weight = float(target - before_time) / (after_time - before_time)
+        weight = _linear_weight(
+            target, before_time, after_time, self.time_type)
         return (
             self._row_ids[before].as_py(),
             self._row_ids[after].as_py(),
@@ -509,6 +517,15 @@ def _linear_output_type(data_type):
         "columns; got %s." % data_type)
 
 
+def _linear_weight(target, before, after, data_type):
+    if pa.types.is_floating(data_type):
+        scale = max(abs(target), abs(before), abs(after))
+        if scale:
+            target, before, after = (
+                target / scale, before / scale, after / scale)
+    return float(target - before) / (after - before)
+
+
 def _interpolate_array(before, after, weights):
     if isinstance(before, pa.ChunkedArray):
         before = before.combine_chunks()
@@ -527,11 +544,16 @@ def _interpolate_array(before, after, weights):
             repeated,
         )
         mask = pc.or_(before.is_null(), after.is_null())
-        return pa.FixedSizeListArray.from_arrays(values, size, mask=mask)
+        result = pa.FixedSizeListArray.from_arrays(values, size)
+        return pc.if_else(mask, pa.scalar(None, type=result.type), result)
 
-    start = pc.cast(before, pa.float64())
-    end = pc.cast(after, pa.float64())
-    result = pc.add(start, pc.multiply(pc.subtract(end, start), weights))
+    start = pc.cast(before, pa.float64(), safe=False)
+    end = pc.cast(after, pa.float64(), safe=False)
+    result = pc.add(
+        pc.multiply(start, pc.subtract(1.0, weights)),
+        pc.multiply(end, weights),
+    )
+    result = pc.if_else(pc.equal(start, end), start, result)
     result = pc.if_else(pc.equal(weights, 0.0), start, result)
     if result.type != output_type:
         result = pc.cast(result, output_type)

--- a/paimon-python/pypaimon/multimodal/temporal.py
+++ b/paimon-python/pypaimon/multimodal/temporal.py
@@ -525,11 +525,16 @@ def _linear_weight(target, before, after, data_type):
         denominator = after - before
         return numerator / denominator, numerator, denominator
     if pa.types.is_floating(data_type):
-        scale = max(abs(target), abs(before), abs(after))
-        if scale:
-            target, before, after = (
-                target / scale, before / scale, after / scale)
-    weight = float(target - before) / (after - before)
+        numerator = target - before
+        denominator = after - before
+        if math.isfinite(numerator) and math.isfinite(denominator):
+            weight = numerator / denominator
+        else:
+            scale = max(abs(target), abs(before), abs(after))
+            weight = ((target / scale - before / scale)
+                      / (after / scale - before / scale))
+    else:
+        weight = float(target - before) / (after - before)
     numerator, denominator = weight.as_integer_ratio()
     return weight, numerator, denominator
 

--- a/paimon-python/pypaimon/tests/multimodal_temporal_test.py
+++ b/paimon-python/pypaimon/tests/multimodal_temporal_test.py
@@ -172,7 +172,7 @@ class MultimodalTemporalTest(unittest.TestCase):
             {"episode_id": 2, "event_time": 10, "value": 120},
         ])
 
-        result = pmm.interpolate_linear(
+        result = pmm.interpolate_by(
             anchors.scan(), states.scan().select("value"),
             on="event_time", by="episode_id", tolerance=5,
         )
@@ -201,7 +201,7 @@ class MultimodalTemporalTest(unittest.TestCase):
             "episode_id": 1, "event_time": 10, "value": float("inf")
         }])
 
-        row = pmm.interpolate_linear(
+        row = pmm.interpolate_by(
             anchors.scan(), states.scan().select("value"),
             on="event_time", by="episode_id",
         ).to_list()[0]
@@ -224,7 +224,7 @@ class MultimodalTemporalTest(unittest.TestCase):
             {"episode_id": 1, "event_time": 10, "value": 10.0},
         ])
 
-        row = pmm.interpolate_linear(
+        row = pmm.interpolate_by(
             anchors.scan(), states.scan().select("value"),
             on="event_time", by="episode_id", tolerance=8,
         ).to_list()[0]
@@ -248,7 +248,7 @@ class MultimodalTemporalTest(unittest.TestCase):
             {"episode_id": 1, "event_time": 10, "state": [10.0, 20.0]},
         ])
 
-        result = pmm.interpolate_linear(
+        result = pmm.interpolate_by(
             anchors.scan(), states.scan().select("state"),
             on="event_time", by="episode_id",
         )
@@ -268,7 +268,7 @@ class MultimodalTemporalTest(unittest.TestCase):
         })
 
         with self.assertRaisesRegex(TypeError, "requires numeric"):
-            pmm.interpolate_linear(
+            pmm.interpolate_by(
                 anchors.scan(), labels.scan().select("label"),
                 on="event_time", by="episode_id",
             )
@@ -299,7 +299,7 @@ class MultimodalTemporalTest(unittest.TestCase):
             anchors.scan(), images.scan().select("image"),
             on="event_time", by="episode_id",
             direction="nearest", tolerance=2,
-        ).interpolate_linear(
+        ).interpolate_by(
             states.scan().select("state"), tolerance=5,
         ).to_list()[0]
 

--- a/paimon-python/pypaimon/tests/multimodal_temporal_test.py
+++ b/paimon-python/pypaimon/tests/multimodal_temporal_test.py
@@ -148,6 +148,142 @@ class MultimodalTemporalTest(unittest.TestCase):
             {row["event_time"]: row["value"] for row in rows},
         )
 
+    def test_linear_interpolation_stays_in_group_without_extrapolation(self):
+        anchors = self._table("linear_anchors", {
+            "episode_id": pa.int32(),
+            "event_time": pa.int64(),
+        })
+        states = self._table("linear_states", {
+            "episode_id": pa.int32(),
+            "event_time": pa.int64(),
+            "value": pa.int32(),
+        })
+        anchors.add([
+            {"episode_id": 1, "event_time": 5},
+            {"episode_id": 1, "event_time": 10},
+            {"episode_id": 1, "event_time": 20},
+            {"episode_id": 2, "event_time": 5},
+        ])
+        states.add([
+            {"episode_id": 1, "event_time": 0, "value": 0},
+            {"episode_id": 1, "event_time": 10, "value": 20},
+            {"episode_id": 1, "event_time": 10, "value": 30},
+            {"episode_id": 2, "event_time": 0, "value": 100},
+            {"episode_id": 2, "event_time": 10, "value": 120},
+        ])
+
+        result = pmm.interpolate_linear(
+            anchors.scan(), states.scan().select("value"),
+            on="event_time", by="episode_id", tolerance=5,
+        )
+        rows = sorted(
+            result.to_list(),
+            key=lambda row: (row["episode_id"], row["event_time"]),
+        )
+
+        self.assertEqual(pa.float64(), result.schema.field("value").type)
+        self.assertEqual([10.0, 30.0, None, 110.0], [
+            row["value"] for row in rows
+        ])
+
+    def test_linear_interpolation_requires_both_neighbors_in_tolerance(self):
+        anchors = self._table("linear_tolerance_anchors", {
+            "episode_id": pa.int32(),
+            "event_time": pa.int64(),
+        })
+        states = self._table("linear_tolerance_states", {
+            "episode_id": pa.int32(),
+            "event_time": pa.int64(),
+            "value": pa.float64(),
+        })
+        anchors.add([{"episode_id": 1, "event_time": 9}])
+        states.add([
+            {"episode_id": 1, "event_time": 0, "value": 0.0},
+            {"episode_id": 1, "event_time": 10, "value": 10.0},
+        ])
+
+        row = pmm.interpolate_linear(
+            anchors.scan(), states.scan().select("value"),
+            on="event_time", by="episode_id", tolerance=8,
+        ).to_list()[0]
+
+        self.assertIsNone(row["value"])
+
+    def test_linear_interpolation_supports_fixed_size_numeric_lists(self):
+        vector = pa.list_(pa.float32(), 2)
+        anchors = self._table("linear_vector_anchors", {
+            "episode_id": pa.int32(),
+            "event_time": pa.int64(),
+        })
+        states = self._table("linear_vector_states", {
+            "episode_id": pa.int32(),
+            "event_time": pa.int64(),
+            "state": vector,
+        })
+        anchors.add([{"episode_id": 1, "event_time": 5}])
+        states.add([
+            {"episode_id": 1, "event_time": 0, "state": [0.0, 10.0]},
+            {"episode_id": 1, "event_time": 10, "state": [10.0, 20.0]},
+        ])
+
+        result = pmm.interpolate_linear(
+            anchors.scan(), states.scan().select("state"),
+            on="event_time", by="episode_id",
+        )
+
+        self.assertEqual(vector, result.schema.field("state").type)
+        self.assertEqual([5.0, 15.0], result.to_list()[0]["state"])
+
+    def test_linear_interpolation_rejects_non_numeric_payloads(self):
+        anchors = self._table("linear_invalid_anchors", {
+            "episode_id": pa.int32(),
+            "event_time": pa.int64(),
+        })
+        labels = self._table("linear_invalid_labels", {
+            "episode_id": pa.int32(),
+            "event_time": pa.int64(),
+            "label": pa.string(),
+        })
+
+        with self.assertRaisesRegex(TypeError, "requires numeric"):
+            pmm.interpolate_linear(
+                anchors.scan(), labels.scan().select("label"),
+                on="event_time", by="episode_id",
+            )
+
+    def test_linear_interpolation_can_follow_an_asof_join(self):
+        anchors = self._table("linear_chain_anchors", {
+            "episode_id": pa.int32(),
+            "event_time": pa.int64(),
+        })
+        images = self._table("linear_chain_images", {
+            "episode_id": pa.int32(),
+            "event_time": pa.int64(),
+            "image": pa.string(),
+        })
+        states = self._table("linear_chain_states", {
+            "episode_id": pa.int32(),
+            "event_time": pa.int64(),
+            "state": pa.float32(),
+        })
+        anchors.add([{"episode_id": 1, "event_time": 5}])
+        images.add([{"episode_id": 1, "event_time": 4, "image": "frame"}])
+        states.add([
+            {"episode_id": 1, "event_time": 0, "state": 0.0},
+            {"episode_id": 1, "event_time": 10, "state": 10.0},
+        ])
+
+        row = pmm.join_asof(
+            anchors.scan(), images.scan().select("image"),
+            on="event_time", by="episode_id",
+            direction="nearest", tolerance=2,
+        ).interpolate_linear(
+            states.scan().select("state"), tolerance=5,
+        ).to_list()[0]
+
+        self.assertEqual("frame", row["image"])
+        self.assertEqual(5.0, row["state"])
+
     def test_alignment_can_return_matched_timestamp(self):
         anchors = self._table("timestamp_output_anchors", {
             "episode_id": pa.int32(),

--- a/paimon-python/pypaimon/tests/multimodal_temporal_test.py
+++ b/paimon-python/pypaimon/tests/multimodal_temporal_test.py
@@ -17,6 +17,7 @@
 import json
 import os
 import shutil
+import sys
 import tempfile
 import unittest
 from datetime import datetime, timedelta
@@ -256,6 +257,153 @@ class MultimodalTemporalTest(unittest.TestCase):
         self.assertEqual(vector, result.schema.field("state").type)
         self.assertEqual([5.0, 15.0], result.to_list()[0]["state"])
 
+    def test_linear_interpolation_accepts_bigint_payloads(self):
+        anchors = self._table("linear_bigint_anchors", {
+            "episode_id": pa.int32(),
+            "event_time": pa.int64(),
+        })
+        states = self._table("linear_bigint_states", {
+            "episode_id": pa.int32(),
+            "event_time": pa.int64(),
+            "value": pa.int64(),
+        })
+        anchors.add([{"episode_id": 1, "event_time": 5}])
+        states.add([
+            {"episode_id": 1, "event_time": 0,
+             "value": (1 << 53) + 1},
+            {"episode_id": 1, "event_time": 10,
+             "value": (1 << 53) + 3},
+        ])
+
+        row = pmm.interpolate_by(
+            anchors.scan(), states.scan().select("value"),
+            on="event_time", by="episode_id",
+        ).to_list()[0]
+
+        self.assertEqual(float((1 << 53) + 2), row["value"])
+
+    def test_linear_interpolation_scales_extreme_float_time_axis(self):
+        anchors = self._table("linear_extreme_time_anchors", {
+            "episode_id": pa.int32(),
+            "event_time": pa.float64(),
+        })
+        states = self._table("linear_extreme_time_states", {
+            "episode_id": pa.int32(),
+            "event_time": pa.float64(),
+            "value": pa.float64(),
+        })
+        anchors.add([{"episode_id": 1, "event_time": 0.0}])
+        states.add([
+            {"episode_id": 1, "event_time": -sys.float_info.max,
+             "value": 0.0},
+            {"episode_id": 1, "event_time": sys.float_info.max,
+             "value": 10.0},
+        ])
+
+        row = pmm.interpolate_by(
+            anchors.scan(), states.scan().select("value"),
+            on="event_time", by="episode_id",
+        ).to_list()[0]
+
+        self.assertEqual(5.0, row["value"])
+
+    def test_linear_interpolation_handles_extreme_float_payloads(self):
+        anchors = self._table("linear_extreme_value_anchors", {
+            "episode_id": pa.int32(),
+            "event_time": pa.int64(),
+        })
+        states = self._table("linear_extreme_value_states", {
+            "episode_id": pa.int32(),
+            "event_time": pa.int64(),
+            "value": pa.float64(),
+            "infinite": pa.float64(),
+        })
+        anchors.add([{"episode_id": 1, "event_time": 5}])
+        states.add([
+            {"episode_id": 1, "event_time": 0,
+             "value": -sys.float_info.max, "infinite": float("inf")},
+            {"episode_id": 1, "event_time": 10,
+             "value": sys.float_info.max, "infinite": float("inf")},
+        ])
+
+        row = pmm.interpolate_by(
+            anchors.scan(), states.scan().select(["value", "infinite"]),
+            on="event_time", by="episode_id",
+        ).to_list()[0]
+
+        self.assertEqual(0.0, row["value"])
+        self.assertEqual(float("inf"), row["infinite"])
+
+    def test_linear_interpolation_uses_effective_masked_payload_type(self):
+        anchors = self._table("linear_masked_anchors", {
+            "episode_id": pa.int32(),
+            "event_time": pa.int64(),
+        })
+        states = self._table("linear_masked_states", {
+            "episode_id": pa.int32(),
+            "event_time": pa.int64(),
+            "value": pa.string(),
+        })
+        anchors.add([{"episode_id": 1, "event_time": 5}])
+        states.add([
+            {"episode_id": 1, "event_time": 0, "value": "0"},
+            {"episode_id": 1, "event_time": 10, "value": "10"},
+        ])
+        auth = TableQueryAuthResult(
+            filter=None,
+            column_masking={"value": json.dumps({
+                "name": "CAST",
+                "fieldRef": {
+                    "index": 2, "name": "value", "type": "STRING",
+                },
+                "type": "DOUBLE",
+            })},
+        )
+        states.raw_table.catalog_environment.table_query_auth = (
+            lambda options, identifier: lambda select: auth)
+
+        row = pmm.interpolate_by(
+            anchors.scan(), states.scan().select("value"),
+            on="event_time", by="episode_id",
+        ).to_list()[0]
+
+        self.assertEqual(5.0, row["value"])
+
+    def test_linear_interpolation_rejects_masked_non_numeric_payload(self):
+        anchors = self._table("linear_invalid_mask_anchors", {
+            "episode_id": pa.int32(),
+            "event_time": pa.int64(),
+        })
+        states = self._table("linear_invalid_mask_states", {
+            "episode_id": pa.int32(),
+            "event_time": pa.int64(),
+            "value": pa.int32(),
+        })
+        anchors.add([{"episode_id": 1, "event_time": 5}])
+        states.add([
+            {"episode_id": 1, "event_time": 0, "value": 0},
+            {"episode_id": 1, "event_time": 10, "value": 10},
+        ])
+        auth = TableQueryAuthResult(
+            filter=None,
+            column_masking={"value": json.dumps({
+                "name": "CAST",
+                "fieldRef": {
+                    "index": 2, "name": "value", "type": "INT",
+                },
+                "type": "STRING",
+            })},
+        )
+        states.raw_table.catalog_environment.table_query_auth = (
+            lambda options, identifier: lambda select: auth)
+
+        aligned = pmm.interpolate_by(
+            anchors.scan(), states.scan().select("value"),
+            on="event_time", by="episode_id",
+        )
+        with self.assertRaisesRegex(TypeError, "requires numeric"):
+            aligned.to_arrow()
+
     def test_linear_interpolation_rejects_non_numeric_payloads(self):
         anchors = self._table("linear_invalid_anchors", {
             "episode_id": pa.int32(),
@@ -271,7 +419,7 @@ class MultimodalTemporalTest(unittest.TestCase):
             pmm.interpolate_by(
                 anchors.scan(), labels.scan().select("label"),
                 on="event_time", by="episode_id",
-            )
+            ).to_arrow()
 
     def test_linear_interpolation_can_follow_an_asof_join(self):
         anchors = self._table("linear_chain_anchors", {

--- a/paimon-python/pypaimon/tests/multimodal_temporal_test.py
+++ b/paimon-python/pypaimon/tests/multimodal_temporal_test.py
@@ -173,7 +173,7 @@ class MultimodalTemporalTest(unittest.TestCase):
             {"episode_id": 2, "event_time": 10, "value": 120},
         ])
 
-        result = pmm.interpolate_by(
+        result = pmm.interpolate(
             anchors.scan(), states.scan().select("value"),
             on="event_time", by="episode_id", tolerance=5,
         )
@@ -182,6 +182,7 @@ class MultimodalTemporalTest(unittest.TestCase):
             key=lambda row: (row["episode_id"], row["event_time"]),
         )
 
+        self.assertIsInstance(result, pmm.TemporalAlignment)
         self.assertEqual(pa.float64(), result.schema.field("value").type)
         self.assertEqual([10.0, 30.0, None, 110.0], [
             row["value"] for row in rows
@@ -202,7 +203,7 @@ class MultimodalTemporalTest(unittest.TestCase):
             "episode_id": 1, "event_time": 10, "value": float("inf")
         }])
 
-        row = pmm.interpolate_by(
+        row = pmm.interpolate(
             anchors.scan(), states.scan().select("value"),
             on="event_time", by="episode_id",
         ).to_list()[0]
@@ -225,7 +226,7 @@ class MultimodalTemporalTest(unittest.TestCase):
             {"episode_id": 1, "event_time": 10, "value": 10.0},
         ])
 
-        row = pmm.interpolate_by(
+        row = pmm.interpolate(
             anchors.scan(), states.scan().select("value"),
             on="event_time", by="episode_id", tolerance=8,
         ).to_list()[0]
@@ -249,7 +250,7 @@ class MultimodalTemporalTest(unittest.TestCase):
             {"episode_id": 1, "event_time": 10, "state": [10.0, 20.0]},
         ])
 
-        result = pmm.interpolate_by(
+        result = pmm.interpolate(
             anchors.scan(), states.scan().select("state"),
             on="event_time", by="episode_id",
         )
@@ -275,7 +276,7 @@ class MultimodalTemporalTest(unittest.TestCase):
              "value": (1 << 53) + 3},
         ])
 
-        row = pmm.interpolate_by(
+        row = pmm.interpolate(
             anchors.scan(), states.scan().select("value"),
             on="event_time", by="episode_id",
         ).to_list()[0]
@@ -300,7 +301,7 @@ class MultimodalTemporalTest(unittest.TestCase):
              "value": 10.0},
         ])
 
-        row = pmm.interpolate_by(
+        row = pmm.interpolate(
             anchors.scan(), states.scan().select("value"),
             on="event_time", by="episode_id",
         ).to_list()[0]
@@ -326,7 +327,7 @@ class MultimodalTemporalTest(unittest.TestCase):
              "value": sys.float_info.max, "infinite": float("inf")},
         ])
 
-        row = pmm.interpolate_by(
+        row = pmm.interpolate(
             anchors.scan(), states.scan().select(["value", "infinite"]),
             on="event_time", by="episode_id",
         ).to_list()[0]
@@ -362,7 +363,7 @@ class MultimodalTemporalTest(unittest.TestCase):
         states.raw_table.catalog_environment.table_query_auth = (
             lambda options, identifier: lambda select: auth)
 
-        row = pmm.interpolate_by(
+        row = pmm.interpolate(
             anchors.scan(), states.scan().select("value"),
             on="event_time", by="episode_id",
         ).to_list()[0]
@@ -397,7 +398,7 @@ class MultimodalTemporalTest(unittest.TestCase):
         states.raw_table.catalog_environment.table_query_auth = (
             lambda options, identifier: lambda select: auth)
 
-        aligned = pmm.interpolate_by(
+        aligned = pmm.interpolate(
             anchors.scan(), states.scan().select("value"),
             on="event_time", by="episode_id",
         )
@@ -416,7 +417,7 @@ class MultimodalTemporalTest(unittest.TestCase):
         })
 
         with self.assertRaisesRegex(TypeError, "requires numeric"):
-            pmm.interpolate_by(
+            pmm.interpolate(
                 anchors.scan(), labels.scan().select("label"),
                 on="event_time", by="episode_id",
             ).to_arrow()
@@ -447,7 +448,7 @@ class MultimodalTemporalTest(unittest.TestCase):
             anchors.scan(), images.scan().select("image"),
             on="event_time", by="episode_id",
             direction="nearest", tolerance=2,
-        ).interpolate_by(
+        ).interpolate(
             states.scan().select("state"), tolerance=5,
         ).to_list()[0]
 
@@ -1225,7 +1226,7 @@ class MultimodalTemporalTest(unittest.TestCase):
         }])
 
         with self.assertRaisesRegex(
-                ValueError, "join_asof.*incremental"):
+                ValueError, "Temporal alignment.*incremental"):
             pmm.join_asof(
                 anchors.scan(), source.scan().select("value"),
                 on="event_time", by="episode_id",
@@ -1562,7 +1563,7 @@ class MultimodalTemporalTest(unittest.TestCase):
                     pa.chunked_array([chunk for _ in row_ids])
                 ], schema=schema)
 
-        aligned = object.__new__(temporal.AsOfJoin)
+        aligned = object.__new__(temporal.TemporalAlignment)
         aligned._anchor_schema = schema
         aligned._sources = ()
         rows = [{temporal._ROW_ID: value} for value in range(2)]

--- a/paimon-python/pypaimon/tests/multimodal_temporal_test.py
+++ b/paimon-python/pypaimon/tests/multimodal_temporal_test.py
@@ -314,6 +314,32 @@ class MultimodalTemporalTest(unittest.TestCase):
 
         self.assertEqual(5.0, row["value"])
 
+    def test_linear_interpolation_preserves_float_time_differences(self):
+        anchors = self._table("linear_nearby_time_anchors", {
+            "episode_id": pa.int32(),
+            "event_time": pa.float64(),
+        })
+        states = self._table("linear_nearby_time_states", {
+            "episode_id": pa.int32(),
+            "event_time": pa.float64(),
+            "value": pa.float64(),
+        })
+        base = 1_700_000_000.0
+        step = 2 ** -21
+        anchors.add([{"episode_id": 1, "event_time": base + step}])
+        states.add([
+            {"episode_id": 1, "event_time": base, "value": 0.0},
+            {"episode_id": 1, "event_time": base + 2 * step,
+             "value": 10.0},
+        ])
+
+        row = pmm.interpolate(
+            anchors.scan(), states.scan().select("value"),
+            on="event_time", by="episode_id",
+        ).to_list()[0]
+
+        self.assertEqual(5.0, row["value"])
+
     def test_linear_interpolation_handles_extreme_float_payloads(self):
         anchors = self._table("linear_extreme_value_anchors", {
             "episode_id": pa.int32(),

--- a/paimon-python/pypaimon/tests/multimodal_temporal_test.py
+++ b/paimon-python/pypaimon/tests/multimodal_temporal_test.py
@@ -172,7 +172,7 @@ class MultimodalTemporalTest(unittest.TestCase):
             {"episode_id": 2, "event_time": 10, "value": 120},
         ])
 
-        result = pmm.interpolate_by(
+        result = pmm.interpolate_linear(
             anchors.scan(), states.scan().select("value"),
             on="event_time", by="episode_id", tolerance=5,
         )
@@ -201,7 +201,7 @@ class MultimodalTemporalTest(unittest.TestCase):
             "episode_id": 1, "event_time": 10, "value": float("inf")
         }])
 
-        row = pmm.interpolate_by(
+        row = pmm.interpolate_linear(
             anchors.scan(), states.scan().select("value"),
             on="event_time", by="episode_id",
         ).to_list()[0]
@@ -224,7 +224,7 @@ class MultimodalTemporalTest(unittest.TestCase):
             {"episode_id": 1, "event_time": 10, "value": 10.0},
         ])
 
-        row = pmm.interpolate_by(
+        row = pmm.interpolate_linear(
             anchors.scan(), states.scan().select("value"),
             on="event_time", by="episode_id", tolerance=8,
         ).to_list()[0]
@@ -248,7 +248,7 @@ class MultimodalTemporalTest(unittest.TestCase):
             {"episode_id": 1, "event_time": 10, "state": [10.0, 20.0]},
         ])
 
-        result = pmm.interpolate_by(
+        result = pmm.interpolate_linear(
             anchors.scan(), states.scan().select("state"),
             on="event_time", by="episode_id",
         )
@@ -268,7 +268,7 @@ class MultimodalTemporalTest(unittest.TestCase):
         })
 
         with self.assertRaisesRegex(TypeError, "requires numeric"):
-            pmm.interpolate_by(
+            pmm.interpolate_linear(
                 anchors.scan(), labels.scan().select("label"),
                 on="event_time", by="episode_id",
             )
@@ -299,7 +299,7 @@ class MultimodalTemporalTest(unittest.TestCase):
             anchors.scan(), images.scan().select("image"),
             on="event_time", by="episode_id",
             direction="nearest", tolerance=2,
-        ).interpolate_by(
+        ).interpolate_linear(
             states.scan().select("state"), tolerance=5,
         ).to_list()[0]
 

--- a/paimon-python/pypaimon/tests/multimodal_temporal_test.py
+++ b/paimon-python/pypaimon/tests/multimodal_temporal_test.py
@@ -186,6 +186,28 @@ class MultimodalTemporalTest(unittest.TestCase):
             row["value"] for row in rows
         ])
 
+    def test_linear_interpolation_preserves_an_exact_infinite_float(self):
+        anchors = self._table("linear_exact_anchors", {
+            "episode_id": pa.int32(),
+            "event_time": pa.int64(),
+        })
+        states = self._table("linear_exact_states", {
+            "episode_id": pa.int32(),
+            "event_time": pa.int64(),
+            "value": pa.float64(),
+        })
+        anchors.add([{"episode_id": 1, "event_time": 10}])
+        states.add([{
+            "episode_id": 1, "event_time": 10, "value": float("inf")
+        }])
+
+        row = pmm.interpolate_linear(
+            anchors.scan(), states.scan().select("value"),
+            on="event_time", by="episode_id",
+        ).to_list()[0]
+
+        self.assertEqual(float("inf"), row["value"])
+
     def test_linear_interpolation_requires_both_neighbors_in_tolerance(self):
         anchors = self._table("linear_tolerance_anchors", {
             "episode_id": pa.int32(),

--- a/paimon-python/pypaimon/tests/multimodal_temporal_test.py
+++ b/paimon-python/pypaimon/tests/multimodal_temporal_test.py
@@ -258,7 +258,7 @@ class MultimodalTemporalTest(unittest.TestCase):
         self.assertEqual(vector, result.schema.field("state").type)
         self.assertEqual([5.0, 15.0], result.to_list()[0]["state"])
 
-    def test_linear_interpolation_accepts_bigint_payloads(self):
+    def test_linear_interpolation_preserves_bigint_precision(self):
         anchors = self._table("linear_bigint_anchors", {
             "episode_id": pa.int32(),
             "event_time": pa.int64(),
@@ -267,21 +267,27 @@ class MultimodalTemporalTest(unittest.TestCase):
             "episode_id": pa.int32(),
             "event_time": pa.int64(),
             "value": pa.int64(),
+            "extreme": pa.int64(),
         })
-        anchors.add([{"episode_id": 1, "event_time": 5}])
+        anchors.add([
+            {"episode_id": 1, "event_time": 1},
+            {"episode_id": 1, "event_time": 2},
+        ])
         states.add([
             {"episode_id": 1, "event_time": 0,
-             "value": (1 << 53) + 1},
-            {"episode_id": 1, "event_time": 10,
-             "value": (1 << 53) + 3},
+             "value": (1 << 53) + 1, "extreme": -(1 << 63)},
+            {"episode_id": 1, "event_time": 4,
+             "value": (1 << 53) + 3, "extreme": (1 << 63) - 1},
         ])
 
-        row = pmm.interpolate(
-            anchors.scan(), states.scan().select("value"),
+        rows = pmm.interpolate(
+            anchors.scan(), states.scan().select(["value", "extreme"]),
             on="event_time", by="episode_id",
-        ).to_list()[0]
+        ).to_list()
 
-        self.assertEqual(float((1 << 53) + 2), row["value"])
+        by_time = {row["event_time"]: row for row in rows}
+        self.assertEqual(float((1 << 53) + 2), by_time[1]["value"])
+        self.assertEqual(-0.5, by_time[2]["extreme"])
 
     def test_linear_interpolation_scales_extreme_float_time_axis(self):
         anchors = self._table("linear_extreme_time_anchors", {
@@ -402,23 +408,23 @@ class MultimodalTemporalTest(unittest.TestCase):
             anchors.scan(), states.scan().select("value"),
             on="event_time", by="episode_id",
         )
-        with self.assertRaisesRegex(TypeError, "requires numeric"):
+        with self.assertRaisesRegex(TypeError, "requires integer or floating"):
             aligned.to_arrow()
 
-    def test_linear_interpolation_rejects_non_numeric_payloads(self):
+    def test_linear_interpolation_rejects_decimal_payloads(self):
         anchors = self._table("linear_invalid_anchors", {
             "episode_id": pa.int32(),
             "event_time": pa.int64(),
         })
-        labels = self._table("linear_invalid_labels", {
+        decimals = self._table("linear_invalid_decimals", {
             "episode_id": pa.int32(),
             "event_time": pa.int64(),
-            "label": pa.string(),
+            "value": pa.decimal128(10, 2),
         })
 
-        with self.assertRaisesRegex(TypeError, "requires numeric"):
+        with self.assertRaisesRegex(TypeError, "requires integer or floating"):
             pmm.interpolate(
-                anchors.scan(), labels.scan().select("label"),
+                anchors.scan(), decimals.scan().select("value"),
                 on="event_time", by="episode_id",
             ).to_arrow()
 

--- a/paimon-python/pypaimon/tests/multimodal_temporal_test.py
+++ b/paimon-python/pypaimon/tests/multimodal_temporal_test.py
@@ -340,6 +340,31 @@ class MultimodalTemporalTest(unittest.TestCase):
 
         self.assertEqual(5.0, row["value"])
 
+    def test_float_time_preserves_bigint_interpolation_precision(self):
+        anchors = self._table("linear_float_bigint_anchors", {
+            "episode_id": pa.int32(),
+            "event_time": pa.float64(),
+        })
+        states = self._table("linear_float_bigint_states", {
+            "episode_id": pa.int32(),
+            "event_time": pa.float64(),
+            "value": pa.int64(),
+        })
+        anchors.add([{"episode_id": 1, "event_time": 2.0}])
+        states.add([
+            {"episode_id": 1, "event_time": 0.0,
+             "value": -(1 << 63)},
+            {"episode_id": 1, "event_time": 3.0,
+             "value": 1 << 62},
+        ])
+
+        row = pmm.interpolate(
+            anchors.scan(), states.scan().select("value"),
+            on="event_time", by="episode_id",
+        ).to_list()[0]
+
+        self.assertEqual(0.0, row["value"])
+
     def test_linear_interpolation_handles_extreme_float_payloads(self):
         anchors = self._table("linear_extreme_value_anchors", {
             "episode_id": pa.int32(),


### PR DESCRIPTION
## Summary

- linearly interpolate integer and floating-point right-side values at each left timestamp
- stay within each `by` group and never extrapolate
- preserve snapshot pinning, authorization masking, and batched row fetching

## API design

- `interpolate` names the operation directly; `interpolate_by` was avoided because Polars uses `by` as the interpolation coordinate, while Paimon uses it as an equality group.
- `join_asof` and `interpolate` both return `TemporalAlignment`, since the lazy result may contain either operation.
- No `temporal_align(left)` entry was added because one scan alone performs no alignment.
- `AsOfJoin` was renamed directly instead of keeping two public names; the API has not been released.

## Tests

- 135 multimodal temporal/table tests passed
- PyArrow 6 compatibility and precision probes passed
- flake8 and Python 3.6 syntax compilation passed