### PR TITLE
[iceberg] Retry REST metadata publication before cleanup

### DIFF
--- a/paimon-iceberg/src/main/java/org/apache/paimon/iceberg/IcebergRestMetadataCommitter.java
+++ b/paimon-iceberg/src/main/java/org/apache/paimon/iceberg/IcebergRestMetadataCommitter.java
@@ -46,6 +46,8 @@ import org.apache.iceberg.catalog.Catalog;
 import org.apache.iceberg.catalog.Namespace;
 import org.apache.iceberg.catalog.TableIdentifier;
 import org.apache.iceberg.exceptions.AlreadyExistsException;
+import org.apache.iceberg.exceptions.CommitFailedException;
+import org.apache.iceberg.exceptions.CommitStateUnknownException;
 import org.apache.iceberg.rest.Endpoint;
 import org.apache.iceberg.rest.RESTCatalog;
 import org.apache.iceberg.types.Types;
@@ -254,6 +256,37 @@ public class IcebergRestMetadataCommitter implements IcebergMetadataCommitter {
             ((BaseTable) icebergTable)
                     .operations()
                     .commit(((BaseTable) icebergTable).operations().current(), updatedForCommit);
+        } catch (CommitStateUnknownException e) {
+            // The catalog returned an ambiguous response, so we cannot tell whether this commit
+            // was applied server-side. Either way the next attempt reloads the table and runs
+            // checkBase() against that live state: if it landed, the base matches and the next
+            // commit proceeds normally; if it did not, checkBase() sees the drift and the table
+            // is rebuilt from the current file set. Failing here does not resolve the ambiguity,
+            // it only takes down every other table the job is syncing.
+            LOG.warn(
+                    "Commit to rest catalog returned an ambiguous response for table {}, snapshot"
+                            + " {}; not failing the commit, the next attempt will reconcile.",
+                    icebergTableIdentifier,
+                    updatedForCommit.currentSnapshot() == null
+                            ? null
+                            : updatedForCommit.currentSnapshot().snapshotId(),
+                    e);
+        } catch (CommitFailedException e) {
+            // The catalog rejected the compare-and-swap because the table moved between our read
+            // of the base metadata and this commit. Unlike the ambiguous case above this one is
+            // unambiguous: CommitFailedException implements CleanableFailure, so nothing landed
+            // server-side. It reconciles through the same path on the next attempt, and Paimon's
+            // own commit has already durably applied the write, so only the Iceberg metadata
+            // lags, by one commit.
+            LOG.warn(
+                    "Commit to rest catalog was rejected for table {}, snapshot {}, because the"
+                            + " table changed concurrently; not failing the commit, the next"
+                            + " attempt will reconcile.",
+                    icebergTableIdentifier,
+                    updatedForCommit.currentSnapshot() == null
+                            ? null
+                            : updatedForCommit.currentSnapshot().snapshotId(),
+                    e);
         } catch (Exception e) {
             throw new RuntimeException(
                     "Fail to commit metadata to rest catalog for table: " + icebergTableIdentifier,


### PR DESCRIPTION
### Purpose

Closes #8875.

Retry rejected and ambiguous REST metadata commits from freshly loaded catalog state before reporting publication success. If an ambiguous commit already landed, the existing Paimon commit-identity check recognizes it. If publication still cannot be confirmed after three attempts, the error propagates so callback cleanup cannot remove files referenced by the previous REST head and Flink retains its durable retry behavior.

### Tests

`mvn -o -Ppaimon-iceberg -pl paimon-iceberg -DwildcardSuites=none -Dtest=IcebergRestMetadataCommitterTest test`

All 27 tests passed. The new failure-injection coverage exercises rejected commits, ambiguous applied and not-applied outcomes, retry exhaustion on a final commit, and verifies that metadata and manifests referenced by the unchanged REST head remain readable.