### PR TITLE
[core] Improve the error when listing a Format Table custom partition location fails

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/table/format/CatalogSplitEnumerator.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/format/CatalogSplitEnumerator.java
@@ -116,19 +116,26 @@ final class CatalogSplitEnumerator extends SplitEnumerator {
         for (Pair<LinkedHashMap<String, String>, Path> partition : partitions) {
             boolean useCatalogContextFileIO =
                     fileIOResolver.useCatalogContextFileIO(partition.getValue());
-            if (useCatalogContextFileIO) {
-                fileIOResolver.prepare(partition.getValue(), true);
-            } else if (!tableFileIOPrepared) {
-                fileIOResolver.prepare(partition.getValue(), false);
-                tableFileIOPrepared = true;
+            try {
+                if (useCatalogContextFileIO) {
+                    fileIOResolver.prepare(partition.getValue(), true);
+                } else if (!tableFileIOPrepared) {
+                    fileIOResolver.prepare(partition.getValue(), false);
+                    tableFileIOPrepared = true;
+                }
+            } catch (IOException e) {
+                throw new RuntimeException(
+                        listFailureMessage(
+                                partition.getKey(), partition.getValue(), useCatalogContextFileIO),
+                        e);
             }
         }
         Function<Pair<LinkedHashMap<String, String>, Path>, List<Split>> lister =
                 pair -> {
                     BinaryRow partitionRow = toPartitionRow(pair.getKey());
+                    boolean useCatalogContextFileIO =
+                            fileIOResolver.useCatalogContextFileIO(pair.getValue());
                     try {
-                        boolean useCatalogContextFileIO =
-                                fileIOResolver.useCatalogContextFileIO(pair.getValue());
                         return createSplits(
                                 fileIOResolver.fileIO(useCatalogContextFileIO),
                                 pair.getValue(),
@@ -139,7 +146,9 @@ final class CatalogSplitEnumerator extends SplitEnumerator {
                         return Collections.emptyList();
                     } catch (IOException e) {
                         throw new RuntimeException(
-                                "Failed to list files for partition " + pair.getValue(), e);
+                                listFailureMessage(
+                                        pair.getKey(), pair.getValue(), useCatalogContextFileIO),
+                                e);
                     }
                 };
         int parallelism =
@@ -360,6 +369,25 @@ final class CatalogSplitEnumerator extends SplitEnumerator {
                                 + "expected exactly the partition keys %s with values usable as "
                                 + "path components.",
                         spec, table.fullName(), table.partitionKeys()));
+    }
+
+    /** Says which credentials listed the partition, so a permission failure is actionable. */
+    private String listFailureMessage(
+            LinkedHashMap<String, String> spec, Path path, boolean useCatalogContextFileIO) {
+        String message =
+                String.format(
+                        "Failed to list files for partition '%s' of format table %s at '%s'.",
+                        PartitionPathUtils.generatePartitionName(spec, false),
+                        table.fullName(),
+                        path);
+        if (!useCatalogContextFileIO) {
+            return message;
+        }
+        return message
+                + " The partition is registered at a custom location outside the table"
+                + " directory, so it is listed with the filesystem credentials of the catalog"
+                + " context (the engine's own configuration, for example fs.oss.* or the Hadoop"
+                + " configuration), not with the table's data token.";
     }
 
     private void warnMissingPartition(LinkedHashMap<String, String> spec, Path path) {

--- a/paimon-core/src/test/java/org/apache/paimon/table/format/CatalogManagedPartitionScanTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/table/format/CatalogManagedPartitionScanTest.java
@@ -546,6 +546,52 @@ class CatalogManagedPartitionScanTest {
     }
 
     @Test
+    void testCustomLocationListingFailureNamesTheCatalogContextCredentials() throws Exception {
+        InjectingLocalFileIO clientFileIO = new InjectingLocalFileIO();
+        Path externalPath = new Path(tempDir.resolve("external").toUri());
+        writeDataFile(clientFileIO, externalPath, "files");
+        clientFileIO.failListingContaining("external", new IOException("not found login secrets"));
+        Catalog catalog = mock(Catalog.class);
+        when(catalog.listPartitionsPaged(eq(IDENTIFIER), eq(1000), isNull(), isNull()))
+                .thenReturn(
+                        new PagedList<>(
+                                Collections.singletonList(
+                                        partition("2025", "11", externalPath.toString())),
+                                null));
+        Path tablePath = new Path(tempDir.resolve("table").toUri());
+        TableRootOnlyLocalFileIO tableFileIO = new TableRootOnlyLocalFileIO(tablePath);
+        FileIOLoader clientLoader =
+                new FileIOLoader() {
+                    @Override
+                    public String getScheme() {
+                        return "file";
+                    }
+
+                    @Override
+                    public LocalFileIO load(Path path) {
+                        return clientFileIO;
+                    }
+                };
+        CatalogContext catalogContext = CatalogContext.create(new Options(), clientLoader, null);
+        FormatTable table =
+                createTable(
+                        tableFileIO, tablePath, partitionManager(catalog), false, catalogContext);
+
+        // A permission failure on an archive bucket must say that the engine's own credentials
+        // listed it, or the user keeps looking at the table token.
+        assertThatThrownBy(() -> new FormatTableScan(table, null, null).plan().splits())
+                .isInstanceOf(RuntimeException.class)
+                .hasMessageContaining("partition 'year=2025/month=11'")
+                .hasMessageContaining(table.fullName())
+                .hasMessageContaining("'" + externalPath + "'")
+                .hasMessageContaining("custom location outside the table directory")
+                .hasMessageContaining("credentials of the catalog context")
+                .hasMessageContaining("not with the table's data token")
+                .hasRootCauseMessage("not found login secrets");
+        assertThat(tableFileIO.listedPaths).isEmpty();
+    }
+
+    @Test
     void testWhitespacePartitionValueIsVisible() throws Exception {
         Catalog catalog = mock(Catalog.class);
         Partition whitespacePartition = partition("   ", "11");
@@ -919,6 +965,8 @@ class CatalogManagedPartitionScanTest {
                 stringPartitionTable(fileIO, tablePath, recordingCatalog(partitions), 4);
         assertThatThrownBy(() -> new FormatTableScan(table, null, null).plan().splits())
                 .isInstanceOf(RuntimeException.class)
+                .hasMessageContaining("partition 'year=2025/month=11'")
+                .hasMessageNotContaining("custom location")
                 .hasRootCauseInstanceOf(IOException.class)
                 .hasRootCauseMessage("boom");
     }


### PR DESCRIPTION
### Purpose

Since #9540 a Format Table partition can be registered at a custom location outside the table directory. Such a partition is listed with the file system of the catalog context, that is the engine's own credentials (`fs.oss.*` or the Hadoop configuration). The table's data token is not used for it.

When that listing fails today, the error only says `Failed to list files for partition oss://archive-bucket/...` and wraps the cause from the file system. On OSS the cause is usually `AccessDenied` or Jindo's `not found login secrets`. The user sees a permission error on a partition of a table they can otherwise read, so they check the table token, which is the wrong place.

This PR makes the error say what happened:

```
Failed to list files for partition 'dt=2026-09-01' of format table db.t at 'oss://archive-bucket/events/dt=2026-09-01'. The partition is registered at a custom location outside the table directory, so it is listed with the filesystem credentials of the catalog context (the engine's own configuration, for example fs.oss.* or the Hadoop configuration), not with the table's data token.
```

For a partition in its default directory the message names the partition, the table and the path, without the hint. The file system preparation that runs before the parallel listing throws the same message, so a custom location whose file system cannot be resolved reports the same way. The original cause is kept.

### Tests

- `CatalogManagedPartitionScanTest#testCustomLocationListingFailureNamesTheCatalogContextCredentials`: a listing failure on a custom location names the partition, the table, the path and the catalog context credentials, keeps the cause, and never lists the table file system.
- `testCatalogPartitionListingIoErrorFailsWholeScan` now also checks that a default partition failure names the partition and carries no custom-location hint.

### API and Format

No.

### Documentation

No.
