### PR TITLE
[common] Reject out-of-range range-bitmap chunk-size option

### DIFF
--- a/paimon-common/src/main/java/org/apache/paimon/fileindex/rangebitmap/RangeBitmapFileIndex.java
+++ b/paimon-common/src/main/java/org/apache/paimon/fileindex/rangebitmap/RangeBitmapFileIndex.java
@@ -72,9 +72,18 @@ public class RangeBitmapFileIndex implements FileIndexer {
         public Writer(DataType dataType, Options options) {
             KeyFactory factory = KeyFactory.create(dataType);
             String chunkSize = options.getString(CHUNK_SIZE, factory.defaultChunkSize());
+            long bytes = MemorySize.parse(chunkSize).getBytes();
+            // the chunk size becomes an eagerly allocated per-chunk buffer, so anything
+            // beyond int range cannot work; reject it instead of silently truncating
+            // (e.g. "2g" narrowing to a negative int) and failing deep inside the writer
+            if (bytes > Integer.MAX_VALUE) {
+                throw new IllegalArgumentException(
+                        String.format(
+                                "The '%s' option must not exceed 2147483647 bytes, but was '%s'.",
+                                CHUNK_SIZE, chunkSize));
+            }
             this.converter = factory.createConverter();
-            this.appender =
-                    new RangeBitmap.Appender(factory, (int) MemorySize.parse(chunkSize).getBytes());
+            this.appender = new RangeBitmap.Appender(factory, (int) bytes);
         }
 
         @Override

--- a/paimon-common/src/test/java/org/apache/paimon/fileindex/rangebitmap/RangeBitmapFileIndexTest.java
+++ b/paimon-common/src/test/java/org/apache/paimon/fileindex/rangebitmap/RangeBitmapFileIndexTest.java
@@ -50,12 +50,34 @@ import static org.apache.paimon.predicate.SortValue.NullOrdering.NULLS_LAST;
 import static org.apache.paimon.predicate.SortValue.SortDirection.ASCENDING;
 import static org.apache.paimon.predicate.SortValue.SortDirection.DESCENDING;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /** test for {@link RangeBitmapFileIndex}. */
 public class RangeBitmapFileIndexTest {
 
     private static final int ROW_COUNT = 10000;
     private static final int BOUND = 1000000;
+
+    @Test
+    public void testChunkSizeBeyondIntRangeRejected() {
+        VarCharType varCharType = new VarCharType();
+
+        // a chunk size beyond int range must fail with a clear validation message instead of
+        // silently truncating to a negative int and crashing inside the writer
+        Options oversized = new Options();
+        oversized.setString(RangeBitmapFileIndex.CHUNK_SIZE, "2g");
+        assertThatThrownBy(() -> new RangeBitmapFileIndex(varCharType, oversized).createWriter())
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("chunk-size");
+
+        // a large but in-range chunk size still works
+        Options valid = new Options();
+        valid.setString(RangeBitmapFileIndex.CHUNK_SIZE, "16mb");
+        FileIndexWriter writer = new RangeBitmapFileIndex(varCharType, valid).createWriter();
+        writer.write(BinaryString.fromString("a"));
+        writer.write(BinaryString.fromString("b"));
+        assertThat(writer.serializedBytes()).isNotEmpty();
+    }
 
     @RepeatedTest(10)
     public void test() {


### PR DESCRIPTION
### Purpose

close #9764

`(int) MemorySize.parse(chunkSize).getBytes()` narrowed the `chunk-size` option to an int, and what the narrowing produces depends on the value:

| chunk-size | narrows to | result |
|---|---|---|
| `2g` | -2147483648 | crashes on the writer's first `ByteBuffer.allocate` |
| `4g`, `8g` | 0 | no failure at all: every key gets its own chunk and the index is silently bloated |
| `5g` | 1g | no failure at all: silently builds the index at a quarter of the requested size |

The crashing case is the one you notice. The other two are the reason to validate, because they produce a working-looking index from a configuration that was never honoured. The chunk size becomes an eagerly allocated per-chunk buffer, so nothing above int range can work in the first place.

This PR rejects anything above `Integer.MAX_VALUE` at writer creation with a message naming the option and the offending value. `chunk-size` is read as a free-form string with no typed `ConfigOption`, and `MemorySize.parseBytes` rejects a negative or overflowing value itself, so the accepted set after this guard is exactly `[0, Integer.MAX_VALUE]`, which is exactly the set that narrows to itself.

### Tests

`RangeBitmapFileIndexTest#testChunkSizeBeyondIntRangeRejected` pins the boundary rather than a sample either side of it: `2147483648 bytes` is rejected with a message containing `chunk-size`, `2147483647 bytes` is accepted, and `16mb` still writes and serializes. `2g` and `4g` were dropped from it because they reach the guard through the same comparison as `2147483648 bytes`, and their narrowing consequences cannot be asserted once the guard prevents them.

Verified on JDK 11 by mutating the comparison rather than reasoning about it. 18 tests pass as they stand. With the guard removed the test fails with `Expecting code to raise a throwable`, which also shows that on master `createWriter()` returns normally and the damage happens later during the write. With `>` changed to `>=` it fails on the accepted case with `The 'chunk-size' option must not exceed 2147483647 bytes, but was '2147483647 bytes'`.

### API and Format

A new validation on an existing user option. Values that previously worked are unaffected; values above 2GB either crashed mid-write or silently built an index that ignored the setting.

### Documentation

None needed. The behaviour on out-of-range values was a crash or silent misconfiguration, not a documented feature.
