### PR TITLE
[common] Support VECTOR elements in InternalArray accessors

### DIFF
--- a/paimon-common/src/main/java/org/apache/paimon/data/BinaryArray.java
+++ b/paimon-common/src/main/java/org/apache/paimon/data/BinaryArray.java
@@ -83,6 +83,7 @@ public final class BinaryArray extends BinarySection implements InternalArray, D
             case TIMESTAMP_WITHOUT_TIME_ZONE:
             case TIMESTAMP_WITH_LOCAL_TIME_ZONE:
             case ARRAY:
+            case VECTOR:
             case MULTISET:
             case MAP:
             case ROW:
@@ -260,7 +261,8 @@ public final class BinaryArray extends BinarySection implements InternalArray, D
 
     @Override
     public InternalVector getVector(int pos) {
-        throw new IllegalArgumentException("Unsupported type: VectorType");
+        assertIndexIsValid(pos);
+        return MemorySegmentUtils.readVectorData(segments, offset, getLong(pos));
     }
 
     @Override

--- a/paimon-common/src/main/java/org/apache/paimon/data/InternalArray.java
+++ b/paimon-common/src/main/java/org/apache/paimon/data/InternalArray.java
@@ -124,6 +124,9 @@ public interface InternalArray extends DataGetters {
             case ARRAY:
                 elementGetter = InternalArray::getArray;
                 break;
+            case VECTOR:
+                elementGetter = InternalArray::getVector;
+                break;
             case MULTISET:
             case MAP:
                 elementGetter = InternalArray::getMap;

--- a/paimon-common/src/main/java/org/apache/paimon/data/InternalRow.java
+++ b/paimon-common/src/main/java/org/apache/paimon/data/InternalRow.java
@@ -150,6 +150,8 @@ public interface InternalRow extends DataGetters {
                 return Timestamp.class;
             case ARRAY:
                 return InternalArray.class;
+            case VECTOR:
+                return InternalVector.class;
             case MULTISET:
             case MAP:
                 return InternalMap.class;

--- a/paimon-common/src/test/java/org/apache/paimon/data/InternalArrayVectorGetterTest.java
+++ b/paimon-common/src/test/java/org/apache/paimon/data/InternalArrayVectorGetterTest.java
@@ -1,0 +1,83 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.data;
+
+import org.apache.paimon.data.serializer.InternalArraySerializer;
+import org.apache.paimon.io.DataInputViewStreamWrapper;
+import org.apache.paimon.io.DataOutputViewStreamWrapper;
+import org.apache.paimon.types.FloatType;
+import org.apache.paimon.types.VectorType;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests that ARRAY&lt;VECTOR&gt; is supported by {@link InternalArray} accessors: the {@link
+ * InternalArraySerializer} eagerly builds an element getter, so a missing VECTOR case fails
+ * serializer construction for an accepted DDL type.
+ */
+class InternalArrayVectorGetterTest {
+
+    private static final VectorType VECTOR_TYPE = new VectorType(3, new FloatType());
+
+    @Test
+    void arraySerializerOverVectorConstructs() {
+        InternalArraySerializer serializer = new InternalArraySerializer(VECTOR_TYPE);
+        assertThat(serializer).isNotNull();
+    }
+
+    @Test
+    void elementGetterReadsVector() {
+        BinaryVector vector = BinaryVector.fromPrimitiveArray(new float[] {1.0f, 2.0f, 3.0f});
+        GenericArray array = new GenericArray(new Object[] {vector});
+
+        InternalArray.ElementGetter getter = InternalArray.createElementGetter(VECTOR_TYPE);
+
+        assertThat(getter.getElementOrNull(array, 0)).isEqualTo(vector);
+    }
+
+    @Test
+    void elementGetterReturnsNullForNullElement() {
+        GenericArray array = new GenericArray(new Object[] {null});
+
+        InternalArray.ElementGetter getter = InternalArray.createElementGetter(VECTOR_TYPE);
+
+        assertThat(getter.getElementOrNull(array, 0)).isNull();
+    }
+
+    @Test
+    void vectorArrayRoundTripsThroughSerializer() throws Exception {
+        InternalArraySerializer serializer = new InternalArraySerializer(VECTOR_TYPE);
+        BinaryVector vector = BinaryVector.fromPrimitiveArray(new float[] {4.0f, 5.0f, 6.0f});
+        GenericArray array = new GenericArray(new Object[] {vector});
+
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        serializer.serialize(array, new DataOutputViewStreamWrapper(out));
+        InternalArray readBack =
+                serializer.deserialize(
+                        new DataInputViewStreamWrapper(
+                                new ByteArrayInputStream(out.toByteArray())));
+
+        assertThat(readBack.getVector(0).toFloatArray()).isEqualTo(new float[] {4.0f, 5.0f, 6.0f});
+    }
+}


### PR DESCRIPTION
### Purpose

close #9772

`ARRAY<VECTOR(n)>` is accepted by schema validation and readable via `ColumnarArray`, but the binary data path rejected it in four places: `InternalArray.createElementGetter` (no VECTOR case — `InternalArraySerializer` failed construction), `BinaryArray.calculateFixLengthPartSize` (threw), `BinaryArray.getVector` (unconditional throw), and `InternalRow.getDataClass` (broke `copy`).

This PR routes VECTOR through the existing accessors: `getVector` in the element getter, the 8-byte variable-length slot in `calculateFixLengthPartSize` (mirroring ARRAY), `readVectorData` in `BinaryArray.getVector` (mirroring `BinaryRow.getVector`), and `InternalVector` in `getDataClass`. The write side (`BinaryWriter.writeVector` + `InternalVectorSerializer`) already existed.

### Tests

New `InternalArrayVectorGetterTest`: serializer construction over VECTOR, element getter read, null element through the nullable wrapper, and a full serialize→deserialize→getVector round-trip. RED verified on master (construction threw `type VECTOR not support`).

### API and Format

No format change: vectors in binary rows/arrays use the existing var-length offset-and-size layout written by `writeVectorToVarLenPart`; this PR adds the missing read/validate paths.

### Documentation

None.