### PR TITLE
[common] Make quoting mean literal in array and row string cast rules

### DIFF
--- a/paimon-common/src/main/java/org/apache/paimon/casting/StringToArrayCastRule.java
+++ b/paimon-common/src/main/java/org/apache/paimon/casting/StringToArrayCastRule.java
@@ -138,7 +138,10 @@ class StringToArrayCastRule extends AbstractCastRule<BinaryString, InternalArray
             } else if (c == '\\') {
                 escaped = true;
             } else if (c == '"') {
+                // quotes group a token across separators; the quote characters
+                // themselves are dropped rather than embedded in the token
                 inQuotes = !inQuotes;
+                continue;
             } else if (!inQuotes) {
                 if (StringUtils.isOpenBracket(c)) {
                     bracketStack.push(c);

--- a/paimon-common/src/main/java/org/apache/paimon/casting/StringToRowCastRule.java
+++ b/paimon-common/src/main/java/org/apache/paimon/casting/StringToRowCastRule.java
@@ -169,7 +169,10 @@ class StringToRowCastRule extends AbstractCastRule<BinaryString, InternalRow> {
             } else if (c == '\\') {
                 escaped = true;
             } else if (c == '"') {
+                // quotes group a token across separators; the quote characters
+                // themselves are dropped rather than embedded in the token
                 inQuotes = !inQuotes;
+                continue;
             } else if (!inQuotes) {
                 if (StringUtils.isOpenBracket(c)) {
                     bracketStack.push(c);

--- a/paimon-common/src/test/java/org/apache/paimon/casting/CastExecutorTest.java
+++ b/paimon-common/src/test/java/org/apache/paimon/casting/CastExecutorTest.java
@@ -976,6 +976,38 @@ public class CastExecutorTest {
     }
 
     @Test
+    public void testStringToArrayPreservesQuotedSeparator() {
+        ArrayType arrayType = new ArrayType(DataTypes.STRING());
+        compareCastResult(
+                CastExecutors.resolve(VarCharType.STRING_TYPE, arrayType),
+                BinaryString.fromString("[\"a,b\", c]"),
+                new GenericArray(
+                        new Object[] {
+                            BinaryString.fromString("a,b"), BinaryString.fromString("c")
+                        }));
+
+        // an empty quoted token is dropped like in the map rule: empty-string elements
+        // are not expressible in this mini-language
+        compareCastResult(
+                CastExecutors.resolve(VarCharType.STRING_TYPE, arrayType),
+                BinaryString.fromString("[\"\", a]"),
+                new GenericArray(new Object[] {BinaryString.fromString("a")}));
+    }
+
+    @Test
+    public void testStringToRowPreservesQuotedSeparator() {
+        RowType rowType =
+                DataTypes.ROW(
+                        DataTypes.FIELD(0, "f0", DataTypes.STRING()),
+                        DataTypes.FIELD(1, "f1", DataTypes.INT()));
+        GenericRow expected = GenericRow.of(BinaryString.fromString("a,b"), 2);
+        compareCastResult(
+                CastExecutors.resolve(VarCharType.STRING_TYPE, rowType),
+                BinaryString.fromString("{\"a,b\", 2}"),
+                expected);
+    }
+
+    @Test
     public void testSplitMapEntriesWithQuotes() {
         String content = "1, \"abc\"";
         List<String> result = StringToMapCastRule.INSTANCE.splitMapEntries(content);


### PR DESCRIPTION
### Purpose

close #9768

The array and row cast rules toggled quote state on `"` but still appended the character, so the quotes ended up inside the token. `ARRAY<STRING>` `["a,b", c]` produced the element `"a,b"` with literal quotes, and a non-string element type such as `ARRAY<INT>` `["1", 2]` failed to parse at all.

Stripping the quotes is only half of it. The splitter also forgot that a token had been quoted, and quoting is precisely how the two values that are otherwise unrepresentable get written:

- `["", a]` dropped the empty token, so the array came back with one element instead of two. For a row that shows up as a field count mismatch.
- `[null, "null"]` read both as SQL NULL, so the four-character string `null` could not be expressed.

Escapes were broken in the mirror-image way: the `\\` branch set the escape flag but fell through to the append, so the backslash survived into the value and `[a\,b]` produced `a\,b`. Nothing could be escaped.

Both rules now share one `TokenSplitter` that reports whether a token was quoted. A quoted token keeps its inner whitespace and is never read as the null literal. The two rules previously carried byte-identical copies of the splitter, which is how their semantics drifted, so this collapses them into one.

### Which level owns a quote

Quotes and backslashes are the syntax of the level that wrote them, so the splitter removes them at bracket depth zero and leaves them alone at depth one or more, where the element's own cast rule parses them again. Without that, `ARRAY<ARRAY<STRING>>` `[["a,b"], [c]]` loses the quotes protecting the inner comma before the inner rule ever runs, and the first element splits into two.

The consequence worth knowing: an element that contains a bracket keeps its own quotes and escapes even when its type is scalar, because the splitter decides by depth and not by type. `ARRAY<STRING>` `[{"a": 1}, b]` keeps `{"a": 1}` intact, where before it came back as `{a: 1}`. For a row, whose fields do not share one type, deciding by type would mean the splitter knowing each field's type before it has split the fields.

### What counts as a token

Whitespace outside quotes is not part of a token, so a token made only of whitespace was never written, wherever it sits. `[1,,3]` and `[1, , 3]` are both two elements, and `{a,,b}` and `{a, , b}` are both a field count mismatch against a three-field row. Writing an empty value is what quoting is for: `{a, "", b}` is three fields. An earlier revision made an interior whitespace-only field mean the empty string instead, which read `[1, , 3]` as `[1, "", 3]` and failed the whole array on `Input is empty.`, and left the first and last field behaving the other way because the caller trims the body before splitting it.

`StringToMapCastRule` is deliberately untouched. It splits entries rather than values and then separates key from value with a regex over the already-stripped text, so quote state at the entry level does not tell it whether a key or value was quoted. That needs quote-aware key/value splitting, filed as #9782.

### Tests

`CastExecutorTest.testStringToArrayQuotingAndEscaping` and `testStringToRowQuotingAndEscaping` cover, for both rules: a quoted separator staying inside one token, a quoted empty token remaining a value, a quoted `null` staying a string while an unquoted one becomes SQL NULL, and a backslash escaping a separator without surviving into the value.

`testStringToNestedArrayKeepsInnerSyntax` covers the depth rule on `ARRAY<ARRAY<STRING>>`: a quoted and an escaped inner comma, an inner `"null"`, an inner `""`, inner padding inside quotes, and a plain nested array.

`testStringToArraySkipsAnEmptyElement` and `testStringToRowWhitespaceOnlyFieldIsNotAField` pin the token rule, including that the first, middle and last position behave alike.

Verified on JDK 11: 46 tests in `CastExecutorTest` and 70 in the `casting` package pass, and `paimon-common` builds clean with checkstyle and spotless enabled. Fail-on-base was run, not assumed: against the empty-field revision the array test errors with `Cannot parse '[1, , 3]' as ARRAY: For input string: ''. Input is empty.` and the row test reports the missing mismatch.
